### PR TITLE
Cancel waiting for unresponsive processes.

### DIFF
--- a/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private readonly Guid? _runtimeInstanceCookieToFilterOut;
         private readonly IEndpointInfoSourceInternal _source;
 
-        public FilteredEndpointInfoSource(IOptions<DiagnosticPortOptions> portOptions)
+        public FilteredEndpointInfoSource(
+            IOptions<DiagnosticPortOptions> portOptions,
+            ILogger<ClientEndpointInfoSource> clientSourceLogger)
         {
             _portOptions = portOptions.Value;
 
@@ -35,7 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             switch (connectionMode)
             {
                 case DiagnosticPortConnectionMode.Connect:
-                    _source = new ClientEndpointInfoSource();
+                    _source = new ClientEndpointInfoSource(clientSourceLogger);
                     break;
                 case DiagnosticPortConnectionMode.Listen:
                     _source = new ServerEndpointInfoSource(_portOptions.EndpointName);

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -142,6 +142,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_NotifyPrivateKey);
 
+        private static readonly Action<ILogger, int, Exception> _diagnosticRequestCancelled =
+            LoggerMessage.Define<int>(
+                eventId: new EventId(41, "DiagnosticRequestCancelled"),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_DiagnosticRequestCancelled);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -239,6 +245,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void NotifyPrivateKey(this ILogger logger, string fieldName)
         {
             _notifyPrivateKey(logger, fieldName, null);
+        }
+
+        public static void DiagnosticRequestCancelled(this ILogger logger, int processId)
+        {
+            _diagnosticRequestCancelled(logger, processId, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -439,6 +439,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancelled waiting for diagnostic response from runtime in process {processId}..
+        /// </summary>
+        internal static string LogFormatString_DiagnosticRequestCancelled {
+            get {
+                return ResourceManager.GetString("LogFormatString_DiagnosticRequestCancelled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Negotiate, Kerberos, and NTLM authentication are not enabled when running with elevated permissions..
         /// </summary>
         internal static string LogFormatString_DisabledNegotiateWhileElevated {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -336,6 +336,9 @@
 1 Format Parameter:
 1. address: The address the metrics api was bound to</comment>
   </data>
+  <data name="LogFormatString_DiagnosticRequestCancelled" xml:space="preserve">
+    <value>Cancelled waiting for diagnostic response from runtime in process {processId}.</value>
+  </data>
   <data name="LogFormatString_DisabledNegotiateWhileElevated" xml:space="preserve">
     <value>Negotiate, Kerberos, and NTLM authentication are not enabled when running with elevated permissions.</value>
     <comment>Gets the format string that is printed in the 20:DisabledNegotiateWhileElevated event.


### PR DESCRIPTION
This change allows dotnet-monitor to skip waiting for unresponsive processes in `connect` mode. Prior to this change, any unresponsive process that dotnet-monitor attempts to communicate with will cause HTTP requests to hang indefinitely until canceled. The change gives a brief window in which processes must respond; otherwise, dotnet-monitor will skip the inclusion of those offending processes in the process list.

This was tested on my local machine using WSL2; the unresponsive processes are skipped whereas the responsive ones are reported via the `/processes` route.

I will run the CI build several times to check that this fixes the `/processes` hang issue that is seen in various tests. Build results:
- Build [20210916.5](https://dev.azure.com/dnceng/public/_build/results?buildId=1367731&view=results): Success
- Build [20210916.6](https://dev.azure.com/dnceng/public/_build/results?buildId=1367766&view=results): Success
- Build [20210916.7](https://dev.azure.com/dnceng/public/_build/results?buildId=1367829&view=results): Success
- Build [20210916.8](https://dev.azure.com/dnceng/public/_build/results?buildId=1367846&view=results): Success
- Build [20210916.9](https://dev.azure.com/dnceng/public/_build/results?buildId=1367934&view=results): Failed; one startup issue on Mac (#439), one pipeline agent lost communication, otherwise all passed.

closes #399 