### PR TITLE
Update System.Text.Encodings.Web to 4.7.2 for RestServer netstandard2.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,6 +43,7 @@
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
     <SystemIOPipelinesVersion>4.5.1</SystemIOPipelinesVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <!-- dotnet/arcade references -->
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21203.1</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/diagnostics references -->

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Microsoft.Diagnostics.Monitoring.RestServer.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Microsoft.Diagnostics.Monitoring.RestServer.csproj
@@ -13,7 +13,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
-
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">
     <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringEventPipeVersion)" />
   </ItemGroup>
@@ -35,6 +34,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="[$(MicrosoftAspNetCoreHttpVersion),2.2.0)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[$(MicrosoftAspNetCoreServerKestrelCoreVersion),2.2.0)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The System.Text.Encodings.Web package is has vulnerabilities; Component Governance advisory says to upgrade to 4.7.2