### PR TITLE
Upgrade ASP.NET Core 2.1 packages to secure versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,17 +11,17 @@
     <UsingToolNetFrameworkReferenceAssemblies>false</UsingToolNetFrameworkReferenceAssemblies>
     <!-- Other libs -->
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>
-    <MicrosoftAspNetCoreVersion>2.1.7</MicrosoftAspNetCoreVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>3.1.10</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
-    <MicrosoftAspNetCoreHttpsPolicyVersion>2.1.1</MicrosoftAspNetCoreHttpsPolicyVersion>
+    <MicrosoftAspNetCoreHttpVersion>2.1.22</MicrosoftAspNetCoreHttpVersion>
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
-    <MicrosoftAspNetCoreResponseCompressionVersion>2.1.1</MicrosoftAspNetCoreResponseCompressionVersion>
+    <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <MicrosoftExtensionsConfigurationKeyPerFileVersion>5.0.2</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>5.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <!-- We use a newer version of LoggingEventSource due to a bug in an older version-->
     <MicrosoftExtensionsLoggingEventSourceVersion>3.1.4</MicrosoftExtensionsLoggingEventSourceVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
+    <SystemIOPipelinesVersion>4.5.1</SystemIOPipelinesVersion>
     <!-- dotnet-monitor references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21151.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21151.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Microsoft.Diagnostics.Monitoring.RestServer.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Microsoft.Diagnostics.Monitoring.RestServer.csproj
@@ -23,11 +23,18 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <!--
+      AspNetCore references use version ranges in order to allow package references to this
+      RestServer package to use newer versions but not reference anything newer than .NET Core 2.1
+    -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="[$(MicrosoftAspNetCoreMvcVersion),2.2.0)" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="$(MicrosoftBclHashCodeVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="$(MicrosoftAspNetCoreHttpsPolicyVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="$(MicrosoftAspNetCoreResponseCompressionVersion)" />
+    <!--
+      Upgraded packages to avoid insecure versions; these are not directly referenced by the code.
+    -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[$(MicrosoftAspNetCoreHttpVersion),2.2.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[$(MicrosoftAspNetCoreServerKestrelCoreVersion),2.2.0)" />
+    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades the following packages to the minimal version that are secure.
- Microsoft.AspNetCore.Http
- Microsoft.AspNetCore.Server.Kestrel.Core
- System.IO.Pipelines

Removed other packages that are not referenced:
- Microsoft.AspNetCore
- Microsoft.AspNetCore.HttpsPolicy
- Microsoft.AspNetCore.ResponseCompression

Lastly, change ASP.NET Core references to version ranges that end at 2.2.0 exclusively.