### PR TITLE
Adding new command to display configuration

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
@@ -12,11 +12,6 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
         private static readonly char[] ValueSeparatorArray = new char[] { ValueSeparator };
         private static readonly string ValueSeparatorString = ValueSeparator.ToString();
 
-        public static string MakeKey(string parent, string child)
-        {
-            return FormattableString.Invariant($"{parent}:{child}");
-        }
-
         public static string[] SplitValue(string value)
         {
             return value.Split(ValueSeparatorArray, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
                     metricUrls: Array.Empty<string>(),
                     metrics: true,
                     diagnosticPort: null,
-                    noAuth: false)
+                    noAuth: false,
+                    configOnly: false)
                 .ConfigureServices(services =>
                 {
                     services.AddSwaggerGen(options =>

--- a/src/Tools/Common/CommandExtensions.cs
+++ b/src/Tools/Common/CommandExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 
@@ -15,6 +16,14 @@ namespace Microsoft.Tools.Common
         public static void Add(this Command command, ICommandHandler handler)
         {
             command.Handler = handler;
+        }
+
+        public static void Add(this Command command, IEnumerable<Option> options)
+        {
+            foreach(Option option in options)
+            {
+                command.AddOption(option);
+            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -1,0 +1,213 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureStorage;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Writes out configuration as JSON.
+    /// </summary>
+    internal sealed class ConfigurationJsonWriter : IDisposable
+    {
+        private readonly Utf8JsonWriter _writer;
+        public ConfigurationJsonWriter(Stream outputStream)
+        {
+            JsonWriterOptions options = new() { Indented = true };
+            _writer = new Utf8JsonWriter(outputStream, options);
+        }
+
+        public void Write(IConfiguration configuration, bool full)
+        {
+            //Note that we avoid IConfigurationRoot.GetDebugView because it shows everything
+            //CONSIDER Should we show this in json, since it cannot represent complete configuration?
+            //CONSIDER Should we convert number based names to arrays?
+            //CONSIDER There's probably room for making this code more generalized, to separate the output from the traversal
+            //but it seemed like over-engineering.
+
+            _writer.WriteStartObject();
+
+            ProcessSection(configuration, WebHostDefaults.ServerUrlsKey);
+            IConfigurationSection kestrel = ProcessSection(configuration, "Kestrel", includeChildSections: false);
+            if (kestrel != null)
+            {
+                _writer.WriteStartObject();
+                IConfigurationSection certificates = ProcessSection(kestrel, "Certificates", includeChildSections: false);
+                if (certificates != null)
+                {
+                    _writer.WriteStartObject();
+                    IConfigurationSection defaultCert = ProcessSection(certificates, "Default", includeChildSections: false);
+                    if (defaultCert != null)
+                    {
+                        _writer.WriteStartObject();
+                        ProcessSection(defaultCert, "Path", includeChildSections: false);
+                        ProcessSection(defaultCert, "Password", includeChildSections: false, redact: !full);
+                        _writer.WriteEndObject();
+                    }
+                    _writer.WriteEndObject();
+                }
+                _writer.WriteEndObject();
+            }
+
+            //No sensitive information
+            ProcessSection(configuration, ConfigurationKeys.CorsConfiguration, includeChildSections: true);
+            ProcessSection(configuration, ConfigurationKeys.DiagnosticPort, includeChildSections: true);
+            ProcessSection(configuration, ConfigurationKeys.Metrics, includeChildSections: true);
+            ProcessSection(configuration, ConfigurationKeys.Storage, includeChildSections: true);
+
+            if (full)
+            {
+                ProcessSection(configuration, ConfigurationKeys.ApiAuthentication, includeChildSections: true);
+                ProcessSection(configuration, ConfigurationKeys.Egress, includeChildSections: true);
+            }
+            else
+            {
+                //Do not emit ApiKeyHash
+                IConfigurationSection authSection = ProcessSection(configuration, ConfigurationKeys.ApiAuthentication, includeChildSections: false);
+                if (authSection != null)
+                {
+                    _writer.WriteStartObject();
+                    ProcessSection(authSection, nameof(ApiAuthenticationOptions.ApiKeyHash), includeChildSections: false, redact: true);
+                    ProcessSection(authSection, nameof(ApiAuthenticationOptions.ApiKeyHashType), includeChildSections: false, redact: false);
+                    _writer.WriteEndObject();
+                }
+
+                IConfigurationSection egress = ProcessSection(configuration, ConfigurationKeys.Egress, includeChildSections: false);
+                if (egress != null)
+                {
+                    _writer.WriteStartObject();
+                    //Redact all the properties since they could include secrets such as storage keys
+                    ProcessSection(egress, nameof(EgressOptions.Properties), includeChildSections: true, redact: true);
+                    WriteProviders(egress);
+                    _writer.WriteEndObject();
+                }
+            }
+            _writer.WriteEndObject();
+        }
+
+        private void WriteProviders(IConfiguration egress)
+        {
+            IConfigurationSection providers = ProcessSection(egress, nameof(EgressOptions.Providers), includeChildSections: false);
+            if (providers != null)
+            {
+                Func<IConfigurationSection, string, bool> matchesProvider = (configSection, providerName) =>
+                                    configSection.Exists() &&
+                                    string.Equals(configSection.Key, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), StringComparison.OrdinalIgnoreCase) &&
+                                    string.Equals(configSection.Value, providerName, StringComparison.OrdinalIgnoreCase);
+
+                _writer.WriteStartObject();
+                foreach (IConfigurationSection provider in providers.GetChildren())
+                {
+                    string egressName = provider.Key;
+                    IEnumerable<IConfigurationSection> egressProperties = provider.GetChildren();
+
+                    _writer.WritePropertyName(egressName);
+                    _writer.WriteStartObject();
+                    //matches azure blob storage provider type.
+                    //Emit well known properties.
+                    if (egressProperties.Any(child => matchesProvider(child, EgressProviderTypes.AzureBlobStorage)))
+                    {
+                        ProcessSection(provider, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), includeChildSections: false);
+                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.AccountUri), includeChildSections: false);
+                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.BlobPrefix), includeChildSections: false);
+                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.ContainerName), includeChildSections: false);
+                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.CopyBufferSize), includeChildSections: false);
+                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.SharedAccessSignature), includeChildSections: false, redact: true);
+                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.AccountKey), includeChildSections: false, redact: true);
+                        ProcessSection(provider, nameof(AzureBlobEgressFactory.ConfigurationOptions.SharedAccessSignatureName), includeChildSections: false, redact: false);
+                        ProcessSection(provider, nameof(AzureBlobEgressFactory.ConfigurationOptions.AccountKeyName), includeChildSections: false, redact: false);
+                    }
+                    //Matches filesystem provider type.
+                    else if (egressProperties.Any(child => matchesProvider(child, EgressProviderTypes.FileSystem)))
+                    {
+                        ProcessSection(provider, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), includeChildSections: false);
+                        ProcessSection(provider, nameof(FileSystemEgressProviderOptions.DirectoryPath), includeChildSections: false);
+                        ProcessSection(provider, nameof(FileSystemEgressProviderOptions.IntermediateDirectoryPath), includeChildSections: false);
+                        ProcessSection(provider, nameof(FileSystemEgressProviderOptions.CopyBufferSize), includeChildSections: false);
+                    }
+                    else
+                    {
+                        //Emit other egress entries, with redaction
+                        foreach (IConfigurationSection providerProperty in egressProperties)
+                        {
+                            if (string.Equals(providerProperty.Key, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), StringComparison.OrdinalIgnoreCase))
+                            {
+                                ProcessSection(providerProperty, includeChildSections: false, redact: false);
+                            }
+                            else
+                            {
+                                ProcessSection(providerProperty, includeChildSections: true, redact: true);
+                            }
+                        }
+                    }
+                    _writer.WriteEndObject();
+                }
+                _writer.WriteEndObject();
+            }
+        }
+
+        private IConfigurationSection ProcessSection(IConfiguration parentSection, string key, bool includeChildSections = true, bool redact = false)
+        {
+            IConfigurationSection section = parentSection.GetSection(key);
+            if (!section.Exists())
+            {
+                _writer.WritePropertyName(key);
+                _writer.WriteStringValue("NOT PRESENT");
+                return null;
+            }
+
+            ProcessSection(section, includeChildSections, redact);
+
+            return section;
+        }
+
+        private void ProcessSection(IConfigurationSection section, bool includeChildSections = true, bool redact = false)
+        {
+            _writer.WritePropertyName(section.Key);
+
+            IEnumerable<IConfigurationSection> children = section.GetChildren();
+
+            if (includeChildSections && children.Any())
+            {
+                _writer.WriteStartObject();
+                foreach (IConfigurationSection child in children)
+                {
+                    ProcessSection(child, includeChildSections, redact);
+                }
+                _writer.WriteEndObject();
+            }
+            else
+            {
+                if (!children.Any())
+                {
+                    if (redact)
+                    {
+                        _writer.WriteStringValue("REDACTED");
+                    }
+                    else
+                    {
+                        _writer.WriteStringValue(section.Value);
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _writer.Dispose();
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -40,21 +40,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             _writer.WriteStartObject();
 
-            ProcessSection(configuration, WebHostDefaults.ServerUrlsKey);
-            IConfigurationSection kestrel = ProcessSection(configuration, "Kestrel", includeChildSections: false);
+            ProcessChildSection(configuration, WebHostDefaults.ServerUrlsKey);
+            IConfigurationSection kestrel = ProcessChildSection(configuration, "Kestrel", includeChildSections: false);
             if (kestrel != null)
             {
                 _writer.WriteStartObject();
-                IConfigurationSection certificates = ProcessSection(kestrel, "Certificates", includeChildSections: false);
+                IConfigurationSection certificates = ProcessChildSection(kestrel, "Certificates", includeChildSections: false);
                 if (certificates != null)
                 {
                     _writer.WriteStartObject();
-                    IConfigurationSection defaultCert = ProcessSection(certificates, "Default", includeChildSections: false);
+                    IConfigurationSection defaultCert = ProcessChildSection(certificates, "Default", includeChildSections: false);
                     if (defaultCert != null)
                     {
                         _writer.WriteStartObject();
-                        ProcessSection(defaultCert, "Path", includeChildSections: false);
-                        ProcessSection(defaultCert, "Password", includeChildSections: false, redact: !full);
+                        ProcessChildSection(defaultCert, "Path", includeChildSections: false);
+                        ProcessChildSection(defaultCert, "Password", includeChildSections: false, redact: !full);
                         _writer.WriteEndObject();
                     }
                     _writer.WriteEndObject();
@@ -63,34 +63,34 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
 
             //No sensitive information
-            ProcessSection(configuration, ConfigurationKeys.CorsConfiguration, includeChildSections: true);
-            ProcessSection(configuration, ConfigurationKeys.DiagnosticPort, includeChildSections: true);
-            ProcessSection(configuration, ConfigurationKeys.Metrics, includeChildSections: true);
-            ProcessSection(configuration, ConfigurationKeys.Storage, includeChildSections: true);
+            ProcessChildSection(configuration, ConfigurationKeys.CorsConfiguration, includeChildSections: true);
+            ProcessChildSection(configuration, ConfigurationKeys.DiagnosticPort, includeChildSections: true);
+            ProcessChildSection(configuration, ConfigurationKeys.Metrics, includeChildSections: true);
+            ProcessChildSection(configuration, ConfigurationKeys.Storage, includeChildSections: true);
 
             if (full)
             {
-                ProcessSection(configuration, ConfigurationKeys.ApiAuthentication, includeChildSections: true);
-                ProcessSection(configuration, ConfigurationKeys.Egress, includeChildSections: true);
+                ProcessChildSection(configuration, ConfigurationKeys.ApiAuthentication, includeChildSections: true);
+                ProcessChildSection(configuration, ConfigurationKeys.Egress, includeChildSections: true);
             }
             else
             {
                 //Do not emit ApiKeyHash
-                IConfigurationSection authSection = ProcessSection(configuration, ConfigurationKeys.ApiAuthentication, includeChildSections: false);
+                IConfigurationSection authSection = ProcessChildSection(configuration, ConfigurationKeys.ApiAuthentication, includeChildSections: false);
                 if (authSection != null)
                 {
                     _writer.WriteStartObject();
-                    ProcessSection(authSection, nameof(ApiAuthenticationOptions.ApiKeyHash), includeChildSections: false, redact: true);
-                    ProcessSection(authSection, nameof(ApiAuthenticationOptions.ApiKeyHashType), includeChildSections: false, redact: false);
+                    ProcessChildSection(authSection, nameof(ApiAuthenticationOptions.ApiKeyHash), includeChildSections: false, redact: true);
+                    ProcessChildSection(authSection, nameof(ApiAuthenticationOptions.ApiKeyHashType), includeChildSections: false, redact: false);
                     _writer.WriteEndObject();
                 }
 
-                IConfigurationSection egress = ProcessSection(configuration, ConfigurationKeys.Egress, includeChildSections: false);
+                IConfigurationSection egress = ProcessChildSection(configuration, ConfigurationKeys.Egress, includeChildSections: false);
                 if (egress != null)
                 {
                     _writer.WriteStartObject();
                     //Redact all the properties since they could include secrets such as storage keys
-                    ProcessSection(egress, nameof(EgressOptions.Properties), includeChildSections: true, redact: true);
+                    ProcessChildSection(egress, nameof(EgressOptions.Properties), includeChildSections: true, redact: true);
                     WriteProviders(egress);
                     _writer.WriteEndObject();
                 }
@@ -100,7 +100,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void WriteProviders(IConfiguration egress)
         {
-            IConfigurationSection providers = ProcessSection(egress, nameof(EgressOptions.Providers), includeChildSections: false);
+            IConfigurationSection providers = ProcessChildSection(egress, nameof(EgressOptions.Providers), includeChildSections: false);
             if (providers != null)
             {
                 Func<IConfigurationSection, string, bool> matchesProvider = (configSection, providerName) =>
@@ -120,23 +120,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     //Emit well known properties.
                     if (egressProperties.Any(child => matchesProvider(child, EgressProviderTypes.AzureBlobStorage)))
                     {
-                        ProcessSection(provider, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), includeChildSections: false);
-                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.AccountUri), includeChildSections: false);
-                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.BlobPrefix), includeChildSections: false);
-                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.ContainerName), includeChildSections: false);
-                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.CopyBufferSize), includeChildSections: false);
-                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.SharedAccessSignature), includeChildSections: false, redact: true);
-                        ProcessSection(provider, nameof(AzureBlobEgressProviderOptions.AccountKey), includeChildSections: false, redact: true);
-                        ProcessSection(provider, nameof(AzureBlobEgressFactory.ConfigurationOptions.SharedAccessSignatureName), includeChildSections: false, redact: false);
-                        ProcessSection(provider, nameof(AzureBlobEgressFactory.ConfigurationOptions.AccountKeyName), includeChildSections: false, redact: false);
+                        ProcessChildSection(provider, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressProviderOptions.AccountUri), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressProviderOptions.BlobPrefix), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressProviderOptions.ContainerName), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressProviderOptions.CopyBufferSize), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressProviderOptions.SharedAccessSignature), includeChildSections: false, redact: true);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressProviderOptions.AccountKey), includeChildSections: false, redact: true);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressFactory.ConfigurationOptions.SharedAccessSignatureName), includeChildSections: false, redact: false);
+                        ProcessChildSection(provider, nameof(AzureBlobEgressFactory.ConfigurationOptions.AccountKeyName), includeChildSections: false, redact: false);
                     }
                     //Matches filesystem provider type.
                     else if (egressProperties.Any(child => matchesProvider(child, EgressProviderTypes.FileSystem)))
                     {
-                        ProcessSection(provider, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), includeChildSections: false);
-                        ProcessSection(provider, nameof(FileSystemEgressProviderOptions.DirectoryPath), includeChildSections: false);
-                        ProcessSection(provider, nameof(FileSystemEgressProviderOptions.IntermediateDirectoryPath), includeChildSections: false);
-                        ProcessSection(provider, nameof(FileSystemEgressProviderOptions.CopyBufferSize), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(EgressConfigureOptions.CommonEgressProviderOptions.Type), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(FileSystemEgressProviderOptions.DirectoryPath), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(FileSystemEgressProviderOptions.IntermediateDirectoryPath), includeChildSections: false);
+                        ProcessChildSection(provider, nameof(FileSystemEgressProviderOptions.CopyBufferSize), includeChildSections: false);
                     }
                     else
                     {
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
-        private IConfigurationSection ProcessSection(IConfiguration parentSection, string key, bool includeChildSections = true, bool redact = false)
+        private IConfigurationSection ProcessChildSection(IConfiguration parentSection, string key, bool includeChildSections = true, bool redact = false)
         {
             IConfigurationSection section = parentSection.GetSection(key);
             if (!section.Exists())
@@ -180,6 +180,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             IEnumerable<IConfigurationSection> children = section.GetChildren();
 
+            //If we do not traverse the child sections, the caller is responsible for creating the value
             if (includeChildSections && children.Any())
             {
                 _writer.WriteStartObject();

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             if (!section.Exists())
             {
                 _writer.WritePropertyName(key);
-                _writer.WriteStringValue("NOT PRESENT");
+                _writer.WriteStringValue(":NOT PRESENT:");
                 return null;
             }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     if (redact)
                     {
-                        _writer.WriteStringValue("REDACTED");
+                        _writer.WriteStringValue(":REDACTED:");
                     }
                     else
                     {

--- a/src/Tools/dotnet-monitor/Egress/AzureBlobEgressFactory.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlobEgressFactory.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         /// <summary>
         /// Egress provider options for Azure blob storage with additional options.
         /// </summary>
-        private class ConfigurationOptions : AzureBlobEgressProviderOptions
+        internal class ConfigurationOptions : AzureBlobEgressProviderOptions
         {
             /// <summary>
             /// The name of the account key used to look up the value from the <see cref="EgressOptions.Properties"/> map.

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigureOptions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
         /// <summary>
         /// Configuration options to all egress providers.
         /// </summary>
-        private class CommonEgressProviderOptions
+        internal class CommonEgressProviderOptions
         {
             /// <summary>
             /// The type of the egress provider.

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.RestServer;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -117,7 +118,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             LoggerMessage.Define(
                 eventId: new EventId(18, "MetricUrlsUpdated"),
                 logLevel: LogLevel.Warning,
-                formatString: $"Metric bindings changed. To host custom metrics over http set {ConfigurationHelper.MakeKey(ConfigurationKeys.Metrics, nameof(MetricsOptions.AllowInsecureChannelForCustomMetrics))} to {true}");
+                formatString: $"Metric bindings changed. To host custom metrics over http set {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.AllowInsecureChannelForCustomMetrics))} to {true}");
 
         private static readonly Action<ILogger, string, string, Exception> _metricUrlUpdated =
             LoggerMessage.Define<string, string>(

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Tools.Common;
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
@@ -32,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
               {
                 // Handler
                 CommandHandler.Create<CancellationToken, IConsole, string[], string[], bool, string, bool>(new DiagnosticsMonitorCommandHandler().Start),
-                Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth()
+                SharedOptions()
               };
 
         private static Command ConfigCommand() =>
@@ -47,10 +48,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         // Handler
                         CommandHandler.Create(Delegate.CreateDelegate(typeof(Func<CancellationToken, IConsole, string[], string[], bool, string, bool, ConfigDisplayLevel, Task<int>>),
                             new DiagnosticsMonitorCommandHandler(), nameof(DiagnosticsMonitorCommandHandler.ShowConfig))),
-                        Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth(), ConfigLevel()
+                        SharedOptions(), ConfigLevel()
                 }
             };
 
+        private static IEnumerable<Option> SharedOptions() => new Option[]
+        {
+            Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth()
+        };
+        
         private static Option Urls() =>
             new Option(
                 aliases: new[] { "-u", "--urls" },


### PR DESCRIPTION
Addresses issue #125

``` json
Sample output:
{
  "urls": "https://localhost:52323",
  "Kestrel": {
    "Certificates": {
      "Default": {
        "Path": "/etc/aspnet/customcert/customcert.pfx",
        "Password": "REDACTED"
      }
    }
  },
  "CorsConfiguration": "NOT PRESENT",
  "DiagnosticPort": {
    "ConnectionMode": "Connect",
    "EndpointName": null
  },
  "Metrics": {
    "AllowInsecureChannelForCustomMetrics": "False",
    "Enabled": "True",
    "Endpoints": "http://localhost:52325",
    "IncludeDefaultProviders": "True",
    "MetricCount": "3",
    "UpdateIntervalSeconds": "10"
  },
  "Storage": {
    "DumpTempFolder": "/tmp/"
  },
  "ApiAuthentication": {
    "ApiKeyHash": "REDACTED",
    "ApiKeyHashType": "SHA256"
  },
  "Egress": {
    "Properties": {
      "MonitorBlobAccountKey": "REDACTED"
    },
    "Providers": {
      "monitorBlob": {
        "Type": "azureBlobStorage",
        "AccountUri": "https://wikaks.blob.core.windows.net",
        "BlobPrefix": "artifacts",
        "ContainerName": "dotnet-monitor",
        "CopyBufferSize": "NOT PRESENT",
        "SharedAccessSignature": "NOT PRESENT",
        "AccountKey": "NOT PRESENT",
        "SharedAccessSignatureName": "NOT PRESENT",
        "AccountKeyName": "MonitorBlobAccountKey"
      }
    }
  }
}
```