### PR TITLE
Publish tests results per runtime version.

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -119,7 +119,7 @@ jobs:
         testResultsFiles: '**/*UnitTests*netcoreapp3.1*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
-        testRunTitle: '${{ parameters.name }} Core 3.1'
+        testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} Core 3.1'
         publishRunAttachments: true
         mergeTestResults: true
         buildConfiguration: ${{ parameters.name }}
@@ -133,7 +133,7 @@ jobs:
         testResultsFiles: '**/*UnitTests*net5.0*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
-        testRunTitle: '${{ parameters.name }} NET 5.0'
+        testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} NET 5.0'
         publishRunAttachments: true
         mergeTestResults: true
         buildConfiguration: ${{ parameters.name }}
@@ -147,7 +147,7 @@ jobs:
         testResultsFiles: '**/*UnitTests*net6.0*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
-        testRunTitle: '${{ parameters.name }} NET 6.0'
+        testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} NET 6.0'
         publishRunAttachments: true
         mergeTestResults: true
         buildConfiguration: ${{ parameters.name }}

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -113,13 +113,41 @@ jobs:
 
     # # Publish test results to Azure Pipelines
     - task: PublishTestResults@2
-      displayName: Publish Test Results
+      displayName: Publish Test Results (Core 3.1)
       inputs:
         testResultsFormat: xUnit
-        testResultsFiles: '**/*UnitTests*.xml' 
+        testResultsFiles: '**/*UnitTests*netcoreapp3.1*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
-        testRunTitle: 'Tests ${{ parameters.name }}'
+        testRunTitle: '${{ parameters.name }} Core 3.1'
+        publishRunAttachments: true
+        mergeTestResults: true
+        buildConfiguration: ${{ parameters.name }}
+      continueOnError: true
+      condition: succeededOrFailed()
+    
+    - task: PublishTestResults@2
+      displayName: Publish Test Results (NET 5.0)
+      inputs:
+        testResultsFormat: xUnit
+        testResultsFiles: '**/*UnitTests*net5.0*.xml' 
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+        failTaskOnFailedTests: true
+        testRunTitle: '${{ parameters.name }} NET 5.0'
+        publishRunAttachments: true
+        mergeTestResults: true
+        buildConfiguration: ${{ parameters.name }}
+      continueOnError: true
+      condition: succeededOrFailed()
+    
+    - task: PublishTestResults@2
+      displayName: Publish Test Results (NET 6.0)
+      inputs:
+        testResultsFormat: xUnit
+        testResultsFiles: '**/*UnitTests*net6.0*.xml' 
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+        failTaskOnFailedTests: true
+        testRunTitle: '${{ parameters.name }} NET 6.0'
         publishRunAttachments: true
         mergeTestResults: true
         buildConfiguration: ${{ parameters.name }}


### PR DESCRIPTION
The test results for each build again are all merged together into one result upload, thus its difficult to determine for which runtime version a test fails. This change separates the uploads by runtime version for easier discernment.