### PR TITLE
Fix race condition in EndpointInfoSourceTests.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
         public int ProcessId => _adapter.ProcessId;
 
+        public Task<int> ProcessIdTask => _adapter.ProcessIdTask;
+
         /// <summary>
         /// Name of the scenario to run in the application.
         /// </summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -58,8 +58,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
         public int ExitCode => _adapter.ExitCode;
 
-        public int ProcessId => _adapter.ProcessId;
-
         public Task<int> ProcessIdTask => _adapter.ProcessIdTask;
 
         /// <summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
@@ -32,12 +32,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         public int ExitCode => _exitCode.HasValue ?
             _exitCode.Value : throw new InvalidOperationException("Must call WaitForExitAsync before getting exit code.");
 
-        /// <remarks>
-        /// Only access this property after the <see cref="StartAsync(CancellationToken)"/> method has completed.
-        /// </remarks>
-        public int ProcessId => _processId.HasValue ?
-            _processId.Value : throw new InvalidOperationException("Process was not started.");
-
         public Task<int> ProcessIdTask => _processIdSource.Task;
 
         public event Action<string> ReceivedStandardErrorLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
     {
         private readonly CancellationTokenSource _cancellation = new();
         private readonly ITestOutputHelper _outputHelper;
+        private readonly TaskCompletionSource<int> _processIdSource =
+            new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly DotNetRunner _runner;
         private readonly List<string> _standardErrorLines = new();
         private readonly List<string> _standardOutputLines = new();
@@ -30,8 +32,13 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         public int ExitCode => _exitCode.HasValue ?
             _exitCode.Value : throw new InvalidOperationException("Must call WaitForExitAsync before getting exit code.");
 
+        /// <remarks>
+        /// Only access this property after the <see cref="StartAsync(CancellationToken)"/> method has completed.
+        /// </remarks>
         public int ProcessId => _processId.HasValue ?
             _processId.Value : throw new InvalidOperationException("Process was not started.");
+
+        public Task<int> ProcessIdTask => _processIdSource.Task;
 
         public event Action<string> ReceivedStandardErrorLine;
 
@@ -55,6 +62,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             }
 
             _cancellation.Cancel();
+
+            _processIdSource.TrySetCanceled(_cancellation.Token);
 
             // Shutdown the runner
             _outputHelper.WriteLine("Stopping...");
@@ -96,11 +105,15 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             }
             _outputHelper.WriteLine("End Environment:");
 
-            _outputHelper.WriteLine("Starting...");
-            await _runner.StartAsync(token).ConfigureAwait(false);
+            using (var _ = token.Register(() => _processIdSource.TrySetCanceled(token)))
+            {
+                _outputHelper.WriteLine("Starting...");
+                await _runner.StartAsync(token).ConfigureAwait(false);
+            }
 
-            _processId = _runner.ProcessId;
             _outputHelper.WriteLine("Process ID: {0}", _runner.ProcessId);
+            _processId = _runner.ProcessId;
+            _processIdSource.TrySetResult(_runner.ProcessId);
 
             _standardErrorTask = ReadLinesAsync(_runner.StandardError, _standardErrorLines, ReceivedStandardErrorLine, _cancellation.Token);
             _standardOutputTask = ReadLinesAsync(_runner.StandardOutput, _standardOutputLines, ReceivedStandardOutputLine, _cancellation.Token);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TaskExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TaskExtensions.cs
@@ -60,5 +60,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 localTokenSource.Cancel();
             }
         }
+
+        public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken token)
+        {
+            await WithCancellation((Task)task, token);
+
+            return task.Result;
+        }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -58,10 +58,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.AsyncWait.Name,
                 appValidate: async (runner, client) =>
                 {
-                    ProcessInfo processInfo = await client.GetProcessAsync(runner.ProcessId);
+                    int processId = await runner.ProcessIdTask;
+
+                    ProcessInfo processInfo = await client.GetProcessAsync(processId);
                     Assert.NotNull(processInfo);
 
-                    using ResponseStreamHolder holder = await client.CaptureDumpAsync(runner.ProcessId, type);
+                    using ResponseStreamHolder holder = await client.CaptureDumpAsync(processId, type);
                     Assert.NotNull(holder);
 
                     byte[] headerBuffer = new byte[64];

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         async () =>
                         {
                             using ResponseStreamHolder _ = await client.CaptureLogsAsync(
-                                runner.ProcessId,
+                                await runner.ProcessIdTask,
                                 TestTimeouts.LogsDuration,
                                 LogLevel.None,
                                 logFormat);
@@ -219,7 +219,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         async () =>
                         {
                             using ResponseStreamHolder _ = await client.CaptureLogsAsync(
-                                runner.ProcessId,
+                                await runner.ProcessIdTask,
                                 TestTimeouts.LogsDuration,
                                 new LogsConfiguration() { LogLevel = LogLevel.None },
                                 logFormat);
@@ -406,11 +406,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 _httpClientFactory,
                 mode,
                 TestAppScenarios.Logger.Name,
-                appValidate: (runner, client) => ValidateResponseStream(
-                    runner,
-                    client.CaptureLogsAsync(runner.ProcessId, TestTimeouts.LogsDuration, logLevel, logFormat),
-                    callback,
-                    logFormat));
+                appValidate: async (runner, client) => 
+                    await ValidateResponseStream(
+                        runner,
+                        client.CaptureLogsAsync(
+                            await runner.ProcessIdTask,
+                            TestTimeouts.LogsDuration,
+                            logLevel,
+                            logFormat),
+                        callback,
+                        logFormat));
         }
 
         private Task ValidateLogsAsync(
@@ -424,11 +429,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 _httpClientFactory,
                 mode,
                 TestAppScenarios.Logger.Name,
-                appValidate: (runner, client) => ValidateResponseStream(
-                    runner,
-                    client.CaptureLogsAsync(runner.ProcessId, TestTimeouts.LogsDuration, configuration, logFormat),
-                    callback,
-                    logFormat));
+                appValidate: async (runner, client) =>
+                    await ValidateResponseStream(
+                        runner,
+                        client.CaptureLogsAsync(
+                            await runner.ProcessIdTask,
+                            TestTimeouts.LogsDuration,
+                            configuration,
+                            logFormat),
+                        callback,
+                        logFormat));
         }
 
         private async Task ValidateResponseStream(AppRunner runner, Task<ResponseStreamHolder> holderTask, Func<ChannelReader<LogEntry>, Task> callback, LogFormat logFormat)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             if (null != postAppValidate)
             {
-                await postAppValidate(apiClient, appRunner.ProcessId);
+                await postAppValidate(apiClient, await appRunner.ProcessIdTask);
             }
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -256,6 +256,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         private sealed class ServerEndpointInfoCallback : IEndpointInfoSourceCallbacks
         {
             private readonly ITestOutputHelper _outputHelper;
+            /// <summary>
+            /// Use to protect the completion list from mutation while processing
+            /// callbacks from it. The processing is done in an async method with async
+            /// calls, which are not allowed in a lock, thus use SemaphoreSlim.
+            /// </summary>
             private readonly SemaphoreSlim _completionEntriesSemaphore = new(1);
             private readonly List<CompletionEntry> _completionEntries = new();
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 Assert.NotNull(endpointInfo.CommandLine);
                 Assert.NotNull(endpointInfo.OperatingSystem);
                 Assert.NotNull(endpointInfo.ProcessArchitecture);
-                VerifyConnection(runner, endpointInfo);
+                await VerifyConnectionAsync(runner, endpointInfo);
 
                 await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
             });
@@ -182,13 +182,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 for (int i = 0; i < appCount; i++)
                 {
-                    IEndpointInfo endpointInfo = endpointInfos.FirstOrDefault(info => info.ProcessId == runners[i].ProcessId);
+                    int processId = await runners[i].ProcessIdTask;
+
+                    IEndpointInfo endpointInfo = endpointInfos.FirstOrDefault(info => info.ProcessId == processId);
                     Assert.NotNull(endpointInfo);
                     Assert.NotNull(endpointInfo.CommandLine);
                     Assert.NotNull(endpointInfo.OperatingSystem);
                     Assert.NotNull(endpointInfo.ProcessArchitecture);
 
-                    VerifyConnection(runners[i], endpointInfo);
+                    await VerifyConnectionAsync(runners[i], endpointInfo);
 
                     await runners[i].SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
                 }
@@ -244,11 +246,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         /// <summary>
         /// Verifies basic information on the connection and that it matches the target process from the runner.
         /// </summary>
-        private static void VerifyConnection(AppRunner runner, IEndpointInfo endpointInfo)
+        private static async Task VerifyConnectionAsync(AppRunner runner, IEndpointInfo endpointInfo)
         {
             Assert.NotNull(runner);
             Assert.NotNull(endpointInfo);
-            Assert.Equal(runner.ProcessId, endpointInfo.ProcessId);
+            Assert.Equal(await runner.ProcessIdTask, endpointInfo.ProcessId);
             Assert.NotEqual(Guid.Empty, endpointInfo.RuntimeInstanceCookie);
             Assert.NotNull(endpointInfo.Endpoint);
         }

--- a/src/Tools/dotnet-monitor/EndpointInfo/IEndpointInfoSourceCallbacks.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/IEndpointInfoSourceCallbacks.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         Task OnBeforeResumeAsync(IEndpointInfo endpointInfo, CancellationToken cancellationToken);
 
-        void OnAddedEndpointInfo(IEndpointInfo endpointInfo);
+        Task OnAddedEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken cancellationToken);
 
         void OnRemovedEndpointInfo(IEndpointInfo endpointInfo);
     }

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     foreach (IEndpointInfoSourceCallbacks callback in _callbacks)
                     {
-                        callback.OnAddedEndpointInfo(endpointInfo);
+                        await callback.OnAddedEndpointInfoAsync(endpointInfo, token).ConfigureAwait(false);
                     }
                 }
                 finally


### PR DESCRIPTION
There's a race condition between when the ServerEndpointInfoCallback is invoked due to a process connecting in reverse mode and the LoggingRunnerAdapter setting the process Id information just after starting the process. Sometimes the reverse server callback is quicker than the adapter, which will then fail to find the runner with a matching process ID.

I changed the code so that the LoggingRunnerAdapter has an additional ProcessIdTask property so that it can be awaited. the ServerEndpointInfoCallback has been updated to await the ProcessIdTask property of each registered runner and process each one as they complete. This guarantees that ServerEndpointInfoCallback will wait for the runner to fulfill the process ID or be cancelled first.