### PR TITLE
Handles incorrectly formatted settings.json files by catching the System.FormatException and outputting a readable error message for the user.

### DIFF
--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -105,7 +105,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             catch (FormatException ex)
             {
                 Console.Error.WriteLine(ex.Message);
-                Console.Error.WriteLine(ex.InnerException.Message);
+                if (ex.InnerException != null)
+                {
+                    Console.Error.WriteLine(ex.InnerException.Message);
+                }
 
                 return -1;
             }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -69,36 +69,44 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey)
         {
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
-            using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, configOnly: false).Build();
             try
             {
-                await host.StartAsync(token);
+                using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, configOnly: false).Build();
+                try
+                {
+                    await host.StartAsync(token);
 
-                await host.WaitForShutdownAsync(token);
-            }
-            catch (MonitoringException)
-            {
-                // It is the responsibility of throwers to ensure that the exceptions are logged.
-                return -1;
-            }
-            catch (OptionsValidationException ex)
-            {
-                host.Services.GetRequiredService<ILoggerFactory>()
-                    .CreateLogger(typeof(DiagnosticsMonitorCommandHandler))
-                    .OptionsValidationFailure(ex);
-                return -1;
-            }
-            finally
-            {
-                if (host is IAsyncDisposable asyncDisposable)
-                {
-                    await asyncDisposable.DisposeAsync();
+                    await host.WaitForShutdownAsync(token);
                 }
-                else
+                catch (MonitoringException)
                 {
-                    host.Dispose();
+                    // It is the responsibility of throwers to ensure that the exceptions are logged.
+                    return -1;
                 }
+                catch (OptionsValidationException ex)
+                {
+                    host.Services.GetRequiredService<ILoggerFactory>()
+                        .CreateLogger(typeof(DiagnosticsMonitorCommandHandler))
+                        .OptionsValidationFailure(ex);
+                    return -1;
+                }
+                finally
+                {
+                    if (host is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync();
+                    }
+                    else
+                    {
+                        host.Dispose();
+                    }
+                }
+            } catch (FormatException ex)
+            {
+                TextWriter errorWriter = Console.Error;
+                errorWriter.WriteLine(ex.Message + "\n" + ex.InnerException.Message);
             }
+
             return 0;
         }
 
@@ -108,7 +116,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter writer = new ConfigurationJsonWriter(Console.OpenStandardOutput());
             writer.Write(configuration, full: level == ConfigDisplayLevel.Full);
-
+            
             return Task.FromResult(0);
         }
 

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -101,10 +101,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         host.Dispose();
                     }
                 }
-            } catch (FormatException ex)
+            }
+            catch (FormatException ex)
             {
-                TextWriter errorWriter = Console.Error;
-                errorWriter.WriteLine(ex.Message + "\n" + ex.InnerException.Message);
+                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine(ex.InnerException.Message);
+
+                return -1;
             }
 
             return 0;


### PR DESCRIPTION
When the settings.json file is incorrectly configured, a crash results. This handles the error and gracefully exits with an error message pointing the user to the issue.

```
Could not parse the JSON file.
'"' is invalid after a value. Expected either ',', '}', or ']'. LineNumber: 6 | BytePositionInLine: 33.
```

closes #203 