### PR TITLE
Collect dumps for hanging tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,9 @@
   <PropertyGroup Label="Arcade">
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>false</UsingToolNetFrameworkReferenceAssemblies>
+    <!-- Use `dotnet test` to have the ability to collect dumps on hanging tests.  -->
+    <UseVSTestRunner>true</UseVSTestRunner>
+    <MicrosoftTestPlatformVersion>16.11.0</MicrosoftTestPlatformVersion>
   </PropertyGroup>
   <!--
     These versions should ONLY be updated by automation.

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -153,3 +153,13 @@ jobs:
         buildConfiguration: ${{ parameters.name }}
       continueOnError: true
       condition: succeededOrFailed()
+    
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Test Result Files
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          PublishLocation: Container
+          ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.configuration }}
+        continueOnError: true
+        condition: succeededOrFailed()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -115,8 +115,8 @@ jobs:
     - task: PublishTestResults@2
       displayName: Publish Test Results (Core 3.1)
       inputs:
-        testResultsFormat: xUnit
-        testResultsFiles: '**/*Tests*netcoreapp3.1*.xml' 
+        testResultsFormat: VSTest
+        testResultsFiles: '**/*Tests*netcoreapp3.1*.trx' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
         testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} Core 3.1'
@@ -129,8 +129,8 @@ jobs:
     - task: PublishTestResults@2
       displayName: Publish Test Results (NET 5.0)
       inputs:
-        testResultsFormat: xUnit
-        testResultsFiles: '**/*Tests*net5.0*.xml' 
+        testResultsFormat: VSTest
+        testResultsFiles: '**/*Tests*net5.0*.trx' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
         testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} NET 5.0'
@@ -143,8 +143,8 @@ jobs:
     - task: PublishTestResults@2
       displayName: Publish Test Results (NET 6.0)
       inputs:
-        testResultsFormat: xUnit
-        testResultsFiles: '**/*Tests*net6.0*.xml' 
+        testResultsFormat: VSTest
+        testResultsFiles: '**/*Tests*net6.0*.trx' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true
         testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} NET 6.0'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,5 +19,9 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=3m"</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
 </Project>


### PR DESCRIPTION
Collect hang dump for the test host when individual tests run longer than 3 minutes.

closes #620 