### PR TITLE
Add ability to specify process name to process selection algorithm.

### DIFF
--- a/documentation/api/defaultprocess.md
+++ b/documentation/api/defaultprocess.md
@@ -1,5 +1,5 @@
 # Default Process
 
-When using APIs to capture diagnostic artifacts, typically a `pid` or `uid` is provided to perform the operation on a specific process. However, these parameters may be omitted if dotnet-monitor is able to resolve a default process.
+When using APIs to capture diagnostic artifacts, typically a `pid`, `uid`, or `name` is provided to perform the operation on a specific process. However, these parameters may be omitted if dotnet-monitor is able to resolve a default process.
 
 The tool is able to resolve a default process if there is one and only one observable process. If there are no processes or there are more that one process, any API that allows operating on the default process will fail when invoked.

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -106,6 +106,7 @@ Object with process identifying information. The properties on this object descr
 |---|---|---|
 | `pid` | int | The ID of the process. |
 | `uid` | guid | `.NET 5+` A value that uniquely identifies a runtime instance within a process.<br/>`.NET Core 3.1` An empty value: `00000000-0000-0000-0000-000000000000` |
+| `name` | string | (Preview 5+) The name of the process. |
 
 The `uid` property is useful for uniquely identifying a process when it is running in an environment where the process ID may not be unique (e.g. multiple containers within a Kubernetes pod will have entrypoint processes with process ID 1).
 

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -104,11 +104,13 @@ Object with process identifying information. The properties on this object descr
 
 | Name | Type | Description |
 |---|---|---|
+| `name` | string | The name of the process. |
 | `pid` | int | The ID of the process. |
 | `uid` | guid | `.NET 5+` A value that uniquely identifies a runtime instance within a process.<br/>`.NET Core 3.1` An empty value: `00000000-0000-0000-0000-000000000000` |
-| `name` | string | (Preview 5+) The name of the process. |
 
 The `uid` property is useful for uniquely identifying a process when it is running in an environment where the process ID may not be unique (e.g. multiple containers within a Kubernetes pod will have entrypoint processes with process ID 1).
+
+The `name` property may not be a unique identifier if the application was built as a [framework-dependent executable](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-framework-dependent). In this case, the name of the process is likely to be either `dotnet.exe` (Windows) or `dotnet` (non-Windows). Framework-dependent executables rely on a shared framework installation, which uses the `dotnet.exe` or `dotnet` executable to run the application.
 
 ### Example
 

--- a/documentation/api/dump.md
+++ b/documentation/api/dump.md
@@ -16,7 +16,7 @@ or
 GET /dump/{uid}?type={type} HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 GET /dump/{name}?type={type} HTTP/1.1
@@ -40,7 +40,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 | `type` | query | false | [DumpType](definitions.md#DumpType) | The type of dump to capture. Default value is `WithHeap` |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected dump. When not specified, the dump is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 

--- a/documentation/api/dump.md
+++ b/documentation/api/dump.md
@@ -16,6 +16,12 @@ or
 GET /dump/{uid}?type={type} HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+GET /dump/{name}?type={type} HTTP/1.1
+```
+
 or
 
 ```http
@@ -34,12 +40,13 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 | `type` | query | false | [DumpType](definitions.md#DumpType) | The type of dump to capture. Default value is `WithHeap` |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected dump. When not specified, the dump is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-If neither `pid` nor `uid` are specified, a dump of the [default process](defaultprocess.md) will be captured. Attempting to capture a dump of the default process when the default process cannot be resolved will fail.
+If none of `pid`, `uid`, or `name` are specified, a dump of the [default process](defaultprocess.md) will be captured. Attempting to capture a dump of the default process when the default process cannot be resolved will fail.
 
 ## Authentication
 

--- a/documentation/api/gcdump.md
+++ b/documentation/api/gcdump.md
@@ -20,6 +20,12 @@ or
 GET /gcdump/{uid} HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+GET /gcdump/{name} HTTP/1.1
+```
+
 or
 
 ```http
@@ -38,11 +44,12 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected GC dump. When not specified, the GC dump is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-If neither `pid` nor `uid` are specified, a GC dump of the [default process](defaultprocess.md) will be captured. Attempting to capture a GC dump of the default process when the default process cannot be resolved will fail.
+If none of `pid`, `uid`, or `name` are specified, a GC dump of the [default process](defaultprocess.md) will be captured. Attempting to capture a GC dump of the default process when the default process cannot be resolved will fail.
 
 ## Authentication
 

--- a/documentation/api/gcdump.md
+++ b/documentation/api/gcdump.md
@@ -20,7 +20,7 @@ or
 GET /gcdump/{uid} HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 GET /gcdump/{name} HTTP/1.1
@@ -44,7 +44,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected GC dump. When not specified, the GC dump is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.

--- a/documentation/api/logs.md
+++ b/documentation/api/logs.md
@@ -16,7 +16,7 @@ or
 GET /logs/{uid}?level={level}&durationSeconds={durationSeconds} HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 GET /logs/{name}?level={level}&durationSeconds={durationSeconds} HTTP/1.1
@@ -40,7 +40,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 | `level` | query | false | [LogLevel](definitions.md#LogLevel) | The name of the log level at which log events are collected. For .NET Core 3.1, the default is `Warning`. For .NET 5+, logs are collected at the levels configured by the application for each logging category; this can be overriden by setting `level`, which will fallback to collecting all categories at or above the specified level. |
 | `durationSeconds` | query | false | int | The duration of the log collection operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected logs. When not specified, the logs are written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |

--- a/documentation/api/logs.md
+++ b/documentation/api/logs.md
@@ -16,6 +16,12 @@ or
 GET /logs/{uid}?level={level}&durationSeconds={durationSeconds} HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+GET /logs/{name}?level={level}&durationSeconds={durationSeconds} HTTP/1.1
+```
+
 or
 
 ```http
@@ -34,13 +40,14 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 | `level` | query | false | [LogLevel](definitions.md#LogLevel) | The name of the log level at which log events are collected. For .NET Core 3.1, the default is `Warning`. For .NET 5+, logs are collected at the levels configured by the application for each logging category; this can be overriden by setting `level`, which will fallback to collecting all categories at or above the specified level. |
 | `durationSeconds` | query | false | int | The duration of the log collection operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected logs. When not specified, the logs are written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-If neither `pid` nor `uid` are specified, logs for the [default process](defaultprocess.md) will be captured. Attempting to capture logs of the default process when the default process cannot be resolved will fail.
+If none of `pid`, `uid`, or `name` are specified, logs for the [default process](defaultprocess.md) will be captured. Attempting to capture logs of the default process when the default process cannot be resolved will fail.
 
 ## Authentication
 

--- a/documentation/api/processes-env.md
+++ b/documentation/api/processes-env.md
@@ -14,6 +14,12 @@ or
 GET /processes/{uid}/env HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+GET /processes/{name}/env HTTP/1.1
+```
+
 > **NOTE:** Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
@@ -26,10 +32,11 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | true | int | The ID of the process. |
 | `uid` | path | true | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-Either `pid` or `uid` are required, but not both.
+One of `pid`, `uid`, or `name` are required, but not all.
 
 ## Authentication
 

--- a/documentation/api/processes-env.md
+++ b/documentation/api/processes-env.md
@@ -32,7 +32,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | true | int | The ID of the process. |
 | `uid` | path | true | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | The name of the process. |
+| `name` | path | true | string | The name of the process. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 

--- a/documentation/api/processes-env.md
+++ b/documentation/api/processes-env.md
@@ -14,7 +14,7 @@ or
 GET /processes/{uid}/env HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 GET /processes/{name}/env HTTP/1.1
@@ -32,7 +32,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | true | int | The ID of the process. |
 | `uid` | path | true | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 

--- a/documentation/api/processes-get.md
+++ b/documentation/api/processes-get.md
@@ -14,6 +14,12 @@ or
 GET /processes/{uid} HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+GET /processes/{name} HTTP/1.1
+```
+
 > **NOTE:** Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
@@ -26,10 +32,11 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | true | int | The ID of the process. |
 | `uid` | path | true | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-Either `pid` or `uid` are required, but not both.
+One of `pid`, `uid`, or `name` are required, but not all.
 
 ## Authentication
 

--- a/documentation/api/processes-get.md
+++ b/documentation/api/processes-get.md
@@ -32,7 +32,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | true | int | The ID of the process. |
 | `uid` | path | true | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | The name of the process. |
+| `name` | path | true | string | The name of the process. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 

--- a/documentation/api/processes-get.md
+++ b/documentation/api/processes-get.md
@@ -14,7 +14,7 @@ or
 GET /processes/{uid} HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 GET /processes/{name} HTTP/1.1
@@ -32,7 +32,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | true | int | The ID of the process. |
 | `uid` | path | true | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 

--- a/documentation/api/trace-custom.md
+++ b/documentation/api/trace-custom.md
@@ -14,6 +14,12 @@ or
 POST /trace/{uid}?durationSeconds={durationSeconds} HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+POST /trace/{name}?durationSeconds={durationSeconds} HTTP/1.1
+```
+
 or
 
 ```http
@@ -32,12 +38,13 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 | `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected trace. When not specified, the trace is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-If neither `pid` nor `uid` are specified, a trace of the [default process](defaultprocess.md) will be captured. Attempting to capture a trace of the default process when the default process cannot be resolved will fail.
+If none of `pid`, `uid`, or `name` are specified, a trace of the [default process](defaultprocess.md) will be captured. Attempting to capture a trace of the default process when the default process cannot be resolved will fail.
 
 ## Authentication
 

--- a/documentation/api/trace-custom.md
+++ b/documentation/api/trace-custom.md
@@ -14,7 +14,7 @@ or
 POST /trace/{uid}?durationSeconds={durationSeconds} HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 POST /trace/{name}?durationSeconds={durationSeconds} HTTP/1.1
@@ -38,7 +38,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 | `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected trace. When not specified, the trace is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 

--- a/documentation/api/trace-get.md
+++ b/documentation/api/trace-get.md
@@ -14,6 +14,12 @@ or
 GET /trace/{uid}?profile={profile}&durationSeconds={durationSeconds}&metricsIntervalSeconds={metricsIntervalSeconds} HTTP/1.1
 ```
 
+or (Preview 5+)
+
+```http
+GET /trace/{name}?profile={profile}&durationSeconds={durationSeconds}&metricsIntervalSeconds={metricsIntervalSeconds} HTTP/1.1
+```
+
 or
 
 ```http
@@ -32,14 +38,15 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | (Preview 5+) The name of the process. |
 | `profile` | query | false | [TraceProfile](definitions.md#TraceProfile) | The name of the profile(s) used to collect events. See [TraceProfile](definitions.md#TraceProfile) for details on the list of event providers, levels, and keywords each profile represents. Multiple profiles may be specified by separating them with commas. Default is `Cpu,Http,Metrics` |
 | `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `metricsIntervalSeconds` | query | false | int | The interval (in seconds) at which metrics are collected. Only applicable for the `Metrics` profile. Default is `1`. Min is `1`. Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected trace. When not specified, the trace is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid` and `uid` parameters.
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
 
-If neither `pid` nor `uid` are specified, a trace of the [default process](defaultprocess.md) will be captured. Attempting to capture a trace of the default process when the default process cannot be resolved will fail.
+If none of `pid`, `uid`, or `name` are specified, a trace of the [default process](defaultprocess.md) will be captured. Attempting to capture a trace of the default process when the default process cannot be resolved will fail.
 
 ## Authentication
 

--- a/documentation/api/trace-get.md
+++ b/documentation/api/trace-get.md
@@ -14,7 +14,7 @@ or
 GET /trace/{uid}?profile={profile}&durationSeconds={durationSeconds}&metricsIntervalSeconds={metricsIntervalSeconds} HTTP/1.1
 ```
 
-or (Preview 5+)
+or
 
 ```http
 GET /trace/{name}?profile={profile}&durationSeconds={durationSeconds}&metricsIntervalSeconds={metricsIntervalSeconds} HTTP/1.1
@@ -38,7 +38,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 |---|---|---|---|---|
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | (Preview 5+) The name of the process. |
+| `name` | path | false | string | The name of the process. |
 | `profile` | query | false | [TraceProfile](definitions.md#TraceProfile) | The name of the profile(s) used to collect events. See [TraceProfile](definitions.md#TraceProfile) for details on the list of event providers, levels, and keywords each profile represents. Multiple profiles may be specified by separating them with commas. Default is `Cpu,Http,Metrics` |
 | `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `metricsIntervalSeconds` | query | false | int | The interval (in seconds) at which metrics are collected. Only applicable for the `Metrics` profile. Default is `1`. Min is `1`. Max is `2147483647`. |

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -46,20 +46,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie."
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name."
             }
           }
         ],
@@ -94,20 +100,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie."
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name."
             }
           }
         ],
@@ -145,20 +157,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
               "nullable": true
             }
           },
@@ -216,20 +234,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
               "nullable": true
             }
           },
@@ -279,20 +303,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
               "nullable": true
             }
           },
@@ -374,20 +404,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
               "nullable": true
             }
           },
@@ -471,20 +507,26 @@
           {
             "name": "processKey",
             "in": "path",
-            "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
             "required": true,
             "schema": {
               "oneOf": [
                 {
                   "type": "integer",
+                  "description": "The ID of the process.",
                   "format": "int32"
                 },
                 {
                   "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
                   "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
                 }
               ],
-              "description": "Value used to identify the target process, either the process ID or the runtime instance cookie.",
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
               "nullable": true
             }
           },
@@ -623,6 +665,10 @@
           "uid": {
             "type": "string",
             "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -68,7 +68,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     processesIdentifiers.Add(new Models.ProcessIdentifier()
                     {
                         Pid = p.EndpointInfo.ProcessId,
-                        Uid = p.EndpointInfo.RuntimeInstanceCookie
+                        Uid = p.EndpointInfo.RuntimeInstanceCookie,
+                        Name = p.ProcessName
                     });
                 }
                 _logger.WrittenToHttpStream();
@@ -79,7 +80,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Get information about the specified process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         [HttpGet("processes/{processKey}", Name = nameof(GetProcessInfo))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(Models.ProcessInfo), StatusCodes.Status200OK)]
@@ -108,7 +109,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Get the environment block of the specified process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         [HttpGet("processes/{processKey}/env", Name = nameof(GetProcessEnvironment))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(Dictionary<string, string>), StatusCodes.Status200OK)]
@@ -138,7 +139,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Capture a dump of a process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         /// <param name="type">The type of dump to capture.</param>
         /// <param name="egressProvider">The egress provider to which the dump is saved.</param>
         /// <returns></returns>
@@ -191,7 +192,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Capture a GC dump of a process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         /// <param name="egressProvider">The egress provider to which the GC dump is saved.</param>
         /// <returns></returns>
         [HttpGet("gcdump/{processKey?}", Name = nameof(CaptureGcDump))]
@@ -242,7 +243,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Capture a trace of a process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         /// <param name="profile">The profiles enabled for the trace session.</param>
         /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
         /// <param name="metricsIntervalSeconds">The reporting interval (in seconds) for event counters.</param>
@@ -296,7 +297,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Capture a trace of a process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         /// <param name="configuration">The trace configuration describing which events to capture.</param>
         /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
         /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
@@ -349,7 +350,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// <summary>
         /// Capture a stream of logs from a process.
         /// </summary>
-        /// <param name="processKey">Value used to identify the target process, either the process ID or the runtime instance cookie.</param>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
         /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
         /// <param name="level">The level of the logs to capture.</param>
         /// <param name="egressProvider">The egress provider to which the trace is saved.</param>

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessIdentifier.cs
@@ -18,5 +18,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
 
         [JsonPropertyName("uid")]
         public Guid Uid { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ProcessKey.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ProcessKey.cs
@@ -14,16 +14,27 @@ namespace Microsoft.Diagnostics.Monitoring
         public ProcessKey(int processId)
         {
             ProcessId = processId;
+            ProcessName = null;
             RuntimeInstanceCookie = null;
         }
 
         public ProcessKey(Guid runtimeInstanceCookie)
         {
             ProcessId = null;
+            ProcessName = null;
             RuntimeInstanceCookie = runtimeInstanceCookie;
         }
 
+        public ProcessKey(string processName)
+        {
+            ProcessId = null;
+            ProcessName = processName;
+            RuntimeInstanceCookie = null;
+        }
+
         public int? ProcessId { get; }
+
+        public string ProcessName { get; }
 
         public Guid? RuntimeInstanceCookie { get; }
     }
@@ -55,6 +66,7 @@ namespace Microsoft.Diagnostics.Monitoring
                 {
                     return new ProcessKey(processId);
                 }
+                return new ProcessKey(valueString);
             }
             else if (value is ProcessKey identifier)
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -12,19 +12,20 @@ using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.Globalization;
 using System.IO;
-using System.Text;
 
 namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
 {
     internal sealed class Program
     {
-        private static readonly OpenApiSchema Int32Schema =
-            new OpenApiSchema() { Type = "integer", Format = "int32" };
-        private static readonly OpenApiSchema GuidSchema =
-            new OpenApiSchema() { Type = "string", Format = "uuid" };
+        private static readonly OpenApiSchema ProcessKey_Int32Schema =
+            new OpenApiSchema() { Type = "integer", Format = "int32", Description = "The ID of the process." };
+        private static readonly OpenApiSchema ProcessKey_GuidSchema =
+            new OpenApiSchema() { Type = "string", Format = "uuid", Description = "The runtime instance cookie of the runtime." };
+        private static readonly OpenApiSchema ProcessKey_StringSchema =
+            new OpenApiSchema() { Type = "string", Description = "The name of the process." };
 
         private static Func<OpenApiSchema> CreateProcessKeySchema =>
-            () => new OpenApiSchema() { OneOf = { Int32Schema, GuidSchema } };
+            () => new OpenApiSchema() { OneOf = { ProcessKey_Int32Schema, ProcessKey_GuidSchema, ProcessKey_StringSchema } };
 
         public static void Main(string[] args)
         {


### PR DESCRIPTION
This change allows process selection based on the process name.

For example, a request such as

```http
GET /processes/pwsh
```

would yield a response such as

```json
{
    "pid": 13564,
    "uid": "199efe46-595b-4640-b957-1fbf7ee78c26",
    "name": "pwsh",
    "commandLine": "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\"",
    "operatingSystem": "Windows",
    "processArchitecture": "x64"
}
```

The resolution of zero or more than one process remains unchanged.

Additional changes include adding the process name to the `/processes` route:

```json
[
    {
        "pid": 13564,
        "uid": "199efe46-595b-4640-b957-1fbf7ee78c26",
        "name": "pwsh"
    },
    {
        "pid": 20412,
        "uid": "87596ba0-b92f-47c9-b065-1cb271d41645",
        "name": "dotnet"
    },
    {
        "pid": 21308,
        "uid": "00000000-0000-0000-0000-000000000000",
        "name": "WebApplication3"
    }
]
```

and updating the OpenAPI document with the additional `ProcessName` field on the `ProcessKey` object.

closes #48
closes #73