### PR TITLE
Ephemeral Keys

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
                     metrics: true,
                     diagnosticPort: null,
                     noAuth: false,
+                    tempApiKey: false,
                     configOnly: false)
                 .ConfigureServices(services =>
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/AuthenticationTests.cs
@@ -194,7 +194,6 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             await using MonitorRunner toolRunner = new(_outputHelper);
             toolRunner.UseTempApiKey = true;
 
-            _outputHelper.WriteLine("Starting Monitor.");
             await toolRunner.StartAsync();
 
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
@@ -233,7 +232,6 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             options.UseApiKey(AlgorithmName, apiKey);
             toolRunner.WriteKeyPerValueConfiguration(options);
 
-            _outputHelper.WriteLine("Starting Monitor.");
             await toolRunner.StartAsync();
 
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/MonitorRunner.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
         /// <summary>
         /// Determines whether a temporary api key should be generated while starting dotnet-monitor.
         /// </summary>
-        public bool TempApiKey { get; set; }
+        public bool UseTempApiKey { get; set; }
 
         /// <summary>
         /// Determines whether metrics are disabled via the command line when starting dotnet-monitor.
@@ -191,7 +191,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
                 argsList.Add("--no-auth");
             }
 
-            if (TempApiKey)
+            if (UseTempApiKey)
             {
                 argsList.Add("--temp-apikey");
             }
@@ -262,6 +262,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
         {
             return _metricsAddressSource.GetAsync(token);
         }
+
         public Task<string> GetMonitorApiKey(CancellationToken token)
         {
             return _monitorApiKeySource.GetAsync(token);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/MonitorRunnerExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -44,6 +45,12 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
 
             using CancellationTokenSource cancellation = new(timeout);
             client.BaseAddress = new Uri(await runner.GetDefaultAddressAsync(cancellation.Token), UriKind.Absolute);
+
+            if (runner.TempApiKey)
+            {
+                string monitorApiKey = await runner.GetMonitorApiKey(cancellation.Token);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthenticationTests.ApiKeyScheme, monitorApiKey);
+            }
 
             return client;
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTests/Runners/MonitorRunnerExtensions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
             using CancellationTokenSource cancellation = new(timeout);
             client.BaseAddress = new Uri(await runner.GetDefaultAddressAsync(cancellation.Token), UriKind.Absolute);
 
-            if (runner.TempApiKey)
+            if (runner.UseTempApiKey)
             {
                 string monitorApiKey = await runner.GetMonitorApiKey(cancellation.Token);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthenticationTests.ApiKeyScheme, monitorApiKey);

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandler.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     /// </summary>
     internal sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationOptions>
     {
+        public const int ApiKeyNumBytes = 32;
+
         public ApiKeyAuthenticationHandler(
             IOptionsMonitor<ApiKeyAuthenticationOptions> options,
             ILoggerFactory loggerFactory,
@@ -63,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             //The user is passing a base 64-encoded version of the secret
             //We will be hash this and compare it to the secret in our configuration.
-            byte[] secret = new byte[32];
+            byte[] secret = new byte[ApiKeyAuthenticationHandler.ApiKeyNumBytes];
             Span<byte> span = new Span<byte>(secret);
             if (!Convert.TryFromBase64String(authHeader.Parameter, span, out int bytesWritten) || bytesWritten < 32)
             {

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationPostConfigureOptions.cs
@@ -20,12 +20,49 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         private static readonly string[] DisallowedHashAlgorithms = new string[]
         {
+            // ------------------   SHA1    ------------------
             "SHA",
             "SHA1",
             "System.Security.Cryptography.SHA1",
+            "System.Security.Cryptography.SHA1Cng",
             "System.Security.Cryptography.HashAlgorithm",
+            "http://www.w3.org/2000/09/xmldsig#sha1",
+            // These give a KeyedHashAlgorith based on SHA1
+            "System.Security.Cryptography.HMAC",
+            "System.Security.Cryptography.KeyedHashAlgorithm",
+            "HMACSHA1",
+            "System.Security.Cryptography.HMACSHA1",
+            "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
+            
+            // ------------------    MD5    ------------------
             "MD5",
-            "System.Security.Cryptography.MD5"
+            "System.Security.Cryptography.MD5",
+            "System.Security.Cryptography.MD5Cng",
+            "http://www.w3.org/2001/04/xmldsig-more#md5",
+            // These give a KeyedHashAlgorith based on MD5
+            "HMACMD5",
+            "System.Security.Cryptography.HMACMD5",
+            "http://www.w3.org/2001/04/xmldsig-more#hmac-md5",
+            
+            // These are defined in .net framework but currently not supported
+            // supported in .net core. Lets add these to the list for future 
+            // proofing, in the event that support is expanded.
+            // See: https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs#L275
+            // ------------------ RIPEMD160 ------------------
+            "RIPEMD160",
+            "RIPEMD-160",
+            "System.Security.Cryptography.RIPEMD160",
+            "System.Security.Cryptography.RIPEMD160Managed",
+            "http://www.w3.org/2001/04/xmlenc#ripemd160",
+            // These give a KeyedHashAlgorith based on RIPEMD160
+            "HMACRIPEMD160",
+            "System.Security.Cryptography.HMACRIPEMD160",
+            "http://www.w3.org/2001/04/xmldsig-more#hmac-ripemd160",
+            
+            // ------------------  MAC3DES  ------------------
+            // This is .net specific non-crypto hash algorithm, don't allow it
+            "MACTripleDES",
+            "System.Security.Cryptography.MACTripleDES",
         };
 
         private readonly IOptionsMonitor<ApiAuthenticationOptions> _apiAuthOptions;

--- a/src/Tools/dotnet-monitor/Auth/AuthOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public bool EnableKeyAuth => (KeyAuthenticationMode == KeyAuthenticationMode.StoredKey) ||
                                      (KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey);
         
-        public byte[] GeneratedKey { get; }
+        public GeneratedApiKey TemporaryKey { get; }
 
         public AuthOptions(KeyAuthenticationMode mode)
         {
@@ -25,10 +25,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             
             if (mode == KeyAuthenticationMode.TemporaryKey)
             {
-                byte[] newKey = new byte[32];
-                RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-                rngCsp.GetBytes(newKey);
-                GeneratedKey = newKey;
+                TemporaryKey = GeneratedApiKey.Create();
             }
         }
     }

--- a/src/Tools/dotnet-monitor/Auth/AuthOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -14,10 +16,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public bool EnableKeyAuth => (KeyAuthenticationMode == KeyAuthenticationMode.StoredKey) ||
                                      (KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey);
+        
+        public byte[] GeneratedKey { get; }
 
         public AuthOptions(KeyAuthenticationMode mode)
         {
             KeyAuthenticationMode = mode;
+            
+            if (mode == KeyAuthenticationMode.TemporaryKey)
+            {
+                byte[] newKey = new byte[32];
+                RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
+                rngCsp.GetBytes(newKey);
+                GeneratedKey = newKey;
+            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/GeneratedApiKey.cs
+++ b/src/Tools/dotnet-monitor/Auth/GeneratedApiKey.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static GeneratedApiKey Create()
         {
-            return GeneratedApiKey.Create("SHA512");
+            return GeneratedApiKey.Create("SHA256");
         }
 
         private static GeneratedApiKey Create(string hashAlgorithm)

--- a/src/Tools/dotnet-monitor/Auth/GeneratedApiKey.cs
+++ b/src/Tools/dotnet-monitor/Auth/GeneratedApiKey.cs
@@ -23,13 +23,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static GeneratedApiKey Create()
         {
-            return GeneratedApiKey.Create("SHA256");
+            return GeneratedApiKey.Create("SHA512");
         }
 
         private static GeneratedApiKey Create(string hashAlgorithm)
         {
             using RandomNumberGenerator rng = RandomNumberGenerator.Create();
-            using HashAlgorithm hasher = SHA256.Create();
+            using HashAlgorithm hasher = System.Security.Cryptography.HashAlgorithm.Create(hashAlgorithm);
 
             byte[] secret = new byte[ApiKeyAuthenticationHandler.ApiKeyNumBytes];
             rng.GetBytes(secret);

--- a/src/Tools/dotnet-monitor/Auth/GeneratedApiKey.cs
+++ b/src/Tools/dotnet-monitor/Auth/GeneratedApiKey.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class GeneratedApiKey
+    {
+        public readonly string MonitorApiKey;
+        public readonly string HashAlgorithm;
+        public readonly string HashValue;
+
+        private GeneratedApiKey(string monitorApiKey, string hashAlgorithm, string hashValue)
+        {
+            this.MonitorApiKey = monitorApiKey;
+            this.HashAlgorithm = hashAlgorithm;
+            this.HashValue = hashValue;
+        }
+
+        public static GeneratedApiKey Create()
+        {
+            return GeneratedApiKey.Create("SHA256");
+        }
+
+        private static GeneratedApiKey Create(string hashAlgorithm)
+        {
+            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            using HashAlgorithm hasher = SHA256.Create();
+
+            byte[] secret = new byte[ApiKeyAuthenticationHandler.ApiKeyNumBytes];
+            rng.GetBytes(secret);
+
+            byte[] hash = hasher.ComputeHash(secret);
+            StringBuilder outHash = new StringBuilder(hash.Length * 2);
+
+            foreach (byte b in hash)
+            {
+                outHash.AppendFormat("{0:X2}", b);
+            }
+
+            string apiKey = Convert.ToBase64String(secret);
+
+            GeneratedApiKey result = new GeneratedApiKey(apiKey, hashAlgorithm, outHash.ToString());
+            return result;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/IAuthOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/IAuthOptions.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         bool EnableNegotiate { get; }
         KeyAuthenticationMode KeyAuthenticationMode { get; }
-        byte[] GeneratedKey { get; }
+        GeneratedApiKey TemporaryKey { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/IAuthOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/IAuthOptions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal enum KeyAuthenticationMode
@@ -15,5 +17,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         bool EnableNegotiate { get; }
         KeyAuthenticationMode KeyAuthenticationMode { get; }
+        byte[] GeneratedKey { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -19,6 +19,8 @@ using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -113,7 +115,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool configOnly)
         {
             IHostBuilder hostBuilder = Host.CreateDefaultBuilder();
-                hostBuilder.UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
+
+            KeyAuthenticationMode authMode = noAuth ? KeyAuthenticationMode.NoAuth : tempApiKey ? KeyAuthenticationMode.TemporaryKey : KeyAuthenticationMode.StoredKey;
+            AuthOptions authenticationOptions = new AuthOptions(authMode);
+
+            hostBuilder.UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
                     //Note these are in precedence order.
@@ -144,133 +150,154 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     builder.AddKeyPerFileWithChangeTokenSupport(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ConfigPrefix);
+
+                    if (!noAuth && tempApiKey)
+                    {
+                        ConfigureTempApiHashKey(builder, authenticationOptions);
+                    }
                 });
 
-                if (!configOnly)
+            if (!configOnly)
+            {
+                hostBuilder.ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
                 {
-                    hostBuilder.ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
+                    //TODO Many of these service additions should be done through extension methods
+
+                    services.AddSingleton<IAuthOptions>(authenticationOptions);
+
+                    // Although this is only observing API key authentication changes, it does handle
+                    // the case when API key authentication is not enabled. This class could evolve
+                    // to observe other options in the future, at which point it might be good to
+                    // refactor the options observers for each into separate implementations and are
+                    // orchestrated by this single service.
+                    services.AddSingleton<ApiKeyAuthenticationOptionsObserver>();
+
+                    List<string> authSchemas = null;
+                    if (authenticationOptions.EnableKeyAuth)
                     {
-                        //TODO Many of these service additions should be done through extension methods
+                        services.ConfigureApiKeyConfiguration(context.Configuration);
 
-                        KeyAuthenticationMode authMode = noAuth ? KeyAuthenticationMode.NoAuth : tempApiKey ? KeyAuthenticationMode.TemporaryKey : KeyAuthenticationMode.StoredKey;
-                        AuthOptions authenticationOptions = new AuthOptions(authMode);
+                        //Add support for Authentication and Authorization.
+                        AuthenticationBuilder authBuilder = services.AddAuthentication(options =>
+                        {
+                            options.DefaultAuthenticateScheme = AuthConstants.ApiKeySchema;
+                            options.DefaultChallengeScheme = AuthConstants.ApiKeySchema;
+                        })
+                        .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKeySchema, _ => { });
 
-                        services.AddSingleton<IAuthOptions>(authenticationOptions);
+                        authSchemas = new List<string> { AuthConstants.ApiKeySchema };
 
-                        // Although this is only observing API key authentication changes, it does handle
-                        // the case when API key authentication is not enabled. This class could evolve
-                        // to observe other options in the future, at which point it might be good to
-                        // refactor the options observers for each into separate implementations and are
-                        // orchestrated by this single service.
-                        services.AddSingleton<ApiKeyAuthenticationOptionsObserver>();
+                        if (authenticationOptions.EnableNegotiate)
+                        {
+                            //On Windows add Negotiate package. This will use NTLM to perform Windows Authentication.
+                            authBuilder.AddNegotiate();
+                            authSchemas.Add(AuthConstants.NegotiateSchema);
+                        }
+                    }
 
-                        List<string> authSchemas = null;
+                    //Apply Authorization Policy for NTLM. Without Authorization, any user with a valid login/password will be authorized. We only
+                    //want to authorize the same user that is running dotnet-monitor, at least for now.
+                    //Note this policy applies to both Authorization schemas.
+                    services.AddAuthorization(authOptions =>
+                    {
                         if (authenticationOptions.EnableKeyAuth)
                         {
-                            services.ConfigureApiKeyConfiguration(context.Configuration);
-
-                            //Add support for Authentication and Authorization.
-                            AuthenticationBuilder authBuilder = services.AddAuthentication(options =>
+                            authOptions.AddPolicy(AuthConstants.PolicyName, (builder) =>
                             {
-                                options.DefaultAuthenticateScheme = AuthConstants.ApiKeySchema;
-                                options.DefaultChallengeScheme = AuthConstants.ApiKeySchema;
-                            })
-                            .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKeySchema, _ => { });
+                                builder.AddRequirements(new AuthorizedUserRequirement());
+                                builder.RequireAuthenticatedUser();
+                                builder.AddAuthenticationSchemes(authSchemas.ToArray());
 
-                            authSchemas = new List<string> { AuthConstants.ApiKeySchema };
-
-                            if (authenticationOptions.EnableNegotiate)
-                            {
-                                //On Windows add Negotiate package. This will use NTLM to perform Windows Authentication.
-                                authBuilder.AddNegotiate();
-                                authSchemas.Add(AuthConstants.NegotiateSchema);
-                            }
+                            });
                         }
-
-                        //Apply Authorization Policy for NTLM. Without Authorization, any user with a valid login/password will be authorized. We only
-                        //want to authorize the same user that is running dotnet-monitor, at least for now.
-                        //Note this policy applies to both Authorization schemas.
-                        services.AddAuthorization(authOptions =>
+                        else
                         {
-                            if (authenticationOptions.EnableKeyAuth)
+                            authOptions.AddPolicy(AuthConstants.PolicyName, (builder) =>
                             {
-                                authOptions.AddPolicy(AuthConstants.PolicyName, (builder) =>
-                                {
-                                    builder.AddRequirements(new AuthorizedUserRequirement());
-                                    builder.RequireAuthenticatedUser();
-                                    builder.AddAuthenticationSchemes(authSchemas.ToArray());
-
-                                });
-                            }
-                            else
-                            {
-                                authOptions.AddPolicy(AuthConstants.PolicyName, (builder) =>
-                                {
-                                    builder.RequireAssertion((_) => true);
-                                });
-                            }
-                        });
-
-                        if (authenticationOptions.EnableKeyAuth)
-                        {
-                            services.AddSingleton<IAuthorizationHandler, UserAuthorizationHandler>();
+                                builder.RequireAssertion((_) => true);
+                            });
                         }
-
-                        services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(ConfigurationKeys.DiagnosticPort));
-                        services.AddSingleton<IValidateOptions<DiagnosticPortOptions>, DiagnosticPortValidateOptions>();
-
-                        services.AddSingleton<IEndpointInfoSource, FilteredEndpointInfoSource>();
-                        services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
-                        services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
-                        services.ConfigureEgress(context.Configuration);
-                        services.ConfigureMetrics(context.Configuration);
-                        services.ConfigureStorage(context.Configuration);
-                        services.ConfigureDefaultProcess(context.Configuration);
                     });
-                }
 
-                //Note this is necessary for config only because Kestrel configuration
-                //is not added until WebHostDefaults are added.
-                hostBuilder.ConfigureWebHostDefaults(webBuilder =>
-                {
-                    AddressListenResults listenResults = new AddressListenResults();
-                    webBuilder.ConfigureServices(services =>
+                    if (authenticationOptions.EnableKeyAuth)
                     {
-                        services.AddSingleton(listenResults);
-                    })
-                    .ConfigureKestrel((context, options) =>
-                    {
-                        //Note our priorities for hosting urls don't match the default behavior.
-                        //Default Kestrel behavior priority
-                        //1) ConfigureKestrel settings
-                        //2) Command line arguments (--urls)
-                        //3) Environment variables (ASPNETCORE_URLS, then DOTNETCORE_URLS)
+                        services.AddSingleton<IAuthorizationHandler, UserAuthorizationHandler>();
+                    }
 
-                        //Our precedence
-                        //1) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
-                        //2) Command line arguments (these have defaults) --urls, --metricUrls
-                        //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
+                    services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(ConfigurationKeys.DiagnosticPort));
+                    services.AddSingleton<IValidateOptions<DiagnosticPortOptions>, DiagnosticPortValidateOptions>();
 
-                        string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
-                        urls = ConfigurationHelper.SplitValue(hostingUrl);
-
-                        var metricsOptions = new MetricsOptions();
-                        context.Configuration.Bind(ConfigurationKeys.Metrics, metricsOptions);
-
-                        //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
-                        options.Configure(context.Configuration.GetSection("Kestrel")).Load();
-
-                        //By default, we bind to https for sensitive data (such as dumps and traces) and bind http for
-                        //non-sensitive data such as metrics. We may be missing a certificate for https binding. We want to continue with the
-                        //http binding in that scenario.
-                        listenResults.Listen(
-                            options,
-                            urls,
-                            metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled) ? metricUrls : Array.Empty<string>());
-                    })
-                    .UseStartup<Startup>();
+                    services.AddSingleton<IEndpointInfoSource, FilteredEndpointInfoSource>();
+                    services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
+                    services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
+                    services.ConfigureEgress(context.Configuration);
+                    services.ConfigureMetrics(context.Configuration);
+                    services.ConfigureStorage(context.Configuration);
+                    services.ConfigureDefaultProcess(context.Configuration);
                 });
+            }
+
+            //Note this is necessary for config only because Kestrel configuration
+            //is not added until WebHostDefaults are added.
+            hostBuilder.ConfigureWebHostDefaults(webBuilder =>
+            {
+                AddressListenResults listenResults = new AddressListenResults();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddSingleton(listenResults);
+                })
+                .ConfigureKestrel((context, options) =>
+                {
+                    //Note our priorities for hosting urls don't match the default behavior.
+                    //Default Kestrel behavior priority
+                    //1) ConfigureKestrel settings
+                    //2) Command line arguments (--urls)
+                    //3) Environment variables (ASPNETCORE_URLS, then DOTNETCORE_URLS)
+
+                    //Our precedence
+                    //1) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
+                    //2) Command line arguments (these have defaults) --urls, --metricUrls
+                    //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
+
+                    string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
+                    urls = ConfigurationHelper.SplitValue(hostingUrl);
+
+                    var metricsOptions = new MetricsOptions();
+                    context.Configuration.Bind(ConfigurationKeys.Metrics, metricsOptions);
+
+                    //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
+                    options.Configure(context.Configuration.GetSection("Kestrel")).Load();
+
+                    //By default, we bind to https for sensitive data (such as dumps and traces) and bind http for
+                    //non-sensitive data such as metrics. We may be missing a certificate for https binding. We want to continue with the
+                    //http binding in that scenario.
+                    listenResults.Listen(
+                        options,
+                        urls,
+                        metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled) ? metricUrls : Array.Empty<string>());
+                })
+                .UseStartup<Startup>();
+            });
+
             return hostBuilder;
+        }
+
+        private static void ConfigureTempApiHashKey(IConfigurationBuilder builder, AuthOptions authenticationOptions)
+        {
+            const string DefaultHashAlgorithm = "SHA512";
+            using HashAlgorithm algorithm = HashAlgorithm.Create(DefaultHashAlgorithm);
+            byte[] hashedSecret = algorithm.ComputeHash(authenticationOptions.GeneratedKey);
+            StringBuilder hashedSecretHex = new StringBuilder(hashedSecret.Length * 2);
+            foreach (byte hashByte in hashedSecret)
+            {
+                hashedSecretHex.AppendFormat("{0:X2}", hashByte);
+            }
+
+            builder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { ConfigurationPath.Combine(ConfigurationKeys.ApiAuthentication, nameof(ApiAuthenticationOptions.ApiKeyHashType)), DefaultHashAlgorithm },
+                { ConfigurationPath.Combine(ConfigurationKeys.ApiAuthentication, nameof(ApiAuthenticationOptions.ApiKeyHash)), hashedSecretHex.ToString() },
+            });
         }
 
         private static void ConfigureStorageDefaults(IConfigurationBuilder builder)

--- a/src/Tools/dotnet-monitor/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/GenerateApiKeyCommandHandler.cs
@@ -3,11 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.IO;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,49 +26,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             console.Out.WriteLine(FormattableString.Invariant($"ApiKeyHashType: {newKey.HashAlgorithm}"));
 
             return Task.FromResult(0);
-        }
-    }
-
-    internal sealed class GeneratedApiKey
-    {
-        private const int KeyLengthBytes = 32;
-
-        public readonly string MonitorApiKey;
-        public readonly string HashAlgorithm;
-        public readonly string HashValue;
-
-        private GeneratedApiKey(string monitorApiKey, string hashAlgorithm, string hashValue)
-        {
-            this.MonitorApiKey = monitorApiKey;
-            this.HashAlgorithm = hashAlgorithm;
-            this.HashValue = hashValue;
-        }
-
-        public static GeneratedApiKey Create()
-        {
-            return GeneratedApiKey.Create("SHA256");
-        }
-
-        private static GeneratedApiKey Create(string hashAlgorithm)
-        {
-            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
-            using HashAlgorithm hasher = SHA256.Create();
-
-            byte[] secret = new byte[KeyLengthBytes];
-            rng.GetBytes(secret);
-
-            byte[] hash = hasher.ComputeHash(secret);
-            StringBuilder outHash = new StringBuilder(hash.Length * 2);
-
-            foreach (byte b in hash)
-            {
-                outHash.AppendFormat("{0:X2}", b);
-            }
-
-            string apiKey = Convert.ToBase64String(secret);
-
-            GeneratedApiKey result = new GeneratedApiKey(apiKey, hashAlgorithm, outHash.ToString());
-            return result;
         }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             LoggerMessage.Define<string, string>(
                 eventId: new EventId(23, "LogTempApiKey"),
                 logLevel: LogLevel.Information,
-                formatString: "Generated one-time-use ApiKey for dotnet-monitor, use the following header for authorization:{0}Authorization: MonitorApiKey{1}");
+                formatString: "Generated one-time-use ApiKey for dotnet-monitor, use the following header for authorization:{0}Authorization: MonitorApiKey {MonitorApiKey}");
 
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
@@ -144,6 +145,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: nameof(ConfigurationKeys.ApiAuthentication) + " settings have changed.");
 
+        private static readonly Action<ILogger, string, string, Exception> _logTempKey =
+            LoggerMessage.Define<string, string>(
+                eventId: new EventId(23, "LogTempApiKey"),
+                logLevel: LogLevel.Information,
+                formatString: "Generated one-time-use ApiKey for dotnet-monitor, use the following header for authorization:{0}Authorization: MonitorApiKey{1}");
+
         public static void EgressProviderAdded(this ILogger logger, string providerName)
         {
             _egressProviderAdded(logger, providerName, null);
@@ -271,6 +278,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void ApiKeyAuthenticationOptionsChanged(this ILogger logger)
         {
             _apiKeyAuthenticationOptionsChanged(logger, null);
+        }
+
+        public static void LogTempKey(this ILogger logger, byte[] generatedKey)
+        {
+            string strKey = Convert.ToBase64String(generatedKey);
+            _logTempKey(logger, Environment.NewLine, strKey, null);
         }
 
         private static string Redact(string value)

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                   description: "Monitor logs and metrics in a .NET application send the results to a chosen destination.")
               {
                 // Handler
-                CommandHandler.Create<CancellationToken, IConsole, string[], string[], bool, string, bool>(new DiagnosticsMonitorCommandHandler().Start),
+                CommandHandler.Create(Delegate.CreateDelegate(typeof(Func<CancellationToken, IConsole, string[], string[], bool, string, bool, bool, Task<int>>),
+                    new DiagnosticsMonitorCommandHandler(), nameof(DiagnosticsMonitorCommandHandler.Start))),
                 SharedOptions()
               };
 
@@ -46,7 +47,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                   description: "Shows configuration, as if dotnet-monitor collect was executed with these parameters.")
                 {
                         // Handler
-                        CommandHandler.Create(Delegate.CreateDelegate(typeof(Func<CancellationToken, IConsole, string[], string[], bool, string, bool, ConfigDisplayLevel, Task<int>>),
+                        CommandHandler.Create(Delegate.CreateDelegate(typeof(Func<CancellationToken, IConsole, string[], string[], bool, string, bool, bool, ConfigDisplayLevel, Task<int>>),
                             new DiagnosticsMonitorCommandHandler(), nameof(DiagnosticsMonitorCommandHandler.ShowConfig))),
                         SharedOptions(), ConfigLevel()
                 }
@@ -54,7 +55,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static IEnumerable<Option> SharedOptions() => new Option[]
         {
-            Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth()
+            Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth(), TempApiKey()
         };
         
         private static Option Urls() =>
@@ -96,6 +97,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 )
             {
                 Argument = new Argument<bool>(name: "noAuth", getDefaultValue: () => false)
+            };
+
+        private static Option TempApiKey() =>
+            new Option(
+                alias: "--temp-apikey",
+                description: "Generates a new MonitorApiKey for each launch of the process."
+                )
+            {
+                Argument = new Argument<bool>(name: "tempApiKey", getDefaultValue: () => false)
             };
 
         private static Option ConfigLevel() =>

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -134,6 +134,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
             else
             {
+                if (options.KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey)
+                {
+                    logger.LogTempKey(options.GeneratedKey);
+                }
                 //Auth is enabled and we are binding on http. Make sure we log a warning.
 
                 string hostingUrl = Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             {
                 if (options.KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey)
                 {
-                    logger.LogTempKey(options.GeneratedKey);
+                    logger.LogTempKey(options.TemporaryKey.MonitorApiKey);
                 }
                 //Auth is enabled and we are binding on http. Make sure we log a warning.
 


### PR DESCRIPTION
# Implements #82 
- Add `--temp-apikey` option to generate an APIKey during startup
- Prints the temporary key to the console like this:
```
D:\repos\github\dotnet-monitor-kelltrick [dev/pafenelo/eph2 ≡ +0 ~9 -0 !]> D:\repos\github\dotnet-monitor-kelltrick\artifacts\bin\dotnet-monitor\Debug\netcoreapp3.1\dotnet-monitor.exe collect --temp-apikey
13:45:24 warn: Microsoft.Diagnostics.Tools.Monitor.Startup[23]
      Generated one-time-use ApiKey for dotnet-monitor; use the following header for authorization:
      Authorization: MonitorApiKey Un3LJob3MqrR69WmFFNiU6G7U6QqgF0cY/Tm4FWSjxI=
13:45:24 warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://localhost:52323'. Binding to endpoints defined in UseKestrel() instead.
```
- Add test hook to add commandline flag `--temp-apikey`, add test to exercise new test
