### PR TITLE
Additional model validation and content type fixes.

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -719,6 +719,7 @@
         "type": "object",
         "properties": {
           "providers": {
+            "minItems": 1,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EventPipeProvider"

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ActionContextExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ActionContextExtensions.cs
@@ -26,8 +26,10 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
             }
             else
             {
-                ActionResult result = new BadRequestObjectResult(ex.ToProblemDetails((int)HttpStatusCode.BadRequest));
-
+                BadRequestObjectResult result = new BadRequestObjectResult(ex.ToProblemDetails((int)HttpStatusCode.BadRequest));
+                // Need to manually add this here because this ObjectResult is not processed by the filter pipeline,
+                // which would look up the applicable content types and apply them before executing the result.
+                result.ContentTypes.Add(ContentTypes.ApplicationProblemJson);
                 return result.ExecuteResultAsync(context);
             }
         }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ContentTypes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ContentTypes.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
     {
         public const string ApplicationJson = "application/json";
         public const string ApplicationNdJson = "application/x-ndjson";
-        public const string ApplicationOctectStream = "application/octet-stream";
+        public const string ApplicationOctetStream = "application/octet-stream";
         public const string ApplicationProblemJson = "application/problem+json";
         public const string TextEventStream = "text/event-stream";
         public const string TextPlain_v0_0_4 = "text/plain; version=0.0.4";

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// Get the list of accessible processes.
         /// </summary>
         [HttpGet("processes", Name = nameof(GetProcesses))]
-        [Produces(ContentTypes.ApplicationJson, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<Models.ProcessIdentifier>), StatusCodes.Status200OK)]
         public Task<ActionResult<IEnumerable<Models.ProcessIdentifier>>> GetProcesses()
         {
@@ -81,7 +81,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// </summary>
         /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
         [HttpGet("processes/{processKey}", Name = nameof(GetProcessInfo))]
-        [Produces(ContentTypes.ApplicationJson, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(Models.ProcessInfo), StatusCodes.Status200OK)]
         public Task<ActionResult<Models.ProcessInfo>> GetProcessInfo(
             ProcessKey processKey)
@@ -110,7 +110,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// </summary>
         /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
         [HttpGet("processes/{processKey}/env", Name = nameof(GetProcessEnvironment))]
-        [Produces(ContentTypes.ApplicationJson, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(Dictionary<string, string>), StatusCodes.Status200OK)]
         public Task<ActionResult<Dictionary<string, string>>> GetProcessEnvironment(
             ProcessKey processKey)
@@ -143,7 +143,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <param name="egressProvider">The egress provider to which the dump is saved.</param>
         /// <returns></returns>
         [HttpGet("dump/{processKey?}", Name = nameof(CaptureDump))]
-        [Produces(ContentTypes.ApplicationOctectStream, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationOctetStream)]
         // FileResult is the closest representation of the output so that the OpenAPI document correctly
         // describes the result as a binary file.
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
@@ -169,7 +169,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     _logger.WrittenToHttpStream();
                     //Compression is done automatically by the response
                     //Chunking is done because the result has no content-length
-                    return File(dumpStream, ContentTypes.ApplicationOctectStream, dumpFileName);
+                    return File(dumpStream, ContentTypes.ApplicationOctetStream, dumpFileName);
                 }
                 else
                 {
@@ -182,7 +182,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                         egressProvider,
                         dumpFileName,
                         processInfo.EndpointInfo,
-                        ContentTypes.ApplicationOctectStream,
+                        ContentTypes.ApplicationOctetStream,
                         scope);
                 }
             }, processKey, ArtifactType_Dump);
@@ -195,7 +195,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <param name="egressProvider">The egress provider to which the GC dump is saved.</param>
         /// <returns></returns>
         [HttpGet("gcdump/{processKey?}", Name = nameof(CaptureGcDump))]
-        [Produces(ContentTypes.ApplicationOctectStream, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationOctetStream)]
         // FileResult is the closest representation of the output so that the OpenAPI document correctly
         // describes the result as a binary file.
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
@@ -234,7 +234,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     egressProvider,
                     ConvertFastSerializeAction(action),
                     fileName,
-                    ContentTypes.ApplicationOctectStream,
+                    ContentTypes.ApplicationOctetStream,
                     processInfo.EndpointInfo);
             }, processKey, ArtifactType_GCDump);
         }
@@ -248,7 +248,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <param name="metricsIntervalSeconds">The reporting interval (in seconds) for event counters.</param>
         /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
         [HttpGet("trace/{processKey?}", Name = nameof(CaptureTrace))]
-        [Produces(ContentTypes.ApplicationOctectStream, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationOctetStream)]
         // FileResult is the closest representation of the output so that the OpenAPI document correctly
         // describes the result as a binary file.
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
@@ -301,7 +301,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
         /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
         [HttpPost("trace/{processKey?}", Name = nameof(CaptureTraceCustom))]
-        [Produces(ContentTypes.ApplicationOctectStream, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationOctetStream)]
         // FileResult is the closest representation of the output so that the OpenAPI document correctly
         // describes the result as a binary file.
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
@@ -354,7 +354,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <param name="level">The level of the logs to capture.</param>
         /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
         [HttpGet("logs/{processKey?}", Name = nameof(CaptureLogs))]
-        [Produces(ContentTypes.ApplicationNdJson, ContentTypes.TextEventStream, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationNdJson, ContentTypes.TextEventStream)]
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [RequestLimit(MaxConcurrency = 3)]
@@ -452,7 +452,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 egressProvider,
                 action,
                 fileName,
-                ContentTypes.ApplicationOctectStream,
+                ContentTypes.ApplicationOctetStream,
                 processInfo.EndpointInfo);
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/MetricsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/MetricsController.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// Get a list of the current backlog of metrics for a process in the Prometheus exposition format.
         /// </summary>
         [HttpGet("metrics", Name = nameof(GetMetrics))]
-        [Produces(ContentTypes.TextPlain_v0_0_4, ContentTypes.ApplicationProblemJson)]
+        [ProducesWithProblemDetails(ContentTypes.TextPlain_v0_0_4)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         public ActionResult GetMetrics()
         {

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/EventPipeConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/EventPipeConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
     public class EventPipeConfiguration
     {
         [JsonPropertyName("providers")]
-        [Required]
+        [Required, MinLength(1)]
         public EventPipeProvider[] Providers { get; set; }
 
         [JsonPropertyName("requestRundown")]

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/EventPipeProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
         public string Keywords { get; set; } = "0x" + EventKeywords.All.ToString("X");
 
         [JsonPropertyName("eventLevel")]
+        [EnumDataType(typeof(EventLevel))]
         public EventLevel EventLevel { get; set; } = EventLevel.Verbose;
 
         [JsonPropertyName("arguments")]

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ProducesWithProblemDetailsAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ProducesWithProblemDetailsAttribute.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    /// <summary>
+    /// Overrides the behavior of the Produces attribute, which clears all content types from the result and
+    /// sets the content types from the attribute to the result. This attribute does the same except that if
+    /// the result is a Bad Request, then only add the application/problem+json content type to the result.
+    /// </summary>
+    /// <remarks>
+    /// This alleviates an issue where application/problem+json would never be returned if some other content
+    /// type, such as application/json, was also specified. The DefaultOutputFormatterSelector will format the
+    /// content using any acceptable content type, which both application/json and application/problem+json are
+    /// acceptable to the SystemTextJsonOutputFormatter, thus it chooses the first one: application/json. This
+    /// selection is incorrect for error results, which typically want application/problem+json.
+    /// 
+    /// The intent of this attribute is to make sure that the output is unconditionally reported with a content
+    /// type of application/problem+json if the result is a Bad Request.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class ProducesWithProblemDetailsAttribute : ProducesAttribute
+    {
+        public ProducesWithProblemDetailsAttribute(string contentType, params string[] additionalContentTypes)
+            : base(contentType, additionalContentTypes)
+        {
+        }
+
+        public override void OnResultExecuting(ResultExecutingContext context)
+        {
+            if (context.Result is BadRequestObjectResult badRequestResult && badRequestResult.Value is ProblemDetails)
+            {
+                badRequestResult.ContentTypes.Add(RestServer.ContentTypes.ApplicationProblemJson);
+            }
+            else
+            {
+                base.OnResultExecuting(context);
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.AddResponseCompression(configureOptions =>
             {
                 configureOptions.Providers.Add<BrotliCompressionProvider>();
-                configureOptions.MimeTypes = new List<string> { ContentTypes.ApplicationOctectStream };
+                configureOptions.MimeTypes = new List<string> { ContentTypes.ApplicationOctetStream };
             });
 
             // This is needed to allow the StreamingLogger to synchronously write to the output stream.


### PR DESCRIPTION
Add content type when custom action result has exception.
Set Bad Request content type only to application/problem+json.

This is a cherry-pick of #148