### PR TITLE
Add .NET 6 runtimes and run tests on .NET 6.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,23 +12,23 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>c13a550fd8135e031678015743557ea2a543403f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21209.17">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>28d9452d7e2ae4e98a1df735b90b03d3cac1f4e7</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.4.21211.7">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>355eff52bed00e7ca9d4a6d769ddbe2bbadbea47</Sha>
-    </Dependency>
+  </ProductDependencies>
+  <ToolsetDependencies>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-preview.4.21211.1">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>1870441efdc00a6c253c2a5c54c20a313fb56ee2</Sha>
     </Dependency>
-  </ProductDependencies>
-  <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21209.17">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>28d9452d7e2ae4e98a1df735b90b03d3cac1f4e7</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21209.17">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>28d9452d7e2ae4e98a1df735b90b03d3cac1f4e7</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.4.21211.7">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>355eff52bed00e7ca9d4a6d769ddbe2bbadbea47</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,13 +4,13 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>166610c56ff732093f0145a2911d4f6c40b786da</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.21209.1">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.21212.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>c13a550fd8135e031678015743557ea2a543403f</Sha>
+      <Sha>43bee2e202124231968f1f710b07a30ba4348a22</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.0-preview.21209.1">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.0-preview.21212.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>c13a550fd8135e031678015743557ea2a543403f</Sha>
+      <Sha>43bee2e202124231968f1f710b07a30ba4348a22</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,6 +16,14 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>28d9452d7e2ae4e98a1df735b90b03d3cac1f4e7</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-preview.4.21211.7">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>355eff52bed00e7ca9d4a6d769ddbe2bbadbea47</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-preview.4.21211.1">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>1870441efdc00a6c253c2a5c54c20a313fb56ee2</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21209.17">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,10 +14,6 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-preview.4.21211.1">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>1870441efdc00a6c253c2a5c54c20a313fb56ee2</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21212.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>db49d790a4bfa977a9ed7436bf2aa242cefae45e</Sha>
@@ -25,6 +21,10 @@
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21212.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>db49d790a4bfa977a9ed7436bf2aa242cefae45e</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.4.21211.1">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>1870441efdc00a6c253c2a5c54c20a313fb56ee2</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.4.21211.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,14 +34,14 @@
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21209.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21209.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
-    <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-preview.4.21211.7</MicrosoftNETCoreAppRuntimewinx64Version>
+    <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-preview.4.21211.7</VSRedistCommonNetCoreSharedFrameworkx6460Version>
   </PropertyGroup>
   <PropertyGroup Label="Runtime Versions">
     <MicrosoftNETCoreApp31Version>3.1.13</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.4</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
-    <MicrosoftNETCoreApp60Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp60Version>
+    <MicrosoftNETCoreApp60Version>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreApp60Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftAspNetCoreAppRefVersion)</MicrosoftAspNetCoreApp60Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup>
+  <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>5.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
@@ -13,24 +13,38 @@
     -->
     <BlobGroupBuildQuality>daily</BlobGroupBuildQuality>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow
-    project references for command line builds. They should match the values in the diagnostics repo. -->
-    <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
-    <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
-    <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>
-    <!-- Runtime versions to test -->
+  <PropertyGroup Label="Arcade">
+    <UsingToolXliff>false</UsingToolXliff>
+    <UsingToolNetFrameworkReferenceAssemblies>false</UsingToolNetFrameworkReferenceAssemblies>
+  </PropertyGroup>
+  <!--
+    These versions should ONLY be updated by automation.
+
+    DO NOT UPDATE THESE MANUALLY. Use the `darc` command line tool to update this file so it stays in sync with
+    Version.Details.xml.
+
+    See https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md for instructions on using darc.
+  -->
+  <PropertyGroup Label="Automated">
+    <!-- dotnet/arcade references -->
+    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21209.17</MicrosoftDotNetXUnitExtensionsVersion>
+    <!-- dotnet/aspnetcore references -->
+    <MicrosoftAspNetCoreAppRefVersion>6.0.0-preview.4.21211.1</MicrosoftAspNetCoreAppRefVersion>
+    <!-- dotnet/diagnostics references -->
+    <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21209.1</MicrosoftDiagnosticsMonitoringVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21209.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
+    <!-- dotnet/runtime references -->
+    <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-preview.4.21211.7</MicrosoftNETCoreAppRuntimewinx64Version>
+  </PropertyGroup>
+  <PropertyGroup Label="Runtime Versions">
     <MicrosoftNETCoreApp31Version>3.1.13</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.4</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
+    <MicrosoftNETCoreApp60Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp60Version>
+    <MicrosoftAspNetCoreApp60Version>$(MicrosoftAspNetCoreAppRefVersion)</MicrosoftAspNetCoreApp60Version>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- Opt-in/out repo features -->
-    <UsingToolXliff>false</UsingToolXliff>
-    <UsingToolNetFrameworkReferenceAssemblies>false</UsingToolNetFrameworkReferenceAssemblies>
-    <!-- Other libs -->
+  <PropertyGroup Label="Manual">
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>3.1.10</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <MicrosoftAspNetCoreHttpVersion>2.1.22</MicrosoftAspNetCoreHttpVersion>
@@ -44,13 +58,16 @@
     <SystemIOPipelinesVersion>4.5.1</SystemIOPipelinesVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
-    <!-- dotnet/arcade references -->
-    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21209.17</MicrosoftDotNetXUnitExtensionsVersion>
-    <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21209.1</MicrosoftDiagnosticsMonitoringVersion>
-    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21209.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- Third-party references -->
     <NJsonSchemaVersion>10.3.11</NJsonSchemaVersion>
     <SwashbuckleAspNetCoreSwaggerGenVersion>5.6.3</SwashbuckleAspNetCoreSwaggerGenVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Dev Workflow">
+    <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow
+         project references for command line builds. They should match the values in the diagnostics repo. -->
+    <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
+    <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <!-- dotnet/arcade references -->
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21212.6</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
-    <MicrosoftAspNetCoreAppRefVersion>6.0.0-preview.4.21211.1</MicrosoftAspNetCoreAppRefVersion>
+    <VSRedistCommonAspNetCoreSharedFrameworkx6460Version>6.0.0-preview.4.21211.1</VSRedistCommonAspNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21212.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21212.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
@@ -42,7 +42,7 @@
     <MicrosoftNETCoreApp50Version>5.0.4</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
     <MicrosoftNETCoreApp60Version>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreApp60Version>
-    <MicrosoftAspNetCoreApp60Version>$(MicrosoftAspNetCoreAppRefVersion)</MicrosoftAspNetCoreApp60Version>
+    <MicrosoftAspNetCoreApp60Version>$(VSRedistCommonAspNetCoreSharedFrameworkx6460Version)</MicrosoftAspNetCoreApp60Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>

--- a/global.json
+++ b/global.json
@@ -4,11 +4,13 @@
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",
-        "$(MicrosoftAspNetCoreApp50Version)"
+        "$(MicrosoftAspNetCoreApp50Version)",
+        "$(MicrosoftAspNetCoreApp60Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp31Version)",
-        "$(MicrosoftNETCoreApp50Version)"
+        "$(MicrosoftNETCoreApp50Version)",
+        "$(MicrosoftNETCoreApp60Version)"
       ]
     }
   },

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetFrameworkReference.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetFrameworkReference.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    public enum DotNetFrameworkReference
+    {
+        Microsoft_NetCore_App,
+        Microsoft_AspNetCore_App
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -8,6 +8,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     public partial class DotNetHost
     {
-        public static readonly string CurrentRuntimeVersion = "$DARCRuntimeVersion$";
+        public static readonly string CurrentAspNetCoreVersion = "$MicrosoftAspNetCoreAppVersion$";
+        public static readonly string CurrentNetCoreVersion = "$MicrosoftNetCoreAppVersion$";
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetRunner.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public int ExitCode => _process.ExitCode;
 
         /// <summary>
+        /// The framework reference of the app to run.
+        /// </summary>
+        public DotNetFrameworkReference FrameworkReference { get; set; } = DotNetFrameworkReference.Microsoft_NetCore_App;
+
+        /// <summary>
         /// Determines if the process has exited.
         /// </summary>
         public bool HasExited => _process.HasExited;
@@ -104,7 +109,20 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         /// </summary>
         public async Task StartAsync(CancellationToken token)
         {
-            _process.StartInfo.Arguments = $"--fx-version {DotNetHost.CurrentRuntimeVersion} \"{EntrypointAssemblyPath}\" {Arguments}";
+            string frameworkVersion;
+            switch (FrameworkReference)
+            {
+                case DotNetFrameworkReference.Microsoft_AspNetCore_App:
+                    frameworkVersion = DotNetHost.CurrentAspNetCoreVersion;
+                    break;
+                case DotNetFrameworkReference.Microsoft_NetCore_App:
+                    frameworkVersion = DotNetHost.CurrentNetCoreVersion;
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported framework reference: {FrameworkReference}");
+            }
+
+            _process.StartInfo.Arguments = $"--fx-version {frameworkVersion} \"{EntrypointAssemblyPath}\" {Arguments}";
 
             if (!_process.Start())
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -8,14 +8,19 @@
 
   <PropertyGroup>
     <DotNetHostGeneratedFileName>$(IntermediateOutputPath)/$(TargetFramework)/DotNetHost.g.cs</DotNetHostGeneratedFileName>
-    <DARCRuntimeVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</DARCRuntimeVersion>
-    <DARCRuntimeVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftNETCoreApp50Version)</DARCRuntimeVersion>
+    <NetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</NetCoreAppVersion>
+    <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftNETCoreApp50Version)</NetCoreAppVersion>
+    <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</NetCoreAppVersion>
+    <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftAspNetCoreApp31Version)</AspNetCoreAppVersion>
+    <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftAspNetCoreApp50Version)</AspNetCoreAppVersion>
+    <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftAspNetCoreApp60Version)</AspNetCoreAppVersion>
   </PropertyGroup>
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
     <PropertyGroup>
       <TemplateContent>$([System.IO.File]::ReadAllText('DotNetHost.cs.template'))</TemplateContent>
-      <TransformedContent>$(TemplateContent.Replace('$DARCRuntimeVersion$', '$(DARCRuntimeVersion)'))</TransformedContent>
+      <TransformedContent>$(TemplateContent.Replace('$MicrosoftNetCoreAppVersion$', '$(NetCoreAppVersion)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreAppVersion$', '$(AspNetCoreAppVersion)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Microsoft.Diagnostics.Monitoring.TestCommon.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Microsoft.Diagnostics.Monitoring.TestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This change allows running tests on .NET 6, which required splitting the `DotNetHost.CurrentRuntimeVersion` property into two (one for the runtime version and one for the ASP.NET version) so that dotnet-monitor can be run on the ASP.NET runtime and the unit test app can be run .NET runtime.

closes #144