### PR TITLE
Fix build to publish artifacts and run SDL checks on packages.

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -28,7 +28,7 @@ stages:
     jobs:
     - template: /eng/build.yml
       parameters:
-        name: windows
+        name: Windows
         displayName: Build
         osGroup: Windows
         configuration: Release
@@ -71,4 +71,4 @@ stages:
           -TsaCodebaseName "dotnet-monitor"
           -TsaPublish $True'
           artifactNames:
-          - 'Packages'
+          - 'PackageArtifacts'

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -24,7 +24,9 @@ jobs:
     artifacts:
       publish:
         logs: true
-        manifests: true
+        ${{ if ne(variables['System.TeamProject'], 'public') }}:
+          artifacts: true
+          manifests: true
 
     pool:
       # Public Linux Build Pool
@@ -64,6 +66,7 @@ jobs:
 
     variables: 
     - ${{ insert }}: ${{ parameters.variables }}
+    - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
     - _SignType: test


### PR DESCRIPTION
Overview:
- Publish artifacts for internal builds.
- Set _BuildConfig variable.
- Execute SDL checks on PackageArtifacts artifact.

Sample internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=999305