### PR TITLE
Generate action and trigger options in schema.

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -1317,7 +1317,7 @@
             "array",
             "null"
           ],
-          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.",
+          "description": "The list of request paths to monitor. If not specified, all request paths are monitored.  A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored.",
           "items": {
             "type": "string"
           }
@@ -1327,7 +1327,7 @@
             "array",
             "null"
           ],
-          "description": "The list of request paths to ignore.",
+          "description": "The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored.",
           "items": {
             "type": "string"
           }
@@ -1369,7 +1369,7 @@
             "array",
             "null"
           ],
-          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.",
+          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored.",
           "items": {
             "type": "string"
           }
@@ -1379,7 +1379,7 @@
             "array",
             "null"
           ],
-          "description": "The list of request paths to ignore.",
+          "description": "The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored.",
           "items": {
             "type": "string"
           }
@@ -1412,7 +1412,7 @@
             "null",
             "string"
           ],
-          "description": "The sliding time window in which the the number of responses with matching status codes must occur.",
+          "description": "The sliding time window in which the number of responses with matching status codes must occur.",
           "format": "time-span",
           "default": "00:01:00"
         },
@@ -1421,7 +1421,7 @@
             "array",
             "null"
           ],
-          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.",
+          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored.",
           "items": {
             "type": "string"
           }
@@ -1431,7 +1431,7 @@
             "array",
             "null"
           ],
-          "description": "The list of request paths to ignore.",
+          "description": "The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored.",
           "items": {
             "type": "string"
           }

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -403,6 +403,7 @@
         },
         "Limits": {
           "description": "The set of limits to constrain the execution of the rule and its components.",
+          "default": {},
           "oneOf": [
             {
               "type": "null"
@@ -482,7 +483,12 @@
         "Type": {
           "type": "string",
           "description": "The type of trigger used to monitor for a condition in the target process.",
-          "minLength": 1
+          "minLength": 1,
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CollectionRuleTriggerType"
+            }
+          ]
         },
         "Settings": {
           "description": "The settings to pass to the trigger when it is executed. Settings may be optional if the trigger doesn't require settings or its settings are all optional.",
@@ -493,7 +499,71 @@
             }
           ]
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "AspNetRequestCount"
+            },
+            "Settings": {
+              "$ref": "#/definitions/AspNetRequestCountOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "AspNetRequestDuration"
+            },
+            "Settings": {
+              "$ref": "#/definitions/AspNetRequestDurationOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "AspNetResponseStatus"
+            },
+            "Settings": {
+              "$ref": "#/definitions/AspNetResponseStatusOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "EventCounter"
+            },
+            "Settings": {
+              "$ref": "#/definitions/EventCounterOptions"
+            }
+          }
+        },
+        {
+          "properties": {
+            "Type": {
+              "const": "Startup"
+            },
+            "Settings": {
+              "type": "null"
+            }
+          }
+        }
+      ]
     },
     "CollectionRuleActionOptions": {
       "type": "object",
@@ -505,7 +575,12 @@
         "Type": {
           "type": "string",
           "description": "The type of action to execute.",
-          "minLength": 1
+          "minLength": 1,
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CollectionRuleActionType"
+            }
+          ]
         },
         "Settings": {
           "description": "The settings to pass to the action when it is executed. Settings may be optional if the action doesn't require settings or its settings are all optional.",
@@ -516,7 +591,74 @@
             }
           ]
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "CollectDump"
+            },
+            "Settings": {
+              "$ref": "#/definitions/CollectDumpOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "CollectGCDump"
+            },
+            "Settings": {
+              "$ref": "#/definitions/CollectGCDumpOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "CollectLogs"
+            },
+            "Settings": {
+              "$ref": "#/definitions/CollectLogsOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "CollectTrace"
+            },
+            "Settings": {
+              "$ref": "#/definitions/CollectTraceOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "Execute"
+            },
+            "Settings": {
+              "$ref": "#/definitions/ExecuteOptions"
+            }
+          }
+        }
+      ]
     },
     "CollectionRuleLimitsOptions": {
       "type": "object",
@@ -528,7 +670,8 @@
             "null"
           ],
           "description": "The number of times the action list may be executed before being throttled.",
-          "format": "int32"
+          "format": "int32",
+          "default": 5
         },
         "ActionCountSlidingWindowDuration": {
           "type": [
@@ -846,6 +989,508 @@
           "items": {
             "$ref": "#/definitions/ProcessFilterDescriptor"
           }
+        }
+      }
+    },
+    "CollectionRuleActionType": {
+      "type": "string",
+      "enum": [
+        "CollectDump",
+        "CollectGCDump",
+        "CollectLogs",
+        "CollectTrace",
+        "Execute"
+      ]
+    },
+    "CollectDumpOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Egress"
+      ],
+      "properties": {
+        "Type": {
+          "description": "The type of dump to collect from the target process.",
+          "default": "WithHeap",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/DumpType"
+            }
+          ]
+        },
+        "Egress": {
+          "type": "string",
+          "description": "The name of the egress provider to which the dump is egressed.",
+          "minLength": 1
+        }
+      }
+    },
+    "DumpType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Full",
+        "Mini",
+        "WithHeap",
+        "Triage"
+      ],
+      "enum": [
+        "Full",
+        "Mini",
+        "WithHeap",
+        "Triage"
+      ]
+    },
+    "CollectGCDumpOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Egress"
+      ],
+      "properties": {
+        "Egress": {
+          "type": "string",
+          "description": "The name of the egress provider to which the GC dump is egressed.",
+          "minLength": 1
+        }
+      }
+    },
+    "CollectLogsOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Egress"
+      ],
+      "properties": {
+        "DefaultLevel": {
+          "description": "The default log level at which logs are collected for entries in the FilterSpecs that do not have a specified LogLevel value.",
+          "default": "Warning",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/LogLevel"
+            }
+          ]
+        },
+        "FilterSpecs": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "description": "A custom mapping of logger categories to log levels that describes at what level a log statement that matches one of the given categories should be captured.",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/definitions/LogLevel"
+              }
+            ]
+          }
+        },
+        "UseAppFilters": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Specifies whether to capture log statements at the levels as specified in the application-defined filters.",
+          "default": true
+        },
+        "Duration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The duration of time in which logs are collected.",
+          "format": "time-span",
+          "default": "00:00:30"
+        },
+        "Egress": {
+          "type": "string",
+          "description": "The name of the egress provider to which the logs are egressed.",
+          "minLength": 1
+        }
+      }
+    },
+    "CollectTraceOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Egress"
+      ],
+      "properties": {
+        "Profile": {
+          "description": "Use a predefined set of event providers and settings to capture in the trace. More than one profile may be specified at the same time. Either Profile or Providers must be specified, but not both.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/TraceProfile"
+            }
+          ]
+        },
+        "MetricsIntervalSeconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "The amount of time (in seconds) between the collection of each sample of the counter. Only applicable when Profile contains Metrics.",
+          "format": "int32",
+          "default": 1,
+          "maximum": 86400.0,
+          "minimum": 1.0
+        },
+        "Providers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "A list of event providers and settings to capture in the trace.  Either Profile or Providers must be specified, but not both.",
+          "items": {
+            "$ref": "#/definitions/EventPipeProvider"
+          }
+        },
+        "RequestRundown": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Indicates that rundown information should be included in the trace.",
+          "default": true
+        },
+        "BufferSizeMegabytes": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "The size of the event pipe buffer to use in the target process. If the event pipe buffer fills with too many events, newer events will be dropped until the buffer is drained to fit new events.",
+          "format": "int32",
+          "default": 256,
+          "maximum": 1024.0,
+          "minimum": 1.0
+        },
+        "Duration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The duration of time in which trace events are collected.",
+          "format": "time-span",
+          "default": "00:00:30"
+        },
+        "Egress": {
+          "type": "string",
+          "description": "The name of the egress provider to which the trace is egressed.",
+          "minLength": 1
+        }
+      }
+    },
+    "TraceProfile": {
+      "type": "string",
+      "description": "",
+      "x-enumFlags": true,
+      "x-enumNames": [
+        "Cpu",
+        "Http",
+        "Logs",
+        "Metrics"
+      ],
+      "enum": [
+        "Cpu",
+        "Http",
+        "Logs",
+        "Metrics"
+      ]
+    },
+    "EventPipeProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Name"
+      ],
+      "properties": {
+        "Name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "Keywords": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "EventLevel": {
+          "$ref": "#/definitions/EventLevel"
+        },
+        "Arguments": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "EventLevel": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "LogAlways",
+        "Critical",
+        "Error",
+        "Warning",
+        "Informational",
+        "Verbose"
+      ],
+      "enum": [
+        "LogAlways",
+        "Critical",
+        "Error",
+        "Warning",
+        "Informational",
+        "Verbose"
+      ]
+    },
+    "ExecuteOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Path"
+      ],
+      "properties": {
+        "Path": {
+          "type": "string",
+          "description": "The path of the executable to start.",
+          "minLength": 1
+        },
+        "Arguments": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The arguments to pass to the executable."
+        }
+      }
+    },
+    "CollectionRuleTriggerType": {
+      "type": "string",
+      "enum": [
+        "AspNetRequestCount",
+        "AspNetRequestDuration",
+        "AspNetResponseStatus",
+        "EventCounter",
+        "Startup"
+      ]
+    },
+    "AspNetRequestCountOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "RequestCount"
+      ],
+      "properties": {
+        "RequestCount": {
+          "type": "integer",
+          "description": "The threshold of the number of requests that start within the sliding window of time.",
+          "format": "int32"
+        },
+        "SlidingWindowDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The sliding time window in which the number of requests are counted.",
+          "format": "time-span",
+          "default": "00:01:00"
+        },
+        "IncludePaths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludePaths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of request paths to ignore.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AspNetRequestDurationOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "RequestCount"
+      ],
+      "properties": {
+        "RequestCount": {
+          "type": "integer",
+          "description": "The threshold of the number of slow requests that start within the sliding window of time.",
+          "format": "int32"
+        },
+        "RequestDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The threshold of the amount of time in which a request is considered to be slow.",
+          "format": "time-span",
+          "default": "00:00:05"
+        },
+        "SlidingWindowDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The sliding time window in which the the number of slow requests are counted.",
+          "format": "time-span",
+          "default": "00:01:00"
+        },
+        "IncludePaths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludePaths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of request paths to ignore.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AspNetResponseStatusOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "StatusCodes",
+        "ResponseCount"
+      ],
+      "properties": {
+        "StatusCodes": {
+          "type": "array",
+          "description": "The list of HTTP response status codes to monitor. Each item of the list can be a single code or a range of codes (e.g. \"400-499\").",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "ResponseCount": {
+          "type": "integer",
+          "description": "The threshold number of responses with matching status codes.",
+          "format": "int32"
+        },
+        "SlidingWindowDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The sliding time window in which the the number of responses with matching status codes must occur.",
+          "format": "time-span",
+          "default": "00:01:00"
+        },
+        "IncludePaths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludePaths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "The list of request paths to ignore.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "EventCounterOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ProviderName",
+        "CounterName"
+      ],
+      "properties": {
+        "ProviderName": {
+          "type": "string",
+          "description": "The name of the event source that provides the counter information.",
+          "minLength": 1
+        },
+        "CounterName": {
+          "type": "string",
+          "description": "The name of the counter to monitor.",
+          "minLength": 1
+        },
+        "GreaterThan": {
+          "type": [
+            "null",
+            "number"
+          ],
+          "description": "The threshold level the counter must maintain (or higher) for the specified duration. Either GreaterThan or LessThan (or both) must be specified.",
+          "format": "double"
+        },
+        "LessThan": {
+          "type": [
+            "null",
+            "number"
+          ],
+          "description": "The threshold level the counter must maintain (or lower) for the specified duration. Either GreaterThan or LessThan (or both) must be specified.",
+          "format": "double"
+        },
+        "SlidingWindowDuration": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The sliding time window in which the counter must maintain its value as specified by the threshold levels in GreaterThan and LessThan.",
+          "format": "time-span",
+          "default": "00:01:00"
+        },
+        "Frequency": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "The amount of time (in seconds) between the collection of each sample of the counter.",
+          "format": "int32",
+          "default": 5,
+          "maximum": 86400.0,
+          "minimum": 1.0
         }
       }
     },

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of request paths to ignore..
+        ///   Looks up a localized string similar to The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths {
             get {
@@ -88,7 +88,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored..
+        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored.  A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths {
             get {
@@ -115,7 +115,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of request paths to ignore..
+        ///   Looks up a localized string similar to The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths {
             get {
@@ -124,7 +124,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored..
+        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths {
             get {
@@ -160,7 +160,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of request paths to ignore..
+        ///   Looks up a localized string similar to The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths {
             get {
@@ -169,7 +169,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored..
+        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths {
             get {
@@ -187,7 +187,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The sliding time window in which the the number of responses with matching status codes must occur..
+        ///   Looks up a localized string similar to The sliding time window in which the number of responses with matching status codes must occur..
         /// </summary>
         public static string DisplayAttributeDescription_AspNetResponseStatusOptions_SlidingWindowDuration {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -79,6 +79,132 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The list of request paths to ignore..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The threshold of the number of requests that start within the sliding window of time..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestCountOptions_RequestCount {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestCountOptions_RequestCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The sliding time window in which the number of requests are counted..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestCountOptions_SlidingWindowDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestCountOptions_SlidingWindowDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of request paths to ignore..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The threshold of the number of slow requests that start within the sliding window of time..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestDurationOptions_RequestCount {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestDurationOptions_RequestCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The threshold of the amount of time in which a request is considered to be slow..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestDurationOptions_RequestDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestDurationOptions_RequestDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The sliding time window in which the the number of slow requests are counted..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetRequestDurationOptions_SlidingWindowDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetRequestDurationOptions_SlidingWindowDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of request paths to ignore..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The threshold number of responses with matching status codes..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetResponseStatusOptions_ResponseCount {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetResponseStatusOptions_ResponseCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The sliding time window in which the the number of responses with matching status codes must occur..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetResponseStatusOptions_SlidingWindowDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetResponseStatusOptions_SlidingWindowDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of HTTP response status codes to monitor. Each item of the list can be a single code or a range of codes (e.g. &quot;400-499&quot;)..
+        /// </summary>
+        public static string DisplayAttributeDescription_AspNetResponseStatusOptions_StatusCodes {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_AspNetResponseStatusOptions_StatusCodes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The account key used to access the Azure blob storage account..
         /// </summary>
         public static string DisplayAttributeDescription_AzureBlobEgressProviderOptions_AccountKey {
@@ -139,6 +265,33 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_AzureBlobEgressProviderOptions_SharedAccessSignatureN" +
                         "ame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the egress provider to which the dump is egressed..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectDumpOptions_Egress {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectDumpOptions_Egress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type of dump to collect from the target process..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectDumpOptions_Type {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectDumpOptions_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the egress provider to which the GC dump is egressed..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectGCDumpOptions_Egress {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectGCDumpOptions_Egress", resourceCulture);
             }
         }
         
@@ -239,6 +392,114 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         public static string DisplayAttributeDescription_CollectionRuleTriggerOptions_Type {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_CollectionRuleTriggerOptions_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The default log level at which logs are collected for entries in the FilterSpecs that do not have a specified LogLevel value..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectLogsOptions_DefaultLevel {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectLogsOptions_DefaultLevel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The duration of time in which logs are collected..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectLogsOptions_Duration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectLogsOptions_Duration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the egress provider to which the logs are egressed..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectLogsOptions_Egress {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectLogsOptions_Egress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A custom mapping of logger categories to log levels that describes at what level a log statement that matches one of the given categories should be captured..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectLogsOptions_FilterSpecs {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectLogsOptions_FilterSpecs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies whether to capture log statements at the levels as specified in the application-defined filters..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectLogsOptions_UseAppFilters {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectLogsOptions_UseAppFilters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The size of the event pipe buffer to use in the target process. If the event pipe buffer fills with too many events, newer events will be dropped until the buffer is drained to fit new events..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_BufferSizeMegabytes {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_BufferSizeMegabytes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The duration of time in which trace events are collected..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_Duration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_Duration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the egress provider to which the trace is egressed..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_Egress {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_Egress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The amount of time (in seconds) between the collection of each sample of the counter. Only applicable when Profile contains Metrics..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use a predefined set of event providers and settings to capture in the trace. More than one profile may be specified at the same time. Either Profile or Providers must be specified, but not both..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_Profile {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_Profile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A list of event providers and settings to capture in the trace.  Either Profile or Providers must be specified, but not both..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_Providers {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_Providers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that rundown information should be included in the trace..
+        /// </summary>
+        public static string DisplayAttributeDescription_CollectTraceOptions_RequestRundown {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_RequestRundown", resourceCulture);
             }
         }
         
@@ -401,6 +662,78 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         public static string DisplayAttributeDescription_EgressOptions_Properties {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_EgressOptions_Properties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the counter to monitor..
+        /// </summary>
+        public static string DisplayAttributeDescription_EventCounterOptions_CounterName {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_CounterName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The amount of time (in seconds) between the collection of each sample of the counter..
+        /// </summary>
+        public static string DisplayAttributeDescription_EventCounterOptions_Frequency {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_Frequency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The threshold level the counter must maintain (or higher) for the specified duration. Either GreaterThan or LessThan (or both) must be specified..
+        /// </summary>
+        public static string DisplayAttributeDescription_EventCounterOptions_GreaterThan {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_GreaterThan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The threshold level the counter must maintain (or lower) for the specified duration. Either GreaterThan or LessThan (or both) must be specified..
+        /// </summary>
+        public static string DisplayAttributeDescription_EventCounterOptions_LessThan {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_LessThan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the event source that provides the counter information..
+        /// </summary>
+        public static string DisplayAttributeDescription_EventCounterOptions_ProviderName {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_ProviderName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The sliding time window in which the counter must maintain its value as specified by the threshold levels in GreaterThan and LessThan..
+        /// </summary>
+        public static string DisplayAttributeDescription_EventCounterOptions_SlidingWindowDuration {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_SlidingWindowDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The arguments to pass to the executable..
+        /// </summary>
+        public static string DisplayAttributeDescription_ExecuteOptions_Arguments {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_ExecuteOptions_Arguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The path of the executable to start..
+        /// </summary>
+        public static string DisplayAttributeDescription_ExecuteOptions_Path {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_ExecuteOptions_Path", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -126,11 +126,11 @@
     <comment>The description provided for the ApiKeyHashType parameter on ApiAuthenticationOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths" xml:space="preserve">
-    <value>The list of request paths to ignore.</value>
+    <value>The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored.</value>
     <comment>The description provided for the ExcludePaths parameter on AspNetRequestCountOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths" xml:space="preserve">
-    <value>The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
+    <value>The list of request paths to monitor. If not specified, all request paths are monitored.  A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
     <comment>The description provided for the IncludePaths parameter on AspNetRequestCountOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetRequestCountOptions_RequestCount" xml:space="preserve">
@@ -142,11 +142,11 @@
     <comment>The description provided for the SlidingWindowDuration parameter on AspNetRequestCountOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths" xml:space="preserve">
-    <value>The list of request paths to ignore.</value>
+    <value>The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored.</value>
     <comment>The description provided for the ExcludePaths parameter on AspNetRequestDurationOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths" xml:space="preserve">
-    <value>The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
+    <value>The list of request paths to monitor. If not specified, all request paths are monitored. A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
     <comment>The description provided for the IncludePaths parameter on AspNetRequestDurationOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_RequestCount" xml:space="preserve">
@@ -162,11 +162,11 @@
     <comment>The description provided for the SlidingWindowDuration parameter on AspNetRequestDurationOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths" xml:space="preserve">
-    <value>The list of request paths to ignore.</value>
+    <value>The list of request paths to ignore. A request path must exactly match one of the items in the list to be ignored.</value>
     <comment>The description provided for the ExcludePaths parameter on AspNetResponseStatusOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths" xml:space="preserve">
-    <value>The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
+    <value>The list of request paths to monitor. If not specified, all request paths are monitored. A request path must exactly match one of the items in the list to be monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
     <comment>The description provided for the IncludePaths parameter on AspNetResponseStatusOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_ResponseCount" xml:space="preserve">
@@ -174,7 +174,7 @@
     <comment>The description provided for the ResponseCount parameter on AspNetResponseStatusOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_SlidingWindowDuration" xml:space="preserve">
-    <value>The sliding time window in which the the number of responses with matching status codes must occur.</value>
+    <value>The sliding time window in which the number of responses with matching status codes must occur.</value>
     <comment>The description provided for the SlidingWindowDuration parameter on AspNetResponseStatusOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_StatusCodes" xml:space="preserve">

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -125,6 +125,62 @@
     <value>Hash algorithm used to compute ApiKeyHash, typically 'SHA256'. 'SHA1' and 'MD5' are not allowed.</value>
     <comment>The description provided for the ApiKeyHashType parameter on ApiAuthenticationOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths" xml:space="preserve">
+    <value>The list of request paths to ignore.</value>
+    <comment>The description provided for the ExcludePaths parameter on AspNetRequestCountOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths" xml:space="preserve">
+    <value>The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
+    <comment>The description provided for the IncludePaths parameter on AspNetRequestCountOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestCountOptions_RequestCount" xml:space="preserve">
+    <value>The threshold of the number of requests that start within the sliding window of time.</value>
+    <comment>The description provided for the RequestCount parameter on AspNetRequestCountOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestCountOptions_SlidingWindowDuration" xml:space="preserve">
+    <value>The sliding time window in which the number of requests are counted.</value>
+    <comment>The description provided for the SlidingWindowDuration parameter on AspNetRequestCountOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths" xml:space="preserve">
+    <value>The list of request paths to ignore.</value>
+    <comment>The description provided for the ExcludePaths parameter on AspNetRequestDurationOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths" xml:space="preserve">
+    <value>The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
+    <comment>The description provided for the IncludePaths parameter on AspNetRequestDurationOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_RequestCount" xml:space="preserve">
+    <value>The threshold of the number of slow requests that start within the sliding window of time.</value>
+    <comment>The description provided for the RequestCount parameter on AspNetRequestDurationOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_RequestDuration" xml:space="preserve">
+    <value>The threshold of the amount of time in which a request is considered to be slow.</value>
+    <comment>The description provided for the RequestDuration parameter on AspNetRequestDurationOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetRequestDurationOptions_SlidingWindowDuration" xml:space="preserve">
+    <value>The sliding time window in which the the number of slow requests are counted.</value>
+    <comment>The description provided for the SlidingWindowDuration parameter on AspNetRequestDurationOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths" xml:space="preserve">
+    <value>The list of request paths to ignore.</value>
+    <comment>The description provided for the ExcludePaths parameter on AspNetResponseStatusOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths" xml:space="preserve">
+    <value>The list of request paths to monitor. If not specified, all request paths are monitored. Request paths matching the ExcludePaths list will not be monitored.</value>
+    <comment>The description provided for the IncludePaths parameter on AspNetResponseStatusOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_ResponseCount" xml:space="preserve">
+    <value>The threshold number of responses with matching status codes.</value>
+    <comment>The description provided for the ResponseCount parameter on AspNetResponseStatusOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_SlidingWindowDuration" xml:space="preserve">
+    <value>The sliding time window in which the the number of responses with matching status codes must occur.</value>
+    <comment>The description provided for the SlidingWindowDuration parameter on AspNetResponseStatusOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_AspNetResponseStatusOptions_StatusCodes" xml:space="preserve">
+    <value>The list of HTTP response status codes to monitor. Each item of the list can be a single code or a range of codes (e.g. "400-499").</value>
+    <comment>The description provided for the StatusCodes parameter on AspNetResponseStatusOptions.</comment>
+  </data>
   <data name="DisplayAttributeDescription_AzureBlobEgressProviderOptions_AccountKey" xml:space="preserve">
     <value>The account key used to access the Azure blob storage account.</value>
     <comment>The description provided for the AccountKey parameter on AzureBlobEgressProviderOptions.</comment>
@@ -152,6 +208,18 @@
   <data name="DisplayAttributeDescription_AzureBlobEgressProviderOptions_SharedAccessSignatureName" xml:space="preserve">
     <value>The name of the shared access signature (SAS) used to look up the value from the Egress options Properties map.</value>
     <comment>The description provided for the SharedAccessSignatureName parameter on AzureBlobEgressProviderOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectDumpOptions_Egress" xml:space="preserve">
+    <value>The name of the egress provider to which the dump is egressed.</value>
+    <comment>The description provided for the Egress parameter on CollectDumpOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectDumpOptions_Type" xml:space="preserve">
+    <value>The type of dump to collect from the target process.</value>
+    <comment>The description provided for the Type parameter on CollectDumpOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectGCDumpOptions_Egress" xml:space="preserve">
+    <value>The name of the egress provider to which the GC dump is egressed.</value>
+    <comment>The description provided for the Egress parameter on CollectGCDumpOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_CollectionRuleActionOptions_Settings" xml:space="preserve">
     <value>The settings to pass to the action when it is executed. Settings may be optional if the action doesn't require settings or its settings are all optional.</value>
@@ -196,6 +264,54 @@
   <data name="DisplayAttributeDescription_CollectionRuleTriggerOptions_Type" xml:space="preserve">
     <value>The type of trigger used to monitor for a condition in the target process.</value>
     <comment>The description provided for the Type parameter on CollectionRuleTriggerOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectLogsOptions_DefaultLevel" xml:space="preserve">
+    <value>The default log level at which logs are collected for entries in the FilterSpecs that do not have a specified LogLevel value.</value>
+    <comment>The description provided for the LogLevel parameter on CollectLogsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectLogsOptions_Duration" xml:space="preserve">
+    <value>The duration of time in which logs are collected.</value>
+    <comment>The description provided for the Duration parameter on CollectLogsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectLogsOptions_Egress" xml:space="preserve">
+    <value>The name of the egress provider to which the logs are egressed.</value>
+    <comment>The description provided for the Egress parameter on CollectLogsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectLogsOptions_FilterSpecs" xml:space="preserve">
+    <value>A custom mapping of logger categories to log levels that describes at what level a log statement that matches one of the given categories should be captured.</value>
+    <comment>The description provided for the FilterSpecs parameter on CollectLogsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectLogsOptions_UseAppFilters" xml:space="preserve">
+    <value>Specifies whether to capture log statements at the levels as specified in the application-defined filters.</value>
+    <comment>The description provided for the UseAppFilters parameter on CollectLogsOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_BufferSizeMegabytes" xml:space="preserve">
+    <value>The size of the event pipe buffer to use in the target process. If the event pipe buffer fills with too many events, newer events will be dropped until the buffer is drained to fit new events.</value>
+    <comment>The description provided for the BufferSizeMegabytes parameter on CollectTraceOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_Duration" xml:space="preserve">
+    <value>The duration of time in which trace events are collected.</value>
+    <comment>The description provided for the Duration parameter on CollectTraceOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_Egress" xml:space="preserve">
+    <value>The name of the egress provider to which the trace is egressed.</value>
+    <comment>The description provided for the Egress parameter on CollectTraceOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds" xml:space="preserve">
+    <value>The amount of time (in seconds) between the collection of each sample of the counter. Only applicable when Profile contains Metrics.</value>
+    <comment>The description provided for the MetricsIntervalSeconds parameter on CollectTraceOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_Profile" xml:space="preserve">
+    <value>Use a predefined set of event providers and settings to capture in the trace. More than one profile may be specified at the same time. Either Profile or Providers must be specified, but not both.</value>
+    <comment>The description provided for the Profile parameter on CollectTraceOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_Providers" xml:space="preserve">
+    <value>A list of event providers and settings to capture in the trace.  Either Profile or Providers must be specified, but not both.</value>
+    <comment>The description provided for the Providers parameter on CollectTraceOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_CollectTraceOptions_RequestRundown" xml:space="preserve">
+    <value>Indicates that rundown information should be included in the trace.</value>
+    <comment>The description provided for the RequestRundown parameter on CollectTraceOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_CommonEgressProviderOptions_CopyBufferSize" xml:space="preserve">
     <value>Buffer size used when copying data from an egress callback returning a stream to the egress callback that is provided a stream to which data is written.</value>
@@ -268,6 +384,38 @@
   <data name="DisplayAttributeDescription_EgressOptions_Properties" xml:space="preserve">
     <value>Additional properties, such as secrets, that can be referenced by the provider definitions.</value>
     <comment>The description provided for the Properties parameter on EgressOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_EventCounterOptions_CounterName" xml:space="preserve">
+    <value>The name of the counter to monitor.</value>
+    <comment>The description provided for the CounterName parameter on EventCounterOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_EventCounterOptions_Frequency" xml:space="preserve">
+    <value>The amount of time (in seconds) between the collection of each sample of the counter.</value>
+    <comment>The description provided for the Frequency parameter on EventCounterOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_EventCounterOptions_GreaterThan" xml:space="preserve">
+    <value>The threshold level the counter must maintain (or higher) for the specified duration. Either GreaterThan or LessThan (or both) must be specified.</value>
+    <comment>The description provided for the GreaterThan parameter on EventCounterOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_EventCounterOptions_LessThan" xml:space="preserve">
+    <value>The threshold level the counter must maintain (or lower) for the specified duration. Either GreaterThan or LessThan (or both) must be specified.</value>
+    <comment>The description provided for the LessThan parameter on EventCounterOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_EventCounterOptions_ProviderName" xml:space="preserve">
+    <value>The name of the event source that provides the counter information.</value>
+    <comment>The description provided for the ProviderName parameter on EventCounterOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_EventCounterOptions_SlidingWindowDuration" xml:space="preserve">
+    <value>The sliding time window in which the counter must maintain its value as specified by the threshold levels in GreaterThan and LessThan.</value>
+    <comment>The description provided for the SlidingWindowDuration parameter on EventCounterOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_ExecuteOptions_Arguments" xml:space="preserve">
+    <value>The arguments to pass to the executable.</value>
+    <comment>The description provided for the Arguments parameter on ExecuteOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_ExecuteOptions_Path" xml:space="preserve">
+    <value>The path of the executable to start.</value>
+    <comment>The description provided for the Path parameter on ExecuteOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_FileSystemEgressProviderOptions_DirectoryPath" xml:space="preserve">
     <value>The directory path to which the stream data will be egressed.</value>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeProvider.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if !SCHEMAGEN
 using Microsoft.Diagnostics.Monitoring.WebApi.Validation;
+#endif
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.Tracing;
@@ -17,7 +19,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public string Name { get; set; }
 
         [JsonPropertyName("keywords")]
+#if !SCHEMAGEN
         [IntegerOrHexString]
+#endif
         public string Keywords { get; set; } = "0x" + EventKeywords.All.ToString("X");
 
         [JsonPropertyName("eventLevel")]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptions.cs" Link="Options\CollectionRules\Triggers\EventCounterOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\EventCounterOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\IAspNetActionPathFilters.cs" Link="Options\CollectionRules\Actions\IAspNetActionPathFilters.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\TriggerOptionsConstants.cs" Link="Options\CollectionRules\Triggers\TriggerOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\RootOptions.cs" Link="Options\RootOptions.cs" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -3,14 +3,39 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);SCHEMAGEN</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Models\DumpType.cs" Link="Models\DumpType.cs" />
+    <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Models\EventPipeProvider.cs" Link="Models\EventPipeProvider.cs" />
+    <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Models\TraceProfile.cs" Link="Models\TraceProfile.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\KnownCollectionRuleActions.cs" Link="Options\CollectionRules\KnownCollectionRuleActions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\KnownCollectionRuleTriggers.cs" Link="Options\CollectionRules\KnownCollectionRuleTriggers.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ActionOptionsConstants.cs" Link="Options\CollectionRules\Actions\ActionOptionsConstants.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectDumpOptions.cs" Link="Options\CollectionRules\Actions\CollectDumpOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectDumpOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectDumpOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectGCDumpOptions.cs" Link="Options\CollectionRules\Actions\CollectGCDumpOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectLogsOptions.cs" Link="Options\CollectionRules\Actions\CollectLogsOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectLogsOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectLogsOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptions.cs" Link="Options\CollectionRules\Actions\CollectTraceOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectTraceOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptions.cs" Link="Options\CollectionRules\Actions\ExecuteOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptions.cs" Link="Options\CollectionRules\CollectionRuleActionOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptions.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptionsDefaults.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptions.cs" Link="Options\CollectionRules\CollectionRuleOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptionsConstants.cs" Link="Options\CollectionRules\CollectionRuleOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleTriggerOptions.cs" Link="Options\CollectionRules\CollectionRuleTriggerOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestCountOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestCountOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestCountOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetRequestCountOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestDurationOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestDurationOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestDurationOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetRequestDurationOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptions.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptions.cs" Link="Options\CollectionRules\Triggers\EventCounterOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\EventCounterOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\TriggerOptionsConstants.cs" Link="Options\CollectionRules\Triggers\TriggerOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\RootOptions.cs" Link="Options\RootOptions.cs" />
   </ItemGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -184,7 +184,6 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
             triggerTypeSchema.Enumeration.Add(triggerType);
         }
 
-
         private static JsonSchemaProperty AddDiscriminatedSubSchema(
             JsonSchema parentSchema,
             string discriminatingPropertyName,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptions.cs" Link="Options\CollectionRules\Triggers\EventCounterOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\EventCounterOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\IAspNetActionPathFilters.cs" Link="Options\CollectionRules\Triggers\IAspNetActionPathFilters.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\TriggerOptionsConstants.cs" Link="Options\CollectionRules\Triggers\TriggerOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\RootOptions.cs" Link="Options\RootOptions.cs" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -12,19 +12,27 @@
   <ItemGroup>
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ActionOptionsConstants.cs" Link="Options\CollectionRules\Actions\ActionOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectDumpOptions.cs" Link="Options\CollectionRules\Actions\CollectDumpOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectDumpOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectDumpOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectGCDumpOptions.cs" Link="Options\CollectionRules\Actions\CollectGCDumpOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectLogsOptions.cs" Link="Options\CollectionRules\Actions\CollectLogsOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectLogsOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectLogsOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptions.cs" Link="Options\CollectionRules\Actions\CollectTraceOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectTraceOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptions.cs" Link="Options\CollectionRules\Actions\ExecuteOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptions.cs" Link="Options\CollectionRules\CollectionRuleActionOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptions.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptionsDefaults.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptions.cs" Link="Options\CollectionRules\CollectionRuleOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleOptionsConstants.cs" Link="Options\CollectionRules\CollectionRuleOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleTriggerOptions.cs" Link="Options\CollectionRules\CollectionRuleTriggerOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestCountOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestCountOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestCountOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetRequestCountOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestDurationOptions.cs" Link="Options\CollectionRules\Triggers\AspNetRequestDurationOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetRequestDurationOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetRequestDurationOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptions.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\AspNetResponseStatusOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\AspNetResponseStatusOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptions.cs" Link="Options\CollectionRules\Triggers\EventCounterOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\EventCounterOptionsDefaults.cs" Link="Options\CollectionRules\Triggers\EventCounterOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Triggers\TriggerOptionsConstants.cs" Link="Options\CollectionRules\Triggers\TriggerOptionsConstants.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\RootOptions.cs" Link="Options\RootOptions.cs" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                         .AddCollectLogsAction(ExpectedEgressProvider, out CollectLogsOptions collectLogsOptions);
 
                     collectLogsOptions.UseAppFilters = ExpectedUseAppFilters;
-                    collectLogsOptions.LogLevel = ExpectedLogLevel;
+                    collectLogsOptions.DefaultLevel = ExpectedLogLevel;
                     collectLogsOptions.FilterSpecs = ExpectedFilterSpecs;
                     collectLogsOptions.Duration = ExpectedDuration;
 
@@ -378,7 +378,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     CollectLogsOptions collectLogsOptions = ruleOptions.VerifyCollectLogsAction(0, ExpectedEgressProvider);
                     Assert.Equal(ExpectedUseAppFilters, collectLogsOptions.UseAppFilters);
-                    Assert.Equal(ExpectedLogLevel, collectLogsOptions.LogLevel);
+                    Assert.Equal(ExpectedLogLevel, collectLogsOptions.DefaultLevel);
                     Assert.NotNull(collectLogsOptions.FilterSpecs);
                     Assert.Equal(ExpectedFilterSpecs.Count, collectLogsOptions.FilterSpecs.Count);
                     foreach ((string expectedCategory, LogLevel? expectedLogLevel) in ExpectedFilterSpecs)
@@ -400,14 +400,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                         .SetStartupTrigger()
                         .AddCollectLogsAction(egress: null, out CollectLogsOptions collectLogsOptions);
 
-                    collectLogsOptions.LogLevel = (LogLevel)100;
+                    collectLogsOptions.DefaultLevel = (LogLevel)100;
                     collectLogsOptions.Duration = TimeSpan.FromDays(3);
                 },
                 ex =>
                 {
                     string[] failures = ex.Failures.ToArray();
                     Assert.Equal(3, failures.Length);
-                    VerifyEnumDataTypeMessage<LogLevel>(failures, 0, nameof(CollectLogsOptions.LogLevel));
+                    VerifyEnumDataTypeMessage<LogLevel>(failures, 0, nameof(CollectLogsOptions.DefaultLevel));
                     VerifyRangeMessage<TimeSpan>(failures, 1, nameof(CollectLogsOptions.Duration),
                         ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue);
                     VerifyRequiredMessage(failures, 2, nameof(CollectLogsOptions.Egress));

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 
@@ -14,11 +16,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     [DebuggerDisplay("CollectDump")]
     internal sealed partial class CollectDumpOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectDumpOptions_Type))]
         [EnumDataType(typeof(DumpType))]
+        [DefaultValue(CollectDumpOptionsDefaults.Type)]
         public DumpType? Type { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectDumpOptions_Egress))]
         [Required]
-#if !UNITTEST
+#if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
         public string Egress { get; set; }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptionsDefaults.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    internal static class CollectDumpOptionsDefaults
+    {
+        public const DumpType Type = DumpType.WithHeap;
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 
@@ -13,8 +14,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     [DebuggerDisplay("CollectGCDump")]
     internal sealed partial class CollectGCDumpOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectGCDumpOptions_Egress))]
         [Required]
-#if !UNITTEST
+#if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
         public string Egress { get; set; }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 
@@ -16,18 +18,36 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     [DebuggerDisplay("CollectLogs")]
     internal sealed partial class CollectLogsOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLogsOptions_DefaultLevel))]
         [EnumDataType(typeof(LogLevel))]
-        public LogLevel? LogLevel { get; set; }
+        [DefaultValue(CollectLogsOptionsDefaults.DefaultLevel)]
+        public LogLevel? DefaultLevel { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLogsOptions_FilterSpecs))]
         public Dictionary<string, LogLevel?> FilterSpecs { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLogsOptions_UseAppFilters))]
+        [DefaultValue(CollectLogsOptionsDefaults.UseAppFilters)]
         public bool? UseAppFilters { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLogsOptions_Duration))]
         [Range(typeof(TimeSpan), ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue)]
+        [DefaultValue(CollectLogsOptionsDefaults.Duration)]
         public TimeSpan? Duration { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLogsOptions_Egress))]
         [Required]
-#if !UNITTEST
+#if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
         public string Egress { get; set; }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptionsDefaults.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    internal static class CollectLogsOptionsDefaults
+    {
+        public const Extensions.Logging.LogLevel DefaultLevel = Extensions.Logging.LogLevel.Warning;
+        public const bool UseAppFilters = true;
+        public const string Duration = "00:00:30";
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 
@@ -16,24 +18,49 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     [DebuggerDisplay("CollectTrace")]
     internal sealed partial class CollectTraceOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_Profile))]
         [EnumDataType(typeof(TraceProfile))]
         public TraceProfile? Profile { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds))]
         [Range(ActionOptionsConstants.MetricsIntervalSeconds_MinValue, ActionOptionsConstants.MetricsIntervalSeconds_MaxValue)]
+        [DefaultValue(CollectTraceOptionsDefaults.MetricsIntervalSeconds)]
         public int? MetricsIntervalSeconds { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_Providers))]
         public List<EventPipeProvider> Providers { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_RequestRundown))]
+        [DefaultValue(CollectTraceOptionsDefaults.RequestRundown)]
         public bool? RequestRundown { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_BufferSizeMegabytes))]
         [Range(ActionOptionsConstants.BufferSizeMegabytes_MinValue, ActionOptionsConstants.BufferSizeMegabytes_MaxValue)]
+        [DefaultValue(CollectTraceOptionsDefaults.BufferSizeMegabytes)]
         public int? BufferSizeMegabytes { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_Duration))]
         [Range(typeof(TimeSpan), ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue)]
+        [DefaultValue(CollectTraceOptionsDefaults.Duration)]
         public TimeSpan? Duration { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_Egress))]
         [Required]
-#if !UNITTEST
+#if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
         public string Egress { get; set; }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptionsDefaults.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    internal static class CollectTraceOptionsDefaults
+    {
+        public const int MetricsIntervalSeconds = 1;
+        public const bool RequestRundown = true;
+        public const int BufferSizeMegabytes = 256;
+        public const string Duration = "00:00:30";
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 
@@ -13,9 +14,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     [DebuggerDisplay("Execute: Path = {Path}")]
     internal sealed class ExecuteOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ExecuteOptions_Path))]
         [Required]
         public string Path { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ExecuteOptions_Arguments))]
         public string Arguments { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
@@ -16,6 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleLimitsOptions_ActionCount))]
+        [DefaultValue(CollectionRuleLimitsOptionsDefaults.ActionCount)]
         public int? ActionCount { get; set; }
 
         [Display(

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptionsDefaults.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
+{
+    internal static class CollectionRuleLimitsOptionsDefaults
+    {
+        public const int ActionCount = 5;
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
@@ -12,14 +14,27 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// </summary>
     internal sealed class AspNetRequestCountOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_RequestCount))]
         [Required]
         public int RequestCount { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_SlidingWindowDuration))]
         [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        [DefaultValue(AspNetRequestCountOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
-        public string IncludePaths { get; set; }
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths))]
+        public string[] IncludePaths { get; set; }
 
-        public string ExcludePaths { get; set; }
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths))]
+        public string[] ExcludePaths { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// <summary>
     /// Options for the AspNetRequestCount trigger.
     /// </summary>
-    internal sealed class AspNetRequestCountOptions
+    internal sealed class AspNetRequestCountOptions :
+        IAspNetActionPathFilters
     {
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -27,11 +28,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [DefaultValue(AspNetRequestCountOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
+        // CONSIDER: Currently described that paths have to exactly match one item in the list.
+        // Consider allowing for wildcard/globbing to simplfy list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths))]
         public string[] IncludePaths { get; set; }
 
+        // CONSIDER: Currently described that paths have to exactly match one item in the list.
+        // Consider allowing for wildcard/globbing to simplfy list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths))]

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptionsDefaults.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+{
+    internal static class AspNetRequestCountOptionsDefaults
+    {
+        public const string SlidingWindowDuration = "00:01:00";
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptionsDefaults.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {
     internal static class AspNetRequestCountOptionsDefaults
     {
-        public const string SlidingWindowDuration = "00:01:00";
+        public const string SlidingWindowDuration = TriggerOptionsConstants.SlidingWindowDuration_Default;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// <summary>
     /// Options for the AspNetRequestDuration trigger.
     /// </summary>
-    internal sealed class AspNetRequestDurationOptions
+    internal sealed class AspNetRequestDurationOptions :
+        IAspNetActionPathFilters
     {
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -33,11 +34,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [DefaultValue(AspNetRequestDurationOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
+        // CONSIDER: Currently described that paths have to exactly match one item in the list.
+        // Consider allowing for wildcard/globbing to simplfy list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths))]
         public string[] IncludePaths { get; set; }
 
+        // CONSIDER: Currently described that paths have to exactly match one item in the list.
+        // Consider allowing for wildcard/globbing to simplfy list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths))]

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
@@ -12,16 +14,33 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// </summary>
     internal sealed class AspNetRequestDurationOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_RequestCount))]
         [Required]
         public int RequestCount { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_RequestDuration))]
+        [DefaultValue(AspNetRequestDurationOptionsDefaults.RequestDuration)]
         public TimeSpan? RequestDuration { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_SlidingWindowDuration))]
         [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        [DefaultValue(AspNetRequestDurationOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
-        public string IncludePaths { get; set; }
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths))]
+        public string[] IncludePaths { get; set; }
 
-        public string ExcludePaths { get; set; }
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths))]
+        public string[] ExcludePaths { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptionsDefaults.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     internal static class AspNetRequestDurationOptionsDefaults
     {
         public const string RequestDuration = "00:00:05";
-        public const string SlidingWindowDuration = "00:01:00";
+        public const string SlidingWindowDuration = TriggerOptionsConstants.SlidingWindowDuration_Default;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptionsDefaults.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+{
+    internal static class AspNetRequestDurationOptionsDefaults
+    {
+        public const string RequestDuration = "00:00:05";
+        public const string SlidingWindowDuration = "00:01:00";
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
@@ -12,17 +14,34 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// </summary>
     internal sealed class AspNetResponseStatusOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_StatusCodes))]
         [Required]
-        public string StatusCodes { get; set; }
+        [MinLength(1)]
+        public string[] StatusCodes { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_ResponseCount))]
         [Required]
         public int ResponseCount { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_SlidingWindowDuration))]
         [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        [DefaultValue(AspNetResponseStatusOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
-        public string IncludePaths { get; set; }
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths))]
+        public string[] IncludePaths { get; set; }
 
-        public string ExcludePaths { get; set; }
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths))]
+        public string[] ExcludePaths { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// <summary>
     /// Options for the AspNetResponseStatus trigger.
     /// </summary>
-    internal sealed class AspNetResponseStatusOptions
+    internal sealed class AspNetResponseStatusOptions :
+        IAspNetActionPathFilters
     {
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -34,11 +35,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [DefaultValue(AspNetResponseStatusOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
+        // CONSIDER: Currently described that paths have to exactly match one item in the list.
+        // Consider allowing for wildcard/globbing to simplfy list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths))]
         public string[] IncludePaths { get; set; }
 
+        // CONSIDER: Currently described that paths have to exactly match one item in the list.
+        // Consider allowing for wildcard/globbing to simplfy list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths))]

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptionsDefaults.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+{
+    internal static class AspNetResponseStatusOptionsDefaults
+    {
+        public const string SlidingWindowDuration = "00:01:00";
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
@@ -12,20 +14,40 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     /// </summary>
     internal sealed partial class EventCounterOptions
     {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_ProviderName))]
         [Required]
         public string ProviderName { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_CounterName))]
         [Required]
         public string CounterName { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_GreaterThan))]
         public double? GreaterThan { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_LessThan))]
         public double? LessThan { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_SlidingWindowDuration))]
         [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
+        [DefaultValue(EventCounterOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
 
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_Frequency))]
         [Range(TriggerOptionsConstants.CounterFrequency_MinValue, TriggerOptionsConstants.CounterFrequency_MaxValue)]
+        [DefaultValue(EventCounterOptionsDefaults.Frequency)]
         public int? Frequency { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
+{
+    internal static class EventCounterOptionsDefaults
+    {
+        public const string SlidingWindowDuration = "00:01:00";
+        public const int Frequency = 5;
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {
     internal static class EventCounterOptionsDefaults
     {
-        public const string SlidingWindowDuration = "00:01:00";
+        public const string SlidingWindowDuration = TriggerOptionsConstants.SlidingWindowDuration_Default;
         public const int Frequency = 5;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/IAspNetActionPathFilters.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/IAspNetActionPathFilters.cs
@@ -4,8 +4,10 @@
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {
-    internal static class AspNetResponseStatusOptionsDefaults
+    internal interface IAspNetActionPathFilters
     {
-        public const string SlidingWindowDuration = TriggerOptionsConstants.SlidingWindowDuration_Default;
+        public string[] IncludePaths { get; }
+
+        public string[] ExcludePaths { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         public static readonly string Frequency_MaxValue_String = CounterFrequency_MaxValue.ToString(CultureInfo.InvariantCulture);
         public const int CounterFrequency_MinValue = 1; // 1 second
         public static readonly string Frequency_MinValue_String = CounterFrequency_MinValue.ToString(CultureInfo.InvariantCulture);
-        
+
+        public const string SlidingWindowDuration_Default = "00:01:00"; // 1 minute
         public const string SlidingWindowDuration_MaxValue = "1.00:00:00"; // 1 day
         public const string SlidingWindowDuration_MinValue = "00:00:01"; // 1 second
     }


### PR DESCRIPTION
- Generate action and trigger options in schema.
- Add display name descriptions to these options.
- Add defaults for the optional properties.
- Other small changes such as property renames and changing IncludePaths and ExcludePaths property to arrays.