### PR TITLE
'config show' now outputs Logging info from appsettings.json

### DIFF
--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             ProcessChildSection(configuration, ConfigurationKeys.Metrics, includeChildSections: true);
             ProcessChildSection(configuration, ConfigurationKeys.Storage, includeChildSections: true);
             ProcessChildSection(configuration, ConfigurationKeys.DefaultProcess, includeChildSections: true);
+            ProcessChildSection(configuration, ConfigurationKeys.Logging, includeChildSections: true);
 
             if (full)
             {

--- a/src/Tools/dotnet-monitor/ConfigurationKeys.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationKeys.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public const string Storage = nameof(Storage);
 
         public const string DefaultProcess = nameof(DefaultProcess);
+
+        public const string Logging = nameof(Logging);
     }
 }


### PR DESCRIPTION
Note: I wasn't entirely sure about the scope of the issue based on what's written in #481, so if this is completely different than what was intended let me know. I essentially just latched onto the existing functionality for config show and added in Logging as one of the outputs. This is an example of the new output for `config show`

![LoggingConfigShow](https://user-images.githubusercontent.com/85592574/126838026-02c582c3-b66f-4a93-b1d8-06a99613eb1d.PNG)


Closes #481 