### PR TITLE
Log authentication configuration errors on startup, configuration change, and HTTP requests.

### DIFF
--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHostedService.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHostedService.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Service that monitors API Key authentication options changes and logs issues with the specified options.
+    /// </summary>
+    internal class ApiKeyAuthenticationHostedService :
+        IHostedService,
+        IDisposable
+    {
+        private readonly ILogger<ApiKeyAuthenticationHostedService> _logger;
+        private readonly IOptionsMonitor<ApiKeyAuthenticationOptions> _options;
+
+        private IDisposable _changeRegistration;
+
+        public ApiKeyAuthenticationHostedService(
+            ILogger<ApiKeyAuthenticationHostedService> logger,
+            IOptionsMonitor<ApiKeyAuthenticationOptions> options
+            )
+        {
+            _logger = logger;
+            _options = options;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _changeRegistration = _options.OnChange(OnApiKeyAuthenticationOptionsChanged);
+
+            // Write out current validation state of options when starting the tool.
+            CheckApiKeyAuthenticationOptions(_options.CurrentValue);
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _changeRegistration.Dispose();
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _changeRegistration.Dispose();
+        }
+
+        private void OnApiKeyAuthenticationOptionsChanged(ApiKeyAuthenticationOptions options)
+        {
+            _logger.ApiKeyAuthenticationOptionsChanged();
+
+            CheckApiKeyAuthenticationOptions(options);
+        }
+
+        private void CheckApiKeyAuthenticationOptions(ApiKeyAuthenticationOptions options)
+        {
+            if (options.ValidationErrors.Any())
+            {
+                _logger.ApiKeyValidationFailures(options.ValidationErrors);
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationOptions.cs
@@ -3,13 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
-    internal sealed class ApiKeyAuthenticationHandlerOptions : AuthenticationSchemeOptions
+    internal sealed class ApiKeyAuthenticationOptions : AuthenticationSchemeOptions
     {
+        public string HashAlgorithm { get; set; }
+
+        public byte[] HashValue { get; set; }
+
+        public IEnumerable<ValidationResult> ValidationErrors { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationOptionsChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationOptionsChangeTokenSource.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Notifies that ApiKeyAuthenticationOptions changes when ApiAuthenticationOptions changes.
+    /// </summary>
+    internal sealed class ApiKeyAuthenticationOptionsChangeTokenSource :
+        IOptionsChangeTokenSource<ApiKeyAuthenticationOptions>,
+        IDisposable
+    {
+        private readonly IOptionsMonitor<ApiAuthenticationOptions> _optionsMonitor;
+        private readonly IDisposable _changeRegistration;
+
+        private ConfigurationReloadToken _reloadToken = new ConfigurationReloadToken();
+
+        public ApiKeyAuthenticationOptionsChangeTokenSource(
+            IOptionsMonitor<ApiAuthenticationOptions> optionsMonitor)
+        {
+            _optionsMonitor = optionsMonitor;
+            _changeRegistration = _optionsMonitor.OnChange(OnReload);
+        }
+
+        public string Name => Options.DefaultName;
+
+        public IChangeToken GetChangeToken()
+        {
+            return _reloadToken;
+        }
+
+        public void Dispose()
+        {
+            _changeRegistration.Dispose();
+        }
+
+        private void OnReload(ApiAuthenticationOptions options)
+        {
+            Interlocked.Exchange(ref _reloadToken, new ConfigurationReloadToken()).OnReload();
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationPostConfigureOptions.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Sets options on ApiKeyAuthenticationOptions based on ApiAuthenticationOptions.
+    /// </summary>
+    internal sealed class ApiKeyAuthenticationPostConfigureOptions :
+        IPostConfigureOptions<ApiKeyAuthenticationOptions>
+    {
+        private static readonly string[] DisallowedHashAlgorithms = new string[]
+        {
+            "SHA",
+            "SHA1",
+            "System.Security.Cryptography.SHA1",
+            "System.Security.Cryptography.HashAlgorithm",
+            "MD5",
+            "System.Security.Cryptography.MD5"
+        };
+
+        private readonly IOptionsMonitor<ApiAuthenticationOptions> _apiAuthOptions;
+
+        public ApiKeyAuthenticationPostConfigureOptions(
+            IOptionsMonitor<ApiAuthenticationOptions> apiAuthOptions)
+        {
+            _apiAuthOptions = apiAuthOptions;
+        }
+
+        public void PostConfigure(string name, ApiKeyAuthenticationOptions options)
+        {
+            ApiAuthenticationOptions sourceOptions = _apiAuthOptions.CurrentValue;
+
+            IList<ValidationResult> errors = new List<ValidationResult>();
+
+            Validator.TryValidateObject(
+                sourceOptions,
+                new ValidationContext(sourceOptions, null, null),
+                errors,
+                validateAllProperties: true);
+
+            // Validate hash algorithm is allowed and is supported.
+            if (!string.IsNullOrEmpty(sourceOptions.ApiKeyHashType))
+            {
+                if (DisallowedHashAlgorithms.Contains(sourceOptions.ApiKeyHashType, StringComparer.OrdinalIgnoreCase))
+                {
+                    errors.Add(new ValidationResult($"API Key hash algorithm '{sourceOptions.ApiKeyHashType}' is not allowed.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHashType) }));
+                }
+                else
+                {
+                    using HashAlgorithm algorithm = HashAlgorithm.Create(sourceOptions.ApiKeyHashType);
+                    if (null == algorithm)
+                    {
+                        errors.Add(new ValidationResult($"API key hash algorithm '{sourceOptions.ApiKeyHashType}' is not supported.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHashType) }));
+                    }
+                }
+            }
+
+            byte[] apiKeyHashBytes = null;
+            if (!string.IsNullOrEmpty(sourceOptions.ApiKeyHash))
+            {
+                // ApiKeyHash is represented as a hex string. e.g. AABBCCDDEEFF
+                if (sourceOptions.ApiKeyHash.Length % 2 == 0)
+                {
+                    apiKeyHashBytes = new byte[sourceOptions.ApiKeyHash.Length / 2];
+                    for (int i = 0; i < sourceOptions.ApiKeyHash.Length; i += 2)
+                    {
+                        if (!byte.TryParse(sourceOptions.ApiKeyHash.AsSpan(i, 2), NumberStyles.HexNumber, provider: NumberFormatInfo.InvariantInfo, result: out byte resultByte))
+                        {
+                            errors.Add(new ValidationResult($"API key hash could not be decoded as hex string.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHash) }));
+                            break;
+                        }
+                        apiKeyHashBytes[i / 2] = resultByte;
+                    }
+                }
+                else
+                {
+                    errors.Add(new ValidationResult("API key hash length must be an even number.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHash) }));
+                }
+            }
+
+            options.ValidationErrors = errors;
+            if (errors.Any())
+            {
+                options.HashAlgorithm = null;
+                options.HashValue = null;
+            }
+            else
+            {
+                options.HashAlgorithm = sourceOptions.ApiKeyHashType;
+                options.HashValue = apiKeyHashBytes;
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationPostConfigureOptions.cs
@@ -53,14 +53,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             {
                 if (DisallowedHashAlgorithms.Contains(sourceOptions.ApiKeyHashType, StringComparer.OrdinalIgnoreCase))
                 {
-                    errors.Add(new ValidationResult($"API Key hash algorithm '{sourceOptions.ApiKeyHashType}' is not allowed.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHashType) }));
+                    errors.Add(new ValidationResult($"The {nameof(ApiAuthenticationOptions.ApiKeyHashType)} field value '{sourceOptions.ApiKeyHashType}' is not allowed.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHashType) }));
                 }
                 else
                 {
                     using HashAlgorithm algorithm = HashAlgorithm.Create(sourceOptions.ApiKeyHashType);
                     if (null == algorithm)
                     {
-                        errors.Add(new ValidationResult($"API key hash algorithm '{sourceOptions.ApiKeyHashType}' is not supported.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHashType) }));
+                        errors.Add(new ValidationResult($"The {nameof(ApiAuthenticationOptions.ApiKeyHashType)} field value '{sourceOptions.ApiKeyHashType}' is not supported.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHashType) }));
                     }
                 }
             }
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         if (!byte.TryParse(sourceOptions.ApiKeyHash.AsSpan(i, 2), NumberStyles.HexNumber, provider: NumberFormatInfo.InvariantInfo, result: out byte resultByte))
                         {
-                            errors.Add(new ValidationResult($"API key hash could not be decoded as hex string.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHash) }));
+                            errors.Add(new ValidationResult($"The {nameof(ApiAuthenticationOptions.ApiKeyHash)} field could not be decoded as hex string.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHash) }));
                             break;
                         }
                         apiKeyHashBytes[i / 2] = resultByte;
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
                 else
                 {
-                    errors.Add(new ValidationResult("API key hash length must be an even number.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHash) }));
+                    errors.Add(new ValidationResult($"The {nameof(ApiAuthenticationOptions.ApiKeyHash)} field value length must be an even number.", new string[] { nameof(ApiAuthenticationOptions.ApiKeyHash) }));
                 }
             }
 

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                         // Although this is only observing API key authentication changes, it does handle
                         // the case when API key authentication is not enabled. This class could evolve
-                        // to observe other opitons in the future, at which point it might be good to
+                        // to observe other options in the future, at which point it might be good to
                         // refactor the options observers for each into separate implementations and are
                         // orchestrated by this single service.
                         services.AddSingleton<ApiKeyAuthenticationOptionsObserver>();

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                                 options.DefaultAuthenticateScheme = AuthConstants.ApiKeySchema;
                                 options.DefaultChallengeScheme = AuthConstants.ApiKeySchema;
                             })
-                            .AddScheme<ApiKeyAuthenticationHandlerOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKeySchema, _ => { });
+                            .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKeySchema, _ => { });
 
                             authSchemas = new List<string> { AuthConstants.ApiKeySchema };
 

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -155,6 +155,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         AuthOptions authenticationOptions = new AuthOptions(noAuth ? KeyAuthenticationMode.NoAuth : KeyAuthenticationMode.StoredKey);
                         services.AddSingleton<IAuthOptions>(authenticationOptions);
 
+                        // Although this is only observing API key authentication changes, it does handle
+                        // the case when API key authentication is not enabled. This class could evolve
+                        // to observe other opitons in the future, at which point it might be good to
+                        // refactor the options observers for each into separate implementations and are
+                        // orchestrated by this single service.
+                        services.AddSingleton<ApiKeyAuthenticationOptionsObserver>();
+
                         List<string> authSchemas = null;
                         if (authenticationOptions.EnableKeyAuth)
                         {

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -136,13 +136,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             LoggerMessage.Define<string>(
                 eventId: new EventId(21, "ApiKeyValidationFailure"),
                 logLevel: LogLevel.Warning,
-                formatString: "{validationFailure}");
+                formatString: nameof(ConfigurationKeys.ApiAuthentication) + " settings are invalid: {validationFailure}");
 
         private static readonly Action<ILogger, Exception> _apiKeyAuthenticationOptionsChanged =
             LoggerMessage.Define(
                 eventId: new EventId(22, "ApiKeyAuthenticationOptionsChanged"),
                 logLevel: LogLevel.Information,
-                formatString: "API key authentication settings have changed.");
+                formatString: nameof(ConfigurationKeys.ApiAuthentication) + " settings have changed.");
 
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.Monitoring.RestServer;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -132,6 +132,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: "Negotiate, Kerberos, and NTLM authentication are not enabled when running with elevated permissions.");
 
+        private static readonly Action<ILogger, string, Exception> _apiKeyValidationFailure =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(21, "ApiKeyValidationFailure"),
+                logLevel: LogLevel.Warning,
+                formatString: "{validationFailure}");
+
+        private static readonly Action<ILogger, Exception> _apiKeyAuthenticationOptionsChanged =
+            LoggerMessage.Define(
+                eventId: new EventId(22, "ApiKeyAuthenticationOptionsChanged"),
+                logLevel: LogLevel.Information,
+                formatString: "API key authentication settings have changed.");
+
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
             _egressProviderAdded(logger, providerName, null);
@@ -246,6 +258,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void DisabledNegotiateWhileElevated(this ILogger logger)
         {
             _disabledNegotiateWhileElevated(logger, null);
+        }
+
+        public static void ApiKeyValidationFailures(this ILogger logger, IEnumerable<ValidationResult> errors)
+        {
+            foreach (ValidationResult error in errors)
+            {
+                _apiKeyValidationFailure(logger, error.ErrorMessage, null);
+            }
+        }
+
+        public static void ApiKeyAuthenticationOptionsChanged(this ILogger logger)
+        {
+            _apiKeyAuthenticationOptionsChanged(logger, null);
         }
 
         private static string Redact(string value)

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -24,9 +24,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 // Loads and validates ApiAuthenticationOptions into ApiKeyAuthenticationOptions
                 .AddSingleton<IPostConfigureOptions<ApiKeyAuthenticationOptions>, ApiKeyAuthenticationPostConfigureOptions>()
                 // Notifies that ApiKeyAuthenticationOptions is changed when ApiAuthenticationOptions is changed.
-                .AddSingleton<IOptionsChangeTokenSource<ApiKeyAuthenticationOptions>, ApiKeyAuthenticationOptionsChangeTokenSource>()
-                // Add hosted service that monitors for ApiKeyAuthenticationOptions changes and logs validation errors.
-                .AddHostedService<ApiKeyAuthenticationHostedService>();
+                .AddSingleton<IOptionsChangeTokenSource<ApiKeyAuthenticationOptions>, ApiKeyAuthenticationOptionsChangeTokenSource>();
         }
 
         public static IServiceCollection ConfigureStorage(this IServiceCollection services, IConfiguration configuration)

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -20,7 +20,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static IServiceCollection ConfigureApiKeyConfiguration(this IServiceCollection services, IConfiguration configuration)
         {
-            return ConfigureOptions<ApiAuthenticationOptions>(services, configuration, ConfigurationKeys.ApiAuthentication);
+            return ConfigureOptions<ApiAuthenticationOptions>(services, configuration, ConfigurationKeys.ApiAuthentication)
+                // Loads and validates ApiAuthenticationOptions into ApiKeyAuthenticationOptions
+                .AddSingleton<IPostConfigureOptions<ApiKeyAuthenticationOptions>, ApiKeyAuthenticationPostConfigureOptions>()
+                // Notifies that ApiKeyAuthenticationOptions is changed when ApiAuthenticationOptions is changed.
+                .AddSingleton<IOptionsChangeTokenSource<ApiKeyAuthenticationOptions>, ApiKeyAuthenticationOptionsChangeTokenSource>()
+                // Add hosted service that monitors for ApiKeyAuthenticationOptions changes and logs validation errors.
+                .AddHostedService<ApiKeyAuthenticationHostedService>();
         }
 
         public static IServiceCollection ConfigureStorage(this IServiceCollection services, IConfiguration configuration)

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IWebHostEnvironment env,
             IAuthOptions options,
             AddressListenResults listenResults,
+            ApiKeyAuthenticationOptionsObserver optionsObserver,
             ILogger<Startup> logger)
         {
             // These errors are populated before Startup.Configure is called because
@@ -123,6 +124,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             lifetime.ApplicationStarted.Register(() => LogBoundAddresses(app.ServerFeatures, listenResults, logger));
 
             LogElevatedPermissions(options, logger);
+
+            // Start listening for options changes so they can be logged when changed.
+            optionsObserver.Initialize();
 
             if (options.KeyAuthenticationMode == KeyAuthenticationMode.NoAuth)
             {


### PR DESCRIPTION
How this works:
- `ApiKeyAuthenticationOptions` is updated to contain the validated hash algorithm, hash value, and validation errors.
- `ApiKeyAuthenticationPostConfigureOptions` fills in properties on the `ApiKeyAuthenticationOptions` instance based on the validated properties from `ApiAuthenticationOptions`.
- `ApiKeyAuthenticationOptionsChangeTokenSource` listens for changes to `ApiAuthenticationOptions` and signals that `ApiKeyAuthenticationOptions` has changed when the change occurs.
- `ApiKeyAuthenticationHostedService` logs the initial state of the API Key configuration, listens for changes to `ApiKeyAuthenticationOptions`, and logs the updated state on the change.
- `ApiKeyAuthenticationHandler` checks if there are any `ApiKeyAuthenticationOptions` validation errors, and if there are, logs them and fails authentication early.

Example console output:
```
22:40:30 warn: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[21]
      ApiAuthentication settings are invalid: The ApiKeyHash field is required.
22:40:30 warn: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[21]
      ApiAuthentication settings are invalid: The ApiKeyHashType field is required.
22:40:31 warn: Microsoft.Diagnostics.Tools.Monitor.Startup[14]
      WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.
22:40:31 warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'http://localhost:52323'. Binding to endpoints defined in UseKestrel() instead.
22:40:32 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:52323
22:40:32 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:52325
22:40:32 info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
22:40:32 info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
22:40:32 info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\src\dotnet\dotnet-monitor\artifacts\bin\dotnet-monitor\Debug\netcoreapp3.1\
22:40:52 info: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[22]
      ApiAuthentication settings have changed.
22:40:52 warn: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[21]
      ApiAuthentication settings are invalid: The field ApiKeyHash must be a string or array type with a minimum length of '64'.
22:40:52 warn: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[21]
      ApiAuthentication settings are invalid: The ApiKeyHashType field is required.
22:41:21 info: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[22]
      API key authentication settings have changed.
22:41:21 warn: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[21]
      ApiAuthentication settings are invalid: The ApiKeyHashType field is required.
22:41:41 info: Microsoft.Diagnostics.Tools.Monitor.ApiKeyAuthenticationHostedService[22]
      API key authentication settings have changed.
```

Initially, dotnet-monitor does not have API Key authentication configured.
- At `22:40:52`, I updated ApiKeyHash with a value that is too small.
- At `22:41:21`, I updated ApiKeyHash with a valid hash value.
- At `22:41:41`, I updated ApiKeyHashType with the hash algorithm name.

closes #74 