### PR TITLE
Set package and informational versions to the version prefix and optional prerelease label

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,29 @@
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   
+  <!--
+    Set InformationalVersion to only include the original version prefix and any prerelease suffix.
+    It will be updated later with commit hash information. Without this setting to the original
+    version prefix, the version would include a patch number that is computed from the build number,
+    which makes it difficult to trace back to the exact release version. This information is also
+    used when invoking the global version option for tools using System.CommandLine.
+  -->
+  <PropertyGroup>
+    <InformationalVersion>$(_OriginalVersionPrefix)</InformationalVersion>
+    <InformationalVersion Condition="'$(VersionSuffix)' != ''">$(InformationalVersion)-$(VersionSuffix)</InformationalVersion>
+  </PropertyGroup>
+
+  <!--
+    Set PackageVersion to only include the original version prefix and any prerelease suffix.
+    Without this setting to the original version prefix, the version would include a patch number
+    that is computed from the build number, which makes it difficult to trace back to the exact
+    release version. Only set this if PackageVersion was not explicitly set.
+  -->
+  <PropertyGroup Condition="'$(PackageVersion)' == ''">
+    <PackageVersion>$(_OriginalVersionPrefix)</PackageVersion>
+    <PackageVersion Condition="'$(VersionSuffix)' != ''">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
+  </PropertyGroup>
+
   <!-- Work around https://github.com/dotnet/sourcelink/issues/572
   Remove once we build using an SDK that contains https://github.com/dotnet/sdk/pull/10613 -->
   <PropertyGroup>


### PR DESCRIPTION
If the current main branch were to be shipped as the final release for 5.0.0, the following versions would be produced:
- Assembly: 5.0.0.0
- AssemblyFile: 5.0.21.17602
- AssemblyInformational: 5.0.217602+0a3cbd909e6c089eb78b0e2f4ee80ef156980288
- Package: 5.0.217602

`dotnet monitor --version` will return `5.0.217602+0a3cbd909e6c089eb78b0e2f4ee80ef156980288`

At least, the package version needs to be fixed such that it represents the actual final version (5.0.0). The assembly informational version should also be fixed similarly so that when a user runs "dotnet monitor --version", they get a version string that corresponds with the publicly expected version.

These fixes are accomplished by resetting the PackageVersion and InformationalVersion properties to be just the original version prefix + the optional prerelease label (e.g. "preview.4"). After these changes, the same build produces:
- Assembly: 5.0.0.0
- AssemblyFile: 5.0.21.17602
- AssemblyInformational: 5.0.0+0a3cbd909e6c089eb78b0e2f4ee80ef156980288
- Package: 5.0.0

`dotnet monitor --version` will return `5.0.0+0a3cbd909e6c089eb78b0e2f4ee80ef156980288`

Prerelease packages are not impacted by this change since Arcade performs the same computation for prerelease versions. For example, `dotnet monitor --version` would return something that looks like `5.0.0-preview.4.21176.2+0a3cbd909e6c089eb78b0e2f4ee80ef156980288` for prerelease versions.