### PR TITLE
Set blob group to include prerelease information.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
       - 'prerelease': allows the blob group release name to use prerelease version information.
       - 'release': sets the blob group release name to 'release'.
     -->
-    <BlobGroupBuildQuality>daily</BlobGroupBuildQuality>
+    <BlobGroupBuildQuality>prerelease</BlobGroupBuildQuality>
   </PropertyGroup>
   <PropertyGroup>
     <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow


### PR DESCRIPTION
This change causes the aka.ms link generation to include the prerelease information in the blob group (e.g. https://aka.ms/dotnet/diagnostics/monitor5.0/preview.4/dotnet-monitor.nupkg.version) so that the preview version can be stabilized independently of the main branch updating the daily link.

closes #79 