### PR TITLE
Add POST /logs route

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -98,6 +98,29 @@ Enumeration that defines logging severity levels.
 
 See [LogLevel](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.loglevel) documentation.
 
+## LogsConfiguration
+
+Object describing the default log level and filtering specifications for collecting logs.
+
+| Name | Type | Description |
+|---|---|---|
+| `logLevel` | [LogLevel](#LogLevel) | The default log level at which logs are collected. |
+| `filterSpecs` | map (of [LogLevel](#LogLevel) or `null`) | A mapping of logger categories and the levels at which those categories should be collected. If level is set to `null`, collect category at the default level set in the `logLevel` property. |
+| `useAppFilters` | bool | Collect logs for the categories and at the levels as specified by the application-defined configuration. |
+
+### Example
+
+The following configuration will collect logs for the Microsoft.AspNetCore.Hosting category at the Information level or higher.
+
+```json
+{
+    "filterSpecs": {
+        "Microsoft.AspNetCore.Hosting": "Information"
+    },
+    "useAppFilters": false
+}
+```
+
 ## ProcessIdentifier
 
 Object with process identifying information. The properties on this object describe indentifying aspects for a found process; these values can be used in other API calls to perform operations on specific processes.

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -104,9 +104,9 @@ Object describing the default log level and filtering specifications for collect
 
 | Name | Type | Description |
 |---|---|---|
-| `logLevel` | [LogLevel](#LogLevel) | The default log level at which logs are collected. |
+| `logLevel` | [LogLevel](#LogLevel) | The default log level at which logs are collected. Default is `Warning`. |
 | `filterSpecs` | map (of [LogLevel](#LogLevel) or `null`) | A mapping of logger categories and the levels at which those categories should be collected. If level is set to `null`, collect category at the default level set in the `logLevel` property. |
-| `useAppFilters` | bool | Collect logs for the categories and at the levels as specified by the application-defined configuration. |
+| `useAppFilters` | bool | Collect logs for the categories and at the levels as specified by the [application-defined configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging). Default is `true`. |
 
 ### Example
 

--- a/documentation/api/logs-custom.md
+++ b/documentation/api/logs-custom.md
@@ -1,6 +1,6 @@
 # Logs - Get Custom
 
-Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process, as described in the settings specified in the request body.
+Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process, as described in the settings specified in the request body. By default, logs are collected at the levels as specified by the [application-defined configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging).
 
 > **NOTE:** The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
 

--- a/documentation/api/logs-custom.md
+++ b/documentation/api/logs-custom.md
@@ -79,7 +79,7 @@ The expected content type is `application/json`.
 ```http
 POST /logs/21632?durationSeconds=60 HTTP/1.1
 Host: localhost:52323
-Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+Authorization: MonitorApiKey fffffffffffffffffffffffffffffffffffffffffff=
 
 {
     "filterSpecs": {
@@ -95,7 +95,7 @@ or
 ```http
 POST /logs/cd4da319-fa9e-4987-ac4e-e57b2aac248b?durationSeconds=60 HTTP/1.1
 Host: localhost:52323
-Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+Authorization: MonitorApiKey fffffffffffffffffffffffffffffffffffffffffff=
 
 {
     "filterSpecs": {

--- a/documentation/api/logs-custom.md
+++ b/documentation/api/logs-custom.md
@@ -1,0 +1,139 @@
+# Logs - Get Custom
+
+Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process, as described in the settings specified in the request body.
+
+> **NOTE:** The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
+
+## HTTP Route
+
+```http
+POST /logs/{pid}?durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+or 
+
+```http
+POST /logs/{uid}?durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+or
+
+```http
+POST /logs/{name}?durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+or
+
+```http
+POST /logs?durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+> **NOTE:** Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+
+## Host Address
+
+The default host address for these routes is `https://localhost:52323`. This route is only available on the addresses configured via the `--urls` command line parameter and the `DOTNETMONITOR_URLS` environment variable.
+
+## URI Parameters
+
+| Name | In | Required | Type | Description |
+|---|---|---|---|---|
+| `pid` | path | false | int | The ID of the process. |
+| `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | The name of the process. |
+| `durationSeconds` | query | false | int | The duration of the log collection operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
+| `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected logs. When not specified, the logs are written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
+
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
+
+If none of `pid`, `uid`, or `name` are specified, logs for the [default process](defaultprocess.md) will be captured. Attempting to capture logs of the default process when the default process cannot be resolved will fail.
+
+## Authentication
+
+Authentication is enforced for this route. See [Authentication](./../authentication.md) for further information.
+
+Allowed schemes:
+- `MonitorApiKey`
+- `Negotiate` (Windows only, running as unelevated)
+
+## Request Body
+
+A request body of type [LogsConfiguration](definitions.md#LogsConfiguration) is required.
+
+The expected content type is `application/json`.
+
+## Responses
+
+| Name | Type | Description | Content Type |
+|---|---|---|---|
+| 200 OK | | The logs from the process formatted as [newline delimited JSON](https://github.com/ndjson/ndjson-spec). Each JSON object is a [LogEntry](definitions.md#LogEntry) | `application/x-ndjson` |
+| 200 OK | | The logs from the process formatted as [server-sent events](https://www.w3.org/TR/eventsource). | `text/event-stream` |
+| 400 Bad Request | [ValidationProblemDetails](definitions.md#ValidationProblemDetails) | An error occurred due to invalid input. The response body describes the specific problem(s). | `application/problem+json` |
+| 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
+| 429 Too Many Requests | | There are too many logs requests at this time. Try to request logs at a later time. | |
+
+## Examples
+
+### Sample Request
+
+```http
+POST /logs/21632?durationSeconds=60 HTTP/1.1
+Host: localhost:52323
+Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+
+{
+    "filterSpecs": {
+        "Microsoft.AspNetCore.Hosting": "Information"
+    },
+    "useAppFilters": false
+}
+
+```
+
+or
+
+```http
+POST /logs/cd4da319-fa9e-4987-ac4e-e57b2aac248b?durationSeconds=60 HTTP/1.1
+Host: localhost:52323
+Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+
+{
+    "filterSpecs": {
+        "Microsoft.AspNetCore.Hosting": "Information"
+    },
+    "useAppFilters": false
+}
+```
+
+### Sample Response
+
+The log statements logged at the Information level or higher for 1 minute is returned as the response body.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+
+data: Information Microsoft.AspNetCore.Hosting.Diagnostics[1]
+data: 2021-05-13 18:06:41Z
+data: Request starting HTTP/1.1 GET http://localhost:5000/  
+data: => RequestId:0HM8M726ENU3K:0000002B, RequestPath:/, SpanId:|4791a4a7-433aa59a9e362743., TraceId:4791a4a7-433aa59a9e362743, ParentId:
+
+data: Information Microsoft.AspNetCore.Hosting.Diagnostics[2]
+data: 2021-05-13 18:06:41Z
+data: Request finished in 6.8026ms 200 text/html; charset=utf-8
+data: => RequestId:0HM8M726ENU3K:0000002B, RequestPath:/, SpanId:|4791a4a7-433aa59a9e362743., TraceId:4791a4a7-433aa59a9e362743, ParentId:
+```
+
+## Supported Runtimes
+
+| Operating System | Runtime Version |
+|---|---|
+| Windows | .NET Core 3.1, .NET 5+ |
+| Linux | .NET Core 3.1, .NET 5+ |
+| MacOS | .NET Core 3.1, .NET 5+ |
+
+## Additional Notes
+
+### When to use `pid` vs `uid`
+
+See [Process ID `pid` vs Unique ID `uid`](pidvsuid.md) for clarification on when it is best to use either parameter.

--- a/documentation/api/logs-get.md
+++ b/documentation/api/logs-get.md
@@ -74,7 +74,7 @@ Allowed schemes:
 ```http
 GET /logs/21632?level=Information&durationSeconds=60 HTTP/1.1
 Host: localhost:52323
-Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+Authorization: MonitorApiKey fffffffffffffffffffffffffffffffffffffffffff=
 ```
 
 or
@@ -82,7 +82,7 @@ or
 ```http
 GET /logs/cd4da319-fa9e-4987-ac4e-e57b2aac248b?level=Information&durationSeconds=60 HTTP/1.1
 Host: localhost:52323
-Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+Authorization: MonitorApiKey fffffffffffffffffffffffffffffffffffffffffff=
 ```
 
 ### Sample Response

--- a/documentation/api/logs-get.md
+++ b/documentation/api/logs-get.md
@@ -1,0 +1,121 @@
+# Logs - Get
+
+Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process.
+
+> **NOTE:** The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
+
+## HTTP Route
+
+```http
+GET /logs/{pid}?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+or 
+
+```http
+GET /logs/{uid}?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+or
+
+```http
+GET /logs/{name}?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+or
+
+```http
+GET /logs?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
+```
+
+> **NOTE:** Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+
+## Host Address
+
+The default host address for these routes is `https://localhost:52323`. This route is only available on the addresses configured via the `--urls` command line parameter and the `DOTNETMONITOR_URLS` environment variable.
+
+## URI Parameters
+
+| Name | In | Required | Type | Description |
+|---|---|---|---|---|
+| `pid` | path | false | int | The ID of the process. |
+| `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | path | false | string | The name of the process. |
+| `level` | query | false | [LogLevel](definitions.md#LogLevel) | The name of the log level at which log events are collected. For .NET Core 3.1, the default is `Warning`. For .NET 5+, logs are collected at the levels configured by the application for each logging category; this can be overriden by setting `level`, which will fallback to collecting all categories at or above the specified level. |
+| `durationSeconds` | query | false | int | The duration of the log collection operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
+| `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected logs. When not specified, the logs are written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
+
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
+
+If none of `pid`, `uid`, or `name` are specified, logs for the [default process](defaultprocess.md) will be captured. Attempting to capture logs of the default process when the default process cannot be resolved will fail.
+
+## Authentication
+
+Authentication is enforced for this route. See [Authentication](./../authentication.md) for further information.
+
+Allowed schemes:
+- `MonitorApiKey`
+- `Negotiate` (Windows only, running as unelevated)
+
+## Responses
+
+| Name | Type | Description | Content Type |
+|---|---|---|---|
+| 200 OK | | The logs from the process formatted as [newline delimited JSON](https://github.com/ndjson/ndjson-spec). Each JSON object is a [LogEntry](definitions.md#LogEntry) | `application/x-ndjson` |
+| 200 OK | | The logs from the process formatted as [server-sent events](https://www.w3.org/TR/eventsource). | `text/event-stream` |
+| 400 Bad Request | [ValidationProblemDetails](definitions.md#ValidationProblemDetails) | An error occurred due to invalid input. The response body describes the specific problem(s). | `application/problem+json` |
+| 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
+| 429 Too Many Requests | | There are too many logs requests at this time. Try to request logs at a later time. | |
+
+## Examples
+
+### Sample Request
+
+```http
+GET /logs/21632?level=Information&durationSeconds=60 HTTP/1.1
+Host: localhost:52323
+Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+```
+
+or
+
+```http
+GET /logs/cd4da319-fa9e-4987-ac4e-e57b2aac248b?level=Information&durationSeconds=60 HTTP/1.1
+Host: localhost:52323
+Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
+```
+
+### Sample Response
+
+The log statements logged at the Information level or higher for 1 minute is returned as the response body.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+
+event: ProcessRequest
+data: Information Agent.RequestProcessor[3]
+data: Processing request 353f398a-dc74-4adc-b107-ec35edd09968.
+
+event: ProcessRequest
+data: Information Agent.RequestProcessor[3]
+data: Processing request eeb18b82-5dfd-49e7-88a3-d0b7cbf2f4bc.
+
+event: ProcessRequest
+data: Information Agent.RequestProcessor[3]
+data: Processing request 0b7ba879-fa80-4eb8-a87d-408f539952ca.
+```
+
+## Supported Runtimes
+
+| Operating System | Runtime Version |
+|---|---|
+| Windows | .NET Core 3.1, .NET 5+ |
+| Linux | .NET Core 3.1, .NET 5+ |
+| MacOS | .NET Core 3.1, .NET 5+ |
+
+## Additional Notes
+
+### When to use `pid` vs `uid`
+
+See [Process ID `pid` vs Unique ID `uid`](pidvsuid.md) for clarification on when it is best to use either parameter.

--- a/documentation/api/logs-get.md
+++ b/documentation/api/logs-get.md
@@ -1,6 +1,6 @@
 # Logs - Get
 
-Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process.
+Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process. By default, logs are collected at the levels as specified by the [application-defined configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging).
 
 > **NOTE:** The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
 
@@ -41,7 +41,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
 | `name` | path | false | string | The name of the process. |
-| `level` | query | false | [LogLevel](definitions.md#LogLevel) | The name of the log level at which log events are collected. For .NET Core 3.1, the default is `Warning`. For .NET 5+, logs are collected at the levels configured by the application for each logging category; this can be overriden by setting `level`, which will fallback to collecting all categories at or above the specified level. |
+| `level` | query | false | [LogLevel](definitions.md#LogLevel) | The name of the log level at which log events are collected. If not specified, logs are collected levels as specified by the [application-defined configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging). |
 | `durationSeconds` | query | false | int | The duration of the log collection operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected logs. When not specified, the logs are written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 

--- a/documentation/api/logs.md
+++ b/documentation/api/logs.md
@@ -1,121 +1,12 @@
-# Logs - Get
+# Logs
 
-Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process.
+The Logs API enables collecting logs that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process.
 
 > **NOTE:** The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
 
-## HTTP Route
-
-```http
-GET /logs/{pid}?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
-```
-
-or 
-
-```http
-GET /logs/{uid}?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
-```
-
-or
-
-```http
-GET /logs/{name}?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
-```
-
-or
-
-```http
-GET /logs?level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider} HTTP/1.1
-```
-
 > **NOTE:** Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
-## Host Address
-
-The default host address for these routes is `https://localhost:52323`. This route is only available on the addresses configured via the `--urls` command line parameter and the `DOTNETMONITOR_URLS` environment variable.
-
-## URI Parameters
-
-| Name | In | Required | Type | Description |
-|---|---|---|---|---|
-| `pid` | path | false | int | The ID of the process. |
-| `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
-| `name` | path | false | string | The name of the process. |
-| `level` | query | false | [LogLevel](definitions.md#LogLevel) | The name of the log level at which log events are collected. For .NET Core 3.1, the default is `Warning`. For .NET 5+, logs are collected at the levels configured by the application for each logging category; this can be overriden by setting `level`, which will fallback to collecting all categories at or above the specified level. |
-| `durationSeconds` | query | false | int | The duration of the log collection operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
-| `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected logs. When not specified, the logs are written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
-
-See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
-
-If none of `pid`, `uid`, or `name` are specified, logs for the [default process](defaultprocess.md) will be captured. Attempting to capture logs of the default process when the default process cannot be resolved will fail.
-
-## Authentication
-
-Authentication is enforced for this route. See [Authentication](./../authentication.md) for further information.
-
-Allowed schemes:
-- `MonitorApiKey`
-- `Negotiate` (Windows only, running as unelevated)
-
-## Responses
-
-| Name | Type | Description | Content Type |
-|---|---|---|---|
-| 200 OK | | The logs from the process formatted as [newline delimited JSON](https://github.com/ndjson/ndjson-spec). Each JSON object is a [LogEntry](definitions.md#LogEntry) | `application/x-ndjson` |
-| 200 OK | | The logs from the process formatted as [server-sent events](https://www.w3.org/TR/eventsource). | `text/event-stream` |
-| 400 Bad Request | [ValidationProblemDetails](definitions.md#ValidationProblemDetails) | An error occurred due to invalid input. The response body describes the specific problem(s). | `application/problem+json` |
-| 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
-| 429 Too Many Requests | | There are too many logs requests at this time. Try to request logs at a later time. | |
-
-## Examples
-
-### Sample Request
-
-```http
-GET /logs/21632?level=Information&durationSeconds=60 HTTP/1.1
-Host: localhost:52323
-Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
-```
-
-or
-
-```http
-GET /logs/cd4da319-fa9e-4987-ac4e-e57b2aac248b?level=Information&durationSeconds=60 HTTP/1.1
-Host: localhost:52323
-Authorization: MonitorApiKey QmFzZTY0RW5jb2RlZERvdG5ldE1vbml0b3JBcGlLZXk=
-```
-
-### Sample Response
-
-The log statements logged at the Information level or higher for 1 minute is returned as the response body.
-
-```http
-HTTP/1.1 200 OK
-Content-Type: text/event-stream
-
-event: ProcessRequest
-data: Information Agent.RequestProcessor[3]
-data: Processing request 353f398a-dc74-4adc-b107-ec35edd09968.
-
-event: ProcessRequest
-data: Information Agent.RequestProcessor[3]
-data: Processing request eeb18b82-5dfd-49e7-88a3-d0b7cbf2f4bc.
-
-event: ProcessRequest
-data: Information Agent.RequestProcessor[3]
-data: Processing request 0b7ba879-fa80-4eb8-a87d-408f539952ca.
-```
-
-## Supported Runtimes
-
-| Operating System | Runtime Version |
+| Operation | Description |
 |---|---|
-| Windows | .NET Core 3.1, .NET 5+ |
-| Linux | .NET Core 3.1, .NET 5+ |
-| MacOS | .NET Core 3.1, .NET 5+ |
-
-## Additional Notes
-
-### When to use `pid` vs `uid`
-
-See [Process ID `pid` vs Unique ID `uid`](pidvsuid.md) for clarification on when it is best to use either parameter.
+| [Get Logs](logs-get.md) | Captures log statements from a process at a specified level or at the application-defined categories and levels. |
+| [Get Custom Logs](logs-custom.md) | Captures log statements from a process using the settings specified in the request body. |

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -533,12 +533,12 @@
           {
             "name": "durationSeconds",
             "in": "query",
-            "description": "The duration of the trace session (in seconds).",
+            "description": "The duration of the logs session (in seconds).",
             "schema": {
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the trace session (in seconds).",
+              "description": "The duration of the logs session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -554,14 +554,118 @@
           {
             "name": "egressProvider",
             "in": "query",
-            "description": "The egress provider to which the trace is saved.",
+            "description": "The egress provider to which the logs are saved.",
             "schema": {
               "type": "string",
-              "description": "The egress provider to which the trace is saved.",
+              "description": "The egress provider to which the logs are saved.",
               "nullable": true
             }
           }
         ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/BadRequestResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequestsResponse"
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/x-ndjson": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Diag"
+        ],
+        "summary": "Capture a stream of logs from a process.",
+        "operationId": "CaptureLogsCustom",
+        "parameters": [
+          {
+            "name": "processKey",
+            "in": "path",
+            "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "description": "The ID of the process.",
+                  "format": "int32"
+                },
+                {
+                  "type": "string",
+                  "description": "The runtime instance cookie of the runtime.",
+                  "format": "uuid"
+                },
+                {
+                  "type": "string",
+                  "description": "The name of the process."
+                }
+              ],
+              "description": "Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.",
+              "nullable": true
+            }
+          },
+          {
+            "name": "durationSeconds",
+            "in": "query",
+            "description": "The duration of the logs session (in seconds).",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": -1,
+              "type": "integer",
+              "description": "The duration of the logs session (in seconds).",
+              "format": "int32",
+              "default": 30
+            }
+          },
+          {
+            "name": "egressProvider",
+            "in": "query",
+            "description": "The egress provider to which the logs are saved.",
+            "schema": {
+              "type": "string",
+              "description": "The egress provider to which the logs are saved.",
+              "nullable": true
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The logs configuration describing which logs to capture.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogsConfiguration"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogsConfiguration"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogsConfiguration"
+              }
+            }
+          }
+        },
         "responses": {
           "400": {
             "$ref": "#/components/responses/BadRequestResponse"
@@ -794,6 +898,30 @@
           "None"
         ],
         "type": "string"
+      },
+      "LogsConfiguration": {
+        "required": [
+          "logLevel"
+        ],
+        "type": "object",
+        "properties": {
+          "logLevel": {
+            "$ref": "#/components/schemas/LogLevel"
+          },
+          "filterSpecs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/LogLevel"
+            },
+            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.",
+            "nullable": true
+          },
+          "useAppFilters": {
+            "type": "boolean",
+            "description": "Set to true to collect logs at the application-defined categories and levels."
+          }
+        },
+        "additionalProperties": false
       }
     },
     "responses": {

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -356,9 +356,9 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// Capture a stream of logs from a process.
         /// </summary>
         /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
-        /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
+        /// <param name="durationSeconds">The duration of the logs session (in seconds).</param>
         /// <param name="level">The level of the logs to capture.</param>
-        /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
+        /// <param name="egressProvider">The egress provider to which the logs are saved.</param>
         [HttpGet("logs/{processKey?}", Name = nameof(CaptureLogs))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationNdJson, ContentTypes.TextEventStream)]
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
@@ -401,9 +401,9 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         /// Capture a stream of logs from a process.
         /// </summary>
         /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
-        /// <param name="configuration"></param>
-        /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
-        /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
+        /// <param name="configuration">The logs configuration describing which logs to capture.</param>
+        /// <param name="durationSeconds">The duration of the logs session (in seconds).</param>
+        /// <param name="egressProvider">The egress provider to which the logs are saved.</param>
         [HttpPost("logs/{processKey?}", Name = nameof(CaptureLogsCustom))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationNdJson, ContentTypes.TextEventStream)]
         [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -377,51 +377,60 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             {
                 TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
 
-                LogFormat format = ComputeLogFormat(Request.GetTypedHeaders().Accept);
-                if (format == LogFormat.None)
+                var settings = new EventLogsPipelineSettings()
                 {
-                    return this.NotAcceptable();
-                }
-
-                string fileName = FormattableString.Invariant($"{GetFileNameTimeStampUtcNow()}_{processInfo.EndpointInfo.ProcessId}.txt");
-                string contentType = format == LogFormat.EventStream ? ContentTypes.TextEventStream : ContentTypes.ApplicationNdJson;
-
-                Func<Stream, CancellationToken, Task> action = async (outputStream, token) =>
-                {
-                    using var loggerFactory = new LoggerFactory();
-
-                    loggerFactory.AddProvider(new StreamingLoggerProvider(outputStream, format, level));
-
-                    var settings = new EventLogsPipelineSettings()
-                    {
-                        Duration = duration
-                    };
-
-                    // Use log level query parameter if specified, otherwise use application-defined filters.
-                    if (level.HasValue)
-                    {
-                        settings.LogLevel = level.Value;
-                        settings.UseAppFilters = false;
-                    }
-                    else
-                    {
-                        Debug.Assert(settings.UseAppFilters, "Expected UseAppFilters settings to have a default value of true.");
-                    }
-
-                    var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);
-
-                    await using EventLogsPipeline pipeline = new EventLogsPipeline(client, settings, loggerFactory);
-                    await pipeline.RunAsync(token);
+                    Duration = duration
                 };
 
-                return Result(
-                    ArtifactType_Logs,
-                    egressProvider,
-                    action,
-                    fileName,
-                    contentType,
-                    processInfo.EndpointInfo,
-                    format != LogFormat.EventStream);
+                // Use log level query parameter if specified, otherwise use application-defined filters.
+                if (level.HasValue)
+                {
+                    settings.LogLevel = level.Value;
+                    settings.UseAppFilters = false;
+                }
+                else
+                {
+                    settings.UseAppFilters = true;
+                }
+
+                return StartLogs(processInfo, settings, egressProvider);
+            }, processKey, ArtifactType_Logs);
+        }
+
+        /// <summary>
+        /// Capture a stream of logs from a process.
+        /// </summary>
+        /// <param name="processKey">Value used to identify the target process, either the process ID, the runtime instance cookie, or process name.</param>
+        /// <param name="configuration"></param>
+        /// <param name="durationSeconds">The duration of the trace session (in seconds).</param>
+        /// <param name="egressProvider">The egress provider to which the trace is saved.</param>
+        [HttpPost("logs/{processKey?}", Name = nameof(CaptureLogsCustom))]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationNdJson, ContentTypes.TextEventStream)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [RequestLimit(MaxConcurrency = 3)]
+        public Task<ActionResult> CaptureLogsCustom(
+            ProcessKey? processKey,
+            [FromBody]
+            Models.LogsConfiguration configuration,
+            [FromQuery][Range(-1, int.MaxValue)]
+            int durationSeconds = 30,
+            [FromQuery]
+            string egressProvider = null)
+        {
+            return InvokeForProcess(processInfo =>
+            {
+                TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
+
+                var settings = new EventLogsPipelineSettings()
+                {
+                    Duration = duration,
+                    FilterSpecs = configuration.FilterSpecs,
+                    LogLevel = configuration.LogLevel,
+                    UseAppFilters = configuration.UseAppFilters
+                };
+
+                return StartLogs(processInfo, settings, egressProvider);
             }, processKey, ArtifactType_Logs);
         }
 
@@ -460,6 +469,42 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 fileName,
                 ContentTypes.ApplicationOctetStream,
                 processInfo.EndpointInfo);
+        }
+
+        private ActionResult StartLogs(
+            IProcessInfo processInfo,
+            EventLogsPipelineSettings settings,
+            string egressProvider)
+        {
+            LogFormat format = ComputeLogFormat(Request.GetTypedHeaders().Accept);
+            if (format == LogFormat.None)
+            {
+                return this.NotAcceptable();
+            }
+
+            string fileName = FormattableString.Invariant($"{GetFileNameTimeStampUtcNow()}_{processInfo.EndpointInfo.ProcessId}.txt");
+            string contentType = format == LogFormat.EventStream ? ContentTypes.TextEventStream : ContentTypes.ApplicationNdJson;
+
+            Func<Stream, CancellationToken, Task> action = async (outputStream, token) =>
+            {
+                using var loggerFactory = new LoggerFactory();
+
+                loggerFactory.AddProvider(new StreamingLoggerProvider(outputStream, format, logLevel: null));
+
+                var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);
+
+                await using EventLogsPipeline pipeline = new EventLogsPipeline(client, settings, loggerFactory);
+                await pipeline.RunAsync(token);
+            };
+
+            return Result(
+                ArtifactType_Logs,
+                egressProvider,
+                action,
+                fileName,
+                contentType,
+                processInfo.EndpointInfo,
+                format != LogFormat.EventStream);
         }
 
         private static TimeSpan ConvertSecondsToTimeSpan(int durationSeconds)

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/LogsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/LogsConfiguration.cs
@@ -11,14 +11,23 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
 {
     public class LogsConfiguration
     {
+        /// <summary>
+        /// The default level at which logs are collected.
+        /// </summary>
         [JsonPropertyName("logLevel")]
         [EnumDataType(typeof(LogLevel))]
         [Required]
         public LogLevel LogLevel { get; set; } = LogLevel.Warning;
 
+        /// <summary>
+        /// The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.
+        /// </summary>
         [JsonPropertyName("filterSpecs")]
         public Dictionary<string, LogLevel?> FilterSpecs { get; set; }
 
+        /// <summary>
+        /// Set to true to collect logs at the application-defined categories and levels.
+        /// </summary>
         [JsonPropertyName("useAppFilters")]
         public bool UseAppFilters { get; set; } = true;
     }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/LogsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/LogsConfiguration.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
+{
+    public class LogsConfiguration
+    {
+        [JsonPropertyName("logLevel")]
+        [EnumDataType(typeof(LogLevel))]
+        [Required]
+        public LogLevel LogLevel { get; set; } = LogLevel.Warning;
+
+        [JsonPropertyName("filterSpecs")]
+        public Dictionary<string, LogLevel?> FilterSpecs { get; set; }
+
+        [JsonPropertyName("useAppFilters")]
+        public bool UseAppFilters { get; set; } = true;
+    }
+}


### PR DESCRIPTION
Add POST /logs route. The body is a object with the following properties:
- `logLevel`: Default log level for any category without a log level.
- `filterSpecs`: The key-value pairs of categories and log levels that should be collected.
- `useAppFilters`: Include the application-defined filters.

Example request:
```http
POST /logs/2584?durationSeconds=15 HTTP/1.1

{
    "filterSpecs": {
        "Microsoft.AspNetCore.Hosting": "Information"
    },
    "useAppFilters": false
}
```

Example response:
```http
HTTP/1.1 200 OK
Content-Type: text/event-stream

﻿data: Information Microsoft.AspNetCore.Hosting.Diagnostics[1]
data: 2021-05-13 18:06:41Z
data: Request starting HTTP/1.1 GET http://localhost:5000/  
data: => RequestId:0HM8M726ENU3K:0000002B, RequestPath:/, SpanId:|4791a4a7-433aa59a9e362743., TraceId:4791a4a7-433aa59a9e362743, ParentId:

﻿data: Information Microsoft.AspNetCore.Hosting.Diagnostics[2]
data: 2021-05-13 18:06:41Z
data: Request finished in 6.8026ms 200 text/html; charset=utf-8
data: => RequestId:0HM8M726ENU3K:0000002B, RequestPath:/, SpanId:|4791a4a7-433aa59a9e362743., TraceId:4791a4a7-433aa59a9e362743, ParentId:
```

closes #54 