### PR TITLE
Fix key-per-file to signal change token.

### DIFF
--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandler.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private readonly ApiAuthenticationOptions _apiAuthOptions;
 
+
         public ApiKeyAuthenticationHandler(
             IOptionsMonitor<ApiKeyAuthenticationHandlerOptions> options,
             IOptionsSnapshot<ApiAuthenticationOptions> apiAuthOptions,
@@ -39,6 +40,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             ISystemClock clock)
             : base(options, loggerFactory, encoder, clock)
         {
+            // AuthenticationHandler<T> implementations are registered as transient services, so its okay to
+            // use IOptionsSnapshot to get the current value of the api authentication options. This also has
+            // the side effect of getting a snapshot of the options rather than getting options that can mutate
+            // (e.g. configuration reload) while attempting to authenticate a particular request.
             _apiAuthOptions = apiAuthOptions.Value;
         }
 

--- a/src/Tools/dotnet-monitor/ConfigurationBuilderExtensions.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.KeyPerFile;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static class ConfigurationBuilderExtensions
+    {
+        // Works arounds an isssue in KeyPerFileConfigurationProvider where the change token is not signaled
+        // when the keys and values are reloaded. See https://github.com/dotnet/aspnetcore/issues/32836
+        public static IConfigurationBuilder AddKeyPerFileWithChangeTokenSupport(this IConfigurationBuilder builder, string directoryPath, bool optional, bool reloadOnChange)
+        {
+            return builder.Add(delegate (KeyPerFileConfigurationSourceWithChangeTokenSupport source)
+            {
+                if (!optional || Directory.Exists(directoryPath))
+                {
+                    source.FileProvider = new PhysicalFileProvider(directoryPath);
+                }
+                source.Optional = optional;
+                source.ReloadOnChange = reloadOnChange;
+            });
+        }
+
+        private class KeyPerFileConfigurationSourceWithChangeTokenSupport :
+            KeyPerFileConfigurationSource,
+            IConfigurationSource
+        {
+            IConfigurationProvider IConfigurationSource.Build(IConfigurationBuilder builder)
+            {
+                return new KeyPerFileConfigurationProviderWithChangeTokenSupport(this);
+            }
+        }
+
+        private class KeyPerFileConfigurationProviderWithChangeTokenSupport :
+            KeyPerFileConfigurationProvider,
+            IDisposable
+        {
+            // KeyPerFileConfigurationProvider.Load(bool) method
+            private readonly static MethodInfo s_loadMethod = typeof(KeyPerFileConfigurationProvider).GetMethod(
+                "Load",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] { typeof(bool) },
+                null);
+
+            private readonly IDisposable _changeTokenRegistration;
+
+            public KeyPerFileConfigurationProviderWithChangeTokenSupport(KeyPerFileConfigurationSourceWithChangeTokenSupport source)
+                : base(source)
+            {
+                Debug.Assert(null != s_loadMethod);
+                if (null != s_loadMethod)
+                {
+                    if (source.ReloadOnChange && source.FileProvider != null)
+                    {
+                        _changeTokenRegistration = ChangeToken.OnChange(
+                            () => source.FileProvider.Watch("*"),
+                            () =>
+                            {
+                                Thread.Sleep(source.ReloadDelay);
+                                Reload();
+                            });
+                    }
+                }
+            }
+
+            void IDisposable.Dispose()
+            {
+                _changeTokenRegistration?.Dispose();
+                base.Dispose();
+            }
+
+            private void Reload()
+            {
+                // Invoke KeyPerFileConfigurationProvider.Load(bool) to reload the keys and values.
+                s_loadMethod.Invoke(this, new object[] { true });
+
+                // The fix for the issue is to invoke the change token after reloading the data.
+                OnReload();
+            }
+        }
+
+    }
+}

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         }
                     }
 
-                    builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
+                    builder.AddKeyPerFileWithChangeTokenSupport(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ConfigPrefix);
                 });
 
@@ -158,6 +158,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         List<string> authSchemas = null;
                         if (authenticationOptions.EnableKeyAuth)
                         {
+                            services.ConfigureApiKeyConfiguration(context.Configuration);
+
                             //Add support for Authentication and Authorization.
                             AuthenticationBuilder authBuilder = services.AddAuthentication(options =>
                             {


### PR DESCRIPTION
This change fixes key-per-file configuration to signal the change token when data is reloaded. This is a workaround until https://github.com/dotnet/aspnetcore/issues/32836 is fixed. This change enables the use of dependency injection to acquire key-per-file options from configuration and perform other options operations, such as post configuration and validation, in future changes.