### PR TITLE
Enable Linux dump tests and OS X Mach-O verification

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -9,8 +9,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     public partial class DotNetHost
     {
+        // The version is in the Major.Minor.Patch-label format; remove the label
+        // and only parse the Major.Minor.Patch part.
         private static Lazy<Version> s_runtimeVersionLazy =
-            new(() => Version.Parse(CurrentNetCoreVersionString));
+            new(() => Version.Parse(CurrentNetCoreVersionString.Split("-")[0]));
 
         public static Version RuntimeVersion =>
             s_runtimeVersionLazy.Value;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/HttpApi/ApiClientExtensions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
         /// </summary>
         public static Task<ResponseStreamHolder> CaptureDumpAsync(this ApiClient client, int pid, DumpType dumpType)
         {
-            return client.CaptureDumpAsync(pid, dumpType, TestTimeouts.HttpApi);
+            return client.CaptureDumpAsync(pid, dumpType, TestTimeouts.DumpTimeout);
         }
 
         /// <summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/TestConditions.cs
@@ -13,10 +13,6 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         {
             get
             {
-                // Linux dumps currently broken by https://github.com/dotnet/diagnostics/issues/2098
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                    return false;
-
                 // MacOS supported dumps starting in .NET 5
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && DotNetHost.RuntimeVersion.Major < 5)
                     return false;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/TestTimeouts.cs
@@ -32,5 +32,10 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         /// Default logs collection duration.
         /// </summary>
         public static readonly TimeSpan LogsDuration = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Default timeout for dump collection.
+        /// </summary>
+        public static readonly TimeSpan DumpTimeout = TimeSpan.FromMinutes(1);
     }
 }


### PR DESCRIPTION
These changes:
- Enable Linux dump testing. Required parsing ELFHeaderIdent header to determine bitness and endianness before adding ELF parsing types for the full ELFHeader header.
- Enable Mach-O dump testing for .NET 6+ on OS X.

closes #228
closes #322