### PR TITLE
Use UseAppFilters for all runtime versions.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,9 +39,9 @@
     <MicrosoftFileFormatsVersion>1.0.215101</MicrosoftFileFormatsVersion>
   </PropertyGroup>
   <PropertyGroup Label="Runtime Versions">
-    <MicrosoftNETCoreApp31Version>3.1.13</MicrosoftNETCoreApp31Version>
+    <MicrosoftNETCoreApp31Version>3.1.15</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
-    <MicrosoftNETCoreApp50Version>5.0.4</MicrosoftNETCoreApp50Version>
+    <MicrosoftNETCoreApp50Version>5.0.6</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
     <MicrosoftNETCoreApp60Version>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreApp60Version>
     <MicrosoftAspNetCoreApp60Version>$(VSRedistCommonAspNetCoreSharedFrameworkx6460Version)</MicrosoftAspNetCoreApp60Version>

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -392,15 +392,14 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                         Duration = duration
                     };
 
-                    //If the user does not explicitly specify a log level, we will use the apps defaults for .net 5.
-                    //Otherwise, we use the log level specified by the query.
-                    if ((!level.HasValue) && (processInfo.EndpointInfo.RuntimeInstanceCookie != Guid.Empty))
+                    // Use log level query parameter if specified, otherwise use application-defined filters.
+                    if (level.HasValue)
                     {
-                        settings.UseAppFilters = true;
+                        settings.LogLevel = level.Value;
                     }
                     else
                     {
-                        settings.LogLevel = level.GetValueOrDefault(LogLevel.Warning);
+                        settings.UseAppFilters = true;
                     }
 
                     var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 }
                 if (profile.HasFlag(Models.TraceProfile.Logs))
                 {
-                    configurations.Add(new LoggingSourceConfiguration());
+                    configurations.Add(new LoggingSourceConfiguration(useAppFilters: true));
                 }
                 if (profile.HasFlag(Models.TraceProfile.Metrics))
                 {


### PR DESCRIPTION
This change has dotnet-monitor use the UseAppFilters sentinel on all runtime versions since the 3.1.15 patch version contains the ability to use the UseAppFilters sentinel in this LoggingEventSource. 

closes #159
closes #183 