### PR TITLE
Initial collection rule options, validation, and unit tests.

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -16,6 +16,16 @@
         }
       ]
     },
+    "CollectionRules": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "default": {},
+      "additionalProperties": {
+        "$ref": "#/definitions/CollectionRuleOptions"
+      }
+    },
     "CorsConfiguration": {
       "default": {},
       "oneOf": [
@@ -102,6 +112,188 @@
           "type": "string",
           "description": "Hash algorithm used to compute ApiKeyHash, typically 'SHA256'. 'SHA1' and 'MD5' are not allowed.",
           "minLength": 1
+        }
+      }
+    },
+    "CollectionRuleOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Trigger"
+      ],
+      "properties": {
+        "Filters": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Process filters used to determine to which process(es) the collection rule is applied. All filters must match. If no filters are specified, the rule is applied to all discovered processes.",
+          "items": {
+            "$ref": "#/definitions/ProcessFilterDescriptor"
+          }
+        },
+        "Trigger": {
+          "description": "The trigger to use to monitor for a condition in the target process.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CollectionRuleTriggerOptions"
+            }
+          ]
+        },
+        "Actions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of actions to be executed when the trigger raises its notification.",
+          "items": {
+            "$ref": "#/definitions/CollectionRuleActionOptions"
+          }
+        },
+        "Limits": {
+          "description": "The set of limits to constrain the execution of the rule and its components.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/CollectionRuleLimitsOptions"
+            }
+          ]
+        }
+      }
+    },
+    "ProcessFilterDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Key",
+        "Value"
+      ],
+      "properties": {
+        "Key": {
+          "description": "The criteria used to compare against the target process.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProcessFilterKey"
+            }
+          ]
+        },
+        "Value": {
+          "type": "string",
+          "description": "The value of the criteria used to compare against the target process.",
+          "minLength": 1
+        },
+        "MatchType": {
+          "description": "Type of match to use against the process criteria.",
+          "default": "Exact",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProcessFilterType"
+            }
+          ]
+        }
+      }
+    },
+    "ProcessFilterKey": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "ProcessId",
+        "ProcessName",
+        "CommandLine"
+      ],
+      "enum": [
+        "ProcessId",
+        "ProcessName",
+        "CommandLine"
+      ]
+    },
+    "ProcessFilterType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Exact",
+        "Contains"
+      ],
+      "enum": [
+        "Exact",
+        "Contains"
+      ]
+    },
+    "CollectionRuleTriggerOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Type"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "The type of trigger used to monitor for a condition in the target process.",
+          "minLength": 1
+        },
+        "Settings": {
+          "description": "The settings to pass to the trigger when it is executed. Settings may be optional if the trigger doesn't require settings or its settings are all optional.",
+          "oneOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "CollectionRuleActionOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Type"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "description": "The type of action to execute.",
+          "minLength": 1
+        },
+        "Settings": {
+          "description": "The settings to pass to the action when it is executed. Settings may be optional if the action doesn't require settings or its settings are all optional.",
+          "oneOf": [
+            {},
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "CollectionRuleLimitsOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ActionCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "The number of times the action list may be executed before being throttled.",
+          "format": "int32"
+        },
+        "ActionCountSlidingWindowDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The sliding window of time to consider whether the action list should be throttled based on the number of times the action list was executed. Executions that fall outside the window will not count toward the limit specified in the ActionCount setting.",
+          "format": "time-span"
+        },
+        "RuleDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The amount of time before the rule will stop monitoring a process after it has been applied to a process. If not specified, the rule will monitor the process with the trigger indefinitely.",
+          "format": "time-span"
         }
       }
     },
@@ -405,64 +597,6 @@
           }
         }
       }
-    },
-    "ProcessFilterDescriptor": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "Key",
-        "Value"
-      ],
-      "properties": {
-        "Key": {
-          "description": "The criteria used to compare against the target process.",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/ProcessFilterKey"
-            }
-          ]
-        },
-        "Value": {
-          "type": "string",
-          "description": "The value of the criteria used to compare against the target process.",
-          "minLength": 1
-        },
-        "MatchType": {
-          "description": "Type of match to use against the process criteria.",
-          "default": "Exact",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/ProcessFilterType"
-            }
-          ]
-        }
-      }
-    },
-    "ProcessFilterKey": {
-      "type": "string",
-      "description": "",
-      "x-enumNames": [
-        "ProcessId",
-        "ProcessName",
-        "CommandLine"
-      ],
-      "enum": [
-        "ProcessId",
-        "ProcessName",
-        "CommandLine"
-      ]
-    },
-    "ProcessFilterType": {
-      "type": "string",
-      "description": "",
-      "x-enumNames": [
-        "Exact",
-        "Contains"
-      ],
-      "enum": [
-        "Exact",
-        "Contains"
-      ]
     }
   }
 }

--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -30,9 +30,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj", "{886D1FD5-125F-435B-934C-30DF2938E7F6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema", "src\Tests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj", "{422ABBF6-6236-4042-AACA-09531DBDFBAA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema", "src\Tests\Microsoft.Diagnostics.Monitoring.ConfigurationSchema\Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj", "{422ABBF6-6236-4042-AACA-09531DBDFBAA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.WebApi.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.WebApi.UnitTests\Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.csproj", "{3AD0A40B-C569-4712-9764-7A788B9CD811}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.Tool.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.Tool.UnitTests\Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj", "{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -80,6 +82,10 @@ Global
 		{3AD0A40B-C569-4712-9764-7A788B9CD811}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3AD0A40B-C569-4712-9764-7A788B9CD811}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3AD0A40B-C569-4712-9764-7A788B9CD811}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -98,6 +104,7 @@ Global
 		{886D1FD5-125F-435B-934C-30DF2938E7F6} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{422ABBF6-6236-4042-AACA-09531DBDFBAA} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{3AD0A40B-C569-4712-9764-7A788B9CD811} = {C7568468-1C79-4944-8136-18812A7F9EA7}
+		{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,6 +53,7 @@
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>5.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationKeyPerFileVersion>5.0.2</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>5.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
@@ -11,8 +11,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal interface IEgressService
     {
+        bool CheckProvider(string providerName);
+
         Task<EgressResult> EgressAsync(
-            string endpointName,
+            string providerName,
             Func<CancellationToken, Task<Stream>> action,
             string fileName,
             string contentType,
@@ -20,7 +22,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             CancellationToken token);
 
         Task<EgressResult> EgressAsync(
-            string endpointName,
+            string providerName,
             Func<Stream, CancellationToken, Task> action,
             string fileName,
             string contentType,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OptionsDisplayStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class OptionsDisplayStrings {
@@ -139,6 +139,106 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_AzureBlobEgressProviderOptions_SharedAccessSignatureN" +
                         "ame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The settings to pass to the action when it is executed. Settings may be optional if the action doesn&apos;t require settings or its settings are all optional..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleActionOptions_Settings {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleActionOptions_Settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type of action to execute..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleActionOptions_Type {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleActionOptions_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of times the action list may be executed before being throttled..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCount {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The sliding window of time to consider whether the action list should be throttled based on the number of times the action list was executed. Executions that fall outside the window will not count toward the limit specified in the ActionCount setting..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCountSlidingWindowDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCountSlidingWindowD" +
+                        "uration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The amount of time before the rule will stop monitoring a process after it has been applied to a process. If not specified, the rule will monitor the process with the trigger indefinitely..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleLimitsOptions_RuleDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleLimitsOptions_RuleDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of actions to be executed when the trigger raises its notification..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleOptions_Actions {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleOptions_Actions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Process filters used to determine to which process(es) the collection rule is applied. All filters must match. If no filters are specified, the rule is applied to all discovered processes..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleOptions_Filters {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleOptions_Filters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The set of limits to constrain the execution of the rule and its components..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleOptions_Limits {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleOptions_Limits", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trigger to use to monitor for a condition in the target process..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleOptions_Trigger {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleOptions_Trigger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The settings to pass to the trigger when it is executed. Settings may be optional if the trigger doesn&apos;t require settings or its settings are all optional..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleTriggerOptions_Settings {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleTriggerOptions_Settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type of trigger used to monitor for a condition in the target process..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectionRuleTriggerOptions_Type {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleTriggerOptions_Type", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OptionsDisplayStrings.resx
@@ -153,6 +153,50 @@
     <value>The name of the shared access signature (SAS) used to look up the value from the Egress options Properties map.</value>
     <comment>The description provided for the SharedAccessSignatureName parameter on AzureBlobEgressProviderOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_CollectionRuleActionOptions_Settings" xml:space="preserve">
+    <value>The settings to pass to the action when it is executed. Settings may be optional if the action doesn't require settings or its settings are all optional.</value>
+    <comment>The description provided for the Settings parameter on CollectionRuleActionOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleActionOptions_Type" xml:space="preserve">
+    <value>The type of action to execute.</value>
+    <comment>The description provided for the Type parameter on CollectionRuleActionOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCount" xml:space="preserve">
+    <value>The number of times the action list may be executed before being throttled.</value>
+    <comment>The description provided for the ActionCount parameter on CollectionRuleLimitsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCountSlidingWindowDuration" xml:space="preserve">
+    <value>The sliding window of time to consider whether the action list should be throttled based on the number of times the action list was executed. Executions that fall outside the window will not count toward the limit specified in the ActionCount setting.</value>
+    <comment>The description provided for the ActionCountSlidingWindowDuration parameter on CollectionRuleLimitsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleLimitsOptions_RuleDuration" xml:space="preserve">
+    <value>The amount of time before the rule will stop monitoring a process after it has been applied to a process. If not specified, the rule will monitor the process with the trigger indefinitely.</value>
+    <comment>The description provided for the RuleDuration parameter on CollectionRuleLimitsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleOptions_Actions" xml:space="preserve">
+    <value>The list of actions to be executed when the trigger raises its notification.</value>
+    <comment>The description provided for the Actions parameter on CollectionRuleOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleOptions_Filters" xml:space="preserve">
+    <value>Process filters used to determine to which process(es) the collection rule is applied. All filters must match. If no filters are specified, the rule is applied to all discovered processes.</value>
+    <comment>The description provided for the Filters parameter on CollectionRuleOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleOptions_Limits" xml:space="preserve">
+    <value>The set of limits to constrain the execution of the rule and its components.</value>
+    <comment>The description provided for the Limits parameter on CollectionRuleOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleOptions_Trigger" xml:space="preserve">
+    <value>The trigger to use to monitor for a condition in the target process.</value>
+    <comment>The description provided for the Trigger parameter on CollectionRuleOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleTriggerOptions_Settings" xml:space="preserve">
+    <value>The settings to pass to the trigger when it is executed. Settings may be optional if the trigger doesn't require settings or its settings are all optional.</value>
+    <comment>The description provided for the Settings parameter on CollectionRuleTriggerOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectionRuleTriggerOptions_Type" xml:space="preserve">
+    <value>The type of trigger used to monitor for a condition in the target process.</value>
+    <comment>The description provided for the Type parameter on CollectionRuleTriggerOptions.</comment>
+  </data>
   <data name="DisplayAttributeDescription_CommonEgressProviderOptions_CopyBufferSize" xml:space="preserve">
     <value>Buffer size used when copying data from an egress callback returning a stream to the egress callback that is provided a stream to which data is written.</value>
     <comment>The description provided for the CopyBufferSize parameter on all egress provider options.</comment>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net50</TargetFramework>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net50</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />
     <PackageReference Include="Microsoft.FileFormats" Version="$(MicrosoftFileFormatsVersion)" />
   </ItemGroup>
 
@@ -61,11 +62,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.ConfigurationSchema" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Options\CollectionRules\Actions\" />
-    <Folder Include="Options\CollectionRules\Triggers\" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -24,10 +24,26 @@
     <Compile Include="..\..\Tools\dotnet-monitor\Auth\ApiAuthenticationOptions.cs" Link="Options\ApiAuthenticationOptions.cs" />
     <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\DiagnosticPortOptions.cs" Link="Options\DiagnosticPortOptions.cs" />
     <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\DiagnosticPortOptionsDefaults.cs" Link="Options\DiagnosticPortOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ActionOptionsConstants.cs" Link="Options\CollectionRules\Actions\ActionOptionsConstants.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectDumpOptions.cs" Link="Options\CollectionRules\Actions\CollectDumpOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectGCDumpOptions.cs" Link="Options\CollectionRules\Actions\CollectGCDumpOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectLogsOptions.cs" Link="Options\CollectionRules\Actions\CollectLogsOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptions.cs" Link="Options\CollectionRules\Actions\CollectTraceOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptions.cs" Link="Options\CollectionRules\Actions\ExecuteOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptions.cs" Link="Options\CollectionRules\CollectionRuleActionOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptions.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptions.cs" Link="Options\CollectionRules\CollectionRuleOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleTriggerOptions.cs" Link="Options\CollectionRules\CollectionRuleTriggerOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestCountOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestCountOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestDurationOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestDurationOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptions.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptions.cs" Link="Options\CollectionRules\Triggers\EventCounterOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\TriggerOptionsConstants.cs" Link="Options\CollectionRules\Triggers\TriggerOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\EgressOptions.cs" Link="Options\EgressOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\Egress\AzureBlob\AzureBlobEgressProviderOptions.cs" Link="Options\AzureBlobEgressProviderOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\Egress\FileSystem\FileSystemEgressProviderOptions.cs" Link="Options\FileSystemEgressProviderOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\Egress\IEgressProviderCommonOptions.cs" Link="Options\IEgressProviderCommonOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\RootOptions.cs" Link="Options\RootOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,6 +60,11 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.ConfigurationSchema" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Options\CollectionRules\Actions\" />
+    <Folder Include="Options\CollectionRules\Triggers\" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptions.cs" Link="Options\CollectionRules\CollectionRuleActionOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptions.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptions.cs" Link="Options\CollectionRules\CollectionRuleOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptionsConstants.cs" Link="Options\CollectionRules\CollectionRuleOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleTriggerOptions.cs" Link="Options\CollectionRules\CollectionRuleTriggerOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestCountOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestCountOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestDurationOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestDurationOptions.cs" />

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,13 +16,13 @@ using System.Text;
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
-using Microsoft.Extensions.Configuration;
 #endif
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 {
     internal static class OptionsExtensions
     {
+        private const string EnvironmentVariablePrefix = "DotnetMonitor_";
         private const string KeySegmentSeparator = "__";
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
         public static IDictionary<string, string> ToEnvironmentConfiguration(this RootOptions options)
         {
             Dictionary<string, string> variables = new(StringComparer.OrdinalIgnoreCase);
-            MapObject(options, DiagnosticsMonitorCommandHandler.ConfigPrefix, KeySegmentSeparator, variables);
+            MapObject(options, EnvironmentVariablePrefix, KeySegmentSeparator, variables);
             return variables;
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -15,12 +15,15 @@ using System.Text;
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
+using Microsoft.Extensions.Configuration;
 #endif
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 {
     internal static class OptionsExtensions
     {
+        private const string KeySegmentSeparator = "__";
+
         /// <summary>
         /// Generates an environment variable map of the options.
         /// </summary>
@@ -30,14 +33,20 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
         public static IDictionary<string, string> ToEnvironmentConfiguration(this RootOptions options)
         {
             Dictionary<string, string> variables = new(StringComparer.OrdinalIgnoreCase);
-            MapObject(options, "DotNetMonitor_", "__", variables);
+            MapObject(options, DiagnosticsMonitorCommandHandler.ConfigPrefix, KeySegmentSeparator, variables);
             return variables;
         }
 
+        /// <summary>
+        /// Generates a map of options that can be passed directly to configuration via an in-memory collection.
+        /// </summary>
+        /// <remarks>
+        /// Each key is the configuration path; each value is the configuration path value.
+        /// </remarks>
         public static IDictionary<string, string> ToConfigurationValues(this RootOptions options)
         {
             Dictionary<string, string> variables = new(StringComparer.OrdinalIgnoreCase);
-            MapObject(options, string.Empty, ":", variables);
+            MapObject(options, string.Empty, ConfigurationPath.KeyDelimiter, variables);
             return variables;
         }
 
@@ -50,7 +59,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
         public static IDictionary<string, string> ToKeyPerFileConfiguration(this RootOptions options)
         {
             Dictionary<string, string> variables = new(StringComparer.OrdinalIgnoreCase);
-            MapObject(options, string.Empty, "__", variables);
+            MapObject(options, string.Empty, KeySegmentSeparator, variables);
             return variables;
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 rootOptions =>
                 {
                     rootOptions.CreateCollectionRule(DefaultRuleName)
-                        .AddExecuteAction("echo");
+                        .AddExecuteAction("cmd.exe");
                 },
                 ex =>
                 {
@@ -666,7 +666,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public Task CollectionRuleOptions_ExecuteAction_MinimumOptions()
         {
-            const string ExpectedExePath = "echo";
+            const string ExpectedExePath = "cmd.exe";
 
             return ValidateSuccess(
                 rootOptions =>
@@ -685,8 +685,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public Task CollectionRuleOptions_ExecuteAction_RoundTrip()
         {
-            const string ExpectedExePath = "echo";
-            const string ExpectedArguments = "\"Hello\"";
+            const string ExpectedExePath = "cmd.exe";
+            const string ExpectedArguments = "/c \"echo Hello\"";
 
             return ValidateSuccess(
                 rootOptions =>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -1,0 +1,884 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
+using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Globalization;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    public sealed class CollectionRuleOptionsTests
+    {
+        private const string DefaultRuleName = "TestRule";
+        private const string UnknownEgressName = "UnknownEgress";
+
+        private readonly ITestOutputHelper _outputHelper;
+
+        public CollectionRuleOptionsTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_MinimumOptions()
+        {
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger();
+                },
+                ruleOptions =>
+                {
+                    Assert.Empty(ruleOptions.Filters);
+
+                    ruleOptions.VerifyStartupTrigger();
+
+                    Assert.Empty(ruleOptions.Actions);
+
+                    Assert.Null(ruleOptions.Limits);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_NoTrigger()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .AddExecuteAction("echo");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(CollectionRuleOptions.Trigger));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_UnknownTrigger()
+        {
+            const string ExpectedTriggerType = "UnknownTrigger";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetTrigger(ExpectedTriggerType);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyUnknownTriggerTypeMessage(failures, 0, ExpectedTriggerType);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_UnknownAction()
+        {
+            const string ExpectedActionType = "UnknownAction";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddAction(ExpectedActionType);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyUnknownActionTypeMessage(failures, 0, ExpectedActionType);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_EventCounterTrigger_MinimumOptions()
+        {
+            const string ExpectedProviderName = "System.Runtime";
+            const string ExpectedCounterName = "cpu-usage";
+            const double ExpectedGreaterThan = 0.5;
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetEventCounterTrigger(out EventCounterOptions eventCounterOptions);
+
+                    eventCounterOptions.ProviderName = ExpectedProviderName;
+                    eventCounterOptions.CounterName = ExpectedCounterName;
+                    eventCounterOptions.GreaterThan = ExpectedGreaterThan;
+                },
+                ruleOptions =>
+                {
+                    EventCounterOptions eventCounterOptions = ruleOptions.VerifyEventCounterTrigger();
+                    Assert.Equal(ExpectedProviderName, eventCounterOptions.ProviderName);
+                    Assert.Equal(ExpectedCounterName, eventCounterOptions.CounterName);
+                    Assert.Equal(ExpectedGreaterThan, eventCounterOptions.GreaterThan);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_EventCounterTrigger_RoundTrip()
+        {
+            const string ExpectedProviderName = "System.Runtime";
+            const string ExpectedCounterName = "cpu-usage";
+            const double ExpectedGreaterThan = 0.5;
+            const double ExpectedLessThan = 0.75;
+            TimeSpan ExpectedDuration = TimeSpan.FromSeconds(30);
+            const int ExpectedFrequency = 5;
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetEventCounterTrigger(out EventCounterOptions eventCounterOptions);
+
+                    eventCounterOptions.ProviderName = ExpectedProviderName;
+                    eventCounterOptions.CounterName = ExpectedCounterName;
+                    eventCounterOptions.GreaterThan = ExpectedGreaterThan;
+                    eventCounterOptions.LessThan = ExpectedLessThan;
+                    eventCounterOptions.SlidingWindowDuration = ExpectedDuration;
+                    eventCounterOptions.Frequency = ExpectedFrequency;
+                },
+                ruleOptions =>
+                {
+                    EventCounterOptions eventCounterOptions = ruleOptions.VerifyEventCounterTrigger();
+                    Assert.Equal(ExpectedProviderName, eventCounterOptions.ProviderName);
+                    Assert.Equal(ExpectedCounterName, eventCounterOptions.CounterName);
+                    Assert.Equal(ExpectedGreaterThan, eventCounterOptions.GreaterThan);
+                    Assert.Equal(ExpectedLessThan, eventCounterOptions.LessThan);
+                    Assert.Equal(ExpectedDuration, eventCounterOptions.SlidingWindowDuration);
+                    Assert.Equal(ExpectedFrequency, eventCounterOptions.Frequency);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_EventCounterTrigger_PropertyValidation()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetEventCounterTrigger(out EventCounterOptions eventCounterOptions);
+
+                    eventCounterOptions.SlidingWindowDuration = TimeSpan.FromSeconds(-1);
+                    eventCounterOptions.Frequency = -1;
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    // Property validation failures will short-circuit the remainder of the validation
+                    // rules, thus only observe 4 errors when one might expect 5 (the fifth being that
+                    // either GreaterThan or LessThan should be specified).
+                    Assert.Equal(4, failures.Length);
+                    VerifyRequiredMessage(failures, 0, nameof(EventCounterOptions.ProviderName));
+                    VerifyRequiredMessage(failures, 1, nameof(EventCounterOptions.CounterName));
+                    VerifyRangeMessage(failures, 2, nameof(EventCounterOptions.SlidingWindowDuration),
+                        TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue);
+                    VerifyRangeMessage(failures, 3, nameof(EventCounterOptions.Frequency),
+                        TriggerOptionsConstants.Frequency_MinValue_String, TriggerOptionsConstants.Frequency_MaxValue_String);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_EventCounterTrigger_NoGreaterThanOrLessThan()
+        {
+            const string ExpectedProviderName = "System.Runtime";
+            const string ExpectedCounterName = "cpu-usage";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetEventCounterTrigger(out EventCounterOptions eventCounterOptions);
+
+                    eventCounterOptions.ProviderName = ExpectedProviderName;
+                    eventCounterOptions.CounterName = ExpectedCounterName;
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyEitherRequiredMessage(failures, 0,
+                        nameof(EventCounterOptions.GreaterThan), nameof(EventCounterOptions.LessThan));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_EventCounterTrigger_GreaterThanLargerThanLessThan()
+        {
+            const string ExpectedProviderName = "System.Runtime";
+            const string ExpectedCounterName = "cpu-usage";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetEventCounterTrigger(out EventCounterOptions eventCounterOptions);
+
+                    eventCounterOptions.ProviderName = ExpectedProviderName;
+                    eventCounterOptions.CounterName = ExpectedCounterName;
+                    eventCounterOptions.GreaterThan = 0.75;
+                    eventCounterOptions.LessThan = 0.5;
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyFieldLessThanOtherFieldMessage(failures, 0, nameof(EventCounterOptions.GreaterThan), nameof(EventCounterOptions.LessThan));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectDumpAction_RoundTrip()
+        {
+            const DumpType ExpectedDumpType = DumpType.Mini;
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectDumpAction(ExpectedDumpType, ExpectedEgressProvider);
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    ruleOptions.VerifyCollectDumpAction(0, ExpectedDumpType, ExpectedEgressProvider);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectDumpAction_PropertyValidation()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectDumpAction((DumpType)20, UnknownEgressName);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Equal(2, failures.Length);
+                    VerifyEnumDataTypeMessage(failures, 0, nameof(CollectDumpOptions.Type));
+                    VerifyEgressNotExistMessage(failures, 1, UnknownEgressName);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectGCDumpAction_RoundTrip()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectGCDumpAction(ExpectedEgressProvider);
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    ruleOptions.VerifyCollectGCDumpAction(0, ExpectedEgressProvider);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectGCDumpAction_PropertyValidation()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectGCDumpAction(UnknownEgressName);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyEgressNotExistMessage(failures, 0, UnknownEgressName);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectLogsAction_MinimumOptions()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectLogsAction(ExpectedEgressProvider);
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    ruleOptions.VerifyCollectLogsAction(0, ExpectedEgressProvider);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectLogsAction_RoundTrip()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+            const bool ExpectedUseAppFilters = true;
+            const LogLevel ExpectedLogLevel = LogLevel.Debug;
+            Dictionary<string, LogLevel?> ExpectedFilterSpecs = new()
+            {
+                { "CategoryA", LogLevel.Information },
+                { "CategoryA.SubCategoryA", LogLevel.Warning }
+            };
+            TimeSpan ExpectedDuration = TimeSpan.FromMinutes(2);
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectLogsAction(ExpectedEgressProvider, out CollectLogsOptions collectLogsOptions);
+
+                    collectLogsOptions.UseAppFilters = ExpectedUseAppFilters;
+                    collectLogsOptions.LogLevel = ExpectedLogLevel;
+                    collectLogsOptions.FilterSpecs = ExpectedFilterSpecs;
+                    collectLogsOptions.Duration = ExpectedDuration;
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    CollectLogsOptions collectLogsOptions = ruleOptions.VerifyCollectLogsAction(0, ExpectedEgressProvider);
+                    Assert.Equal(ExpectedUseAppFilters, collectLogsOptions.UseAppFilters);
+                    Assert.Equal(ExpectedLogLevel, collectLogsOptions.LogLevel);
+                    Assert.NotNull(collectLogsOptions.FilterSpecs);
+                    Assert.Equal(ExpectedFilterSpecs.Count, collectLogsOptions.FilterSpecs.Count);
+                    foreach ((string expectedCategory, LogLevel? expectedLogLevel) in ExpectedFilterSpecs)
+                    {
+                        Assert.True(collectLogsOptions.FilterSpecs.TryGetValue(expectedCategory, out LogLevel? actualLogLevel));
+                        Assert.Equal(expectedLogLevel, actualLogLevel);
+                    }
+                    Assert.Equal(ExpectedDuration, collectLogsOptions.Duration);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectLogsAction_PropertyValidation()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectLogsAction(egress: null, out CollectLogsOptions collectLogsOptions);
+
+                    collectLogsOptions.LogLevel = (LogLevel)100;
+                    collectLogsOptions.Duration = TimeSpan.FromDays(3);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Equal(3, failures.Length);
+                    VerifyEnumDataTypeMessage(failures, 0, nameof(CollectLogsOptions.LogLevel));
+                    VerifyRangeMessage(failures, 1, nameof(CollectLogsOptions.Duration),
+                        ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue);
+                    VerifyRequiredMessage(failures, 2, nameof(CollectLogsOptions.Egress));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectLogsAction_FilterSpecValidation()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectLogsAction(ExpectedEgressProvider, out CollectLogsOptions collectLogsOptions);
+
+                    collectLogsOptions.FilterSpecs = new Dictionary<string, LogLevel?>()
+                    {
+                        { "CategoryA", (LogLevel)50 }
+                    };
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyEnumDataTypeMessage(failures, 0, nameof(CollectLogsOptions.FilterSpecs));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_MinimumOptions_Profile()
+        {
+            const TraceProfile ExpectedProfile = TraceProfile.Http;
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(ExpectedProfile, ExpectedEgressProvider);
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    ruleOptions.VerifyCollectTraceAction(0, ExpectedProfile, ExpectedEgressProvider);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_MinimumOptions_Providers()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+            List<EventPipeProvider> ExpectedProviders = new()
+            {
+                new() { Name = "Microsoft-Extensions-Logging" }
+            };
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(ExpectedProviders, ExpectedEgressProvider);
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    ruleOptions.VerifyCollectTraceAction(0, ExpectedProviders, ExpectedEgressProvider);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_RoundTrip_Profile()
+        {
+            const TraceProfile ExpectedProfile = TraceProfile.Logs;
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+            TimeSpan ExpectedDuration = TimeSpan.FromSeconds(45);
+            const int ExpectedMetricsIntervalSeconds = 3;
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(ExpectedProfile, ExpectedEgressProvider, out CollectTraceOptions collectTraceOptions);
+
+                    collectTraceOptions.Duration = ExpectedDuration;
+                    collectTraceOptions.MetricsIntervalSeconds = ExpectedMetricsIntervalSeconds;
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    CollectTraceOptions collectTraceOptions = ruleOptions.VerifyCollectTraceAction(0, ExpectedProfile, ExpectedEgressProvider);
+
+                    Assert.Equal(ExpectedDuration, collectTraceOptions.Duration);
+                    Assert.Equal(ExpectedMetricsIntervalSeconds, collectTraceOptions.MetricsIntervalSeconds);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_RoundTrip_Providers()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+            List<EventPipeProvider> ExpectedProviders = new()
+            {
+                new()
+                {
+                    Name = "Microsoft-Extensions-Logging",
+                    EventLevel = EventLevel.Warning,
+                    Keywords = "0xC",
+                    Arguments = new Dictionary<string, string>()
+                    {
+                        { "FilterSpecs", "UseAppFilters" }
+                    }
+                }
+            };
+            TimeSpan ExpectedDuration = TimeSpan.FromSeconds(20);
+            const int ExpectedBufferSizeMegabytes = 128;
+            const bool ExpectedRequestRundown = false;
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(ExpectedProviders, ExpectedEgressProvider, out CollectTraceOptions collectTraceOptions);
+
+                    collectTraceOptions.BufferSizeMegabytes = ExpectedBufferSizeMegabytes;
+                    collectTraceOptions.Duration = ExpectedDuration;
+                    collectTraceOptions.RequestRundown = ExpectedRequestRundown;
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ruleOptions =>
+                {
+                    CollectTraceOptions collectTraceOptions = ruleOptions.VerifyCollectTraceAction(0, ExpectedProviders, ExpectedEgressProvider);
+
+                    Assert.Equal(ExpectedBufferSizeMegabytes, collectTraceOptions.BufferSizeMegabytes);
+                    Assert.Equal(ExpectedDuration, collectTraceOptions.Duration);
+                    Assert.Equal(ExpectedRequestRundown, collectTraceOptions.RequestRundown);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_PropertyValidation()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction((TraceProfile)75, egress: null, out CollectTraceOptions collectTraceOptions);
+
+                    collectTraceOptions.BufferSizeMegabytes = 2048;
+                    collectTraceOptions.Duration = TimeSpan.FromDays(7);
+                    collectTraceOptions.MetricsIntervalSeconds = (int)TimeSpan.FromDays(3).TotalSeconds;
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Equal(5, failures.Length);
+                    VerifyEnumDataTypeMessage(failures, 0, nameof(CollectTraceOptions.Profile));
+                    VerifyRangeMessage(failures, 1, nameof(CollectTraceOptions.MetricsIntervalSeconds),
+                        ActionOptionsConstants.MetricsIntervalSeconds_MinValue_String, ActionOptionsConstants.MetricsIntervalSeconds_MaxValue_String);
+                    VerifyRangeMessage(failures, 2, nameof(CollectTraceOptions.BufferSizeMegabytes),
+                        ActionOptionsConstants.BufferSizeMegabytes_MinValue_String, ActionOptionsConstants.BufferSizeMegabytes_MaxValue_String);
+                    VerifyRangeMessage(failures, 3, nameof(CollectTraceOptions.Duration),
+                        ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue);
+                    VerifyRequiredMessage(failures, 4, nameof(CollectTraceOptions.Egress));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_NoProfileOrProviders()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(Enumerable.Empty<EventPipeProvider>(), ExpectedEgressProvider);
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyEitherRequiredMessage(failures, 0,
+                        nameof(CollectTraceOptions.Profile), nameof(CollectTraceOptions.Providers));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_BothProfileAndProviders()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(TraceProfile.Metrics, ExpectedEgressProvider, out CollectTraceOptions collectTraceOptions);
+
+                    collectTraceOptions.Providers = new List<EventPipeProvider>()
+                    {
+                        new() { Name = "Microsoft-Extensions-Logging" }
+                    };
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyBothCannotBeSpecifiedMessage(failures, 0,
+                        nameof(CollectTraceOptions.Profile), nameof(CollectTraceOptions.Providers));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_CollectTraceAction_ProviderPropertyValidation()
+        {
+            const string ExpectedEgressProvider = "TmpEgressProvider";
+            List<EventPipeProvider> ExpectedProviders = new()
+            {
+                new() { Keywords = null }
+            };
+
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCollectTraceAction(ExpectedProviders, ExpectedEgressProvider);
+
+                    rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(EventPipeProvider.Name));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_ExecuteAction_MinimumOptions()
+        {
+            const string ExpectedExePath = "echo";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddExecuteAction(ExpectedExePath);
+                },
+                ruleOptions =>
+                {
+                    Assert.Single(ruleOptions.Actions);
+                    ruleOptions.VerifyExecuteAction(0, ExpectedExePath);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_ExecuteAction_RoundTrip()
+        {
+            const string ExpectedExePath = "echo";
+            const string ExpectedArguments = "\"Hello\"";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddExecuteAction(ExpectedExePath, ExpectedArguments);
+                },
+                ruleOptions =>
+                {
+                    Assert.Single(ruleOptions.Actions);
+                    ruleOptions.VerifyExecuteAction(0, ExpectedExePath, ExpectedArguments);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_ExecuteAction_PropertyValidation()
+        {
+            return ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddExecuteAction(path: null, "arg1 arg2");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(ExecuteOptions.Path));
+                });
+        }
+
+        private async Task Validate(
+            Action<RootOptions> setup,
+            Action<IOptionsMonitor<CollectionRuleOptions>> validate)
+        {
+            using IHost host = new HostBuilder()
+                .ConfigureAppConfiguration(builder =>
+                {
+                    RootOptions options = new();
+                    setup(options);
+
+                    IDictionary<string, string> configurationValues = options.ToConfigurationValues();
+                    _outputHelper.WriteLine("Begin Configuration:");
+                    foreach ((string key, string value) in configurationValues)
+                    {
+                        _outputHelper.WriteLine("{0} = {1}", key, value);
+                    }
+                    _outputHelper.WriteLine("End Configuration");
+
+                    builder.AddInMemoryCollection(configurationValues);
+                })
+                .ConfigureServices(services =>
+                {
+                    services.ConfigureCollectionRules();
+                    services.ConfigureEgress();
+                })
+                .Build();
+
+            try
+            {
+                validate(host.Services.GetRequiredService<IOptionsMonitor<CollectionRuleOptions>>());
+            }
+            finally
+            {
+                if (host is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else
+                {
+                    host.Dispose();
+                }
+            }
+        }
+
+        private Task ValidateSuccess(
+            Action<RootOptions> setup,
+            Action<CollectionRuleOptions> validate)
+        {
+            return Validate(
+                setup,
+                monitor => validate(monitor.Get(DefaultRuleName)));
+        }
+
+        private Task ValidateFailure(
+            Action<RootOptions> setup,
+            Action<OptionsValidationException> validate)
+        {
+            return Validate(
+                setup,
+                monitor =>
+                {
+                    OptionsValidationException ex = Assert.Throws<OptionsValidationException>(() => monitor.Get(DefaultRuleName));
+                    _outputHelper.WriteLine("Exception: {0}", ex.Message);
+                    validate(ex);
+                });
+        }
+
+        private static void VerifyUnknownActionTypeMessage(string[] failures, int index, string actionType)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.ErrorMessage_UnknownActionType,
+                actionType);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyUnknownTriggerTypeMessage(string[] failures, int index, string triggerType)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.ErrorMessage_UnknownTriggerType,
+                triggerType);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyRequiredMessage(string[] failures, int index, string fieldName)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                "The {0} field is required.",
+                fieldName);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyEnumDataTypeMessage(string[] failures, int index, string fieldName)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                "The field {0} is invalid.",
+                fieldName);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyRangeMessage(string[] failures, int index, string fieldName, string min, string max)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                "The field {0} must be between {1} and {2}.",
+                fieldName,
+                min,
+                max);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyEitherRequiredMessage(string[] failures, int index, string fieldName1, string fieldName2)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.ErrorMessage_TwoFieldsMissing,
+                fieldName1,
+                fieldName2);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyBothCannotBeSpecifiedMessage(string[] failures, int index, string fieldName1, string fieldName2)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.ErrorMessage_TwoFieldsCannotBeSpecified,
+                fieldName1,
+                fieldName2);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyFieldLessThanOtherFieldMessage(string[] failures, int index, string fieldName1, string fieldName2)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.ErrorMessage_FieldMustBeLessThanOtherField,
+                fieldName1,
+                fieldName2);
+
+            Assert.Equal(message, failures[index]);
+        }
+
+        private static void VerifyEgressNotExistMessage(string[] failures, int index, string egressProvider)
+        {
+            string message = string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.ErrorMessage_EgressProviderDoesNotExist,
+                egressProvider);
+
+            Assert.Equal(message, failures[index]);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests\Options\OptionsExtensions.cs" Link="Options\OptionsExtensions.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj" />
+        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
@@ -1,0 +1,270 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+{
+    internal static class CollectionRuleOptionsExtensions
+    {
+        public static CollectionRuleOptions AddAction(this CollectionRuleOptions options, string type)
+        {
+            return options.AddAction(type, out _);
+        }
+
+        public static CollectionRuleOptions AddAction(this CollectionRuleOptions options, string type, out CollectionRuleActionOptions actionOptions)
+        {
+            actionOptions = new();
+            actionOptions.Type = type;
+
+            options.Actions.Add(actionOptions);
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddCollectDumpAction(this CollectionRuleOptions options, DumpType type, string egress)
+        {
+            options.AddAction(KnownCollectionRuleActions.CollectDump, out CollectionRuleActionOptions actionOptions);
+
+            CollectDumpOptions collectDumpOptions = new();
+            collectDumpOptions.Egress = egress;
+            collectDumpOptions.Type = type;
+
+            actionOptions.Settings = collectDumpOptions;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddCollectGCDumpAction(this CollectionRuleOptions options, string egress)
+        {
+            options.AddAction(KnownCollectionRuleActions.CollectGCDump, out CollectionRuleActionOptions actionOptions);
+
+            CollectGCDumpOptions collectGCDumpOptions = new();
+            collectGCDumpOptions.Egress = egress;
+
+            actionOptions.Settings = collectGCDumpOptions;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddCollectLogsAction(this CollectionRuleOptions options, string egress)
+        {
+            return options.AddCollectLogsAction(egress, out _);
+        }
+
+        public static CollectionRuleOptions AddCollectLogsAction(this CollectionRuleOptions options, string egress, out CollectLogsOptions collectLogsOptions)
+        {
+            options.AddAction(KnownCollectionRuleActions.CollectLogs, out CollectionRuleActionOptions actionOptions);
+
+            collectLogsOptions = new();
+            collectLogsOptions.Egress = egress;
+
+            actionOptions.Settings = collectLogsOptions;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddCollectTraceAction(this CollectionRuleOptions options, TraceProfile profile, string egress)
+        {
+            return options.AddCollectTraceAction(profile, egress, out _);
+        }
+
+        public static CollectionRuleOptions AddCollectTraceAction(this CollectionRuleOptions options, TraceProfile profile, string egress, out CollectTraceOptions collectTraceOptions)
+        {
+            options.AddAction(KnownCollectionRuleActions.CollectTrace, out CollectionRuleActionOptions actionOptions);
+
+            collectTraceOptions = new();
+            collectTraceOptions.Profile = profile;
+            collectTraceOptions.Egress = egress;
+
+            actionOptions.Settings = collectTraceOptions;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddCollectTraceAction(this CollectionRuleOptions options, IEnumerable<EventPipeProvider> providers, string egress)
+        {
+            return options.AddCollectTraceAction(providers, egress, out _);
+        }
+
+        public static CollectionRuleOptions AddCollectTraceAction(this CollectionRuleOptions options, IEnumerable<EventPipeProvider> providers, string egress, out CollectTraceOptions collectTraceOptions)
+        {
+            options.AddAction(KnownCollectionRuleActions.CollectTrace, out CollectionRuleActionOptions actionOptions);
+
+            collectTraceOptions = new();
+            collectTraceOptions.Providers = new List<EventPipeProvider>(providers);
+            collectTraceOptions.Egress = egress;
+
+            actionOptions.Settings = collectTraceOptions;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddExecuteAction(this CollectionRuleOptions options, string path, string arguments = null)
+        {
+            options.AddAction(KnownCollectionRuleActions.Execute, out CollectionRuleActionOptions actionOptions);
+
+            ExecuteOptions executeOptions = new();
+            executeOptions.Arguments = arguments;
+            executeOptions.Path = path;
+
+            actionOptions.Settings = executeOptions;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions SetEventCounterTrigger(this CollectionRuleOptions options, out EventCounterOptions settings)
+        {
+            SetTrigger(options, KnownCollectionRuleTriggers.EventCounter, out CollectionRuleTriggerOptions triggerOptions);
+
+            settings = new();
+
+            triggerOptions.Settings = settings;
+
+            return options;
+        }
+
+        public static CollectionRuleOptions SetStartupTrigger(this CollectionRuleOptions options)
+        {
+            return SetTrigger(options, KnownCollectionRuleTriggers.Startup, out _);
+        }
+
+        public static CollectionRuleOptions SetTrigger(this CollectionRuleOptions options, string type)
+        {
+            return options.SetTrigger(type, out _);
+        }
+
+        public static CollectionRuleOptions SetTrigger(this CollectionRuleOptions options, string type, out CollectionRuleTriggerOptions triggerOptions)
+        {
+            triggerOptions = new();
+            triggerOptions.Type = type;
+
+            options.Trigger = triggerOptions;
+
+            return options;
+        }
+
+        public static EventCounterOptions VerifyEventCounterTrigger(this CollectionRuleOptions ruleOptions)
+        {
+            ruleOptions.VerifyTrigger(KnownCollectionRuleTriggers.EventCounter);
+            return Assert.IsType<EventCounterOptions>(ruleOptions.Trigger.Settings);
+        }
+
+        public static void VerifyStartupTrigger(this CollectionRuleOptions ruleOptions)
+        {
+            ruleOptions.VerifyTrigger(KnownCollectionRuleTriggers.Startup);
+            Assert.Null(ruleOptions.Trigger.Settings);
+        }
+
+        private static void VerifyTrigger(this CollectionRuleOptions ruleOptions, string triggerType)
+        {
+            Assert.NotNull(ruleOptions.Trigger);
+            Assert.Equal(triggerType, ruleOptions.Trigger.Type);
+        }
+
+        public static CollectDumpOptions VerifyCollectDumpAction(this CollectionRuleOptions ruleOptions, int actionIndex, DumpType expectedDumpType, string expectedEgress)
+        {
+            CollectDumpOptions collectDumpOptions = ruleOptions.VerifyAction<CollectDumpOptions>(
+                actionIndex, KnownCollectionRuleActions.CollectDump);
+
+            Assert.Equal(expectedDumpType, collectDumpOptions.Type);
+            Assert.Equal(expectedEgress, collectDumpOptions.Egress);
+
+            return collectDumpOptions;
+        }
+
+        public static CollectGCDumpOptions VerifyCollectGCDumpAction(this CollectionRuleOptions ruleOptions, int actionIndex, string expectedEgress)
+        {
+            CollectGCDumpOptions collectGCDumpOptions = ruleOptions.VerifyAction<CollectGCDumpOptions>(
+                actionIndex, KnownCollectionRuleActions.CollectGCDump);
+
+            Assert.Equal(expectedEgress, collectGCDumpOptions.Egress);
+
+            return collectGCDumpOptions;
+        }
+
+        public static CollectLogsOptions VerifyCollectLogsAction(this CollectionRuleOptions ruleOptions, int actionIndex, string expectedEgress)
+        {
+            CollectLogsOptions collectLogsOptions = ruleOptions.VerifyAction<CollectLogsOptions>(
+                actionIndex, KnownCollectionRuleActions.CollectLogs);
+
+            Assert.Equal(expectedEgress, collectLogsOptions.Egress);
+
+            return collectLogsOptions;
+        }
+
+        public static CollectTraceOptions VerifyCollectTraceAction(this CollectionRuleOptions ruleOptions, int actionIndex, TraceProfile expectedProfile, string expectedEgress)
+        {
+            CollectTraceOptions collectTraceOptions = ruleOptions.VerifyAction<CollectTraceOptions>(
+                actionIndex, KnownCollectionRuleActions.CollectTrace);
+
+            Assert.Equal(expectedProfile, collectTraceOptions.Profile);
+            Assert.Equal(expectedEgress, collectTraceOptions.Egress);
+
+            return collectTraceOptions;
+        }
+
+        public static CollectTraceOptions VerifyCollectTraceAction(this CollectionRuleOptions ruleOptions, int actionIndex, IEnumerable<EventPipeProvider> providers, string expectedEgress)
+        {
+            CollectTraceOptions collectTraceOptions = ruleOptions.VerifyAction<CollectTraceOptions>(
+                actionIndex, KnownCollectionRuleActions.CollectTrace);
+
+            Assert.Equal(expectedEgress, collectTraceOptions.Egress);
+            Assert.NotNull(collectTraceOptions.Providers);
+            Assert.Equal(providers.Count(), collectTraceOptions.Providers.Count);
+
+            int index = 0;
+            foreach (EventPipeProvider expectedProvider in providers)
+            {
+                EventPipeProvider actualProvider = collectTraceOptions.Providers[index];
+                Assert.Equal(expectedProvider.Name, actualProvider.Name);
+                Assert.Equal(expectedProvider.Keywords, actualProvider.Keywords);
+                Assert.Equal(expectedProvider.EventLevel, actualProvider.EventLevel);
+                if (null == expectedProvider.Arguments)
+                {
+                    Assert.Null(actualProvider.Arguments);
+                }
+                else
+                {
+                    Assert.NotNull(actualProvider.Arguments);
+                    Assert.Equal(expectedProvider.Arguments.Count, actualProvider.Arguments.Count);
+                    foreach ((string expectedKey, string expectedValue) in expectedProvider.Arguments)
+                    {
+                        Assert.True(actualProvider.Arguments.TryGetValue(expectedKey, out string actualValue));
+                        Assert.Equal(expectedValue, actualValue);
+                    }
+                }
+            }
+
+            return collectTraceOptions;
+        }
+
+        public static ExecuteOptions VerifyExecuteAction(this CollectionRuleOptions ruleOptions, int actionIndex, string expectedPath, string expectedArguments = null)
+        {
+            ExecuteOptions executeOptions = ruleOptions.VerifyAction<ExecuteOptions>(
+                actionIndex, KnownCollectionRuleActions.Execute);
+
+            Assert.Equal(expectedPath, executeOptions.Path);
+            Assert.Equal(expectedArguments, executeOptions.Arguments);
+
+            return executeOptions;
+        }
+
+        private static TOptions VerifyAction<TOptions>(this CollectionRuleOptions ruleOptions, int actionIndex, string actionType)
+        {
+            CollectionRuleActionOptions actionOptions = ruleOptions.Actions[actionIndex];
+
+            Assert.Equal(actionType, actionOptions.Type);
+
+            return Assert.IsType<TOptions>(actionOptions.Settings);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
@@ -242,6 +242,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
                         Assert.Equal(expectedValue, actualValue);
                     }
                 }
+
+                index++;
             }
 
             return collectTraceOptions;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleActionOptionsProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleActionOptionsProvider.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal sealed class CollectionRuleActionOptionsProvider :
+        ICollectionRuleActionOptionsProvider
+    {
+        private readonly IEnumerable<ICollectionRuleActionProvider> _actionProviders;
+
+        public CollectionRuleActionOptionsProvider(IEnumerable<ICollectionRuleActionProvider> actionProviders)
+        {
+            _actionProviders = actionProviders;
+        }
+
+        public bool TryGetOptionsType(string actionType, out Type optionsType)
+        {
+            ICollectionRuleActionProvider actionProvider = _actionProviders
+                .FirstOrDefault(provider => string.Equals(actionType, provider.ActionType, StringComparison.Ordinal));
+            if (null == actionProvider)
+            {
+                optionsType = null;
+                return false;
+            }
+
+            optionsType = actionProvider.OptionsType;
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleActionProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleActionProvider.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal sealed class CollectionRuleActionProvider<TOptions> :
+        ICollectionRuleActionProvider
+    {
+        public CollectionRuleActionProvider(string actionType)
+        {
+            ActionType = actionType;
+            OptionsType = typeof(TOptions);
+        }
+
+        public string ActionType { get; }
+
+        public Type OptionsType { get; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
             if (ruleSection.Exists())
             {
                 ruleSection.Bind(options);
-            }
 
-            BindTriggerSettings(ruleSection, options);
+                BindTriggerSettings(ruleSection, options);
 
-            for (int i = 0; i < options.Actions.Count; i++)
-            {
-                BindActionSettings(ruleSection, options, i);
+                for (int i = 0; i < options.Actions.Count; i++)
+                {
+                    BindActionSettings(ruleSection, options, i);
+                }
             }
         }
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal sealed class CollectionRuleConfigureNamedOptions :
+        IConfigureNamedOptions<CollectionRuleOptions>
+    {
+        private readonly ICollectionRuleActionOptionsProvider _actionOptionsProvider;
+        private readonly IConfigurationSection _collectionRulesSection;
+        private readonly ICollectionRuleTriggerOptionsProvider _triggerOptionsProvider;
+
+        public CollectionRuleConfigureNamedOptions(
+            IConfiguration configuration,
+            ICollectionRuleActionOptionsProvider actionOptionsProvider,
+            ICollectionRuleTriggerOptionsProvider triggerOptionsProvider)
+        {
+            _actionOptionsProvider = actionOptionsProvider;
+            _collectionRulesSection = configuration.GetSection(nameof(ConfigurationKeys.CollectionRules));
+            _triggerOptionsProvider = triggerOptionsProvider;
+        }
+
+        public void Configure(string name, CollectionRuleOptions options)
+        {
+            IConfigurationSection ruleSection = _collectionRulesSection.GetSection(name);
+            Debug.Assert(ruleSection.Exists());
+            if (ruleSection.Exists())
+            {
+                ruleSection.Bind(options);
+            }
+
+            BindTriggerSettings(ruleSection, options);
+
+            for (int i = 0; i < options.Actions.Count; i++)
+            {
+                BindActionSettings(ruleSection, options, i);
+            }
+        }
+
+        public void Configure(CollectionRuleOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        private void BindActionSettings(IConfigurationSection ruleSection, CollectionRuleOptions ruleOptions, int actionIndex)
+        {
+            CollectionRuleActionOptions actionOptions = ruleOptions.Actions[actionIndex];
+
+            if (null != actionOptions &&
+                _actionOptionsProvider.TryGetOptionsType(actionOptions.Type, out Type optionsType) &&
+                null != optionsType)
+            {
+                object actionSettings = Activator.CreateInstance(optionsType);
+
+                IConfigurationSection settingsSection = ruleSection.GetSection(ConfigurationPath.Combine(
+                    nameof(CollectionRuleOptions.Actions),
+                    actionIndex.ToString(CultureInfo.InvariantCulture),
+                    nameof(CollectionRuleActionOptions.Settings)));
+
+                settingsSection.Bind(actionSettings);
+
+                actionOptions.Settings = actionSettings;
+            }
+        }
+
+        private void BindTriggerSettings(IConfigurationSection ruleSection, CollectionRuleOptions ruleOptions)
+        {
+            CollectionRuleTriggerOptions triggerOptions = ruleOptions.Trigger;
+
+            if (null != triggerOptions &&
+                _triggerOptionsProvider.TryGetOptionsType(triggerOptions.Type, out Type optionsType) &&
+                null != optionsType)
+            {
+                object triggerSettings = Activator.CreateInstance(optionsType);
+
+                IConfigurationSection settingsSection = ruleSection.GetSection(ConfigurationPath.Combine(
+                    nameof(CollectionRuleOptions.Trigger),
+                    nameof(CollectionRuleTriggerOptions.Settings)));
+
+                settingsSection.Bind(triggerSettings);
+
+                triggerOptions.Settings = triggerSettings;
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerOptionsProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerOptionsProvider.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal sealed class CollectionRuleTriggerOptionsProvider :
+        ICollectionRuleTriggerOptionsProvider
+    {
+        private readonly IEnumerable<ICollectionRuleTriggerProvider> _triggerProviders;
+
+        public CollectionRuleTriggerOptionsProvider(IEnumerable<ICollectionRuleTriggerProvider> triggerProviders)
+        {
+            _triggerProviders = triggerProviders;
+        }
+
+        public bool TryGetOptionsType(string triggerType, out Type optionsType)
+        {
+            ICollectionRuleTriggerProvider triggerProvider = _triggerProviders
+                .FirstOrDefault(provider => string.Equals(triggerType, provider.TriggerType, StringComparison.Ordinal));
+            if (null == triggerProvider)
+            {
+                optionsType = null;
+                return false;
+            }
+
+            optionsType = triggerProvider.OptionsType;
+            return true;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerProvider.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal class CollectionRuleTriggerProvider :
+        ICollectionRuleTriggerProvider
+    {
+        public CollectionRuleTriggerProvider(string triggerType) :
+            this (triggerType, null)
+        {
+        }
+
+        public CollectionRuleTriggerProvider(string triggerType, Type optionsType)
+        {
+            TriggerType = triggerType;
+            OptionsType = optionsType;
+        }
+
+        public string TriggerType { get; }
+
+        public Type OptionsType { get; }
+    }
+
+    internal sealed class CollectionRuleTriggerProvider<TOptions> :
+        CollectionRuleTriggerProvider
+    {
+        public CollectionRuleTriggerProvider(string triggerType)
+            : base(triggerType, typeof(TOptions))
+        {
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleActionOptionsProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleActionOptionsProvider.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal interface ICollectionRuleActionOptionsProvider
+    {
+        bool TryGetOptionsType(string actionType, out Type optionsType);
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleActionProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleActionProvider.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal interface ICollectionRuleActionProvider
+    {
+        string ActionType { get; }
+
+        Type OptionsType { get; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerOptionsProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerOptionsProvider.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    internal interface ICollectionRuleTriggerOptionsProvider
+    {
+        bool TryGetOptionsType(string actionType, out Type optionsType);
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerProvider.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    interface ICollectionRuleTriggerProvider
+    {
+        string TriggerType { get; }
+
+        Type OptionsType { get; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleActions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleActions.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
+{
+    internal static class KnownCollectionRuleActions
+    {
+        public const string CollectDump = nameof(CollectDump);
+        public const string CollectGCDump = nameof(CollectGCDump);
+        public const string CollectLogs = nameof(CollectLogs);
+        public const string CollectTrace = nameof(CollectTrace);
+        public const string Execute = nameof(Execute);
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleTriggers.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleTriggers.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
+{
+    internal static class KnownCollectionRuleTriggers
+    {
+        // Startup Triggers
+        public const string Startup = nameof(Startup);
+
+        // Event Source Triggers
+        public const string AspNetRequestCount = nameof(AspNetRequestCount);
+        public const string AspNetRequestDuration = nameof(AspNetRequestDuration);
+        public const string AspNetResponseStatus = nameof(AspNetResponseStatus);
+        public const string EventCounter = nameof(EventCounter);
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 #else
@@ -12,16 +14,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     internal static class ActionOptionsConstants
     {
         public const int BufferSizeMegabytes_MaxValue = 1024;
-        public static readonly string BufferSizeMegabytes_MaxValue_String = BufferSizeMegabytes_MaxValue.ToString();
+        public static readonly string BufferSizeMegabytes_MaxValue_String = BufferSizeMegabytes_MaxValue.ToString(CultureInfo.InvariantCulture);
         public const int BufferSizeMegabytes_MinValue = 1;
-        public static readonly string BufferSizeMegabytes_MinValue_String = BufferSizeMegabytes_MinValue.ToString();
+        public static readonly string BufferSizeMegabytes_MinValue_String = BufferSizeMegabytes_MinValue.ToString(CultureInfo.InvariantCulture);
 
         public const string Duration_MaxValue = "1.00:00:00"; // 1 day
         public const string Duration_MinValue = "00:00:01"; // 1 second
 
         public const int MetricsIntervalSeconds_MaxValue = 24 * 60 * 60; // 1 day
-        public static readonly string MetricsIntervalSeconds_MaxValue_String = MetricsIntervalSeconds_MaxValue.ToString();
+        public static readonly string MetricsIntervalSeconds_MaxValue_String = MetricsIntervalSeconds_MaxValue.ToString(CultureInfo.InvariantCulture);
         public const int MetricsIntervalSeconds_MinValue = 1; // 1 second
-        public static readonly string MetricsIntervalSeconds_MinValue_String = MetricsIntervalSeconds_MinValue.ToString();
+        public static readonly string MetricsIntervalSeconds_MinValue_String = MetricsIntervalSeconds_MinValue.ToString(CultureInfo.InvariantCulture);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    // Constants for action options allowing reuse among multiple actions and for tests to verify ranges.
+    internal static class ActionOptionsConstants
+    {
+        public const int BufferSizeMegabytes_MaxValue = 1024;
+        public static readonly string BufferSizeMegabytes_MaxValue_String = BufferSizeMegabytes_MaxValue.ToString();
+        public const int BufferSizeMegabytes_MinValue = 1;
+        public static readonly string BufferSizeMegabytes_MinValue_String = BufferSizeMegabytes_MinValue.ToString();
+
+        public const string Duration_MaxValue = "1.00:00:00"; // 1 day
+        public const string Duration_MinValue = "00:00:01"; // 1 second
+
+        public const int MetricsIntervalSeconds_MaxValue = 24 * 60 * 60; // 1 day
+        public static readonly string MetricsIntervalSeconds_MaxValue_String = MetricsIntervalSeconds_MaxValue.ToString();
+        public const int MetricsIntervalSeconds_MinValue = 1; // 1 second
+        public static readonly string MetricsIntervalSeconds_MinValue_String = MetricsIntervalSeconds_MinValue.ToString();
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    /// <summary>
+    /// Options for the CollectDump action.
+    /// </summary>
+    [DebuggerDisplay("CollectDump")]
+    internal sealed partial class CollectDumpOptions
+    {
+        [EnumDataType(typeof(DumpType))]
+        public DumpType? Type { get; set; }
+
+        [Required]
+#if !UNITTEST
+        [ValidateEgressProvider]
+#endif
+        public string Egress { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    /// <summary>
+    /// Options for the CollectGCDump action.
+    /// </summary>
+    [DebuggerDisplay("CollectGCDump")]
+    internal sealed partial class CollectGCDumpOptions
+    {
+        [Required]
+#if !UNITTEST
+        [ValidateEgressProvider]
+#endif
+        public string Egress { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.Validate.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    partial class CollectLogsOptions :
+        IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            List<ValidationResult> results = new();
+
+            if (null != FilterSpecs)
+            {
+                RequiredAttribute requiredAttribute = new();
+                EnumDataTypeAttribute enumValidationAttribute = new(typeof(LogLevel));
+
+                ValidationContext filterSpecsContext = new(FilterSpecs, validationContext, validationContext.Items);
+                filterSpecsContext.MemberName = nameof(FilterSpecs);
+
+                // Validate that the category is not null and that the level is a valid level value.
+                foreach ((string category, LogLevel? level) in FilterSpecs)
+                {
+                    ValidationResult result = requiredAttribute.GetValidationResult(category, filterSpecsContext);
+                    if (result != ValidationResult.Success)
+                    {
+                        results.Add(result);
+                    }
+
+                    result = enumValidationAttribute.GetValidationResult(level, filterSpecsContext);
+                    if (result != ValidationResult.Success)
+                    {
+                        results.Add(result);
+                    }
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    /// <summary>
+    /// Options for the CollectLogs action.
+    /// </summary>
+    [DebuggerDisplay("CollectLogs")]
+    internal sealed partial class CollectLogsOptions
+    {
+        [EnumDataType(typeof(LogLevel))]
+        public LogLevel? LogLevel { get; set; }
+
+        public Dictionary<string, LogLevel?> FilterSpecs { get; set; }
+
+        public bool? UseAppFilters { get; set; }
+
+        [Range(typeof(TimeSpan), ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue)]
+        public TimeSpan? Duration { get; set; }
+
+        [Required]
+#if !UNITTEST
+        [ValidateEgressProvider]
+#endif
+        public string Egress { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    partial class CollectTraceOptions :
+        IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            List<ValidationResult> results = new();
+
+            bool hasProfile = Profile.HasValue;
+            bool hasProviders = null != Providers && Providers.Any();
+
+            if (hasProfile)
+            {
+                if (hasProviders)
+                {
+                    // Both Profile and Providers cannot specified at the same time, otherwise
+                    // cannot determine whether to use providers from the profile or the custom
+                    // specified providers.
+                    results.Add(new ValidationResult(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            Strings.ErrorMessage_TwoFieldsCannotBeSpecified,
+                            nameof(Profile),
+                            nameof(Providers))));
+                }
+            }
+            else if (hasProviders)
+            {
+                // Validate that each provider is valid.
+                int index = 0;
+                foreach (EventPipeProvider provider in Providers)
+                {
+                    ValidationContext providerContext = new(provider, validationContext, validationContext.Items);
+                    providerContext.MemberName = nameof(Providers) + "[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+
+                    Validator.TryValidateObject(provider, providerContext, results, validateAllProperties: true);
+
+                    index++;
+                }
+            }
+            else
+            {
+                // Either Profile or Providers must be specified
+                results.Add(new ValidationResult(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Strings.ErrorMessage_TwoFieldsMissing,
+                        nameof(Profile),
+                        nameof(Providers))));
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
             {
                 if (hasProviders)
                 {
-                    // Both Profile and Providers cannot specified at the same time, otherwise
+                    // Both Profile and Providers cannot be specified at the same time, otherwise
                     // cannot determine whether to use providers from the profile or the custom
                     // specified providers.
                     results.Add(new ValidationResult(

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    /// <summary>
+    /// Options for the CollectTrace action.
+    /// </summary>
+    [DebuggerDisplay("CollectTrace")]
+    internal sealed partial class CollectTraceOptions
+    {
+        [EnumDataType(typeof(TraceProfile))]
+        public TraceProfile? Profile { get; set; }
+
+        [Range(ActionOptionsConstants.MetricsIntervalSeconds_MinValue, ActionOptionsConstants.MetricsIntervalSeconds_MaxValue)]
+        public int? MetricsIntervalSeconds { get; set; }
+
+        public List<EventPipeProvider> Providers { get; set; }
+
+        public bool? RequestRundown { get; set; }
+
+        [Range(ActionOptionsConstants.BufferSizeMegabytes_MinValue, ActionOptionsConstants.BufferSizeMegabytes_MaxValue)]
+        public int? BufferSizeMegabytes { get; set; }
+
+        [Range(typeof(TimeSpan), ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue)]
+        public TimeSpan? Duration { get; set; }
+
+        [Required]
+#if !UNITTEST
+        [ValidateEgressProvider]
+#endif
+        public string Egress { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Linq;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+#endif
+{
+    /// <summary>
+    /// Options for the Execute  action.
+    /// </summary>
+    [DebuggerDisplay("Execute: Path = {Path}")]
+    internal sealed class ExecuteOptions : IValidatableObject
+    {
+        [Required]
+        public string Path { get; set; }
+
+        public string Arguments { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
-using System.Linq;
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
@@ -14,19 +12,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #endif
 {
     /// <summary>
-    /// Options for the Execute  action.
+    /// Options for the Execute action.
     /// </summary>
     [DebuggerDisplay("Execute: Path = {Path}")]
-    internal sealed class ExecuteOptions : IValidatableObject
+    internal sealed class ExecuteOptions
     {
         [Required]
         public string Path { get; set; }
 
         public string Arguments { get; set; }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            return Enumerable.Empty<ValidationResult>();
-        }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ValidateEgressProviderAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ValidateEgressProviderAttribute.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    internal sealed class ValidateEgressProviderAttribute :
+        ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            string egressProvider = (string)value;
+
+            IEgressService egressService = validationContext.GetRequiredService<IEgressService>();
+            if (!egressService.CheckProvider(egressProvider))
+            {
+                return new ValidationResult(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Strings.ErrorMessage_EgressProviderDoesNotExist,
+                        egressProvider));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.Validate.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+{
+    partial class CollectionRuleActionOptions : IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            ICollectionRuleActionOptionsProvider actionOptionsProvider = validationContext.GetRequiredService<ICollectionRuleActionOptionsProvider>();
+
+            List<ValidationResult> results = new();
+
+            if (!string.IsNullOrEmpty(Type))
+            {
+                if (actionOptionsProvider.TryGetOptionsType(Type, out Type optionsType))
+                {
+                    if (null != optionsType)
+                    {
+                        ValidationHelper.TryValidateOptions(optionsType, Settings, validationContext, results);
+                    }
+                }
+                else
+                {
+                    results.Add(new ValidationResult(string.Format(CultureInfo.InvariantCulture, Strings.ErrorMessage_UnknownActionType, Type)));
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+#endif
+{
+    /// <summary>
+    /// Options for describing the type of action to execute and the settings to pass to that action.
+    /// </summary>
+    [DebuggerDisplay("Action: Type = {Type}")]
+    internal sealed partial class CollectionRuleActionOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleActionOptions_Type))]
+        [Required]
+        public string Type { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleActionOptions_Settings))]
+        public object Settings { get; internal set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+#endif
+{
+    /// <summary>
+    /// Options for limiting the execution of a collection rule.
+    /// </summary>
+    internal sealed class CollectionRuleLimitsOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCount))]
+        public int? ActionCount { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCountSlidingWindowDuration))]
+        [Range(typeof(TimeSpan), "00:00:01", "1.00:00:00")]
+        public TimeSpan? ActionCountSlidingWindowDuration { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleLimitsOptions_RuleDuration))]
+        [Range(typeof(TimeSpan), "00:00:01", "365.00:00:00")]
+        public TimeSpan? RuleDuration { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCountSlidingWindowDuration))]
-        [Range(typeof(TimeSpan), "00:00:01", "1.00:00:00")]
+        [Range(typeof(TimeSpan), CollectionRuleOptionsConstants.ActionCountSlidingWindowDuration_MinValue, CollectionRuleOptionsConstants.ActionCountSlidingWindowDuration_MaxValue)]
         public TimeSpan? ActionCountSlidingWindowDuration { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleLimitsOptions_RuleDuration))]
-        [Range(typeof(TimeSpan), "00:00:01", "365.00:00:00")]
+        [Range(typeof(TimeSpan), CollectionRuleOptionsConstants.RuleDuration_MinValue, CollectionRuleOptionsConstants.RuleDuration_MaxValue)]
         public TimeSpan? RuleDuration { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.Validate.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+{
+    partial class CollectionRuleOptions : IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            List<ValidationResult> results = new();
+
+            ValidationContext filtersContext = new(Filters, validationContext, validationContext.Items);
+            filtersContext.MemberName = nameof(Filters);
+            ValidationHelper.TryValidateItems(Filters, filtersContext, results);
+
+            if (null != Trigger)
+            {
+                ValidationContext triggerContext = new(Trigger, validationContext, validationContext.Items);
+                triggerContext.MemberName = nameof(Trigger);
+                Validator.TryValidateObject(Trigger, triggerContext, results);
+            }
+
+            ValidationContext actionsContext = new(Actions, validationContext, validationContext.Items);
+            actionsContext.MemberName = nameof(Actions);
+            ValidationHelper.TryValidateItems(Actions, actionsContext, results);
+
+            return results;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+#endif
+{
+    /// <summary>
+    /// Options for describing an entire collection rule.
+    /// </summary>
+    internal sealed partial class CollectionRuleOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Filters))]
+        public List<ProcessFilterDescriptor> Filters { get; } = new List<ProcessFilterDescriptor>(0);
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Trigger))]
+        [Required]
+        public CollectionRuleTriggerOptions Trigger { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Actions))]
+        public List<CollectionRuleActionOptions> Actions { get; } = new List<CollectionRuleActionOptions>(0);
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Limits))]
+        public CollectionRuleLimitsOptions Limits { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptionsConstants.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+#endif
+{
+    internal static class CollectionRuleOptionsConstants
+    {
+        public const string ActionCountSlidingWindowDuration_MaxValue = "1.00:00:00"; // 1 day
+        public const string ActionCountSlidingWindowDuration_MinValue = "00:00:01"; // 1 second
+
+        public const string RuleDuration_MaxValue = "365.00:00:00"; // 1 day
+        public const string RuleDuration_MinValue = "00:00:01"; // 1 second
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.Validate.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+{
+    partial class CollectionRuleTriggerOptions : IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            ICollectionRuleTriggerOptionsProvider triggerOptionsProvider = validationContext.GetRequiredService<ICollectionRuleTriggerOptionsProvider>();
+
+            List<ValidationResult> results = new();
+
+            if (!string.IsNullOrEmpty(Type))
+            {
+                if (triggerOptionsProvider.TryGetOptionsType(Type, out Type optionsType))
+                {
+                    if (null != optionsType)
+                    {
+                        ValidationHelper.TryValidateOptions(optionsType, Settings, validationContext, results);
+                    }
+                }
+                else
+                {
+                    results.Add(new ValidationResult(string.Format(CultureInfo.InvariantCulture, Strings.ErrorMessage_UnknownTriggerType, Type)));
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+#endif
+{
+    /// <summary>
+    /// Options for describing the type of trigger and the settings to pass to that trigger.
+    /// </summary>
+    [DebuggerDisplay("Trigger: Type = {Type}")]
+    internal sealed partial class CollectionRuleTriggerOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleTriggerOptions_Type))]
+        [Required]
+        public string Type { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleTriggerOptions_Settings))]
+        public object Settings { get; internal set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+#endif
+{
+    /// <summary>
+    /// Options for the AspNetRequestCount trigger.
+    /// </summary>
+    internal sealed class AspNetRequestCountOptions
+    {
+        [Required]
+        public int RequestCount { get; set; }
+
+        [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        public TimeSpan? SlidingWindowDuration { get; set; }
+
+        public string IncludePaths { get; set; }
+
+        public string ExcludePaths { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+#endif
+{
+    /// <summary>
+    /// Options for the AspNetRequestDuration trigger.
+    /// </summary>
+    internal sealed class AspNetRequestDurationOptions
+    {
+        [Required]
+        public int RequestCount { get; set; }
+
+        public TimeSpan? RequestDuration { get; set; }
+
+        [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        public TimeSpan? SlidingWindowDuration { get; set; }
+
+        public string IncludePaths { get; set; }
+
+        public string ExcludePaths { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+#endif
+{
+    /// <summary>
+    /// Options for the AspNetResponseStatus trigger.
+    /// </summary>
+    internal sealed class AspNetResponseStatusOptions
+    {
+        [Required]
+        public string StatusCodes { get; set; }
+
+        [Required]
+        public int ResponseCount { get; set; }
+
+        [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        public TimeSpan? SlidingWindowDuration { get; set; }
+
+        public string IncludePaths { get; set; }
+
+        public string ExcludePaths { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.Validate.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+{
+    partial class EventCounterOptions : IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            List<ValidationResult> results = new();
+
+            if (!GreaterThan.HasValue && !LessThan.HasValue)
+            {
+                // Either GreaterThan or LessThan must be specified.
+                results.Add(new ValidationResult(
+                    string.Format(
+                        Strings.ErrorMessage_TwoFieldsMissing,
+                        nameof(GreaterThan),
+                        nameof(LessThan))));
+            }
+            else if (GreaterThan.HasValue && LessThan.HasValue && LessThan.Value < GreaterThan.Value)
+            {
+                // The GreaterThan must be lower than LessThan if both are specified.
+                results.Add(new ValidationResult(
+                    string.Format(
+                        Strings.ErrorMessage_FieldMustBeLessThanOtherField,
+                        nameof(GreaterThan),
+                        nameof(LessThan))));
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+#endif
+{
+    /// <summary>
+    /// Options for the EventCounter trigger.
+    /// </summary>
+    internal sealed partial class EventCounterOptions
+    {
+        [Required]
+        public string ProviderName { get; set; }
+
+        [Required]
+        public string CounterName { get; set; }
+
+        public double? GreaterThan { get; set; }
+
+        public double? LessThan { get; set; }
+
+        [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        public TimeSpan? SlidingWindowDuration { get; set; }
+
+        [Range(TriggerOptionsConstants.CounterFrequency_MinValue, TriggerOptionsConstants.CounterFrequency_MaxValue)]
+        public int? Frequency { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+#endif
+{
+    // Constants for trigger options allowing reuse among multiple trigger and for tests to verify ranges.
+    internal static class TriggerOptionsConstants
+    {
+        public const int CounterFrequency_MaxValue = 24*60*60; // 1 day
+        public static readonly string Frequency_MaxValue_String = CounterFrequency_MaxValue.ToString();
+        public const int CounterFrequency_MinValue = 1; // 1 second
+        public static readonly string Frequency_MinValue_String = CounterFrequency_MinValue.ToString();
+        
+        public const string SlidingWindowDuration_MaxValue = "1.00:00:00"; // 1 day
+        public const string SlidingWindowDuration_MinValue = "00:00:01"; // 1 second
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 #else
@@ -12,9 +14,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     internal static class TriggerOptionsConstants
     {
         public const int CounterFrequency_MaxValue = 24*60*60; // 1 day
-        public static readonly string Frequency_MaxValue_String = CounterFrequency_MaxValue.ToString();
+        public static readonly string Frequency_MaxValue_String = CounterFrequency_MaxValue.ToString(CultureInfo.InvariantCulture);
         public const int CounterFrequency_MinValue = 1; // 1 second
-        public static readonly string Frequency_MinValue_String = CounterFrequency_MinValue.ToString();
+        public static readonly string Frequency_MinValue_String = CounterFrequency_MinValue.ToString(CultureInfo.InvariantCulture);
         
         public const string SlidingWindowDuration_MaxValue = "1.00:00:00"; // 1 day
         public const string SlidingWindowDuration_MinValue = "00:00:01"; // 1 second

--- a/src/Tools/dotnet-monitor/ConfigurationKeys.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationKeys.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public const string ApiAuthentication = nameof(ApiAuthentication);
 
+        public const string CollectionRules = nameof(CollectionRules);
+
         public const string CorsConfiguration = nameof(CorsConfiguration);
 
         public const string DiagnosticPort = nameof(DiagnosticPort);

--- a/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
@@ -1,25 +1,25 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
+namespace Microsoft.Diagnostics.Tools.Monitor
 {
-    /// <summary>
-    /// Validates the settings within a <typeparamref name="TOptions"/> instance
-    /// using data annotation validation.
-    /// </summary>
-    internal sealed class EgressProviderValidateOptions<TOptions> :
-        IValidateOptions<TOptions> where TOptions : class
+    internal sealed class DataAnnotationValidateOptions<TOptions> :
+        IValidateOptions<TOptions>
+        where TOptions : class
     {
+        private readonly IServiceProvider _serviceProvider;
+
+        public DataAnnotationValidateOptions(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
         public ValidateOptionsResult Validate(string name, TOptions options)
         {
-            ValidationContext validationContext = new ValidationContext(options);
+            ValidationContext validationContext = new(options, _serviceProvider, null);
             ICollection<ValidationResult> results = new Collection<ValidationResult>();
             if (!Validator.TryValidateObject(options, validationContext, results, validateAllProperties: true))
             {

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class DiagnosticsMonitorCommandHandler
     {
-        private const string ConfigPrefix = "DotnetMonitor_";
+        public const string ConfigPrefix = "DotnetMonitor_";
         private const string SettingsFileName = "settings.json";
         private const string ProductFolderName = "dotnet-monitor";
 
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
             try
             {
-                using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress, configOnly: false).Build();
+                IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress, configOnly: false).Build();
                 try
                 {
                     await host.StartAsync(token);

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -247,10 +247,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
                     services.AddSingleton<RequestLimitTracker>();
                     services.ConfigureOperationStore();
-                    services.ConfigureEgress(context.Configuration);
+                    services.ConfigureEgress();
                     services.ConfigureMetrics(context.Configuration);
                     services.ConfigureStorage(context.Configuration);
                     services.ConfigureDefaultProcess(context.Configuration);
+                    services.ConfigureCollectionRules();
                 });
             }
 

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -55,6 +55,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
             _changeRegistration.Dispose();
         }
 
+        public bool CheckProvider(string providerName)
+        {
+            try
+            {
+                return null != GetProvider(providerName);
+            }
+            catch (EgressException)
+            {
+                return false;
+            }
+        }
+
         public async Task<EgressResult> EgressAsync(string providerName, Func<CancellationToken, Task<Stream>> action, string fileName, string contentType, IEndpointInfo source, CancellationToken token)
         {
             string value = await GetProvider(providerName).EgressAsync(

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -133,6 +133,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateEgressProviderIgnored);
 
+        private static readonly Action<ILogger, string, Exception> _duplicateCollectionRuleActionIgnored =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(25, "DuplicateCollectionRuleActionIgnored"),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_DuplicateCollectionRuleActionIgnored);
+
+        private static readonly Action<ILogger, string, Exception> _duplicateCollectionRuleTriggerIgnored =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(26, "DuplicateCollectionRuleTriggerIgnored"),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_DuplicateCollectionRuleTriggerIgnored);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -224,6 +236,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void DuplicateEgressProviderIgnored(this ILogger logger, string providerName, string providerType, string existingProviderType)
         {
             _duplicateEgressProviderIgnored(logger, providerName, providerType, existingProviderType, null);
+        }
+
+        public static void DuplicateCollectionRuleActionIgnored(this ILogger logger, string actionType)
+        {
+            _duplicateCollectionRuleActionIgnored(logger, actionType, null);
+        }
+
+        public static void DuplicateCollectionRuleTriggerIgnored(this ILogger logger, string triggerType)
+        {
+            _duplicateCollectionRuleTriggerIgnored(logger, triggerType, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/RootOptions.cs
+++ b/src/Tools/dotnet-monitor/RootOptions.cs
@@ -2,11 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if !UNITTEST
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+#endif
+using System.Collections.Generic;
+
+#if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor
+#endif
 {
-    internal class RootOptions
+    internal sealed class RootOptions
     {
         public ApiAuthenticationOptions ApiAuthentication { get; set; }
+
+        public IDictionary<string, CollectionRuleOptions> CollectionRules { get; }
+            = new Dictionary<string, CollectionRuleOptions>(0);
 
         public CorsConfiguration CorsConfiguration { get; set; }
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -151,6 +151,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of field {0} must be less than the value of field {1}..
+        /// </summary>
+        internal static string ErrorMessage_FieldMustBeLessThanOtherField {
+            get {
+                return ResourceManager.GetString("ErrorMessage_FieldMustBeLessThanOtherField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} field value &apos;{1}&apos; is not allowed..
         /// </summary>
         internal static string ErrorMessage_FieldNotAllowed {
@@ -223,6 +232,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Both the {0} field and the {1} field cannot be specified..
+        /// </summary>
+        internal static string ErrorMessage_TwoFieldsCannotBeSpecified {
+            get {
+                return ResourceManager.GetString("ErrorMessage_TwoFieldsCannotBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} field or the {1} field is required..
         /// </summary>
         internal static string ErrorMessage_TwoFieldsMissing {
@@ -246,6 +264,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string ErrorMessage_UnhandledConnectionMode {
             get {
                 return ResourceManager.GetString("ErrorMessage_UnhandledConnectionMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a known action type..
+        /// </summary>
+        internal static string ErrorMessage_UnknownActionType {
+            get {
+                return ResourceManager.GetString("ErrorMessage_UnknownActionType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a known trigger type..
+        /// </summary>
+        internal static string ErrorMessage_UnknownTriggerType {
+            get {
+                return ResourceManager.GetString("ErrorMessage_UnknownTriggerType", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -457,6 +457,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collection rule action &apos;{actionType}&apos; was previously registered; the new registration will be ignored..
+        /// </summary>
+        internal static string LogFormatString_DuplicateCollectionRuleActionIgnored {
+            get {
+                return ResourceManager.GetString("LogFormatString_DuplicateCollectionRuleActionIgnored", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Collection rule trigger &apos;{triggerType}&apos; was previously registered; the new registration will be ignored..
+        /// </summary>
+        internal static string LogFormatString_DuplicateCollectionRuleTriggerIgnored {
+            get {
+                return ResourceManager.GetString("LogFormatString_DuplicateCollectionRuleTriggerIgnored", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New provider &apos;{providerName}&apos; under type &apos;{providerType}&apos; was already registered with type &apos;{existingProviderType}&apos; and will be ignored..
         /// </summary>
         internal static string LogFormatString_DuplicateEgressProviderIgnored {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -167,6 +167,11 @@
 1 Format Parameter:
 0. intermediateFileDirectory: The directory where the intermediate file was attempted to be created.</comment>
   </data>
+  <data name="ErrorMessage_FieldMustBeLessThanOtherField" xml:space="preserve">
+    <value>The value of field {0} must be less than the value of field {1}.</value>
+    <comment>{0} = Field name that must be lower.
+{1} = Field name that must be higher.</comment>
+  </data>
   <data name="ErrorMessage_FieldNotAllowed" xml:space="preserve">
     <value>The {0} field value '{1}' is not allowed.</value>
     <comment>Gets the format string for rejecting a field value.
@@ -214,6 +219,11 @@
 2. minBytes: The minimum number of bytes acceptable
 3. maxBytes: The maximum number of bytes acceptable</comment>
   </data>
+  <data name="ErrorMessage_TwoFieldsCannotBeSpecified" xml:space="preserve">
+    <value>Both the {0} field and the {1} field cannot be specified.</value>
+    <comment>{0} = Name of first field that must not be specified if second field is specified.
+{1} = Name of second field that must not be specified if first field is specified.</comment>
+  </data>
   <data name="ErrorMessage_TwoFieldsMissing" xml:space="preserve">
     <value>The {0} field or the {1} field is required.</value>
     <comment>Gets the format string for rejecting validation due to 2 missing fields where at least one is required.
@@ -230,6 +240,14 @@
     <comment>Gets the format string for egress provider failure due to missing provider.
 1 Format Parameter:
 0. connectionMode: The provided DiagnosticPortConnectionMode that could not be parsed.</comment>
+  </data>
+  <data name="ErrorMessage_UnknownActionType" xml:space="preserve">
+    <value>'{0}' is not a known action type.</value>
+    <comment>{0} = The type of action that is unknown.</comment>
+  </data>
+  <data name="ErrorMessage_UnknownTriggerType" xml:space="preserve">
+    <value>'{0}' is not a known trigger type.</value>
+    <comment>{0} = The type of trigger that is unknown.</comment>
   </data>
   <data name="HelpDescription_CommandCollect" xml:space="preserve">
     <value>Monitor logs and metrics in a .NET application send the results to a chosen destination.</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -335,6 +335,18 @@
     <comment>Gets the format string that is printed in the 20:DisabledNegotiateWhileElevated event.
 0 Format Parameters</comment>
   </data>
+  <data name="LogFormatString_DuplicateCollectionRuleActionIgnored" xml:space="preserve">
+    <value>Collection rule action '{actionType}' was previously registered; the new registration will be ignored.</value>
+    <comment>Gets the format string that is printed in the 25:DuplicateCollectionRuleActionIgnored event.
+1 Format Parameter:
+1. actionType: The registration name of the collection rule action.</comment>
+  </data>
+  <data name="LogFormatString_DuplicateCollectionRuleTriggerIgnored" xml:space="preserve">
+    <value>Collection rule trigger '{triggerType}' was previously registered; the new registration will be ignored.</value>
+    <comment>Gets the format string that is printed in the 26:DuplicateCollectionRuleTriggerIgnored event.
+1 Format Parameter:
+1. triggerType: The registration name of the collection rule trigger.</comment>
+  </data>
   <data name="LogFormatString_DuplicateEgressProviderIgnored" xml:space="preserve">
     <value>New provider '{providerName}' under type '{providerType}' was already registered with type '{existingProviderType}' and will be ignored.</value>
     <comment>Gets the format string that is printed in the 24:DuplicateEgressProviderIgnored event.

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -55,6 +55,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.OpenApiGen" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.Tool.UnitTests" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change defines all of the options classes and properties of all of the aspects of the collection rules / triggers feature. Validation for the collection rule options and action options have been implemented and unit tests were added to verify the options validation for these types.

The validation for the triggers options is partially implemented (I plan to complete that in a subsequent change) but has been completely implemented for the EventCount trigger options.

The unit tests also validate that the custom binding of the trigger and actions options is done correctly since binding those uses a small custom algorithm.

To be done in subsequent PRs:
- Finish validation and unit tests for trigger options.
- Add trigger and action options to JSON schema document.
- Add descriptions for trigger and action option property so they are reflected in JSON schema document.

Partial completions for #630, #631, #632, #633, #634, #635, #648, #649, #656, #658, #659, #660

closes #625
closes #626
closes #627
closes #628
closes #629
closes #640