### PR TITLE
Fix obsolete type usage error in tests.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/AuthenticationTests.cs
@@ -286,10 +286,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         private static byte[] GenerateApiKey()
         {
             byte[] apiKey = new byte[32]; // 256 bits
-
-            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
-            rng.GetBytes(apiKey);
-
+            RandomNumberGenerator.Fill(apiKey);
             return apiKey;
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/AuthenticationTests.cs
@@ -287,8 +287,8 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         {
             byte[] apiKey = new byte[32]; // 256 bits
 
-            using RNGCryptoServiceProvider rngProvider = new();
-            rngProvider.GetBytes(apiKey);
+            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(apiKey);
 
             return apiKey;
         }


### PR DESCRIPTION
The `RNGCryptoServiceProvider` is [obsolete](https://github.com/dotnet/runtime/blob/ebd695fee1ccccac472e39adb2a2469e89a7ccb2/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RNGCryptoServiceProvider.cs#L8) in .NET 6. Replace usage with `RandomNumberGenerator.Create`, which is what `RNGCryptoServiceProvider` was doing internally all the back to .NET Core 3.1.