### PR TITLE
Use async DiagnosticsClient APIs

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -157,13 +157,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             ProcessKey? processKey = GetProcessKey(pid, uid, name);
 
-            return InvokeForProcess<Dictionary<string, string>>(processInfo =>
+            return InvokeForProcess<Dictionary<string, string>>(async processInfo =>
             {
                 var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);
 
                 try
                 {
-                    Dictionary<string, string> environment = client.GetProcessEnvironment();
+                    Dictionary<string, string> environment = await client.GetProcessEnvironmentAsync(HttpContext.RequestAborted);
 
                     _logger.WrittenToHttpStream();
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public async Task<Stream> GetDump(IProcessInfo pi, Models.DumpType mode, CancellationToken token)
         {
             string dumpFilePath = Path.Combine(_storageOptions.CurrentValue.DumpTempFolder, FormattableString.Invariant($"{Guid.NewGuid()}_{pi.EndpointInfo.ProcessId}"));
-            NETCore.Client.DumpType dumpType = MapDumpType(mode);
+            DumpType dumpType = MapDumpType(mode);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -94,11 +94,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
             else
             {
-                await Task.Run(() =>
-                {
-                    var client = new DiagnosticsClient(pi.EndpointInfo.Endpoint);
-                    client.WriteDump(dumpType, dumpFilePath);
-                });
+                var client = new DiagnosticsClient(pi.EndpointInfo.Endpoint);
+                await client.WriteDumpAsync(dumpType, dumpFilePath, logDumpGeneration: false, token);
             }
 
             return new AutoDeleteFileStream(dumpFilePath);

--- a/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             // a GetProcessInfo command to the runtime instance to get additional information.
             foreach (int pid in DiagnosticsClient.GetPublishedProcesses())
             {
-                endpointInfoTasks.Add(Task.Run(() =>
+                endpointInfoTasks.Add(Task.Run(async () =>
                 {
                     try
                     {
-                        return EndpointInfo.FromProcessId(pid);
+                        return await EndpointInfo.FromProcessIdAsync(pid, token);
                     }
                     // Catch when runtime instance shuts down while attepting to use the established diagnostic port connection.
                     catch (EndOfStreamException)

--- a/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
@@ -6,13 +6,15 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using System;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal class EndpointInfo : IEndpointInfo
     {
-        public static EndpointInfo FromProcessId(int processId)
+        public static async Task<EndpointInfo> FromProcessIdAsync(int processId, CancellationToken token)
         {
             var client = new DiagnosticsClient(processId);
 
@@ -22,7 +24,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 // Primary motivation is to get the runtime instance cookie in order to
                 // keep parity with the FromIpcEndpointInfo implementation; store the
                 // remainder of the information since it already has access to it.
-                processInfo = client.GetProcessInfo();
+                processInfo = await client.GetProcessInfoAsync(token);
 
                 Debug.Assert(processId == unchecked((int)processInfo.ProcessId));
             }
@@ -48,7 +50,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
         }
 
-        public static EndpointInfo FromIpcEndpointInfo(IpcEndpointInfo info)
+        public static async Task<EndpointInfo> FromIpcEndpointInfoAsync(IpcEndpointInfo info, CancellationToken token)
         {
             var client = new DiagnosticsClient(info.Endpoint);
 
@@ -58,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 // Primary motivation is to keep parity with the FromProcessId implementation,
                 // which provides the additional process information because it already has
                 // access to it.
-                processInfo = client.GetProcessInfo();
+                processInfo = await client.GetProcessInfoAsync(token);
 
                 Debug.Assert(info.ProcessId == unchecked((int)processInfo.ProcessId));
                 Debug.Assert(info.RuntimeInstanceCookie == processInfo.RuntimeInstanceCookie);

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             try
             {
-                EndpointInfo endpointInfo = EndpointInfo.FromIpcEndpointInfo(info);
+                EndpointInfo endpointInfo = await EndpointInfo.FromIpcEndpointInfoAsync(info, token);
 
                 foreach (IEndpointInfoSourceCallbacks callback in _callbacks)
                 {
@@ -229,7 +229,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 var client = new DiagnosticsClient(info.Endpoint);
                 try
                 {
-                    client.ResumeRuntime();
+                    await client.ResumeRuntimeAsync(token);
                 }
                 catch (ServerErrorException)
                 {


### PR DESCRIPTION
These changes rely on the following PR from the diagnostics repo: https://github.com/dotnet/diagnostics/pull/2350

These changes only switch to using the async APIs on the DiagnosticsClient class. Subsequent changes to timeout on querying the process list will be made in a different PR.