### PR TITLE
Log bound default vs metrics addresses.

### DIFF
--- a/src/Tools/dotnet-monitor/AddressListenResults.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResults.cs
@@ -7,21 +7,25 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
-    internal sealed class AddressBindingResults
+    internal sealed class AddressListenResults
     {
-        public IList<AddressBindingResult> Errors { get; }
-            = new List<AddressBindingResult>();
+        public IList<AddressListenResult> Errors { get; }
+            = new List<AddressListenResult>();
 
-        public bool AnyBoundPorts { get; set; }
+        public bool AnyAddresses => (AddressesCount + MetricAddressesCount) > 0;
+
+        public int MetricAddressesCount { get; set; }
+
+        public int AddressesCount { get; set; }
     }
 
-    internal sealed class AddressBindingResult
+    internal sealed class AddressListenResult
     {
         public readonly string Url;
 
         public readonly Exception Exception;
 
-        public AddressBindingResult(string Url, Exception exception)
+        public AddressListenResult(string Url, Exception exception)
         {
             this.Url = Url;
             Exception = exception;

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -93,11 +93,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: "WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.");
 
-        private static readonly Action<ILogger, string, Exception> _unableToBindToAddress =
+        private static readonly Action<ILogger, string, Exception> _unableToListenToAddress =
             LoggerMessage.Define<string>(
-                eventId: new EventId(15, "UnableToBindToAddress"),
+                eventId: new EventId(15, "UnableToListenToAddress"),
                 logLevel: LogLevel.Error,
-                formatString: "Unable to bind to {url}. Dotnet-monitor functionality will be limited.");
+                formatString: "Unable to listen to {url}. Dotnet-monitor functionality will be limited.");
+
+        private static readonly Action<ILogger, string, Exception> _boundDefaultAddress =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(16, "BoundDefaultAddress"),
+                logLevel: LogLevel.Debug,
+                formatString: "Bound default address: {address}");
+
+        private static readonly Action<ILogger, string, Exception> _boundMetricsAddress =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(17, "BoundMetricsAddress"),
+                logLevel: LogLevel.Debug,
+                formatString: "Bound metrics address: {address}");
 
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
@@ -184,9 +196,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _insecureAuthenticationConfiguration(logger, null);
         }
 
-        public static void UnableToBindToAddress(this ILogger logger, string url, Exception ex)
+        public static void UnableToListenToAddress(this ILogger logger, string address, Exception ex)
         {
-            _unableToBindToAddress(logger, url, ex);
+            _unableToListenToAddress(logger, address, ex);
+        }
+
+        public static void BoundDefaultAddress(this ILogger logger, string address)
+        {
+            _boundDefaultAddress(logger, address, null);
+        }
+
+        public static void BoundMetricsAddress(this ILogger logger, string address)
+        {
+            _boundMetricsAddress(logger, address, null);
         }
 
         private static string Redact(string value)


### PR DESCRIPTION
This change allows dotnet-monitor to report which addresses are default and which are metrics. This will be used for testing when telling dotnet-monitor to bind to any port for each of these types of addresses, e.g.

```
dotnet-monitor collect --urls https://127.0.0.1:0 --metricUrls http://127.0.0.1:0
```

Output (with Debug log level set for Microsoft.Diagnostics logging category):
```
17:33:31 warn: Microsoft.Diagnostics.Tools.Monitor.ExperimentalToolLogger[0]
      WARNING: dotnet-monitor is experimental and is not intended for production environments yet.
17:33:32 warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://127.0.0.1:0'. Binding to endpoints defined in UseKestrel() instead.
17:33:32 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: https://127.0.0.1:53960
17:33:32 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://127.0.0.1:53961
17:33:32 dbug: Microsoft.Diagnostics.Tools.Monitor.Startup[16]
      Bound default address: https://127.0.0.1:53960
17:33:32 dbug: Microsoft.Diagnostics.Tools.Monitor.Startup[17]
      Bound metrics address: http://127.0.0.1:53961
17:33:32 info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
17:33:32 info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
17:33:32 info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\src\dotnet\dotnet-monitor\artifacts\bin\dotnet-monitor\Debug\netcoreapp3.1\
```