### PR TITLE
Install ASP.NET Core on Unix systems.

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,8 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <PowershellWrapper>powershell -NonInteractive -ExecutionPolicy ByPass -NoProfile -command</PowershellWrapper>
-    <DotnetInstallScriptCmd>'$(RepositoryEngineeringDir)common\dotnet-install.ps1'</DotnetInstallScriptCmd>
-  </PropertyGroup>
 
   <ItemGroup>
     <AspNetCoreInstallation Include="31x64" Version="$(MicrosoftAspNetCoreApp31Version)" Architecture="x64" />
@@ -16,8 +12,26 @@
       not have the ability to install ASP.NET Core runtimes. Add a target that
       executes after Arcade's target so that the ASP.NET Core runtimes can be installed.
   -->
-  <Target Name="InstallAspNetCore" 
-    AfterTargets="InstallDotNetCore">
+  <Target Name="InstallAspNetCore"
+    AfterTargets="InstallDotNetCore"
+    DependsOnTargets="InstallAspNetCoreWindows;InstallAspNetCoreUnix" />
+
+  <Target Name="InstallAspNetCoreWindows"
+    Condition="$([MSBuild]::IsOsPlatform(Windows))">
+    <PropertyGroup>
+      <PowershellWrapper>powershell -NonInteractive -ExecutionPolicy ByPass -NoProfile -command</PowershellWrapper>
+      <DotnetInstallScriptCmd>'$(RepositoryEngineeringDir)common\dotnet-install.ps1'</DotnetInstallScriptCmd>
+    </PropertyGroup>
     <Exec Command="$(PowershellWrapper) &quot;&amp; { &amp;$(DotnetInstallScriptCmd) -Architecture %(AspNetCoreInstallation.Architecture) -Version %(AspNetCoreInstallation.Version) -Runtime aspnetcore }&quot;" />
   </Target>
+
+  <Target Name="InstallAspNetCoreUnix"
+    Condition="!$([MSBuild]::IsOsPlatform(Windows))">
+    <PropertyGroup>
+      <DotnetInstallScriptCmd>$(RepositoryEngineeringDir)common\dotnet-install.sh</DotnetInstallScriptCmd>
+    </PropertyGroup>
+    <Exec Command="$(DotnetInstallScriptCmd) -Architecture %(AspNetCoreInstallation.Architecture) -Version %(AspNetCoreInstallation.Version) -Runtime aspnetcore"
+          Condition="'%(AspNetCoreInstallation.Architecture)' == 'x64'" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
With this change, dotnet-monitor can be built and tested on Linux.