### PR TITLE
Refactor schema gen to generically create discriminated subschemas

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -716,7 +716,6 @@
       ]
     },
     "JsonConsoleFormatterOptions": {
-      "title": "JsonConsoleFormatterOptions",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -724,7 +723,7 @@
           "description": "Gets or sets JsonWriterOptions.",
           "oneOf": [
             {
-              "$ref": "#/definitions/JsonConsoleFormatterOptions/definitions/JsonWriterOptions"
+              "$ref": "#/definitions/JsonWriterOptions"
             }
           ]
         },
@@ -744,51 +743,48 @@
           "description": "Gets or sets whether or not UTC timezone should be used for timestamps in logging messages. Defaults to false.",
           "default": false
         }
-      },
-      "definitions": {
-        "JsonWriterOptions": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "Encoder": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/JsonConsoleFormatterOptions/definitions/JavaScriptEncoder"
-                }
-              ]
-            },
-            "Indented": {
-              "type": "boolean"
-            },
-            "SkipValidation": {
-              "type": "boolean"
-            }
-          }
-        },
-        "JavaScriptEncoder": {
-          "allOf": [
+      }
+    },
+    "JsonWriterOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Encoder": {
+          "oneOf": [
             {
-              "$ref": "#/definitions/JsonConsoleFormatterOptions/definitions/TextEncoder"
+              "type": "null"
             },
             {
-              "type": "object",
-              "x-abstract": true,
-              "additionalProperties": false
+              "$ref": "#/definitions/JavaScriptEncoder"
             }
           ]
         },
-        "TextEncoder": {
+        "Indented": {
+          "type": "boolean"
+        },
+        "SkipValidation": {
+          "type": "boolean"
+        }
+      }
+    },
+    "JavaScriptEncoder": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TextEncoder"
+        },
+        {
           "type": "object",
           "x-abstract": true,
           "additionalProperties": false
         }
-      }
+      ]
+    },
+    "TextEncoder": {
+      "type": "object",
+      "x-abstract": true,
+      "additionalProperties": false
     },
     "SimpleConsoleFormatterOptions": {
-      "title": "SimpleConsoleFormatterOptions",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -796,7 +792,7 @@
           "description": "Determines when to use color when logging messages.",
           "oneOf": [
             {
-              "$ref": "#/definitions/SimpleConsoleFormatterOptions/definitions/LoggerColorBehavior"
+              "$ref": "#/definitions/LoggerColorBehavior"
             }
           ]
         },
@@ -820,26 +816,23 @@
           "description": "Gets or sets whether or not UTC timezone should be used for timestamps in logging messages. Defaults to false.",
           "default": false
         }
-      },
-      "definitions": {
-        "LoggerColorBehavior": {
-          "type": "string",
-          "description": "",
-          "x-enumNames": [
-            "Default",
-            "Enabled",
-            "Disabled"
-          ],
-          "enum": [
-            "Default",
-            "Enabled",
-            "Disabled"
-          ]
-        }
       }
     },
+    "LoggerColorBehavior": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Default",
+        "Enabled",
+        "Disabled"
+      ],
+      "enum": [
+        "Default",
+        "Enabled",
+        "Disabled"
+      ]
+    },
     "ConsoleFormatterOptions": {
-      "title": "ConsoleFormatterOptions",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -98,9 +98,9 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
 
         private static JsonSchemaProperty AddDiscriminatedSubSchema(
             JsonSchema parentSchema,
-            string descriminatingPropertyName,
-            string descriminatingPropertyValue,
-            string descriminatedPropertyName,
+            string discriminatingPropertyName,
+            string discriminatingPropertyValue,
+            string discriminatedPropertyName,
             JsonSchema subSchema = null)
         {
             if (null == subSchema)
@@ -110,13 +110,13 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
 
             JsonSchemaProperty descriminatingProperty = new JsonSchemaProperty();
             descriminatingProperty.ExtensionData = new Dictionary<string, object>();
-            descriminatingProperty.ExtensionData.Add("const", descriminatingPropertyValue);
+            descriminatingProperty.ExtensionData.Add("const", discriminatingPropertyValue);
 
-            subSchema.Properties.Add(descriminatingPropertyName, descriminatingProperty);
+            subSchema.Properties.Add(discriminatingPropertyName, descriminatingProperty);
 
             JsonSchemaProperty descriminatedProperty = new JsonSchemaProperty();
 
-            subSchema.Properties.Add(descriminatedPropertyName, descriminatedProperty);
+            subSchema.Properties.Add(discriminatedPropertyName, descriminatedProperty);
 
             parentSchema.OneOf.Add(subSchema);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -108,19 +108,19 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
                 subSchema = new JsonSchema();
             }
 
-            JsonSchemaProperty descriminatingProperty = new JsonSchemaProperty();
-            descriminatingProperty.ExtensionData = new Dictionary<string, object>();
-            descriminatingProperty.ExtensionData.Add("const", discriminatingPropertyValue);
+            JsonSchemaProperty discriminatingProperty = new JsonSchemaProperty();
+            discriminatingProperty.ExtensionData = new Dictionary<string, object>();
+            discriminatingProperty.ExtensionData.Add("const", discriminatingPropertyValue);
 
-            subSchema.Properties.Add(discriminatingPropertyName, descriminatingProperty);
+            subSchema.Properties.Add(discriminatingPropertyName, discriminatingProperty);
 
-            JsonSchemaProperty descriminatedProperty = new JsonSchemaProperty();
+            JsonSchemaProperty discriminatedProperty = new JsonSchemaProperty();
 
-            subSchema.Properties.Add(discriminatedPropertyName, descriminatedProperty);
+            subSchema.Properties.Add(discriminatedPropertyName, discriminatedProperty);
 
             parentSchema.OneOf.Add(subSchema);
 
-            return descriminatedProperty;
+            return discriminatedProperty;
         }
 
         private class GenerationContext


### PR DESCRIPTION
This change allows adding more discriminated subschemas in the future without reimplementing the concept for each set of options. Also, generate schemas from type information and cache it in a resolver so that type schemas can be reused across multiple type generations.