### PR TITLE
Disable http response egress - testing

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressTests.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
 
         private const string FileProviderName = "files";
 
+        // This should be identical to the error message found in Strings.resx
+        private const string DisabledHTTPEgressErrorMessage = "HTTP egress is not enabled.";
+
         public EgressTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
         {
             _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
@@ -156,7 +159,6 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                     Assert.Equal(HttpStatusCode.TooManyRequests, ex.StatusCode);
                     Assert.Equal((int)HttpStatusCode.TooManyRequests, ex.Details.Status.GetValueOrDefault());
 
-
                     await CancelEgressOperation(apiClient, response1);
                     await CancelEgressOperation(apiClient, response2);
 
@@ -235,16 +237,14 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                         () => appClient.CaptureDumpAsync(appRunner.ProcessId, DumpType.Mini));
                     Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsExceptionDumps.StatusCode);
                     Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsExceptionDumps.Details.Status);
-                    // This should be identical to the error message found in Strings.resx
-                    Assert.Equal("HTTP egress is not enabled.", validationProblemDetailsExceptionDumps.Message);
+                    Assert.Equal(DisabledHTTPEgressErrorMessage, validationProblemDetailsExceptionDumps.Message);
 
                     // Logs Error Check
                     ValidationProblemDetailsException validationProblemDetailsExceptionLogs = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
-                            () => appClient.CaptureLogsAsync(appRunner.ProcessId, TestTimeouts.LogsDuration, Extensions.Logging.LogLevel.None, WebApi.LogFormat.NDJson));
+                            () => appClient.CaptureLogsAsync(appRunner.ProcessId, TestTimeouts.LogsDuration, LogLevel.None, LogFormat.NDJson));
                     Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsExceptionLogs.StatusCode);
                     Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsExceptionLogs.Details.Status);
-                    // This should be identical to the error message found in Strings.resx
-                    Assert.Equal("HTTP egress is not enabled.", validationProblemDetailsExceptionLogs.Message);
+                    Assert.Equal(DisabledHTTPEgressErrorMessage, validationProblemDetailsExceptionLogs.Message);
 
                     await appRunner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
                 },

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressTests.cs
@@ -9,7 +9,9 @@ using Microsoft.Diagnostics.Monitoring.UnitTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Models;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Options;
 using Microsoft.Diagnostics.Monitoring.UnitTests.Runners;
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.FileFormats;
 using Microsoft.FileFormats.ELF;
 using Microsoft.FileFormats.MachO;
@@ -25,6 +27,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+using DiagnosticPortConnectionMode = Microsoft.Diagnostics.Monitoring.UnitTests.Options.DiagnosticPortConnectionMode;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTests
 {
@@ -232,12 +235,16 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
                         () => appClient.CaptureDumpAsync(appRunner.ProcessId, DumpType.Mini));
                     Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsExceptionDumps.StatusCode);
                     Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsExceptionDumps.Details.Status);
+                    // This should be identical to the error message found in Strings.resx
+                    Assert.Equal("HTTP egress is not enabled.", validationProblemDetailsExceptionDumps.Message);
 
                     // Logs Error Check
                     ValidationProblemDetailsException validationProblemDetailsExceptionLogs = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
                             () => appClient.CaptureLogsAsync(appRunner.ProcessId, TestTimeouts.LogsDuration, Extensions.Logging.LogLevel.None, WebApi.LogFormat.NDJson));
                     Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsExceptionLogs.StatusCode);
                     Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsExceptionLogs.Details.Status);
+                    // This should be identical to the error message found in Strings.resx
+                    Assert.Equal("HTTP egress is not enabled.", validationProblemDetailsExceptionLogs.Message);
 
                     await appRunner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
                 },

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/MonitorRunner.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
         private readonly string _runnerTmpPath =
             Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
 
-        private bool _isDiposed;
+        private bool _isDisposed;
 
         /// <summary>
         /// The path of the currently executing assembly.
@@ -94,6 +94,11 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
         public bool DisableAuthentication { get; set; }
 
         /// <summary>
+        /// Determines whether HTTP egress is disabled when starting dotnet-monitor.
+        /// </summary>
+        public bool DisableHttpEgress { get; set; }
+
+        /// <summary>
         /// Determines whether a temporary api key should be generated while starting dotnet-monitor.
         /// </summary>
         public bool UseTempApiKey { get; set; }
@@ -132,11 +137,11 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
         {
             lock (_adapter)
             {
-                if (_isDiposed)
+                if (_isDisposed)
                 {
                     return;
                 }
-                _isDiposed = true;
+                _isDisposed = true;
             }
 
             _adapter.ReceivedStandardOutputLine -= StandardOutputCallback;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/MonitorRunner.cs
@@ -196,6 +196,11 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
                 argsList.Add("--no-auth");
             }
 
+            if (DisableHttpEgress)
+            {
+                argsList.Add("--no-http-egress");
+            }
+
             if (UseTempApiKey)
             {
                 argsList.Add("--temp-apikey");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Runners/ScenarioRunner.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
             Func<AppRunner, ApiClient, Task> appValidate,
             Func<ApiClient, int, Task> postAppValidate = null,
             Action<AppRunner> configureApp = null,
-            Action<MonitorRunner> configureTool = null)
+            Action<MonitorRunner> configureTool = null,
+            bool disableHttpEgress = false)
         {
             DiagnosticPortHelper.Generate(
                 mode,
@@ -34,6 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests.Runners
             toolRunner.ConnectionMode = mode;
             toolRunner.DiagnosticPortPath = diagnosticPortPath;
             toolRunner.DisableAuthentication = true;
+            toolRunner.DisableHttpEgress = disableHttpEgress;
 
             configureTool?.Invoke(toolRunner);
 


### PR DESCRIPTION
Added in two test cases to ensure the proper error ensues when using the --no-http-egress flag for dumps and logs.
