### PR TITLE
Move *EndpointInfo implementations to dotnet-monitor.

### DIFF
--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.Options", "src\Microsoft.Diagnostics.Monitoring.Options\Microsoft.Diagnostics.Monitoring.Options.csproj", "{173F959B-231B-45D1-8328-9460D4C5BC71}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.Tool.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.Tool.UnitTests\Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj", "{C5D14E28-DACA-4884-B513-9246B788BC22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{173F959B-231B-45D1-8328-9460D4C5BC71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{173F959B-231B-45D1-8328-9460D4C5BC71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{173F959B-231B-45D1-8328-9460D4C5BC71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5D14E28-DACA-4884-B513-9246B788BC22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5D14E28-DACA-4884-B513-9246B788BC22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5D14E28-DACA-4884-B513-9246B788BC22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5D14E28-DACA-4884-B513-9246B788BC22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,6 +111,7 @@ Global
 		{422ABBF6-6236-4042-AACA-09531DBDFBAA} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{3AD0A40B-C569-4712-9764-7A788B9CD811} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{173F959B-231B-45D1-8328-9460D4C5BC71} = {19FAB78C-3351-4911-8F0C-8C6056401740}
+		{C5D14E28-DACA-4884-B513-9246B788BC22} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-monitor" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.OpenApiGen" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.Tool.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi.UnitTests" />
   </ItemGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
         private const string SchemaGeneratorName = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema";
 
         private static readonly string SchemaGeneratorPath =
-            CurrentExecutingAssemblyPath.Replace(Assembly.GetExecutingAssembly().GetName().Name, SchemaGeneratorName);
+            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), SchemaGeneratorName);
 
         public SchemaGenerationTests(ITestOutputHelper outputHelper)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
@@ -32,7 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
             Path.Combine(Path.GetDirectoryName(CurrentExecutingAssemblyPath), OpenApiBaselineName);
 
         private static readonly string OpenApiGenPath =
-            CurrentExecutingAssemblyPath.Replace(Assembly.GetExecutingAssembly().GetName().Name, OpenApiGenName);
+            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), OpenApiGenName);
 
         private readonly ITestOutputHelper _outputHelper;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
@@ -19,27 +19,13 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
             if (tfm != TargetFrameworkMoniker.Current)
             {
-                string currentFolderName = GetTargetFrameworkMonikerFolderName(DotNetHost.BuiltTargetFrameworkMoniker);
-                string targetFolderName = GetTargetFrameworkMonikerFolderName(tfm);
+                string currentFolderName = DotNetHost.BuiltTargetFrameworkMoniker.ToFolderName();
+                string targetFolderName = tfm.ToFolderName();
 
                 assemblyPath = assemblyPath.Replace(currentFolderName, targetFolderName);
             }
 
             return assemblyPath;
-        }
-
-        private static string GetTargetFrameworkMonikerFolderName(TargetFrameworkMoniker moniker)
-        {
-            switch (moniker)
-            {
-                case TargetFrameworkMoniker.Net50:
-                    return "net5.0";
-                case TargetFrameworkMoniker.Net60:
-                    return "net6.0";
-                case TargetFrameworkMoniker.NetCoreApp31:
-                    return "netcoreapp3.1";
-            }
-            throw new ArgumentException($"Moniker '{moniker:G}' is not supported.");
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    public static class AssemblyHelper
+    {
+        public static string GetAssemblyArtifactBinPath(
+            Assembly testAssembly,
+            string assemblyName,
+            TargetFrameworkMoniker tfm = TargetFrameworkMoniker.Current)
+        {
+            string assemblyPath = testAssembly.Location
+                .Replace(testAssembly.GetName().Name, assemblyName);
+
+            if (tfm != TargetFrameworkMoniker.Current)
+            {
+                string currentFolderName = GetTargetFrameworkMonikerFolderName(DotNetHost.BuiltTargetFrameworkMoniker);
+                string targetFolderName = GetTargetFrameworkMonikerFolderName(tfm);
+
+                assemblyPath = assemblyPath.Replace(currentFolderName, targetFolderName);
+            }
+
+            return assemblyPath;
+        }
+
+        private static string GetTargetFrameworkMonikerFolderName(TargetFrameworkMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case TargetFrameworkMoniker.Net50:
+                    return "net5.0";
+                case TargetFrameworkMoniker.Net60:
+                    return "net6.0";
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return "netcoreapp3.1";
+            }
+            throw new ArgumentException($"Moniker '{moniker:G}' is not supported.");
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -20,5 +20,20 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static string HostExePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             @"..\..\..\..\..\.dotnet\dotnet.exe" :
             "../../../../../.dotnet/dotnet";
+
+        public static TargetFrameworkMoniker BuiltTargetFrameworkMoniker
+        {
+            get
+            {
+                // Update with specific TFM when building this assembly for a new target framework.
+#if NETCOREAPP3_1
+                return TargetFrameworkMoniker.NetCoreApp31;
+#elif NET5_0
+                return TargetFrameworkMoniker.Net50;
+#elif NET6_0
+                return TargetFrameworkMoniker.Net60;
+#endif
+            }
+        }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -10,5 +10,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
     {
         public static readonly string CurrentAspNetCoreVersionString = "$MicrosoftAspNetCoreAppVersion$";
         public static readonly string CurrentNetCoreVersionString = "$MicrosoftNetCoreAppVersion$";
+
+        public static readonly string NetCore31VersionString = "$MicrosoftNetCoreApp31Version$";
+        public static readonly string NetCore50VersionString = "$MicrosoftNetCoreApp50Version$";
+        public static readonly string NetCore60VersionString = "$MicrosoftNetCoreApp60Version$";
+
+        public static readonly TargetFrameworkMoniker BuiltTargetFrameworkMoniker = TargetFrameworkMoniker.$BuiltTargetFrameworkMoniker$;
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -14,7 +14,5 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly string NetCore31VersionString = "$MicrosoftNetCoreApp31Version$";
         public static readonly string NetCore50VersionString = "$MicrosoftNetCoreApp50Version$";
         public static readonly string NetCore60VersionString = "$MicrosoftNetCoreApp60Version$";
-
-        public static readonly TargetFrameworkMoniker BuiltTargetFrameworkMoniker = TargetFrameworkMoniker.$BuiltTargetFrameworkMoniker$;
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -14,6 +14,10 @@
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftAspNetCoreApp31Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftAspNetCoreApp50Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftAspNetCoreApp60Version)</AspNetCoreAppVersion>
+    <!-- There values must match the values in the TargetFrameworkMoniker enum. -->
+    <BuiltTargetFrameworkMonikerEnumValue Condition="'$(TargetFramework)' == 'netcoreapp3.1'">NetCoreApp31</BuiltTargetFrameworkMonikerEnumValue>
+    <BuiltTargetFrameworkMonikerEnumValue Condition="'$(TargetFramework)' == 'net5.0'">Net50</BuiltTargetFrameworkMonikerEnumValue>
+    <BuiltTargetFrameworkMonikerEnumValue Condition="'$(TargetFramework)' == 'net6.0'">Net60</BuiltTargetFrameworkMonikerEnumValue>
   </PropertyGroup>
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
@@ -21,6 +25,10 @@
       <TemplateContent>$([System.IO.File]::ReadAllText('DotNetHost.cs.template'))</TemplateContent>
       <TransformedContent>$(TemplateContent.Replace('$MicrosoftNetCoreAppVersion$', '$(NetCoreAppVersion)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreAppVersion$', '$(AspNetCoreAppVersion)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp31Version$', '$(MicrosoftNETCoreApp31Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp50Version$', '$(MicrosoftNETCoreApp50Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp60Version$', '$(MicrosoftNETCoreApp60Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$BuiltTargetFrameworkMoniker$', '$(BuiltTargetFrameworkMonikerEnumValue)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -14,10 +14,6 @@
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftAspNetCoreApp31Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftAspNetCoreApp50Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftAspNetCoreApp60Version)</AspNetCoreAppVersion>
-    <!-- There values must match the values in the TargetFrameworkMoniker enum. -->
-    <BuiltTargetFrameworkMonikerEnumValue Condition="'$(TargetFramework)' == 'netcoreapp3.1'">NetCoreApp31</BuiltTargetFrameworkMonikerEnumValue>
-    <BuiltTargetFrameworkMonikerEnumValue Condition="'$(TargetFramework)' == 'net5.0'">Net50</BuiltTargetFrameworkMonikerEnumValue>
-    <BuiltTargetFrameworkMonikerEnumValue Condition="'$(TargetFramework)' == 'net6.0'">Net60</BuiltTargetFrameworkMonikerEnumValue>
   </PropertyGroup>
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
@@ -28,7 +24,6 @@
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp31Version$', '$(MicrosoftNETCoreApp31Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp50Version$', '$(MicrosoftNETCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp60Version$', '$(MicrosoftNETCoreApp60Version)'))</TransformedContent>
-      <TransformedContent>$(TransformedContent.Replace('$BuiltTargetFrameworkMoniker$', '$(BuiltTargetFrameworkMonikerEnumValue)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -36,16 +36,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         private bool _isDiposed;
 
         /// <summary>
-        /// The path of the current test assembly.
-        /// </summary>
-        private string CurrentTestAssembly => _testAssembly.Location;
-
-        /// <summary>
         /// The path to the application.
         /// </summary>
-        private string AppPath =>
-            CurrentTestAssembly
-                .Replace(_testAssembly.GetName().Name, "Microsoft.Diagnostics.Monitoring.UnitTestApp");
+        private string AppPath => AssemblyHelper.GetAssemblyArtifactBinPath(_testAssembly, "Microsoft.Diagnostics.Monitoring.UnitTestApp");
 
         /// <summary>
         /// The mode of the diagnostic port connection. Default is <see cref="DiagnosticPortConnectionMode.Listen"/>
@@ -74,12 +67,14 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
         public int AppId { get; }
 
-        public AppRunner(ITestOutputHelper outputHelper, Assembly testAssembly, int appId = 1)
+        public AppRunner(ITestOutputHelper outputHelper, Assembly testAssembly, int appId = 1, TargetFrameworkMoniker tfm = TargetFrameworkMoniker.Current)
         {
             AppId = appId;
 
             _testAssembly = testAssembly;
             _outputHelper = new PrefixedOutputHelper(outputHelper, FormattableString.Invariant($"[App{appId}] "));
+
+            _runner.TargetFramework = tfm;
 
             _adapter = new LoggingRunnerAdapter(_outputHelper, _runner);
             _adapter.ReceivedStandardOutputLine += StandardOutputCallback;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         /// Gets the process ID of the running process.
         /// </summary>
         public int ProcessId => _process.Id;
-        
+
         /// <summary>
         /// Gets a <see cref="StreamReader"/> that reads stderr.
         /// </summary>
@@ -85,6 +85,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         /// Gets a <see cref="StreamReader"/> that reads stdout.
         /// </summary>
         public StreamReader StandardOutput => _process.StandardOutput;
+
+        /// <summary>
+        /// Get or set the target framework on which the application should run.
+        /// </summary>
+        public TargetFrameworkMoniker TargetFramework { get; set; } = TargetFrameworkMoniker.Current;
 
         /// <summary>
         /// Determines if <see cref="StartAsync(CancellationToken)" /> should wait for the diagnostic pipe to be available.
@@ -123,10 +128,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             switch (FrameworkReference)
             {
                 case DotNetFrameworkReference.Microsoft_AspNetCore_App:
-                    frameworkVersion = DotNetHost.CurrentAspNetCoreVersionString;
+                    frameworkVersion = GetAspNetCoreFrameworkVersion();
                     break;
                 case DotNetFrameworkReference.Microsoft_NetCore_App:
-                    frameworkVersion = DotNetHost.CurrentNetCoreVersionString;
+                    frameworkVersion = GetNetCoreAppFrameworkVersion();
                     break;
                 default:
                     throw new InvalidOperationException($"Unsupported framework reference: {FrameworkReference}");
@@ -187,6 +192,31 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             {
                 _process.Kill();
             }
+        }
+
+        private string GetAspNetCoreFrameworkVersion()
+        {
+            if (TargetFrameworkMoniker.Current == TargetFramework)
+            {
+                return DotNetHost.CurrentAspNetCoreVersionString;
+            }
+            throw new InvalidOperationException($"Unsupported target framework moniker: {TargetFramework}");
+        }
+
+        private string GetNetCoreAppFrameworkVersion()
+        {
+            switch (TargetFramework)
+            {
+                case TargetFrameworkMoniker.Current:
+                    return DotNetHost.CurrentNetCoreVersionString;
+                case TargetFrameworkMoniker.Net50:
+                    return DotNetHost.NetCore50VersionString;
+                case TargetFrameworkMoniker.Net60:
+                    return DotNetHost.NetCore60VersionString;
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return DotNetHost.NetCore31VersionString;
+            }
+            throw new InvalidOperationException($"Unsupported target framework moniker: {TargetFramework}");
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -128,10 +128,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             switch (FrameworkReference)
             {
                 case DotNetFrameworkReference.Microsoft_AspNetCore_App:
-                    frameworkVersion = GetAspNetCoreFrameworkVersion();
+                    frameworkVersion = TargetFramework.GetAspNetCoreFrameworkVersion();
                     break;
                 case DotNetFrameworkReference.Microsoft_NetCore_App:
-                    frameworkVersion = GetNetCoreAppFrameworkVersion();
+                    frameworkVersion = TargetFramework.GetNetCoreAppFrameworkVersion();
                     break;
                 default:
                     throw new InvalidOperationException($"Unsupported framework reference: {FrameworkReference}");
@@ -192,31 +192,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             {
                 _process.Kill();
             }
-        }
-
-        private string GetAspNetCoreFrameworkVersion()
-        {
-            if (TargetFrameworkMoniker.Current == TargetFramework)
-            {
-                return DotNetHost.CurrentAspNetCoreVersionString;
-            }
-            throw new InvalidOperationException($"Unsupported target framework moniker: {TargetFramework}");
-        }
-
-        private string GetNetCoreAppFrameworkVersion()
-        {
-            switch (TargetFramework)
-            {
-                case TargetFrameworkMoniker.Current:
-                    return DotNetHost.CurrentNetCoreVersionString;
-                case TargetFrameworkMoniker.Net50:
-                    return DotNetHost.NetCore50VersionString;
-                case TargetFrameworkMoniker.Net60:
-                    return DotNetHost.NetCore60VersionString;
-                case TargetFrameworkMoniker.NetCoreApp31:
-                    return DotNetHost.NetCore31VersionString;
-            }
-            throw new InvalidOperationException($"Unsupported target framework moniker: {TargetFramework}");
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     public enum TargetFrameworkMoniker
@@ -10,5 +12,53 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         NetCoreApp31,
         Net50,
         Net60
+    }
+
+    public static class TargetFrameworkMonikerExtensions
+    {
+        public static string GetAspNetCoreFrameworkVersion(this TargetFrameworkMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case TargetFrameworkMoniker.Current:
+                    return DotNetHost.CurrentAspNetCoreVersionString;
+            }
+            throw CreateUnsupportedException(moniker);
+        }
+
+        public static string GetNetCoreAppFrameworkVersion(this TargetFrameworkMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case TargetFrameworkMoniker.Current:
+                    return DotNetHost.CurrentNetCoreVersionString;
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return DotNetHost.NetCore31VersionString;
+                case TargetFrameworkMoniker.Net50:
+                    return DotNetHost.NetCore50VersionString;
+                case TargetFrameworkMoniker.Net60:
+                    return DotNetHost.NetCore60VersionString;
+            }
+            throw CreateUnsupportedException(moniker);
+        }
+
+        public static string ToFolderName(this TargetFrameworkMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case TargetFrameworkMoniker.Net50:
+                    return "net5.0";
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return "netcoreapp3.1";
+                case TargetFrameworkMoniker.Net60:
+                    return "net6.0";
+            }
+            throw CreateUnsupportedException(moniker);
+        }
+
+        private static ArgumentException CreateUnsupportedException(TargetFrameworkMoniker moniker)
+        {
+            return new ArgumentException($"Unsupported target framework moniker: {moniker:G}");
+        }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    public enum TargetFrameworkMoniker
+    {
+        Current,
+        NetCoreApp31,
+        Net50,
+        Net60
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -46,25 +46,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         protected Task<int> RunnerExitedTask => _runner.ExitedTask;
 
         /// <summary>
-        /// The path of the currently executing assembly.
-        /// </summary>
-        private static string CurrentExecutingAssemblyPath =>
-            Assembly.GetExecutingAssembly().Location;
-
-        /// <summary>
-        /// The target framework name of the currently executing assembly.
-        /// </summary>
-        private static string CurrentTargetFrameworkFolderName =>
-            new FileInfo(CurrentExecutingAssemblyPath).Directory.Name;
-
-        /// <summary>
-        /// The path to dotnet-monitor. It is currently only build for the
+        /// The path to dotnet-monitor. It is currently only built for the
         /// netcoreapp3.1 target framework.
         /// </summary>
         private static string DotNetMonitorPath =>
-            CurrentExecutingAssemblyPath
-                .Replace(Assembly.GetExecutingAssembly().GetName().Name, "dotnet-monitor")
-                .Replace(CurrentTargetFrameworkFolderName, "netcoreapp3.1");
+            AssemblyHelper.GetAssemblyArtifactBinPath(
+                Assembly.GetExecutingAssembly(),
+                "dotnet-monitor",
+                TargetFrameworkMoniker.NetCoreApp31);
 
         private string SharedConfigDirectoryPath =>
             Path.Combine(_runnerTmpPath, "SharedConfig");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.Options\Microsoft.Diagnostics.Monitoring.Options.csproj" />
+    <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj" />
+    <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostics.Monitoring.WebApi
+namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class ClientEndpointInfoSource : IEndpointInfoSourceInternal
     {

--- a/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using System;
 using System.Diagnostics;
 
-namespace Microsoft.Diagnostics.Monitoring.WebApi
+namespace Microsoft.Diagnostics.Tools.Monitor
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal class EndpointInfo : IEndpointInfo

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostics.Monitoring.WebApi
+namespace Microsoft.Diagnostics.Tools.Monitor
 {
     /// <summary>
     /// Aggregates diagnostic endpoints that are established at a transport path via a reversed server.


### PR DESCRIPTION
The collection rule system will hook directly into the ServerEndpointInfoSource (and eventually, the ClientEndpointInfoSource), so this class needs to move to the dotnet-monitor project. This means that the unit tests for these types need to move to a new unit test assembly for dotnet-monitor (this unit test assembly already exists in the feature/triggers branch, but I'm bringing it to the main branch). As part of this, I've refactored entry point assembly path calculation for the tests into a common helper since I needed to changed some of the ServerEndpointInfoSource tests into theories with each supported TFM.

Overview of changes:
- Move *EndpointInfo implementations to dotnet-monitor.
- Add dotnet-monitor unit test assembly and move *EndpointInfo tests to it.
- Consolidate calculating entry point assembly path into single utility method.