### PR TITLE
Use HttpClientFactory shared among tests to avoid socket exhaustion.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.UnitTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Options;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Runners;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -15,20 +17,22 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Extensions;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTests
 {
+    [Collection(DefaultCollectionFixture.Name)]
     public class AuthenticationTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
 
         private const string ApiKeyScheme = "MonitorApiKey";
 
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ITestOutputHelper _outputHelper;
 
-        public AuthenticationTests(ITestOutputHelper outputHelper)
+        public AuthenticationTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
         {
+            _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
             _outputHelper = outputHelper;
         }
 
@@ -43,19 +47,21 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Any authenticated route on the default address should 401 Unauthenticated
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => client.GetProcessesAsync(DefaultTimeout));
+                () => apiClient.GetProcessesAsync(DefaultTimeout));
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
 
             // TODO: Verify other routes (e.g. /dump, /trace, /logs) also 401 Unauthenticated
 
             // Metrics should not throw on the default address
 
-            var metrics = await client.GetMetricsAsync(DefaultTimeout);
+            var metrics = await apiClient.GetMetricsAsync(DefaultTimeout);
             Assert.NotNull(metrics);
         }
 
@@ -70,17 +76,19 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetMetricsAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetMetricsAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Any non-metrics route on the metrics address should 404 Not Found
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => client.GetProcessesAsync(DefaultTimeout));
+                () => apiClient.GetProcessesAsync(DefaultTimeout));
             Assert.Equal(HttpStatusCode.NotFound, statusCodeException.StatusCode);
 
             // TODO: Verify other routes (e.g. /dump, /trace, /logs) also 404 Not Found
 
             // Metrics should not throw on the metrics address
-            var metrics = await client.GetMetricsAsync(DefaultTimeout);
+            var metrics = await apiClient.GetMetricsAsync(DefaultTimeout);
             Assert.NotNull(metrics);
         }
 
@@ -94,14 +102,16 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             toolRunner.DisableAuthentication = true;
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /processes does not challenge for authentication
-            var processes = await client.GetProcessesAsync(DefaultTimeout);
+            var processes = await apiClient.GetProcessesAsync(DefaultTimeout);
             Assert.NotNull(processes);
 
             // Check that /metrics does not challenge for authentication
-            var metrics = await client.GetMetricsAsync(DefaultTimeout);
+            var metrics = await apiClient.GetMetricsAsync(DefaultTimeout);
             Assert.NotNull(metrics);
         }
 
@@ -130,14 +140,14 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             await toolRunner.StartAsync(DefaultTimeout);
 
             // Create HttpClient with default request headers
-            using HttpClient httpClient = new();
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
             httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(ApiKeyScheme, Convert.ToBase64String(apiKey));
-
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout), httpClient);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /processes does not challenge for authentication
-            var processes = await client.GetProcessesAsync(DefaultTimeout);
+            var processes = await apiClient.GetProcessesAsync(DefaultTimeout);
             Assert.NotNull(processes);
 
             _outputHelper.WriteLine("Rotating API key.");
@@ -161,7 +171,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
                 try
                 {
-                    await client.GetProcessesAsync(DefaultTimeout);
+                    await apiClient.GetProcessesAsync(DefaultTimeout);
                 }
                 catch (ApiStatusCodeException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
                 {
@@ -178,7 +188,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                 new AuthenticationHeaderValue(ApiKeyScheme, Convert.ToBase64String(apiKey2));
 
             // Check that /processes does not challenge for authentication
-            processes = await client.GetProcessesAsync(DefaultTimeout);
+            processes = await apiClient.GetProcessesAsync(DefaultTimeout);
             Assert.NotNull(processes);
         }
 
@@ -198,11 +208,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             // is launched by the test process, the usage of these credentials
             // should authenticate correctly (except when elevated, which the
             // tool will deny authorization).
-            using HttpClientHandler handler = new();
-            handler.Credentials = CredentialCache.DefaultCredentials;
-            using HttpClient httpClient = new(handler);
-
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout), httpClient);
+            using HttpClient httpClient = _httpClientFactory.CreateClient(ServiceProviderFixture.HttpClientName_DefaultCredentials);
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient client = new(_outputHelper, httpClient);
 
             // TODO: Split test into elevated vs non-elevated tests and skip
             // when not running in the corresponding context. Possibly unelevate

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Any authenticated route on the default address should 401 Unauthenticated
@@ -76,8 +75,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetMetricsAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientMetricsAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Any non-metrics route on the metrics address should 404 Not Found
@@ -102,8 +100,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             toolRunner.DisableAuthentication = true;
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /processes does not challenge for authentication
@@ -140,8 +137,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             await toolRunner.StartAsync(DefaultTimeout);
 
             // Create HttpClient with default request headers
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(ApiKeyScheme, Convert.ToBase64String(apiKey));
             ApiClient apiClient = new(_outputHelper, httpClient);
@@ -208,8 +204,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             // is launched by the test process, the usage of these credentials
             // should authenticate correctly (except when elevated, which the
             // tool will deny authorization).
-            using HttpClient httpClient = _httpClientFactory.CreateClient(ServiceProviderFixture.HttpClientName_DefaultCredentials);
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient client = new(_outputHelper, httpClient);
 
             // TODO: Split test into elevated vs non-elevated tests and skip

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             // is launched by the test process, the usage of these credentials
             // should authenticate correctly (except when elevated, which the
             // tool will deny authorization).
-            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout, ServiceProviderFixture.HttpClientName_DefaultCredentials);
             ApiClient client = new(_outputHelper, httpClient);
 
             // TODO: Split test into elevated vs non-elevated tests and skip

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Fixtures/DefaultCollectionFixture.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Fixtures/DefaultCollectionFixture.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTests.Fixtures
+{
+    /// <summary>
+    /// This fixture allows injecting of a single <see cref="ServiceProviderFixture"/> instance
+    /// that is available to all tests in the collection. This allows providing a singleton
+    /// service provider for all test invocations within the collection.
+    /// </summary>
+    [CollectionDefinition(Name)]
+    public class DefaultCollectionFixture : ICollectionFixture<ServiceProviderFixture>
+    {
+        public const string Name = nameof(DefaultCollectionFixture);
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Fixtures/ServiceProviderFixture.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Fixtures/ServiceProviderFixture.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net.Http;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTests.Fixtures
+{
+    /// <summary>
+    /// Provides common services to tests.
+    /// </summary>
+    public class ServiceProviderFixture : IDisposable
+    {
+        public const string HttpClientName_DefaultCredentials = "DefaultCredentials";
+
+        public ServiceProviderFixture()
+        {
+            ServiceCollection services = new();
+            services.AddHttpClient();
+            services.AddHttpClient(HttpClientName_DefaultCredentials)
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                {
+                    HttpClientHandler handler = new HttpClientHandler();
+                    handler.UseDefaultCredentials = true;
+                    return handler;
+                });
+
+            ServiceProvider = services.BuildServiceProvider();
+        }
+
+        public ServiceProvider ServiceProvider { get; }
+
+        public void Dispose()
+        {
+            ServiceProvider.Dispose();
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/HttpApi/ApiClient.cs
@@ -17,32 +17,16 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
 {
-    internal sealed class ApiClient : IDisposable
+    internal sealed class ApiClient
     {
-        private readonly string _baseUrl;
-        private readonly bool _disposeHttpClient;
         private readonly HttpClient _httpClient;
         private readonly ITestOutputHelper _outputHelper;
 
-        public ApiClient(ITestOutputHelper outputHelper, string baseUrl)
-            : this(outputHelper, baseUrl, new HttpClient())
-        {
-            _disposeHttpClient = true;
-        }
 
-        public ApiClient(ITestOutputHelper outputHelper, string baseUrl, HttpClient httpClient)
+        public ApiClient(ITestOutputHelper outputHelper, HttpClient httpClient)
         {
-            _baseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
-        }
-
-        public void Dispose()
-        {
-            if (_disposeHttpClient)
-            {
-                _httpClient.Dispose();
-            }
         }
 
         /// <summary>
@@ -50,9 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
         /// </summary>
         public async Task<IEnumerable<Models.ProcessIdentifier>> GetProcessesAsync(CancellationToken token)
         {
-            Uri uri = new($"{_baseUrl}/processes", UriKind.Absolute);
-
-            using HttpRequestMessage request = new(HttpMethod.Get, uri);
+            using HttpRequestMessage request = new(HttpMethod.Get, "/processes");
             request.Headers.Add(HeaderNames.Accept, ContentTypes.ApplicationJson);
 
             using HttpResponseMessage response = await _httpClient.SendAsync(request, token);
@@ -88,9 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
         /// </summary>
         public async Task<string> GetMetricsAsync(CancellationToken token)
         {
-            Uri uri = new($"{_baseUrl}/metrics", UriKind.Absolute);
-
-            using HttpRequestMessage request = new(HttpMethod.Get, uri);
+            using HttpRequestMessage request = new(HttpMethod.Get, "/metrics");
             request.Headers.Add(HeaderNames.Accept, ContentTypes.TextPlain);
 
             using HttpResponseMessage response = await _httpClient.SendAsync(request, token);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/MetricsTests.cs
@@ -3,11 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Diagnostics.Monitoring.UnitTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Options;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Runners;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -15,14 +18,17 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTests
 {
+    [Collection(DefaultCollectionFixture.Name)]
     public class MetricsTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
 
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ITestOutputHelper _outputHelper;
 
-        public MetricsTests(ITestOutputHelper outputHelper)
+        public MetricsTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
         {
+            _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
             _outputHelper = outputHelper;
         }
 
@@ -36,11 +42,13 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             toolRunner.DisableMetricsViaCommandLine = true;
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
             var validationProblemDetailsException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
-                () => client.GetMetricsAsync(DefaultTimeout));
+                () => apiClient.GetMetricsAsync(DefaultTimeout));
             Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsException.StatusCode);
             Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsException.Details.Status);
         }
@@ -58,11 +66,13 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             };
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
             var validationProblemDetailsException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
-                () => client.GetMetricsAsync(DefaultTimeout));
+                () => apiClient.GetMetricsAsync(DefaultTimeout));
             Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsException.StatusCode);
             Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsException.Details.Status);
         }
@@ -85,7 +95,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient client = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
             var validationProblemDetailsException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
@@ -112,11 +124,13 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using ApiClient client = new(_outputHelper, await toolRunner.GetDefaultAddressAsync(DefaultTimeout));
+            using HttpClient httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
             var validationProblemDetailsException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
-                () => client.GetMetricsAsync(DefaultTimeout));
+                () => apiClient.GetMetricsAsync(DefaultTimeout));
             Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsException.StatusCode);
             Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsException.Details.Status);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/MetricsTests.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             toolRunner.DisableMetricsViaCommandLine = true;
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
@@ -66,8 +65,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             };
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
@@ -95,8 +93,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient client = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics
@@ -124,8 +121,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             await toolRunner.StartAsync(DefaultTimeout);
 
-            using HttpClient httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(await toolRunner.GetDefaultAddressAsync(DefaultTimeout), UriKind.Absolute);
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, DefaultTimeout);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             // Check that /metrics does not serve metrics

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/DotNetMonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/DotNetMonitorRunner.cs
@@ -1,6 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Options;
@@ -243,21 +243,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
             return GetCompletionSourceResultAsync(_defaultAddressSource, token);
         }
 
-        public async Task<string> GetDefaultAddressAsync(TimeSpan timeout)
-        {
-            using CancellationTokenSource cancellation = new(timeout);
-            return await GetDefaultAddressAsync(cancellation.Token);
-        }
-
         public Task<string> GetMetricsAddressAsync(CancellationToken token)
         {
             return GetCompletionSourceResultAsync(_metricsAddressSource, token);
-        }
-
-        public async Task<string> GetMetricsAddressAsync(TimeSpan timeout)
-        {
-            using CancellationTokenSource cancellation = new(timeout);
-            return await GetMetricsAddressAsync(cancellation.Token);
         }
 
         public void WriteKeyPerValueConfiguration(RootOptions options)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/DotNetMonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/DotNetMonitorRunnerExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
+{
+    internal static class DotNetMonitorRunnerExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="HttpClient"/> over the default address of the <paramref name="runner"/>.
+        /// </summary>
+        public static Task<HttpClient> CreateHttpClientDefaultAddressAsync(this DotNetMonitorRunner runner, IHttpClientFactory factory, TimeSpan timeout)
+        {
+            return CreateHttpClientDefaultAddressAsync(runner, factory, timeout, Extensions.Options.Options.DefaultName);
+        }
+
+        /// <summary>
+        /// Creates a named <see cref="HttpClient"/> over the default address of the <paramref name="runner"/>.
+        /// </summary>
+        public static async Task<HttpClient> CreateHttpClientDefaultAddressAsync(this DotNetMonitorRunner runner, IHttpClientFactory factory, TimeSpan timeout, string name)
+        {
+            HttpClient client = factory.CreateClient(name);
+
+            using CancellationTokenSource cancellation = new(timeout);
+            client.BaseAddress = new Uri(await runner.GetDefaultAddressAsync(cancellation.Token), UriKind.Absolute);
+
+            return client;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="HttpClient"/> over the metrics address of the <paramref name="runner"/>.
+        /// </summary>
+        public static async Task<HttpClient> CreateHttpClientMetricsAddressAsync(this DotNetMonitorRunner runner, IHttpClientFactory factory, TimeSpan timeout)
+        {
+            HttpClient client = factory.CreateClient();
+
+            using CancellationTokenSource cancellation = new(timeout);
+            client.BaseAddress = new Uri(await runner.GetMetricsAddressAsync(cancellation.Token), UriKind.Absolute);
+
+            return client;
+        }
+    }
+}


### PR DESCRIPTION
There is a problem in the tests where HttpClient.SendAsync will hang and only return when cancelled. This happens due to exhaustion of the available sockets for use by HttpClientHandler.

To mitigate this, create an HttpClientFactory (via the AddHttpClient service method in the ServiceProviderFixture) which pools HttpClientHandlers. The ServiceProviderFixture provides for two HttpCliendHandlers: a default one and one that authenticates with the current user credentials. All of the tests use the default one except for NegotiateAuthenticationSchemeTest which uses the one with default credentials.

Additional refactoring to the ApiClient was done to remove the privately created HttpClient since it shouldn't encourage the use of separately instantiated HttpClient instances.