### PR TITLE
Increase extra process information timeout.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         // The amount of time to wait before cancelling get additional process information (e.g. getting
         // the process command line if the IEndpointInfo doesn't provide it).
-        private static readonly TimeSpan ExtendedProcessInfoTimeout = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan ExtendedProcessInfoTimeout = TimeSpan.FromMilliseconds(1000);
 
         private readonly IEndpointInfoSourceInternal _endpointInfoSource;
         private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();


### PR DESCRIPTION
In recent builds, the `/processes` route is failing to calculate the process name on .NET Core 3.1 for MacOS. The timeout for determining the extra process information, such as command line and process name, is too short. This change increases the timeout to 1 second which seems to be sufficient to work around the problem.

In the long term, this code should be changed to cache process information between lookups so that subsequent querying for process information is fast and accurate. Re #523 