### PR TITLE
Write ndjson logs in same format at JsonConsoleFormatter and event-stream logs in format as SimpleConsoleFormatter

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ScopeState.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ScopeState.cs
@@ -43,5 +43,7 @@ namespace Microsoft.Diagnostics.Monitoring
         {
             return GetEnumerator();
         }
+
+        public bool HasScopes => _scopes.Count > 0;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/StreamingLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/StreamingLogger.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
             //CONSIDER Should we cache up the loggers and writers?
             using (var jsonWriter = new Utf8JsonWriter(outputStream, new JsonWriterOptions { Indented = false }))
             {
-                // Matches the format of JSONConsoleFormatter
+                // Matches the format of JsonConsoleFormatter
 
                 jsonWriter.WriteStartObject();
                 // TODO: Write timestamp as string
@@ -141,12 +141,15 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
         {
             Stream outputStream = _outputStream;
 
+            // Matches the format of SimpleConsoleFormatter as much as possible
+
             using var writer = new StreamWriter(outputStream, Encoding.UTF8, 1024, leaveOpen: true) { NewLine = "\n" };
 
             //event: eventName (if exists)
             //data: level category[eventId]
             //data: message
             //data: => scope1, scope2 => scope3, scope4
+            //data: exception (if exists)
             //\n
             
             if (!string.IsNullOrEmpty(eventId.Name))
@@ -164,6 +167,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
             writer.Write("data: ");
             writer.WriteLine(formatter(state, exception));
 
+            // Scopes
             bool firstScope = true;
             foreach (IReadOnlyList<KeyValuePair<string, object>> scope in _scopes)
             {
@@ -194,6 +198,14 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
             {
                 writer.WriteLine();
             }
+
+            // Exception
+            if (null != exception)
+            {
+                writer.Write("data: ");
+                writer.WriteLine(exception.ToString().Replace(Environment.NewLine, $"{Environment.NewLine}data: "));
+            }
+
             writer.WriteLine();
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/StreamingLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/StreamingLogger.cs
@@ -91,6 +91,9 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
                 //jsonWriter.WriteString("Timestamp", DateTime.UtcNow.ToString());
                 jsonWriter.WriteString("LogLevel", logLevel.ToString());
                 jsonWriter.WriteNumber("EventId", eventId.Id);
+                // EventId.Name is optional; use empty string if it is null as this
+                // works better with analytic platforms such as Azure Monitor.
+                jsonWriter.WriteString("EventName", eventId.Name ?? string.Empty);
                 jsonWriter.WriteString("Category", _categoryName);
                 jsonWriter.WriteString("Message", formatter(state, exception));
                 if (exception != null)


### PR DESCRIPTION
C# code that logs:

```cs
try
{
    throw new InvalidOperationException("Uh oh!");
}
catch (Exception ex)
{
    _logger.LogError(new EventId(7, "FailedAfterRetries"), ex, "Failed to get resource after {attempts} attempts.", 5);
}
```

will appear in the `/logs` call (`application/x-ndjson`) as:

```json
{
    "LogLevel": "Error",
    "EventId": 7,
    "EventName": "FailedAfterRetries",
    "Category": "WebApplication1Pages.IndexModel",
    "Message": "Failed to get resource after 5 attempts.",
    "Exception": "System.InvalidOperationException: Uh oh!\r\n   at WebApplication1.Pages.IndexModel.OnGet() in C:\\Users\\username\\source\\WebApplication1\\WebApplication1\\Pages\\Index.cshtml.cs:line 25",
    "State": {
        "Message": "Failed to get resource after 5 attempts.",
        "attempts": "5",
        "{OriginalFormat}": "Failed to get resource after {attempts} attempts."
    },
    "Scopes": [
        {
            "RequestId": "80000005-0006-fd00-b63f-84710c7967bb",
            "RequestPath": "/",
            "SpanId": "|7cc52286-450013e8212a49b2.",
            "TraceId": "7cc52286-450013e8212a49b2",
            "ParentId": ""
        },
        {
            "ActionId": "fffe72c8-3237-4ef5-aff5-5760c829d34b",
            "ActionName": "/Index"
        }
    ]
}
```

(newlines and indents added for readability).

or (`text/event-stream`) as:

```
event: FailedAfterRetries
data: Error WebApplication1.Pages.IndexModel[7]
data: Failed to get resource after 5 attempts.
data: => RequestId:0HM892TCMKAOI:00000005, RequestPath:/, SpanId:|1dd6f6c7-4f0343320e3f6568., TraceId:1dd6f6c7-4f0343320e3f6568, ParentId: => ActionId:b54a79e8-1cf5-4e00-bc53-f21e50d2b87c, ActionName:/Index
data: System.InvalidOperationException: Uh oh!
data:    at WebApplication1.Pages.IndexModel.OnGet() in C:\Users\username\source\WebApplication1\WebApplication1\Pages\Index.cshtml.cs:line 26
```

Closes #190, #198