### PR TITLE
Replace the dash in the kestrel provider name to for Prometheus

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/MetricsStore.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Monitoring
             }
 
             metricValue = value.ToString(CultureInfo.InvariantCulture);
-            return FormattableString.Invariant($"{metric.Provider.Replace(".", string.Empty).ToLowerInvariant()}_{metric.Name.Replace('-', '_')}{unitSuffix}");
+            return FormattableString.Invariant($"{metric.Provider.Replace(".", string.Empty).Replace('-', '_').ToLowerInvariant()}_{metric.Name.Replace('-', '_')}{unitSuffix}");
         }
 
         private static bool CompareMetrics(ICounterPayload first, ICounterPayload second)


### PR DESCRIPTION
Bug found [here](https://github.com/dotnet/dotnet-monitor/issues/529). Looking to solve this error when enabling Kestrel metrics:
`invalid metric type "aspnetcore-server-kestrel_connections_per_second gauge"`