### PR TITLE
Add logged warnings for elevated launch on windows

### DIFF
--- a/src/Tools/dotnet-monitor/Auth/AuthOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class AuthOptions : IAuthOptions
     {
-        public bool EnableNegotiate => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        public bool EnableNegotiate => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && KeyAuthenticationMode != KeyAuthenticationMode.NoAuth;
 
         public KeyAuthenticationMode KeyAuthenticationMode { get; }
 

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -131,6 +131,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Critical,
                 formatString: "{failure}");
 
+        private static readonly Action<ILogger, Exception> _runningElevated =
+            LoggerMessage.Define(
+                eventId: new EventId(21, "RunningElevated"),
+                logLevel: LogLevel.Warning,
+                formatString: "The process was launched elevated and will have access to all processes on the system. Do not run elevated unless you need to monitor processes launched by another user (e.g., IIS worker processes)");
+
+        private static readonly Action<ILogger, Exception> _disabledNegotiateWhileElevated =
+            LoggerMessage.Define(
+                eventId: new EventId(22, "DisabledNegotiateWhileElevated"),
+                logLevel: LogLevel.Warning,
+                formatString: "Negotiate, Kerberos, and NTLM authentication are not enabled when running with elevated permissions.");
+
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
             _egressProviderAdded(logger, providerName, null);
@@ -245,6 +257,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             foreach (string failure in exception.Failures)
                 _optionsValidationFalure(logger, failure, null);
+        }
+
+        public static void RunningElevated(this ILogger logger)
+        {
+            _runningElevated(logger, null);
+        }
+
+        public static void DisabledNegotiateWhileElevated(this ILogger logger)
+        {
+            _disabledNegotiateWhileElevated(logger, null);
         }
 
         private static string Redact(string value)


### PR DESCRIPTION
Resolve issue #5: Add warning when running as an elevated processes
- Adds a warning when launched as admin on windows:
```
11:53:37 warn: Microsoft.Diagnostics.Tools.Monitor.Startup[21]
      The process was launched as an administrator level and will have access to all processes on the system. The dotnet-monitor process should be launched as the same user as the target dotnet process.
```
- Adds warning when launched as admin on windows and NTLM auth is enabled:
```
11:53:37 warn: Microsoft.Diagnostics.Tools.Monitor.Startup[22]
      While running as administrator NTLM authentication is not possible, NTLM has been disabled.
```