### PR TITLE
Don't publish nupkg to blob feed

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -54,18 +54,9 @@
     <ItemGroup>
       <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageFile.IsShipping)' != 'true'" />
     </ItemGroup>
-    <ItemGroup>
-      <_PackageArtifactData Include="@(_CommonArtifactData)" />
-      <!-- Setting Category to Other will upload to installers blob feed. -->
-      <!-- Feed configuration categories are uppercase and case sensitive in PublishArtifactsInManifest task. -->
-      <_PackageArtifactData Include="Category=OTHER" />
-    </ItemGroup>
 
     <!-- Capture each blob item to upload to blob feed -->
     <ItemGroup>
-      <_BlobItem Include="%(PackageFile.FullPath)">
-        <ManifestArtifactData>@(_PackageArtifactData)</ManifestArtifactData>
-      </_BlobItem>
       <_BlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_BlobItem>


### PR DESCRIPTION
The dotnet-docker repo uses the *.nupkg.version file to detect the latest package version, so it is not necessary to publish the package to the blob feed. The package is still published to the dotnet-tools NuGet package feed.