### PR TITLE
Disabling infinite traces due to their inability to complete; the valid trace duration range now goes from 1 second to 2147483647 seconds

### DIFF
--- a/documentation/api/trace-custom.md
+++ b/documentation/api/trace-custom.md
@@ -39,7 +39,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
 | `name` | path | false | string | The name of the process. |
-| `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
+| `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is '1`. Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected trace. When not specified, the trace is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.

--- a/documentation/api/trace-custom.md
+++ b/documentation/api/trace-custom.md
@@ -39,7 +39,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 | `pid` | path | false | int | The ID of the process. |
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
 | `name` | path | false | string | The name of the process. |
-| `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is '1`. Max is `2147483647`. |
+| `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `1`. Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected trace. When not specified, the trace is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 
 See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.

--- a/documentation/api/trace-get.md
+++ b/documentation/api/trace-get.md
@@ -40,7 +40,7 @@ The default host address for these routes is `https://localhost:52323`. This rou
 | `uid` | path | false | guid | A value that uniquely identifies a runtime instance within a process. |
 | `name` | path | false | string | The name of the process. |
 | `profile` | query | false | [TraceProfile](definitions.md#TraceProfile) | The name of the profile(s) used to collect events. See [TraceProfile](definitions.md#TraceProfile) for details on the list of event providers, levels, and keywords each profile represents. Multiple profiles may be specified by separating them with commas. Default is `Cpu,Http,Metrics` |
-| `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `-1` (indefinite duration). Max is `2147483647`. |
+| `durationSeconds` | query | false | int | The duration of the trace operation in seconds. Default is `30`. Min is `1`. Max is `2147483647`. |
 | `metricsIntervalSeconds` | query | false | int | The interval (in seconds) at which metrics are collected. Only applicable for the `Metrics` profile. Default is `1`. Min is `1`. Max is `2147483647`. |
 | `egressProvider` | query | false | string | If specified, uses the named egress provider for egressing the collected trace. When not specified, the trace is written to the HTTP response stream. See [Egress Providers](../egress.md) for more details. |
 

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -340,7 +340,7 @@
             "description": "The duration of the trace session (in seconds).",
             "schema": {
               "maximum": 2147483647,
-              "minimum": -1,
+              "minimum": 1,
               "type": "integer",
               "description": "The duration of the trace session (in seconds).",
               "format": "int32",
@@ -433,7 +433,7 @@
             "description": "The duration of the trace session (in seconds).",
             "schema": {
               "maximum": 2147483647,
-              "minimum": -1,
+              "minimum": 1,
               "type": "integer",
               "description": "The duration of the trace session (in seconds).",
               "format": "int32",

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             ProcessKey? processKey,
             [FromQuery]
             Models.TraceProfile profile = DefaultTraceProfiles,
-            [FromQuery][Range(-1, int.MaxValue)]
+            [FromQuery][Range(1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery][Range(1, int.MaxValue)]
             int metricsIntervalSeconds = 1,
@@ -317,7 +317,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             ProcessKey? processKey,
             [FromBody][Required]
             Models.EventPipeConfiguration configuration,
-            [FromQuery][Range(-1, int.MaxValue)]
+            [FromQuery][Range(1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
             string egressProvider = null)

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -105,7 +105,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             catch (FormatException ex)
             {
                 Console.Error.WriteLine(ex.Message);
-                Console.Error.WriteLine(ex.InnerException.Message);
+                if (ex.InnerException != null)
+                {
+                    Console.Error.WriteLine(ex.InnerException.Message);
+                }
 
                 return -1;
             }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -69,36 +69,44 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey)
         {
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
-            using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, configOnly: false).Build();
             try
             {
-                await host.StartAsync(token);
+                using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, configOnly: false).Build();
+                try
+                {
+                    await host.StartAsync(token);
 
-                await host.WaitForShutdownAsync(token);
-            }
-            catch (MonitoringException)
-            {
-                // It is the responsibility of throwers to ensure that the exceptions are logged.
-                return -1;
-            }
-            catch (OptionsValidationException ex)
-            {
-                host.Services.GetRequiredService<ILoggerFactory>()
-                    .CreateLogger(typeof(DiagnosticsMonitorCommandHandler))
-                    .OptionsValidationFailure(ex);
-                return -1;
-            }
-            finally
-            {
-                if (host is IAsyncDisposable asyncDisposable)
-                {
-                    await asyncDisposable.DisposeAsync();
+                    await host.WaitForShutdownAsync(token);
                 }
-                else
+                catch (MonitoringException)
                 {
-                    host.Dispose();
+                    // It is the responsibility of throwers to ensure that the exceptions are logged.
+                    return -1;
                 }
+                catch (OptionsValidationException ex)
+                {
+                    host.Services.GetRequiredService<ILoggerFactory>()
+                        .CreateLogger(typeof(DiagnosticsMonitorCommandHandler))
+                        .OptionsValidationFailure(ex);
+                    return -1;
+                }
+                finally
+                {
+                    if (host is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync();
+                    }
+                    else
+                    {
+                        host.Dispose();
+                    }
+                }
+            } catch (FormatException ex)
+            {
+                TextWriter errorWriter = Console.Error;
+                errorWriter.WriteLine(ex.Message + "\n" + ex.InnerException.Message);
             }
+
             return 0;
         }
 
@@ -108,7 +116,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter writer = new ConfigurationJsonWriter(Console.OpenStandardOutput());
             writer.Write(configuration, full: level == ConfigDisplayLevel.Full);
-
+            
             return Task.FromResult(0);
         }
 

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -101,10 +101,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         host.Dispose();
                     }
                 }
-            } catch (FormatException ex)
+            }
+            catch (FormatException ex)
             {
-                TextWriter errorWriter = Console.Error;
-                errorWriter.WriteLine(ex.Message + "\n" + ex.InnerException.Message);
+                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine(ex.InnerException.Message);
+
+                return -1;
             }
 
             return 0;


### PR DESCRIPTION
Trace files cannot be opened when terminated before completion. As a result, traces that run indefinitely will never be accessible to users. The new range allows traces to run between 1 second and a signed integer's max value (equating roughly to 68 years). 

Closes #334 