### PR TITLE
Fix CollectionRulePipelineTests failure due to callback registration timing.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                     // Register first callback before pipeline starts. This callback should be completed before
                     // the pipeline finishes starting.
-                    Task callback1Task = callbackService.WaitWithCancellationAsync(cancellationSource.Token);
+                    Task callback1Task = await callbackService.StartWaitForCallbackAsync(cancellationSource.Token);
 
                     // Startup trigger will cause the the pipeline to complete the start phase
                     // after the action list has been completed.
@@ -72,12 +72,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     // completed because it was registered after the pipeline had finished starting. Since
                     // the action list is only ever executed once and is executed before the pipeline finishes
                     // starting, thus subsequent invocations of the action list should not occur.
-                    Task callback2Task = callbackService.WaitWithCancellationAsync(cancellationSource.Token);
+                    Task callback2Task = await callbackService.StartWaitForCallbackAsync(cancellationSource.Token);
 
                     // Since the action list was completed before the pipeline finished starting,
                     // the action should have invoked it's callback.
-                    using CancellationTokenSource callbackCancellationSource = new(TimeSpan.FromMilliseconds(50));
-                    await callback1Task.WithCancellation(callbackCancellationSource.Token);
+                    await callback1Task.WithCancellation(cancellationSource.Token);
 
                     // Regardless of the action list constraints, the pipeline should have only
                     // executed the action list once due to the use of a startup trigger.
@@ -132,7 +131,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                     // Register first callback before pipeline starts. This callback should be completed after
                     // the pipeline finishes starting.
-                    Task callbackTask = callbackService.WaitWithCancellationAsync(cancellationSource.Token);
+                    Task callbackTask = await callbackService.StartWaitForCallbackAsync(cancellationSource.Token);
 
                     // Start pipeline with EventCounter trigger.
                     await pipeline.StartAsync(cancellationSource.Token);
@@ -140,7 +139,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     await runner.SendCommandAsync(TestAppScenarios.SpinWait.Commands.StartSpin);
 
                     // This should not complete until the trigger conditions are satisfied for the first time.
-                    await callbackTask;
+                    await callbackTask.WithCancellation(cancellationSource.Token);
 
                     VerifyExecutionCount(callbackService, 1);
 


### PR DESCRIPTION
This is an effort to fix the following test failure: https://runfo.azurewebsites.net/search/tests/?q=started%3A%7E7+definition%3Adotnet-monitor-ci+name%3ACollectionRulePipeline_StartupTriggerTest

My belief that that the callback is failing to register before the pipeline finishes is causing the TCS to not be completed and thus causing the test to fail with a TaskCanceledException. The changes make sure that the callback TCS is registered before yielding back another Task that represents the invocation of the callback, thus ensuring that the callback is registered before the test continues to start the pipeline.

I will run this PR through the build several times to see if this fixes the issue before completing it:
- Build [20210914.9](https://dev.azure.com/dnceng/public/_build/results?buildId=1361926&view=results): Success
- Build [20210914.10](https://dev.azure.com/dnceng/public/_build/results?buildId=1362136&view=results): Success
- Build [20210914.11](https://dev.azure.com/dnceng/public/_build/results?buildId=1362448&view=results): Failures unrelated to this change
- Build [20210915.5](https://dev.azure.com/dnceng/public/_build/results?buildId=1364182&view=results): Failures unrelated to this change
- Build [20210915.9](https://dev.azure.com/dnceng/public/_build/results?buildId=1364354&view=results): Failures unrelated to this change
- Build [20210915.10](https://dev.azure.com/dnceng/public/_build/results?buildId=1364594&view=results): Failures unrelated to this change

Most of the above test failures are likely related to #399. The `/processes` route is not returning within the timeout established by the test, which is 15 seconds.