### PR TITLE
Retry process routes when name is "unknown"

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HttpApi/ApiClientExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
         /// <summary>
         /// GET /processes with retry attempts
         /// </summary>
-        public static async Task<IEnumerable<ProcessIdentifier>> GetProcessesWithRetryAsync(this ApiClient client, ITestOutputHelper outputHelper, Func<ProcessIdentifier, bool> filter = null, int maxAttempts = 5)
+        public static async Task<IEnumerable<ProcessIdentifier>> GetProcessesWithRetryAsync(this ApiClient client, ITestOutputHelper outputHelper, int[] pidFilters, int maxAttempts = 5)
         {
             IList<ProcessIdentifier> identifiers = null;
 
@@ -50,9 +50,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi
 
                 identifiers = (await client.GetProcessesAsync()).ToList();
 
-                if (null != filter)
+                if (pidFilters.Length > 0)
                 {
-                    identifiers = identifiers.Where(filter).ToList();
+                    identifiers = identifiers.Where(i => pidFilters.Contains(i.Pid)).ToList();
                 }
 
                 // In .NET 5+, the process name comes from the command line from the ProcessInfo command, which can fail

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ProcessTests.cs
@@ -55,17 +55,27 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                 TestAppScenarios.AsyncWait.Name,
                 appValidate: async (runner, client) =>
                 {
-                    await VerifyProcessAsync(client, await client.GetProcessesAsync(), runner.ProcessId, expectedEnvVarValue);
+                    // GET /processes and filter to just the single process
+                    IEnumerable<ProcessIdentifier> identifiers = await client.GetProcessesWithRetryAsync(
+                        _outputHelper,
+                        filter: identifier => identifier.Pid == runner.ProcessId);
+                    Assert.NotNull(identifiers);
+                    Assert.Single(identifiers);
+
+                    await VerifyProcessAsync(client, identifiers, runner.ProcessId, expectedEnvVarValue);
 
                     await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
                 },
                 postAppValidate: async (client, processId) =>
                 {
+                    // GET /processes and filter to just the single process
+                    IEnumerable<ProcessIdentifier> identifiers = await client.GetProcessesWithRetryAsync(
+                        _outputHelper,
+                        filter: identifier => identifier.Pid == processId);
+
                     // Verify app is no longer reported
-                    IEnumerable<ProcessIdentifier> identifiers = await client.GetProcessesAsync();
                     Assert.NotNull(identifiers);
-                    ProcessIdentifier identifier = identifiers.FirstOrDefault(p => p.Pid == processId);
-                    Assert.Null(identifier);
+                    Assert.Empty(identifiers);
                 },
                 configureApp: runner =>
                 {
@@ -114,16 +124,18 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             IList<ProcessIdentifier> identifiers;
             await appRunners.ExecuteAsync(async () =>
             {
-                // Query for process identifiers
-                identifiers = (await apiClient.GetProcessesAsync()).ToList();
-                Assert.NotNull(identifiers);
-
                 // Scope to only the processes that were launched by the test
                 IList<int> unmatchedPids = new List<int>();
                 foreach (AppRunner runner in appRunners)
                 {
                     unmatchedPids.Add(runner.ProcessId);
                 }
+
+                // Query for process identifiers
+                identifiers = (await apiClient.GetProcessesWithRetryAsync(
+                    _outputHelper,
+                    filter: identifier => unmatchedPids.Contains(identifier.Pid))).ToList();
+                Assert.NotNull(identifiers);
 
                 _outputHelper.WriteLine("Start enumerating discovered processes.");
                 foreach (ProcessIdentifier identifier in identifiers.ToList())
@@ -132,15 +144,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                     _outputHelper.WriteLine($"  UID:  {identifier.Uid}");
                     _outputHelper.WriteLine($"  Name: {identifier.Name}");
 
-                    if (!unmatchedPids.Remove(identifier.Pid))
-                    {
-                        _outputHelper.WriteLine($"  State: Ignored");
-                        identifiers.Remove(identifier);
-                    }
-                    else
-                    {
-                        _outputHelper.WriteLine($"  State: Included");
-                    }
+                    unmatchedPids.Remove(identifier.Pid);
                 }
                 _outputHelper.WriteLine("End enumerating discovered processes");
 
@@ -157,7 +161,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
                     List<ProcessInfo> processInfoQueriesCheck1 = new List<ProcessInfo>();
 
-                    processInfoQueriesCheck1.Add(await apiClient.GetProcessAsync(pid: pid, uid: null, name: null));
+                    processInfoQueriesCheck1.Add(await apiClient.GetProcessWithRetryAsync(_outputHelper, pid: pid));
                     // Only check with uid if it is non-empty; this can happen in connect mode if the ProcessInfo command fails
                     // to respond within the short period of time that is used to get the additional process information.
                     if (uid == Guid.Empty)
@@ -166,7 +170,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                     }
                     else
                     {
-                        processInfoQueriesCheck1.Add(await apiClient.GetProcessAsync(pid: null, uid: uid, name: null));
+                        processInfoQueriesCheck1.Add(await apiClient.GetProcessWithRetryAsync(_outputHelper, uid: uid));
                     }
 
                     VerifyProcessInfoEquality(processInfoQueriesCheck1);
@@ -175,9 +179,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
                     List<ProcessInfo> processInfoQueriesCheck2 = new List<ProcessInfo>();
 
-                    processInfoQueriesCheck2.Add(await apiClient.GetProcessAsync(pid: pid, uid: null, name: null));
-                    processInfoQueriesCheck2.Add(await apiClient.GetProcessAsync(pid: pid, uid: uid, name: null));
-                    processInfoQueriesCheck2.Add(await apiClient.GetProcessAsync(pid: pid, uid: uid, name: name));
+                    processInfoQueriesCheck2.Add(await apiClient.GetProcessWithRetryAsync(_outputHelper, pid: pid));
+                    processInfoQueriesCheck2.Add(await apiClient.GetProcessWithRetryAsync(_outputHelper, pid: pid, uid: uid));
+                    processInfoQueriesCheck2.Add(await apiClient.GetProcessWithRetryAsync(_outputHelper, pid: pid, uid: uid, name: name));
 
                     VerifyProcessInfoEquality(processInfoQueriesCheck2);
 
@@ -245,23 +249,13 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
             Assert.Single(processInfoPIDs.Distinct());
             Assert.Single(processInfoUIDs.Distinct());
-            // In .NET 5+, the process name comes from the command line from the ProcessInfo command, which can fail
-            // or be abandoned if it takes too long to respond. In .NET Core 3.1, the process name comes from the
-            // command line from issuing a very brief event source trace, which can also fail or be abandoned if it
-            // takes too long to finish. Additionally, for 'connect' mode, these values are recomputed for every http
-            // invocation, so a prior invocation could succeed whereas a subsequent one could fail. Much of this could
-            // be mitigated if process information could be cached between calls. In any of these scenarios, if the
-            // process name is failed to be determined, the http api will return "unknown". For testing purposes,
-            // filter out the "unknown" value before comparing the real process names. This technically can still fail
-            // the test if all of the responses yield "unknown" for the process name, however, that is very unlikely;
-            // that can be addressed if it becomes a frequent problem.
-            Assert.Single(processInfoNames.Except(new[] { "unknown" }, StringComparer.Ordinal).Distinct(StringComparer.Ordinal));
+            Assert.Single(processInfoNames.Distinct(StringComparer.Ordinal));
         }
 
         /// <summary>
         /// Verifies that an invalid Process request throws the correct exception (ValidationProblemDetailsException) and has the correct Status and StatusCode.
         /// </summary>
-        private static async Task VerifyInvalidRequestException(ApiClient client, int? pid, Guid? uid, string name)
+        private async Task VerifyInvalidRequestException(ApiClient client, int? pid, Guid? uid, string name)
         {
             ValidationProblemDetailsException validationProblemDetailsException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
                 () => client.GetProcessAsync(pid: pid, uid: uid, name: name));
@@ -272,19 +266,19 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         /// <summary>
         /// Verifies that a process was found in the identifiers list and checks the /process?pid={processKey} route for the same process.
         /// </summary>
-        private static async Task VerifyProcessAsync(ApiClient client, IEnumerable<ProcessIdentifier> identifiers, int processId, string expectedEnvVarValue)
+        private async Task VerifyProcessAsync(ApiClient client, IEnumerable<ProcessIdentifier> identifiers, int processId, string expectedEnvVarValue)
         {
             Assert.NotNull(identifiers);
             ProcessIdentifier identifier = identifiers.FirstOrDefault(p => p.Pid == processId);
             Assert.NotNull(identifier);
 
-            ProcessInfo info = await client.GetProcessAsync(identifier.Pid);
+            ProcessInfo info = await client.GetProcessWithRetryAsync(_outputHelper, pid: identifier.Pid);
             Assert.NotNull(info);
             Assert.Equal(identifier.Pid, info.Pid);
 
 #if NET5_0_OR_GREATER
             // Currently, the runtime instance identifier is only provided for .NET 5 and higher
-            info = await client.GetProcessAsync(identifier.Uid);
+            info = await client.GetProcessWithRetryAsync(_outputHelper, uid: identifier.Uid);
             Assert.NotNull(info);
             Assert.Equal(identifier.Pid, info.Pid);
             Assert.Equal(identifier.Uid, info.Uid);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ProcessTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                     // GET /processes and filter to just the single process
                     IEnumerable<ProcessIdentifier> identifiers = await client.GetProcessesWithRetryAsync(
                         _outputHelper,
-                        filter: identifier => identifier.Pid == runner.ProcessId);
+                        new[] { runner.ProcessId });
                     Assert.NotNull(identifiers);
                     Assert.Single(identifiers);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                     // GET /processes and filter to just the single process
                     IEnumerable<ProcessIdentifier> identifiers = await client.GetProcessesWithRetryAsync(
                         _outputHelper,
-                        filter: identifier => identifier.Pid == processId);
+                        new[] { processId });
 
                     // Verify app is no longer reported
                     Assert.NotNull(identifiers);
@@ -134,7 +134,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                 // Query for process identifiers
                 identifiers = (await apiClient.GetProcessesWithRetryAsync(
                     _outputHelper,
-                    filter: identifier => unmatchedPids.Contains(identifier.Pid))).ToList();
+                    unmatchedPids.ToArray())).ToList();
                 Assert.NotNull(identifiers);
 
                 _outputHelper.WriteLine("Start enumerating discovered processes.");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ProcessTests.cs
@@ -246,13 +246,15 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
             Assert.Single(processInfoPIDs.Distinct());
             Assert.Single(processInfoUIDs.Distinct());
             // In .NET 5+, the process name comes from the command line from the ProcessInfo command, which can fail
-            // or be abandoned if it takes too long to response. In .NET Core 3.1, the process name comes from the
+            // or be abandoned if it takes too long to respond. In .NET Core 3.1, the process name comes from the
             // command line from issuing a very brief event source trace, which can also fail or be abandoned if it
             // takes too long to finish. Additionally, for 'connect' mode, these values are recomputed for every http
             // invocation, so a prior invocation could succeed whereas a subsequent one could fail. Much of this could
             // be mitigated if process information could be cached between calls. In any of these scenarios, if the
             // process name is failed to be determined, the http api will return "unknown". For testing purposes,
-            // filter out the "unknown" value before comparing the real process names. 
+            // filter out the "unknown" value before comparing the real process names. This technically can still fail
+            // the test if all of the responses yield "unknown" for the process name, however, that is very unlikely;
+            // that can be addressed if it becomes a frequent problem.
             Assert.Single(processInfoNames.Except(new[] { "unknown" }, StringComparer.Ordinal).Distinct(StringComparer.Ordinal));
         }
 


### PR DESCRIPTION
I created #523 to so that we can better mitigate this type of problem. We can never guarantee that we get all of the process information on the first call, but once we getting it, we should be able to cache it.