### PR TITLE
Validate that diagnostic port endpoint name is specified if running in listen mode.

### DIFF
--- a/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal class DiagnosticPortValidateOptions :
+        IValidateOptions<DiagnosticPortOptions>
+    {
+        public ValidateOptionsResult Validate(string name, DiagnosticPortOptions options)
+        {
+            if (options.ConnectionMode == DiagnosticPortConnectionMode.Listen
+                && string.IsNullOrEmpty(options.EndpointName))
+            {
+                return ValidateOptionsResult.Fail("In 'Listen' mode, the diagnostic port endpoint name must be specified.");
+            }
+
+            return ValidateOptionsResult.Success;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -11,6 +11,8 @@ using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -68,12 +70,32 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth).Build();
             try
             {
-                await host.RunAsync(token);
+                await host.StartAsync(token);
+
+                await host.WaitForShutdownAsync(token);
             }
             catch (MonitoringException)
             {
                 // It is the responsibility of throwers to ensure that the exceptions are logged.
                 return -1;
+            }
+            catch (OptionsValidationException ex)
+            {
+                host.Services.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(typeof(DiagnosticsMonitorCommandHandler))
+                    .OptionsValidationFailure(ex);
+                return -1;
+            }
+            finally
+            {
+                if (host is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else
+                {
+                    host.Dispose();
+                }
             }
             return 0;
         }
@@ -171,6 +193,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     }
 
                     services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(ConfigurationKeys.DiagnosticPort));
+                    services.AddSingleton<IValidateOptions<DiagnosticPortOptions>, DiagnosticPortValidateOptions>();
+
                     services.AddSingleton<IEndpointInfoSource, FilteredEndpointInfoSource>();
                     services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
                     services.AddSingleton<IDiagnosticServices, DiagnosticServices>();

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
@@ -124,6 +125,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: "Updated {originalUrl} to {newUrl} due to custom metrics.");
 
+        private static readonly Action<ILogger, string, Exception> _optionsValidationFalure =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(20, "OptionsValidationFailure"),
+                logLevel: LogLevel.Critical,
+                formatString: "{failure}");
+
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
             _egressProviderAdded(logger, providerName, null);
@@ -232,6 +239,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void MetricUrlsUpdated(this ILogger logger)
         {
             _metricUrlsUpdated(logger, null);
+        }
+
+        public static void OptionsValidationFailure(this ILogger logger, OptionsValidationException exception)
+        {
+            foreach (string failure in exception.Failures)
+                _optionsValidationFalure(logger, failure, null);
         }
 
         private static string Redact(string value)


### PR DESCRIPTION
* Validate that diagnostic port endpoint name is specified if running in listen mode.

* Send options validation failures through logging.

This is a cherry-pick of #154 