### PR TITLE
Small changes to the WithCancellation extension method.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TaskExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TaskExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
         public static async Task WithCancellation(this Task task, CancellationToken token)
         {
-            CancellationTokenSource localTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+            using CancellationTokenSource localTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
 
             try
             {
@@ -56,11 +56,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             }
             finally
             {
-                // If the token provided wasn't cancelled, cancel our own token
-                if (!token.IsCancellationRequested)
-                {
-                    localTokenSource.Cancel();
-                }
+                // Cancel to make sure Task.Delay token registration is removed.
+                localTokenSource.Cancel();
             }
         }
     }


### PR DESCRIPTION
The CTS should be disposed.
Unconditionally call Cancel on the CTS since it will short-circuit if the underlying tokens were already cancelled.