### PR TITLE
Have blob group include release subfolder based on build quality.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,13 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>4</PreReleaseVersionIteration>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
+    <!--
+      Build quality notion for blob group naming, similar to aka.ms channel build quality in Arcade:
+      - 'daily': sets the blob group release name to 'daily' so a release type does not have to be assigned.
+      - 'prerelease': allows the blob group release name to use prerelease version information.
+      - 'release': sets the blob group release name to 'release'.
+    -->
+    <BlobGroupBuildQuality>daily</BlobGroupBuildQuality>
   </PropertyGroup>
   <PropertyGroup>
     <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,9 +16,52 @@
           AfterTargets="Pack"
           Condition="'$(IsPackable)' == 'true' and '$(BlobGroupPrefix)' != ''">
     <PropertyGroup>
-      <_BlobGroupVersionMajor>$(PackageVersion.Split('.')[0])</_BlobGroupVersionMajor>
-      <_BlobGroupVersionMinor>$(PackageVersion.Split('.')[1])</_BlobGroupVersionMinor>
-      <_BlobGroupName>$(BlobGroupPrefix)$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)</_BlobGroupName>
+      <!--
+        These properties take a package version and transform it into a blob group name so that
+        all builds from the same product and release version are grouped together. This code has
+        to consider when the version is a release version (e.g. 5.0.0) or has a prerelease label
+        (e.g. 5.0.0-preview.1). The former is transformed into '$(BlobGroupPrefix)5.0/release' whereas
+        the latter is transformed into '$(BlobGroupPrefix)5.0/preview.1'. It also accounts for the
+        BlobGroupBuildQuality defined in Version.props, which determines if the prerelease information
+        should be used in the final blob group name.
+        -->
+      <_PreReleaseSeperatorIndex>$(PackageVersion.IndexOf('-'))</_PreReleaseSeperatorIndex>
+      
+      <!-- Prerelease: '5.0.0-preview.1' -> '5.0.0' and 'preview.1' -->
+      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring(0, $(_PreReleaseSeperatorIndex)))</_BlobGroupVersion>
+      <_BlobGroupPreRelease Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring($([MSBuild]::Add($(_PreReleaseSeperatorIndex), 1))))</_BlobGroupPreRelease>
+      
+      <!-- Release: take the package version as-is. -->
+      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' == '-1'">$(PackageVersion)</_BlobGroupVersion>
+
+      <!--
+        Prerelease may contain additional fields; only want the label and first number
+        (e.g. 'preview.1.12345' -> 'preview' and '1').
+        -->
+      <_BlobGroupPreReleaseLabel Condition="'$(_BlobGroupPreRelease)' != ''">$(_BlobGroupPreRelease.Split('.')[0])</_BlobGroupPreReleaseLabel>
+      <_BlobGroupPreReleaseIteration Condition="'$(_BlobGroupPreRelease)' != ''">$(_BlobGroupPreRelease.Split('.')[1])</_BlobGroupPreReleaseIteration>
+
+      <!--
+        Calculate release name based on version parts and blob group build quality.
+        Daily: use 'daily'
+        Prerelease: 'preview' and '1' -> 'preview.1'
+        Release: use 'release'
+        -->
+      <_BlobGroupReleaseName  Condition="'$(BlobGroupBuildQuality)' == 'daily'">daily</_BlobGroupReleaseName>
+      <_BlobGroupReleaseName  Condition="'$(BlobGroupBuildQuality)' == 'prerelease'">$(_BlobGroupPreReleaseLabel).$(_BlobGroupPreReleaseIteration)</_BlobGroupReleaseName>
+      <_BlobGroupReleaseName  Condition="'$(BlobGroupBuildQuality)' == 'release'">release</_BlobGroupReleaseName>
+
+      <!-- Extract major and minor version fields from version number. -->
+      <_BlobGroupVersionMajor>$(_BlobGroupVersion.Split('.')[0])</_BlobGroupVersionMajor>
+      <_BlobGroupVersionMinor>$(_BlobGroupVersion.Split('.')[1])</_BlobGroupVersionMinor>
+
+      <!--
+        Combine all parts to create blob group name. For example (with BlobGroupPrefix = 'monitor'):
+        Daily: '5.0.0-preview.1.12345' -> 'monitor5.0/daily'
+        Prerelease: '5.0.0-preview.1.12345' -> 'monitor5.0/preview.1'
+        Release: '5.0.0' -> 'monitor5.0/release'
+        -->
+      <_BlobGroupName>$(BlobGroupPrefix)$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>
     </PropertyGroup>
     <!-- A file that contains the blob group so that publishing can use it in the blob path calculation. -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.blobgroup"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -40,21 +40,30 @@
         -->
       <_BlobGroupPreReleaseLabel Condition="'$(_BlobGroupPreRelease)' != ''">$(_BlobGroupPreRelease.Split('.')[0])</_BlobGroupPreReleaseLabel>
       <_BlobGroupPreReleaseIteration Condition="'$(_BlobGroupPreRelease)' != ''">$(_BlobGroupPreRelease.Split('.')[1])</_BlobGroupPreReleaseIteration>
-
-      <!--
-        Calculate release name based on version parts and blob group build quality.
-        Daily: use 'daily'
-        Prerelease: 'preview' and '1' -> 'preview.1'
-        Release: use 'release'
-        -->
-      <_BlobGroupReleaseName  Condition="'$(BlobGroupBuildQuality)' == 'daily'">daily</_BlobGroupReleaseName>
-      <_BlobGroupReleaseName  Condition="'$(BlobGroupBuildQuality)' == 'prerelease'">$(_BlobGroupPreReleaseLabel).$(_BlobGroupPreReleaseIteration)</_BlobGroupReleaseName>
-      <_BlobGroupReleaseName  Condition="'$(BlobGroupBuildQuality)' == 'release'">release</_BlobGroupReleaseName>
-
+    </PropertyGroup>
+    <!-- These are the valid BlobGroupBuildQuality values. -->
+    <ItemGroup>
+      <_BlobGroupBuildQualityName Include="daily" ReleaseName="daily" />
+      <_BlobGroupBuildQualityName Include="prerelease" ReleaseName="$(_BlobGroupPreReleaseLabel).$(_BlobGroupPreReleaseIteration)" />
+      <_BlobGroupBuildQualityName Include="release" ReleaseName="release" />
+    </ItemGroup>
+    <!-- Select the blob group build quality based on the specified property. -->
+    <ItemGroup>
+      <_SelectedBlobGroupQualityName Include="@(_BlobGroupBuildQualityName)" Condition="'%(Identity)' == '$(BlobGroupBuildQuality)'" />
+    </ItemGroup>
+    <PropertyGroup>
       <!-- Extract major and minor version fields from version number. -->
       <_BlobGroupVersionMajor>$(_BlobGroupVersion.Split('.')[0])</_BlobGroupVersionMajor>
       <_BlobGroupVersionMinor>$(_BlobGroupVersion.Split('.')[1])</_BlobGroupVersionMinor>
-
+      <!-- Get release name from blob group build quality. -->
+      <_BlobGroupReleaseName>@(_SelectedBlobGroupQualityName->'%(ReleaseName)')</_BlobGroupReleaseName>
+    </PropertyGroup>
+    <!-- Validate the selected and calculated values. -->
+    <Error Text="BlobGroupBuildQuality must be set to a valid value: @(_BlobGroupBuildQualityName, ', ')" Condition="'@(_SelectedBlobGroupQualityName)' == ''" />
+    <Error Text="Unable to calculate _BlobGroupVersionMajor" Condition="'$(_BlobGroupVersionMajor)' == ''" />
+    <Error Text="Unable to calculate _BlobGroupVersionMinor" Condition="'$(_BlobGroupVersionMinor)' == ''" />
+    <Error Text="Unable to calculate _BlobGroupReleaseName" Condition="'$(_BlobGroupReleaseName)' == ''" />
+    <PropertyGroup>
       <!--
         Combine all parts to create blob group name. For example (with BlobGroupPrefix = 'monitor'):
         Daily: '5.0.0-preview.1.12345' -> 'monitor5.0/daily'


### PR DESCRIPTION
The current aka.ms link generation for the latest version produces a link that represents the absolute latest version within a given release. For example, the link 'aka.ms/dotnet/diagnostics/monitor5.0/dotnet-monitor.nupkg.version' only allows for pointing to a single version within the 5.0.X release.

In order to allow dotnet-docker to consume a specific preview version, the link generation needs to be updated to include the prerelease information. This change adds the prerelease information as a subfolder to the existing blob group name calculation. It also introduces a build quality notion that is similar to aka.ms channel build quality so that the main branch does not have to declare its release name.

For example, we could fork main into a release branch (which would build preview 4 bits) and update main to preview 5. The dotnet-docker repo would then be able to monitoring for the stabilizing versions under preview 4 without being impacted by the main branch producing preview 5 bits. The release branch would have a build quality set to 'prerelease'. Thus, the release branch would update the 'aka.ms/dotnet/diagnostics/monitor5.0/preview.4/dotnet-monitor.nupkg.version' link with its latest build whereas the main branch would update 'aka.ms/dotnet/diagnostics/monitor5.0/daily/dotnet-monitor.nupkg.version'. When it comes time to produce the final release, the release branch build quality would be set to 'release' and would update the 'aka.ms/dotnet/diagnostics/monitor5.0/release/dotnet-monitor.nupkg.version' link.

closes #80 