### PR TITLE
Route address binding failures through logging.

### DIFF
--- a/src/Tools/dotnet-monitor/AddressBindingResults.cs
+++ b/src/Tools/dotnet-monitor/AddressBindingResults.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
     internal sealed class AddressBindingResult
     {
-        public readonly string Message;
+        public readonly string Url;
 
         public readonly Exception Exception;
 
-        public AddressBindingResult(string message, Exception exception)
+        public AddressBindingResult(string Url, Exception exception)
         {
-            Message = message;
+            this.Url = Url;
             Exception = exception;
         }
     }

--- a/src/Tools/dotnet-monitor/AddressBindingResults.cs
+++ b/src/Tools/dotnet-monitor/AddressBindingResults.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class AddressBindingResults
+    {
+        public IList<AddressBindingResult> Errors { get; }
+            = new List<AddressBindingResult>();
+
+        public bool AnyBoundPorts { get; set; }
+    }
+
+    internal sealed class AddressBindingResult
+    {
+        public readonly string Message;
+
+        public readonly Exception Exception;
+
+        public AddressBindingResult(string message, Exception exception)
+        {
+            Message = message;
+            Exception = exception;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -57,12 +57,22 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
             using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth).Build();
-            await host.RunAsync(token);
+            try
+            {
+                await host.RunAsync(token);
+            }
+            catch (MonitoringException)
+            {
+                // It is the responsibility of throwers to ensure that the exceptions are logged.
+                return -1;
+            }
             return 0;
         }
 
         public IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth)
         {
+            AddressBindingResults bindingResults = new AddressBindingResults();
+
             return Host.CreateDefaultBuilder()
                 .UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
@@ -158,6 +168,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.ConfigureEgress(context.Configuration);
                     services.ConfigureMetrics(context.Configuration);
                     services.AddSingleton<ExperimentalToolLogger>();
+                    services.AddSingleton<AddressBindingResults>(bindingResults);
                 })
                 .ConfigureLogging(builder =>
                 {
@@ -191,19 +202,31 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                             urls = urls.Concat(metricUrls).ToArray();
                         }
 
-                        bool boundListeningPort = false;
-
                         //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
                         options.Configure(context.Configuration.GetSection("Kestrel")).Load();
+
+                        bindingResults.AnyBoundPorts = false;
 
                         //By default, we bind to https for sensitive data (such as dumps and traces) and bind http for
                         //non-sensitive data such as metrics. We may be missing a certificate for https binding. We want to continue with the
                         //http binding in that scenario.
-                        foreach (BindingAddress url in urls.Select(BindingAddress.Parse))
+                        foreach (string url in urls)
                         {
+                            BindingAddress address = null;
+                            try
+                            {
+                                address = BindingAddress.Parse(url);
+                            }
+                            catch (Exception ex)
+                            {
+                                // Record the exception; it will be logged later through ILogger.
+                                bindingResults.Errors.Add(new AddressBindingResult(ex.Message, ex));
+                                continue;
+                            }
+
                             Action<ListenOptions> configureListenOptions = (listenOptions) =>
                             {
-                                if (url.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                                if (address.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                                 {
                                     listenOptions.UseHttps();
                                 }
@@ -211,32 +234,28 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                             try
                             {
-                                if (url.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+                                if (address.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    options.ListenLocalhost(url.Port, configureListenOptions);
+                                    options.ListenLocalhost(address.Port, configureListenOptions);
                                 }
-                                else if (IPAddress.TryParse(url.Host, out IPAddress ipAddress))
+                                else if (IPAddress.TryParse(address.Host, out IPAddress ipAddress))
                                 {
-                                    options.Listen(ipAddress, url.Port, configureListenOptions);
+                                    options.Listen(ipAddress, address.Port, configureListenOptions);
                                 }
                                 else
                                 {
-                                    options.ListenAnyIP(url.Port, configureListenOptions);
+                                    options.ListenAnyIP(address.Port, configureListenOptions);
                                 }
-                                boundListeningPort = true;
+                                bindingResults.AnyBoundPorts = true;
                             }
-                            catch (InvalidOperationException e)
+                            catch (InvalidOperationException ex)
                             {
-                                //This binding failure is typically due to missing default certificate
-                                console.Error.WriteLine($"Unable to bind to {url}. Dotnet-monitor functionality will be limited.");
-                                console.Error.WriteLine(e.Message);
+                                // This binding failure is typically due to missing default certificate.
+                                // Record the exception; it will be logged later through ILogger.
+                                bindingResults.Errors.Add(new AddressBindingResult(
+                                    $"Unable to bind to {url}. Dotnet-monitor functionality will be limited.",
+                                    ex));
                             }
-                        }
-
-                        //If we end up not binding any ports, Kestrel defaults to port 5000. Make sure we don't attempt this.
-                        if (!boundListeningPort)
-                        {
-                            throw new InvalidOperationException("Unable to bind any urls.");
                         }
                     })
                     .UseStartup<Startup>();

--- a/src/Tools/dotnet-monitor/ExperimentalToolLogger.cs
+++ b/src/Tools/dotnet-monitor/ExperimentalToolLogger.cs
@@ -6,12 +6,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
-    // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool
+    // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool.
+    // Do not add any additional logging to this class; instead, add to LoggingExtensions class.
     internal class ExperimentalToolLogger
     {
         private const string ExperimentMessage = "WARNING: dotnet-monitor is experimental and is not intended for production environments yet.";
-        private const string NoAuthMessage = "WARNING: Authentication has been disabled. This can pose a security risk and is not intended for production environments.";
-        private const string InsecureAuthMessage = "WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.";
 
         private readonly ILogger<ExperimentalToolLogger> _logger;
 
@@ -23,16 +22,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public void LogExperimentMessage()
         {
             _logger.LogWarning(ExperimentMessage);
-        }
-
-        public void LogNoAuthMessage()
-        {
-            _logger.LogWarning(NoAuthMessage);
-        }
-
-        public void LogInsecureAuthMessage()
-        {
-            _logger.LogWarning(InsecureAuthMessage);
         }
 
         public static void AddLogFilter(ILoggingBuilder builder)

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -81,6 +81,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Debug,
                 formatString: "Provider {providerType}: Saved stream to {path}");
 
+        private static readonly Action<ILogger, Exception> _noAuthentication =
+            LoggerMessage.Define(
+                eventId: new EventId(13, "NoAuthentication"),
+                logLevel: LogLevel.Warning,
+                formatString: "WARNING: Authentication has been disabled. This can pose a security risk and is not intended for production environments.");
+
+        private static readonly Action<ILogger, Exception> _insecureAuthenticationConfiguration =
+            LoggerMessage.Define(
+                eventId: new EventId(14, "InsecureAutheticationConfiguration"),
+                logLevel: LogLevel.Warning,
+                formatString: "WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.");
+
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
             _egressProviderAdded(logger, providerName, null);
@@ -154,6 +166,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void EgressProviderSavedStream(this ILogger logger, string providerName, string path)
         {
             _egressProviderSavedStream(logger, providerName, path, null);
+        }
+
+        public static void NoAuthentication(this ILogger logger)
+        {
+            _noAuthentication(logger, null);
+        }
+
+        public static void InsecureAuthenticationConfiguration(this ILogger logger)
+        {
+            _insecureAuthenticationConfiguration(logger, null);
         }
 
         private static string Redact(string value)

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -93,6 +93,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: "WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.");
 
+        private static readonly Action<ILogger, string, Exception> _unableToBindToAddress =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(15, "UnableToBindToAddress"),
+                logLevel: LogLevel.Error,
+                formatString: "Unable to bind to {url}. Dotnet-monitor functionality will be limited.");
+
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
             _egressProviderAdded(logger, providerName, null);
@@ -176,6 +182,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void InsecureAuthenticationConfiguration(this ILogger logger)
         {
             _insecureAuthenticationConfiguration(logger, null);
+        }
+
+        public static void UnableToBindToAddress(this ILogger logger, string url, Exception ex)
+        {
+            _unableToBindToAddress(logger, url, ex);
         }
 
         private static string Redact(string value)

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -98,14 +98,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             // first opportunity to log anything through ILogger (a dedicated HostedService
             // could be written for this, but there is no guarantee that service would run
             // after the GenericWebHostServer is instantiated but before it is started).
-            // Additionally, Startup.Configure is called before KestrelServer is started
-            // by the GenericWebHostServer, so there is no duplication of logging errors.
             foreach (AddressBindingResult result in bindingResults.Errors)
             {
-                logger.LogError(result.Exception, result.Message);
+                logger.UnableToBindToAddress(result.Url, result.Exception);
             }
 
             // If we end up not binding any ports, Kestrel defaults to port 5000. Make sure we don't attempt this.
+            // Startup.Configure is called before KestrelServer is started
+            // by the GenericWebHostServer, so there is no duplication of logging errors
+            // and Kestrel does not bind to default ports.
             if (!bindingResults.AnyBoundPorts)
             {
                 // This is logged by GenericWebHostServer.StartAsync

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Diagnostics.Monitoring.RestServer.Controllers;
 using Microsoft.Extensions.Configuration;
@@ -17,7 +18,6 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
-using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -84,13 +84,37 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public void Configure(
             IApplicationBuilder app,
             IWebHostEnvironment env,
-            ExperimentalToolLogger logger,
-            IAuthOptions options)
+            ExperimentalToolLogger exprLogger,
+            IAuthOptions options,
+            AddressBindingResults bindingResults,
+            ILogger<Startup> logger)
         {
-            logger.LogExperimentMessage();
+            exprLogger.LogExperimentMessage();
+
+            // These errors are populated before Startup.Configure is called because
+            // the KestrelServer class is configured as a prerequisite of
+            // GenericWebHostServer being instantiated. The GenericWebHostServer invokes
+            // Startup.Configure as part of its StartAsync method. This method is the 
+            // first opportunity to log anything through ILogger (a dedicated HostedService
+            // could be written for this, but there is no guarantee that service would run
+            // after the GenericWebHostServer is instantiated but before it is started).
+            // Additionally, Startup.Configure is called before KestrelServer is started
+            // by the GenericWebHostServer, so there is no duplication of logging errors.
+            foreach (AddressBindingResult result in bindingResults.Errors)
+            {
+                logger.LogError(result.Exception, result.Message);
+            }
+
+            // If we end up not binding any ports, Kestrel defaults to port 5000. Make sure we don't attempt this.
+            if (!bindingResults.AnyBoundPorts)
+            {
+                // This is logged by GenericWebHostServer.StartAsync
+                throw new MonitoringException("Unable to bind any urls.");
+            }
+
             if (options.KeyAuthenticationMode == KeyAuthenticationMode.NoAuth)
             {
-                logger.LogNoAuthMessage();
+                logger.NoAuthentication();
             }
             else
             {
@@ -98,11 +122,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                 string hostingUrl = Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
                 string[] urls = ConfigurationHelper.SplitValue(hostingUrl);
-                foreach(BindingAddress address in urls.Select(BindingAddress.Parse))
+                foreach (string url in urls)
                 {
+                    BindingAddress address = null;
+                    try
+                    {
+                        address = BindingAddress.Parse(url);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+
                     if (string.Equals(Uri.UriSchemeHttp, address.Scheme, StringComparison.OrdinalIgnoreCase))
                     {
-                        logger.LogInsecureAuthMessage();
+                        logger.InsecureAuthenticationConfiguration();
                         break;
                     }
                 }


### PR DESCRIPTION
Route address binding failures through logging so that anything scraping stdout can more easily parse the errors.

Additional changes:
- Move authentication log messages to LoggingExtensions.
- Handle invalid addresses when parsing binding addresses.

Sample output when SSL cert is not configured and when authentication is disabled:
```
11:57:08 warn: Microsoft.Diagnostics.Tools.Monitor.ExperimentalToolLogger[0]
      WARNING: dotnet-monitor is experimental and is not intended for production environments yet.
11:57:09 fail: Microsoft.Diagnostics.Tools.Monitor.Startup[0]
      Unable to bind to https://localhost:52323. Dotnet-monitor functionality will be limited.
      System.InvalidOperationException: Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.
      To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
      For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
         at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions, Action`1 configureOptions)
         at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions)
         at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_2.<CreateHostBuilder>b__11(ListenOptions listenOptions) in D:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 231
         at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenLocalhost(Int32 port, Action`1 configure)
         at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_0.<CreateHostBuilder>b__10(WebHostBuilderContext context, KestrelServerOptions options) in D:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 239
11:57:09 warn: Microsoft.Diagnostics.Tools.Monitor.Startup[13]
      WARNING: Authentication has been disabled. This can pose a security risk and is not intended for production environments.
11:57:09 warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://localhost:52323'. Binding to endpoints defined in UseKestrel() instead.
11:57:09 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:52325
11:57:09 info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
11:57:09 info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
11:57:09 info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\src\dotnet\dotnet-monitor\artifacts\bin\dotnet-monitor\Debug\netcoreapp3.1\
```

Sample output with no viable bindings e.g. no SSL cert and turn off metrics:
```
12:13:55 warn: Microsoft.Diagnostics.Tools.Monitor.ExperimentalToolLogger[0]
      WARNING: dotnet-monitor is experimental and is not intended for production environments yet.
12:13:55 fail: Microsoft.Diagnostics.Tools.Monitor.Startup[0]
      Unable to bind to https://localhost:52323. Dotnet-monitor functionality will be limited.
      System.InvalidOperationException: Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.
      To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
      For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
         at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions, Action`1 configureOptions)
         at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions)
         at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_2.<CreateHostBuilder>b__11(ListenOptions listenOptions) in D:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 231
         at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenLocalhost(Int32 port, Action`1 configure)
         at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_0.<CreateHostBuilder>b__10(WebHostBuilderContext context, KestrelServerOptions options) in D:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 239
12:14:04 crit: Microsoft.AspNetCore.Hosting.Diagnostics[6]
      Application startup exception
      Microsoft.Diagnostics.Monitoring.MonitoringException: Unable to bind any urls.
         at Microsoft.Diagnostics.Tools.Monitor.Startup.Configure(IApplicationBuilder app, IWebHostEnvironment env, ExperimentalToolLogger exprLogger, IAuthOptions options, AddressBindingResults bindingResults, ILogger`1 logger) in D:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\Startup.cs:line 115
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
         at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
         at Microsoft.AspNetCore.Hosting.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
         at Microsoft.AspNetCore.Hosting.ConfigureBuilder.<>c__DisplayClass4_0.<Build>b__0(IApplicationBuilder builder)
         at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.<>c__DisplayClass13_0.<UseStartup>b__2(IApplicationBuilder app)
         at Microsoft.AspNetCore.Mvc.Filters.MiddlewareFilterBuilderStartupFilter.<>c__DisplayClass0_0.<Configure>g__MiddlewareFilterBuilder|0(IApplicationBuilder builder)
         at Microsoft.AspNetCore.HostFilteringStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder app)
         at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(CancellationToken cancellationToken)
```
in the above example, dotnet-monitor process is no longer running because of the application startup failure.