### PR TITLE
Generate schema for configuration options

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://www.github.com/dotnet/dotnet-monitor",
+  "title": "DotnetMonitorConfiguration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ApiAuthentication": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/ApiAuthenticationOptions"
+        }
+      ]
+    },
+    "CorsConfiguration": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/CorsConfiguration"
+        }
+      ]
+    },
+    "DiagnosticPort": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/DiagnosticPortOptions"
+        }
+      ]
+    },
+    "Egress": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/EgressOptions"
+        }
+      ]
+    },
+    "Metrics": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/MetricsOptions"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "ApiAuthenticationOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ApiKeyHash",
+        "ApiKeyHashType"
+      ],
+      "properties": {
+        "ApiKeyHash": {
+          "type": "string",
+          "description": "API Key in Hashed form. Each byte should be two hex based digits.",
+          "minLength": 64,
+          "pattern": "[0-9a-fA-F]+"
+        },
+        "ApiKeyHashType": {
+          "type": "string",
+          "description": "Type of Hash Algorithm used to computed ApiKeyHash. Typically SHA256.  SHA1 and MD5 are not allowed.",
+          "minLength": 1
+        }
+      }
+    },
+    "CorsConfiguration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "AllowedOrigins"
+      ],
+      "properties": {
+        "AllowedOrigins": {
+          "type": "string",
+          "description": "List of allowed cors origins, separated by ;",
+          "minLength": 1
+        }
+      }
+    },
+    "DiagnosticPortOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ConnectionMode": {
+          "description": "In Connect mode, dotnet-monitor connects to the application for diagnostics. In Listen\r\nmode the application connects to dotnet-monitor via EndpointName",
+          "default": "Connect",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/DiagnosticPortConnectionMode"
+            }
+          ]
+        },
+        "EndpointName": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "In Listen mode, specifies the name of the named pipe or unix domain socket to use for connecting\r\nto the diagnostic server"
+        },
+        "MaxConnections": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "In Listen mode, the maximum amount of connections to accept.",
+          "format": "int32"
+        }
+      }
+    },
+    "DiagnosticPortConnectionMode": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Connect",
+        "Listen"
+      ],
+      "enum": [
+        "Connect",
+        "Listen"
+      ]
+    },
+    "EgressOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Providers": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "description": "Named providers for egress. The names can be referenced when requesting artifacts, such as dumps or traces.",
+          "additionalProperties": {
+            "$ref": "#/definitions/EgressProvider"
+          }
+        },
+        "Properties": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "description": "Additional properties, such as secrets, that can be referenced by the provider definitions.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "EgressProvider": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of provider. Currently this supports fileSystem and azureBlobStorage."
+        }
+      }
+    },
+    "MetricsOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Enable or disable metrics collection. Defaults to true.",
+          "default": true
+        },
+        "Endpoints": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Endpoints that expose prometheus metrics. Defaults to http://localhost:52325"
+        },
+        "UpdateIntervalSeconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "How often metrics are collected.",
+          "format": "int32",
+          "default": 10
+        },
+        "MetricCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Amount of data points to store per metric.",
+          "format": "int32",
+          "default": 3
+        },
+        "IncludeDefaultProviders": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Include default providers, such as System.Runtime.",
+          "default": true
+        },
+        "AllowInsecureChannelForCustomMetrics": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "When using custom metrics, the default binding address changes from http to https. Set this to true to enable http.",
+          "default": false
+        },
+        "Providers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Providers for custom metrics",
+          "items": {
+            "$ref": "#/definitions/MetricProvider"
+          }
+        }
+      }
+    },
+    "MetricProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ProviderName"
+      ],
+      "properties": {
+        "ProviderName": {
+          "type": "string",
+          "description": "The name of the custom metric provider.",
+          "minLength": 1
+        },
+        "CounterNames": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Name of custom metric counters.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://www.github.com/dotnet/dotnet-monitor",
+  "id": "https://www.github.com/dotnet/dotnet-monitor",
   "title": "DotnetMonitorConfiguration",
   "type": "object",
   "additionalProperties": false,
@@ -67,13 +67,13 @@
       "properties": {
         "ApiKeyHash": {
           "type": "string",
-          "description": "API Key in Hashed form. Each byte should be two hex based digits.",
+          "description": "API key in hashed form. Each byte should be two hexadecimal-based digits.",
           "minLength": 64,
           "pattern": "[0-9a-fA-F]+"
         },
         "ApiKeyHashType": {
           "type": "string",
-          "description": "Type of Hash Algorithm used to computed ApiKeyHash. Typically SHA256.  SHA1 and MD5 are not allowed.",
+          "description": "Hash algorithm used to compute ApiKeyHash, typically 'SHA256'. 'SHA1' and 'MD5' are not allowed.",
           "minLength": 1
         }
       }
@@ -87,7 +87,7 @@
       "properties": {
         "AllowedOrigins": {
           "type": "string",
-          "description": "List of allowed cors origins, separated by ;",
+          "description": "List of allowed CORS origins, separated by semicolons.",
           "minLength": 1
         }
       }
@@ -97,7 +97,7 @@
       "additionalProperties": false,
       "properties": {
         "ConnectionMode": {
-          "description": "In Connect mode, dotnet-monitor connects to the application for diagnostics. In Listen\nmode the application connects to dotnet-monitor via EndpointName",
+          "description": "In 'Connect' mode, dotnet-monitor connects to the application for diagnostics. In 'Listen'\nmode, the application connects to dotnet-monitor via EndpointName.",
           "default": "Connect",
           "oneOf": [
             {
@@ -113,14 +113,14 @@
             "null",
             "string"
           ],
-          "description": "In Listen mode, specifies the name of the named pipe or unix domain socket to use for connecting\nto the diagnostic server"
+          "description": "In 'Listen' mode, specifies the name of the named pipe or unix domain socket to use for connecting\nto the diagnostic server."
         },
         "MaxConnections": {
           "type": [
             "integer",
             "null"
           ],
-          "description": "In Listen mode, the maximum amount of connections to accept.",
+          "description": "In 'Listen' mode, the maximum amount of connections to accept.",
           "format": "int32"
         }
       }
@@ -177,7 +177,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of provider. Currently this supports fileSystem and azureBlobStorage."
+          "description": "The type of provider. Currently this supports 'fileSystem' and 'azureBlobStorage'."
         }
       }
     },
@@ -190,7 +190,7 @@
             "boolean",
             "null"
           ],
-          "description": "Enable or disable metrics collection. Defaults to true.",
+          "description": "Enable or disable metrics collection.",
           "default": true
         },
         "Endpoints": {
@@ -198,7 +198,7 @@
             "null",
             "string"
           ],
-          "description": "Endpoints that expose prometheus metrics. Defaults to http://localhost:52325"
+          "description": "Endpoints that expose prometheus metrics. Defaults to http://localhost:52325."
         },
         "UpdateIntervalSeconds": {
           "type": [
@@ -223,7 +223,7 @@
             "boolean",
             "null"
           ],
-          "description": "Include default providers, such as System.Runtime.",
+          "description": "Include default providers: System.Runtime, Microsoft.AspNetCore.Hosting, and Grpc.AspNetCore.Server.",
           "default": true
         },
         "AllowInsecureChannelForCustomMetrics": {
@@ -239,7 +239,7 @@
             "array",
             "null"
           ],
-          "description": "Providers for custom metrics",
+          "description": "Providers for custom metrics.",
           "items": {
             "$ref": "#/definitions/MetricProvider"
           }
@@ -255,7 +255,7 @@
       "properties": {
         "ProviderName": {
           "type": "string",
-          "description": "The name of the custom metric provider.",
+          "description": "The name of the custom metrics provider.",
           "minLength": 1
         },
         "CounterNames": {
@@ -263,7 +263,7 @@
             "array",
             "null"
           ],
-          "description": "Name of custom metric counters.",
+          "description": "Name of custom metrics counters.",
           "items": {
             "type": "string"
           }

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -97,7 +97,7 @@
       "additionalProperties": false,
       "properties": {
         "ConnectionMode": {
-          "description": "In Connect mode, dotnet-monitor connects to the application for diagnostics. In Listen\r\nmode the application connects to dotnet-monitor via EndpointName",
+          "description": "In Connect mode, dotnet-monitor connects to the application for diagnostics. In Listen\nmode the application connects to dotnet-monitor via EndpointName",
           "default": "Connect",
           "oneOf": [
             {
@@ -113,7 +113,7 @@
             "null",
             "string"
           ],
-          "description": "In Listen mode, specifies the name of the named pipe or unix domain socket to use for connecting\r\nto the diagnostic server"
+          "description": "In Listen mode, specifies the name of the named pipe or unix domain socket to use for connecting\nto the diagnostic server"
         },
         "MaxConnections": {
           "type": [

--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj", "{886D1FD5-125F-435B-934C-30DF2938E7F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema", "src\Tests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj", "{422ABBF6-6236-4042-AACA-09531DBDFBAA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,10 @@ Global
 		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{422ABBF6-6236-4042-AACA-09531DBDFBAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{422ABBF6-6236-4042-AACA-09531DBDFBAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{422ABBF6-6236-4042-AACA-09531DBDFBAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{422ABBF6-6236-4042-AACA-09531DBDFBAA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -87,6 +93,7 @@ Global
 		{04427BC9-8F54-4633-9BBB-6661715BD271} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{DC672D2F-3A21-40BD-B495-660850EBC5F7} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{886D1FD5-125F-435B-934C-30DF2938E7F6} = {C7568468-1C79-4944-8136-18812A7F9EA7}
+		{422ABBF6-6236-4042-AACA-09531DBDFBAA} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.UnitTestApp", "src\Tests\Microsoft.Diagnostics.Monitoring.UnitTestApp\Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj", "{DC672D2F-3A21-40BD-B495-660850EBC5F7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj", "{886D1FD5-125F-435B-934C-30DF2938E7F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{DC672D2F-3A21-40BD-B495-660850EBC5F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC672D2F-3A21-40BD-B495-660850EBC5F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC672D2F-3A21-40BD-B495-660850EBC5F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{886D1FD5-125F-435B-934C-30DF2938E7F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,6 +86,7 @@ Global
 		{FCEC25E0-9EE1-416E-A7C4-2898E5640157} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{04427BC9-8F54-4633-9BBB-6661715BD271} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{DC672D2F-3A21-40BD-B495-660850EBC5F7} = {C7568468-1C79-4944-8136-18812A7F9EA7}
+		{886D1FD5-125F-435B-934C-30DF2938E7F6} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,6 +49,7 @@
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21181.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21181.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- Third-party references -->
+    <NJsonSchemaVersion>10.3.11</NJsonSchemaVersion>
     <SwashbuckleAspNetCoreSwaggerGenVersion>5.6.3</SwashbuckleAspNetCoreSwaggerGenVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/CorsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/CorsConfiguration.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
@@ -11,6 +13,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 {
     public class CorsConfiguration
     {
+        [Description("List of allowed cors origins, separated by ;")]
+        [Required]
         public string AllowedOrigins { get; set; }
 
         public string[] GetOrigins() => AllowedOrigins?.Split(';');

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/CorsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/CorsConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 {
     public class CorsConfiguration
     {
-        [Description("List of allowed cors origins, separated by ;")]
+        [Display(Description = "List of allowed CORS origins, separated by semicolons.")]
         [Required]
         public string AllowedOrigins { get; set; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
@@ -18,24 +20,40 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
     /// </summary>
     public class MetricsOptions
     {
+        [Description("Enable or disable metrics collection. Defaults to true.")]
+        [DefaultValue(MetricsOptionsDefaults.Enabled)]
         public bool? Enabled { get; set; }
-        
+
+        [Description("Endpoints that expose prometheus metrics. Defaults to http://localhost:52325")]
         public string Endpoints { get; set; }
 
+        [DefaultValue(MetricsOptionsDefaults.UpdateIntervalSeconds)]
+        [Description("How often metrics are collected.")]
         public int? UpdateIntervalSeconds { get; set; }
 
+        [DefaultValue(MetricsOptionsDefaults.MetricCount)]
+        [Description("Amount of data points to store per metric.")]
         public int? MetricCount { get; set; }
 
+        [DefaultValue(MetricsOptionsDefaults.IncludeDefaultProviders)]
+        [Description("Include default providers, such as System.Runtime.")]
         public bool? IncludeDefaultProviders { get; set; }
 
+        [DefaultValue(MetricsOptionsDefaults.AllowInsecureChannelForCustomMetrics)]
+        [Description("When using custom metrics, the default binding address changes from http to https. Set this to true to enable http.")]
         public bool? AllowInsecureChannelForCustomMetrics { get; set; }
 
+        [Description("Providers for custom metrics")]
         public List<MetricProvider> Providers { get; set; } = new List<MetricProvider>(0);
     }
 
     public class MetricProvider
     {
+        [Description("The name of the custom metric provider.")]
+        [Required]
         public string ProviderName { get; set; }
+
+        [Description("Name of custom metric counters.")]
         public List<string> CounterNames { get; set; } = new List<string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -20,40 +20,40 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
     /// </summary>
     public class MetricsOptions
     {
-        [Description("Enable or disable metrics collection. Defaults to true.")]
+        [Display(Description = "Enable or disable metrics collection.")]
         [DefaultValue(MetricsOptionsDefaults.Enabled)]
         public bool? Enabled { get; set; }
 
-        [Description("Endpoints that expose prometheus metrics. Defaults to http://localhost:52325")]
+        [Display(Description = "Endpoints that expose prometheus metrics. Defaults to http://localhost:52325.")]
         public string Endpoints { get; set; }
 
         [DefaultValue(MetricsOptionsDefaults.UpdateIntervalSeconds)]
-        [Description("How often metrics are collected.")]
+        [Display(Description = "How often metrics are collected.")]
         public int? UpdateIntervalSeconds { get; set; }
 
         [DefaultValue(MetricsOptionsDefaults.MetricCount)]
-        [Description("Amount of data points to store per metric.")]
+        [Display(Description = "Amount of data points to store per metric.")]
         public int? MetricCount { get; set; }
 
         [DefaultValue(MetricsOptionsDefaults.IncludeDefaultProviders)]
-        [Description("Include default providers, such as System.Runtime.")]
+        [Display(Description = "Include default providers: System.Runtime, Microsoft.AspNetCore.Hosting, and Grpc.AspNetCore.Server.")]
         public bool? IncludeDefaultProviders { get; set; }
 
         [DefaultValue(MetricsOptionsDefaults.AllowInsecureChannelForCustomMetrics)]
-        [Description("When using custom metrics, the default binding address changes from http to https. Set this to true to enable http.")]
+        [Display(Description = "When using custom metrics, the default binding address changes from http to https. Set this to true to enable http.")]
         public bool? AllowInsecureChannelForCustomMetrics { get; set; }
 
-        [Description("Providers for custom metrics")]
+        [Display(Description = "Providers for custom metrics.")]
         public List<MetricProvider> Providers { get; set; } = new List<MetricProvider>(0);
     }
 
     public class MetricProvider
     {
-        [Description("The name of the custom metric provider.")]
+        [Display(Description = "The name of the custom metrics provider.")]
         [Required]
         public string ProviderName { get; set; }
 
-        [Description("Name of custom metric counters.")]
+        [Display(Description = "Name of custom metrics counters.")]
         public List<string> CounterNames { get; set; } = new List<string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptionsDefaults.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
+#else
 namespace Microsoft.Diagnostics.Monitoring.RestServer
+#endif
 {
     internal class MetricsOptionsDefaults
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
@@ -11,11 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="NJsonSchema" Version="10.3.11" />
+        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.ConfigurationSchema\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj">
+            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
     </ItemGroup>
-    
-    <ItemGroup>
-        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.UnitTests\Microsoft.Diagnostics.Monitoring.UnitTests.csproj" />
-    </ItemGroup>
-
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <OutputType>Library</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="..\..\..\documentation\schema.json" Link="schema.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="NJsonSchema" Version="10.3.11" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.UnitTests\Microsoft.Diagnostics.Monitoring.UnitTests.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using Xunit.Abstractions;
+using NJsonSchema;
+using Microsoft.Diagnostics.Monitoring.UnitTests.Options;
+using System.IO;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System;
+using System.Reflection;
+using NJsonSchema.Generation;
+
+namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
+{
+    public class SchemaGenerationTests
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        private const string SchemaBaseline = "schema.json";
+
+        private static readonly string CurrentExecutingAssemblyPath =
+            Assembly.GetExecutingAssembly().Location;
+
+        private static readonly string SchemaBaselinePath =
+            Path.Combine(Path.GetDirectoryName(CurrentExecutingAssemblyPath), SchemaBaseline);
+
+        public SchemaGenerationTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public void TestGenerateSchema()
+        {
+            string completeSchema = GenerateSchema();
+            _outputHelper.WriteLine(completeSchema);
+        }
+
+        [Fact]
+        public async Task TestSchemaBaseline()
+        {
+            string generatedSchema = GenerateSchema();
+            using StreamReader baseline = new StreamReader(SchemaBaselinePath);
+            using StringReader generated = new StringReader(generatedSchema);
+            bool equal = await CompareLines(baseline, generated);
+            Assert.True(equal, "Generated schema differs from baseline.");
+        }
+
+        private string GenerateSchema()
+        {
+            var settings = new JsonSchemaGeneratorSettings();
+
+            JsonSchema schema = JsonSchema.FromType<RootOptions>(settings);
+            schema.Id = @"http://www.github.com/dotnet/dotnet-monitor";
+            schema.Title = "DotnetMonitorConfiguration";
+
+            //HACK Even though Properties is defined as JsonDataExtension, it still emits a property
+            //called 'Properties' into the schema, instead of just specifying additionalProperties.
+            //There is likely a more elegant way to fix this.
+            schema.Definitions[nameof(EgressProvider)].Properties.Remove(nameof(EgressProvider.Properties));
+
+            string schemaPayload = schema.ToJson();
+            return schemaPayload;
+        }
+
+        private async Task<bool> CompareLines(TextReader first, TextReader second)
+        {
+            IList<string> firstLines = await ReadAllLines(first);
+            IList<string> secondLines = await ReadAllLines(second);
+
+            for (int i = 0; i < Math.Min(firstLines.Count, secondLines.Count); i++)
+            {
+                if (!string.Equals(firstLines[i], secondLines[i], StringComparison.Ordinal))
+                {
+                    _outputHelper.WriteLine($"Differs from baseline on line {i + 1}:");
+                    _outputHelper.WriteLine(firstLines[i]);
+                    _outputHelper.WriteLine(secondLines[i]);
+                    return false;
+                }
+            }
+
+            if (firstLines.Count != secondLines.Count)
+            {
+                _outputHelper.WriteLine($"Count differs from baseline: {firstLines.Count} {secondLines.Count}");
+                return false;
+            }
+
+            return true;
+        }
+
+        private async Task<IList<string>> ReadAllLines(TextReader reader)
+        {
+            var lines = new List<string>();
+            string line = null;
+
+            while ((line = await reader.ReadLineAsync()) != null)
+            {
+                lines.Add(line);
+            }
+
+            return lines;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.UnitTests\Microsoft.Diagnostics.Monitoring.UnitTests.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Program.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                throw new InvalidOperationException("Missing output path");
+            }
+
+            var generator = new SchemaGenerator();
+            string result = generator.GenerateSchema();
+
+            File.WriteAllText(args[0], result);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Diagnostics.Monitoring.UnitTests.Options;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
+{
+    internal sealed class SchemaGenerator
+    {
+        public string GenerateSchema()
+        {
+            var settings = new JsonSchemaGeneratorSettings();
+            JsonSchema schema = JsonSchema.FromType<RootOptions>(settings);
+            schema.Id = @"http://www.github.com/dotnet/dotnet-monitor";
+            schema.Title = "DotnetMonitorConfiguration";
+
+            //HACK Even though Properties is defined as JsonDataExtension, it still emits a property
+            //called 'Properties' into the schema, instead of just specifying additionalProperties.
+            //There is likely a more elegant way to fix this.
+            schema.Definitions[nameof(EgressProvider)].Properties.Remove(nameof(EgressProvider.Properties));
+
+            string schemaPayload = schema.ToJson();
+
+            //Normalize newlines embedded into json
+            schemaPayload = schemaPayload.Replace(@"\r\n", @"\n", StringComparison.Ordinal);
+            return schemaPayload;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
         {
             var settings = new JsonSchemaGeneratorSettings();
             JsonSchema schema = JsonSchema.FromType<RootOptions>(settings);
-            schema.Id = @"http://www.github.com/dotnet/dotnet-monitor";
+            schema.Id = @"https://www.github.com/dotnet/dotnet-monitor";
             schema.Title = "DotnetMonitorConfiguration";
 
             //HACK Even though Properties is defined as JsonDataExtension, it still emits a property

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
 {
     public class OpenApiGeneratorTests
     {
-        private static readonly TimeSpan GenerationTimemout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan GenerationTimeout = TimeSpan.FromSeconds(30);
 
         private const string OpenApiBaselineName = "openapi.json";
         private const string OpenApiGenName = "Microsoft.Diagnostics.Monitoring.OpenApiGen";
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
 
             await using LoggingRunnerAdapter adapter = new(_outputHelper, runner);
 
-            using CancellationTokenSource cancellation = new(GenerationTimemout);
+            using CancellationTokenSource cancellation = new(GenerationTimeout);
 
             await adapter.StartAsync(cancellation.Token);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests" />
+        <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.ConfigurationSchema" />
     </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
@@ -12,10 +12,12 @@
   <ItemGroup>
     <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.RestServer\CorsConfiguration.cs" Link="Options\CorsConfiguration.cs" />
     <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.RestServer\MetricsOptions.cs" Link="Options\MetricsOptions.cs" />
+    <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.RestServer\MetricsOptionsDefaults.cs" Link="Options\MetricsOptionsDefaults.cs" />
     <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.RestServer\Models\ProcessIdentifier.cs" Link="Models\ProcessIdentifier.cs" />
     <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.RestServer\Models\ProcessInfo.cs" Link="Models\ProcessInfo.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\Auth\ApiAuthenticationOptions.cs" Link="Options\ApiAuthenticationOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\DiagnosticPortOptions.cs" Link="Options\DiagnosticPortOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\DiagnosticPortOptionsDefaults.cs" Link="Options\DiagnosticPortOptionsDefaults.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,5 +26,9 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
   </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests" />
+    </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Options/EgressOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Options/EgressOptions.cs
@@ -4,15 +4,32 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
 {
     internal class EgressOptions
     {
-        public Dictionary<string, Dictionary<string, string>> Providers { get; }
+        [Description("Named providers for egress. The names can be referenced when requesting artifacts, such as dumps or traces.")]
+        public Dictionary<string, EgressProvider> Providers { get; set; }
             = new(StringComparer.OrdinalIgnoreCase);
 
-        public Dictionary<string, string> Properties { get; }
+        [Description("Additional properties, such as secrets, that can be referenced by the provider definitions.")]
+        public Dictionary<string, string> Properties { get; set; }
             = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal class EgressProvider
+    {
+        [Description("The type of provider. Currently this supports fileSystem and azureBlobStorage.")]
+        //TODO This should honor DataMember, but only seems to work with JsonProperty
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Always)]
+        public string EgressType { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Options/EgressOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Options/EgressOptions.cs
@@ -13,18 +13,18 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
 {
     internal class EgressOptions
     {
-        [Description("Named providers for egress. The names can be referenced when requesting artifacts, such as dumps or traces.")]
+        [Display(Description = "Named providers for egress. The names can be referenced when requesting artifacts, such as dumps or traces.")]
         public Dictionary<string, EgressProvider> Providers { get; set; }
             = new(StringComparer.OrdinalIgnoreCase);
 
-        [Description("Additional properties, such as secrets, that can be referenced by the provider definitions.")]
+        [Display(Description = "Additional properties, such as secrets, that can be referenced by the provider definitions.")]
         public Dictionary<string, string> Properties { get; set; }
             = new(StringComparer.OrdinalIgnoreCase);
     }
 
     internal class EgressProvider
     {
-        [Description("The type of provider. Currently this supports fileSystem and azureBlobStorage.")]
+        [Display(Description = "The type of provider. Currently this supports 'fileSystem' and 'azureBlobStorage'.")]
         //TODO This should honor DataMember, but only seems to work with JsonProperty
         [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Always)]
         public string EgressType { get; set; }

--- a/src/Tests/test.runsettings
+++ b/src/Tests/test.runsettings
@@ -2,7 +2,7 @@
 <RunSettings>
   <RunConfiguration>
     <EnvironmentVariables>
-      <COMPlus_EnableDiagnostics>1</COMPlus_EnableDiagnostics>
+      <COMPlus_EnableDiagnostics>0</COMPlus_EnableDiagnostics>
     </EnvironmentVariables>
   </RunConfiguration>
 </RunSettings>

--- a/src/Tests/test.runsettings
+++ b/src/Tests/test.runsettings
@@ -2,7 +2,7 @@
 <RunSettings>
   <RunConfiguration>
     <EnvironmentVariables>
-      <COMPlus_EnableDiagnostics>0</COMPlus_EnableDiagnostics>
+      <COMPlus_EnableDiagnostics>1</COMPlus_EnableDiagnostics>
     </EnvironmentVariables>
   </RunConfiguration>
 </RunSettings>

--- a/src/Tools/dotnet-monitor/Auth/ApiAuthenticationOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiAuthenticationOptions.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
 #else
@@ -10,7 +13,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class ApiAuthenticationOptions
     {
+        [Description("API Key in Hashed form. Each byte should be two hex based digits.")]
+        [RegularExpression("[0-9a-fA-F]+")]
+        [MinLength(64)]
+        [Required]
         public string ApiKeyHash { get; set; }
+
+        [Description("Type of Hash Algorithm used to computed ApiKeyHash. Typically SHA256.  SHA1 and MD5 are not allowed.")]
+        [Required]
         public string ApiKeyHashType { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiAuthenticationOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiAuthenticationOptions.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class ApiAuthenticationOptions
     {
-        [Description("API Key in Hashed form. Each byte should be two hex based digits.")]
+        [Display(Description = "API key in hashed form. Each byte should be two hexadecimal-based digits.")]
         [RegularExpression("[0-9a-fA-F]+")]
         [MinLength(64)]
         [Required]
         public string ApiKeyHash { get; set; }
 
-        [Description("Type of Hash Algorithm used to computed ApiKeyHash. Typically SHA256.  SHA1 and MD5 are not allowed.")]
+        [Display(Description = "Hash algorithm used to compute ApiKeyHash, typically 'SHA256'. 'SHA1' and 'MD5' are not allowed.")]
         [Required]
         public string ApiKeyHashType { get; set; }
     }

--- a/src/Tools/dotnet-monitor/DiagnosticPortOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortOptions.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
 #else
@@ -10,13 +14,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     public class DiagnosticPortOptions
     {
+        [Description(@"In Connect mode, dotnet-monitor connects to the application for diagnostics. In Listen
+mode the application connects to dotnet-monitor via " + nameof(EndpointName))]
+        [DefaultValue(DiagnosticPortOptionsDefaults.ConnectionMode)]
         public DiagnosticPortConnectionMode? ConnectionMode { get; set; }
 
+        [Description(@"In Listen mode, specifies the name of the named pipe or unix domain socket to use for connecting
+to the diagnostic server")]
         public string EndpointName { get; set; }
 
+        [Description(@"In Listen mode, the maximum amount of connections to accept.")]
         public int? MaxConnections { get; set; }
     }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum DiagnosticPortConnectionMode
     {
         Connect,

--- a/src/Tools/dotnet-monitor/DiagnosticPortOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -14,16 +15,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     public class DiagnosticPortOptions
     {
-        [Description(@"In Connect mode, dotnet-monitor connects to the application for diagnostics. In Listen
-mode the application connects to dotnet-monitor via " + nameof(EndpointName))]
+        [Display(Description = @"In 'Connect' mode, dotnet-monitor connects to the application for diagnostics. In 'Listen'
+mode, the application connects to dotnet-monitor via " + nameof(EndpointName) + ".")]
         [DefaultValue(DiagnosticPortOptionsDefaults.ConnectionMode)]
         public DiagnosticPortConnectionMode? ConnectionMode { get; set; }
 
-        [Description(@"In Listen mode, specifies the name of the named pipe or unix domain socket to use for connecting
-to the diagnostic server")]
+        [Display(Description = @"In 'Listen' mode, specifies the name of the named pipe or unix domain socket to use for connecting
+to the diagnostic server.")]
         public string EndpointName { get; set; }
 
-        [Description(@"In Listen mode, the maximum amount of connections to accept.")]
+        [Display(Description = @"In 'Listen' mode, the maximum amount of connections to accept.")]
         public int? MaxConnections { get; set; }
     }
 

--- a/src/Tools/dotnet-monitor/DiagnosticPortOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortOptionsDefaults.cs
@@ -1,8 +1,16 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.UnitTests.Options
+#else
 namespace Microsoft.Diagnostics.Tools.Monitor
+#endif
 {
     internal class DiagnosticPortOptionsDefaults
     {


### PR DESCRIPTION
Generate schema for dotnet-monitor configuration. This uses https://github.com/RicoSuter/NJsonSchema