### PR TITLE
Check if test process exits before it is ready

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/MonitorRunner.cs
@@ -230,6 +230,13 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
 
             using IDisposable _ = token.Register(() => CancelCompletionSources(token));
 
+            // Await ready and exited tasks in case process exits before it is ready.
+            if (_runner.ExitedTask == await Task.WhenAny(_readySource.Task, _runner.ExitedTask))
+            {
+                throw new InvalidOperationException("Process exited before it was ready.");
+            }
+
+            // Await ready task to check if it faulted or cancelled.
             await _readySource.Task;
         }
 


### PR DESCRIPTION
Sometimes the tests on MacOS just hang and timeout waiting for the dotnet-monitor process to start. It's difficult to see why that is happening but one cause might be that the process exits before it becomes ready. These changes await for the process to be ready OR exit. If it exits before it is ready, then throw an exception to fail the test.