### PR TITLE
Update logs tests to have custom logger state.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/LogsTests.cs
@@ -560,8 +560,8 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             return new LogEntry()
             {
                 Category = category,
-                EventId = 1,
-                EventName = "EventIdInformation",
+                EventId = 0,
+                EventName = string.Empty,
                 Exception = null,
                 LogLevel = LogLevel.Information,
                 Message = "Information message with values hello and goodbye.",
@@ -580,17 +580,17 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             return new LogEntry()
             {
                 Category = category,
-                EventId = 1,
+                EventId = 5,
                 EventName = "EventIdWarning",
                 Exception = null,
                 LogLevel = LogLevel.Warning,
-                Message = "Warning message with values 3.5 and 7.",
+                Message = "'Warning message with custom state.' with 3 state values.",
                 State = new Dictionary<string, string>()
                 {
-                    { "{OriginalFormat}", "Warning message with values {value1} and {value2}." },
-                    { "Message", "Warning message with values 3.5 and 7." },
-                    { "value1", "3.5" },
-                    { "value2", "7" }
+                    { "Message", "'Warning message with custom state.' with 3 state values." },
+                    { "KeyA", "4" },
+                    { "Key2", "p" },
+                    { "KeyZ", "Error" }
                 }
             };
         }


### PR DESCRIPTION
This change allows the logs tests to flex the EventLogsPipeline code path that handles log events that do not have a message format (https://github.com/dotnet/diagnostics/blob/614bad036c73b37123d5f8db6e383164d452429d/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs#L155).