### PR TITLE
Increase dump collection timeout and log request durations.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HttpApi/ApiClient.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -318,10 +319,12 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
 
         private async Task<HttpResponseMessage> SendAndLogAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken token)
         {
+            Stopwatch sw = Stopwatch.StartNew();
             HttpResponseMessage response;
             try
             {
                 response = await _httpClient.SendAsync(request, completionOption, token).ConfigureAwait(false);
+                sw.Stop();
             }
             finally
             {
@@ -329,6 +332,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
             }
 
             _outputHelper.WriteLine("<- {0}", response.ToString());
+            _outputHelper.WriteLine($"Request duration: {sw.ElapsedMilliseconds} ms");
 
             return response;
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestTimeouts.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         /// <summary>
         /// Default timeout for dump collection.
         /// </summary>
-        public static readonly TimeSpan DumpTimeout = TimeSpan.FromMinutes(1);
+        /// <remarks>
+        /// Dumps (especially full dumps) can be quite large and take a significant amount of time to transfer.
+        /// </remarks>
+        public static readonly TimeSpan DumpTimeout = TimeSpan.FromMinutes(3);
     }
 }


### PR DESCRIPTION
Increasing the dump collection timeout to help mitigate #440. Adding additional logging for request durations to help track down similar issues in the future.