### PR TITLE
Add detailed message to output in TestSchemaBaseline

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -5,6 +5,7 @@
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -110,7 +111,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
             int formatQty = (endLine + 1).ToString("D").Length; // Get the length of the biggest number (add 1 for the 1-based index)
             for (int i = startLine; i <= endLine; i++)
             {
-                outputHelper.WriteLine("{0}:{1}{2}", (i+1).ToString("D" + formatQty), (i == lineHighlighted) ? " >" : "  ", lines[i]);
+                outputHelper.WriteLine("{0}:{1}{2}", (i+1).ToString("D" + formatQty, CultureInfo.InvariantCulture), (i == lineHighlighted) ? " >" : "  ", lines[i]);
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -77,29 +77,41 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
             return new FileStream(tempSchema, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
         }
 
-        private async Task<bool> CompareLines(TextReader first, TextReader second)
+        private async Task<bool> CompareLines(TextReader baseline, TextReader generated)
         {
-            IList<string> firstLines = await ReadAllLines(first);
-            IList<string> secondLines = await ReadAllLines(second);
+            IList<string> baselineLines = await ReadAllLines(baseline);
+            IList<string> generatedLines = await ReadAllLines(generated);
 
-            for (int i = 0; i < Math.Min(firstLines.Count, secondLines.Count); i++)
+            for (int i = 0; i < Math.Min(baselineLines.Count, generatedLines.Count); i++)
             {
-                if (!string.Equals(firstLines[i], secondLines[i], StringComparison.Ordinal))
+                if (!string.Equals(baselineLines[i], generatedLines[i], StringComparison.Ordinal))
                 {
                     _outputHelper.WriteLine($"Differs from baseline on line {i + 1}:");
-                    _outputHelper.WriteLine(firstLines[i]);
-                    _outputHelper.WriteLine(secondLines[i]);
+                    PrintSection(_outputHelper, nameof(baseline), baselineLines, i);
+                    PrintSection(_outputHelper, nameof(generated), generatedLines, i);
                     return false;
                 }
             }
 
-            if (firstLines.Count != secondLines.Count)
+            if (baselineLines.Count != generatedLines.Count)
             {
-                _outputHelper.WriteLine($"Count differs from baseline: {firstLines.Count} {secondLines.Count}");
+                _outputHelper.WriteLine($"Count differs from baseline: {baselineLines.Count} {generatedLines.Count}");
                 return false;
             }
 
             return true;
+        }
+
+        private static void PrintSection(ITestOutputHelper outputHelper, string header, IList<string> lines, int lineHighlighted, int contextQty = 7)
+        {
+            outputHelper.WriteLine($"-----{header}-----");
+            int startLine = Math.Max(0, lineHighlighted - contextQty);
+            int endLine = Math.Min(lines.Count, lineHighlighted + contextQty);
+            int formatQty = (endLine + 1).ToString("D").Length; // Get the length of the biggest number (add 1 for the 1-based index)
+            for (int i = startLine; i <= endLine; i++)
+            {
+                outputHelper.WriteLine("{0}:{1}{2}", (i+1).ToString("D" + formatQty), (i == lineHighlighted) ? " >" : "  ", lines[i]);
+            }
         }
 
         private async Task<IList<string>> ReadAllLines(TextReader reader)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
             int formatQty = (endLine + 1).ToString("D").Length; // Get the length of the biggest number (add 1 for the 1-based index)
             for (int i = startLine; i <= endLine; i++)
             {
-                outputHelper.WriteLine("{0}:{1}{2}", (i+1).ToString("D" + formatQty, CultureInfo.InvariantCulture), (i == lineHighlighted) ? " >" : "  ", lines[i]);
+                outputHelper.WriteLine("{0}:{1}{2}", (i+1).ToString("D" + formatQty.ToString(CultureInfo.InvariantCulture)), (i == lineHighlighted) ? " >" : "  ", lines[i]);
             }
         }
 


### PR DESCRIPTION
This adds a more detailed output to `TestSchemaBaseline` to make it easier at a glance to tell what changed in `schema.json` when the baseline differs from the checked-in schema.

### Old output
- ![image](https://user-images.githubusercontent.com/700511/129313270-35d9dfb7-b74f-48dd-bc86-f89565eab4af.png)

### New output
- ![image](https://user-images.githubusercontent.com/700511/129314899-aeb0472b-e187-4de4-b20f-594803b0126b.png)

