### PR TITLE
Allow PR build to run on all changes

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -7,12 +7,6 @@ pr:
     - main
     - release/*
     - internal/release/*
-  paths:
-    exclude:
-    - documentation/*
-    - '*.md'
-    - THIRD-PARTY-NOTICES.TXT
-    - LICENSE.TXT
 
 variables:
   - name: _TeamName


### PR DESCRIPTION
GitHub security policies require that the dotnet-monitor-ci build completes, however the pipeline definition excludes some paths such as documentation. Thus, PR owners cannot complete pull requests due to blocking on a condition that will never complete. This change removes the exclusions to have the pipeline run for all changes.