### PR TITLE
Implement collection rule filters.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -2,29 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Diagnostics.Monitoring.EventPipe;
-using Microsoft.Diagnostics.NETCore.Client;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal sealed class DiagnosticServices : IDiagnosticServices
     {
-        // The value of the operating system field of the ProcessInfo result when the target process is running
-        // on a Windows operating system.
-        private const string ProcessOperatingSystemWindowsValue = "windows";
-
-        // The amount of time to wait before cancelling get additional process information (e.g. getting
-        // the process command line if the IEndpointInfo doesn't provide it).
-        private static readonly TimeSpan ExtendedProcessInfoTimeout = TimeSpan.FromMilliseconds(1000);
-
         private readonly IEndpointInfoSourceInternal _endpointInfoSource;
         private readonly IOptionsMonitor<ProcessFilterOptions> _defaultProcessOptions;
 
@@ -42,7 +30,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             try
             {
                 using CancellationTokenSource extendedInfoCancellation = CancellationTokenSource.CreateLinkedTokenSource(token);
-                IList<Task<ProcessInfo>> processInfoTasks = new List<Task<ProcessInfo>>();
+                IList<Task<IProcessInfo>> processInfoTasks = new List<Task<IProcessInfo>>();
                 foreach (IEndpointInfo endpointInfo in await _endpointInfoSource.GetEndpointInfoAsync(token))
                 {
                     // CONSIDER: Can this processing be pushed into the IEndpointInfoSource implementation and cached
@@ -51,13 +39,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     // - .NET Core 3.1 processes, which require issuing a brief event pipe session to get the process commmand
                     //   line information and parse out the process name
                     // - Caching entrypoint information (when that becomes available).
-                    processInfoTasks.Add(ProcessInfo.FromEndpointInfoAsync(endpointInfo, extendedInfoCancellation.Token));
+                    processInfoTasks.Add(ProcessInfoImpl.FromEndpointInfoAsync(endpointInfo, extendedInfoCancellation.Token));
                 }
 
                 // FromEndpointInfoAsync can fill in the command line for .NET Core 3.1 processes by invoking the
                 // event pipe and capturing the ProcessInfo event. Timebox this operation with the cancellation token
                 // so that getting the process list does not take a long time or wait indefinitely.
-                extendedInfoCancellation.CancelAfter(ExtendedProcessInfoTimeout);
+                extendedInfoCancellation.CancelAfter(ProcessInfoImpl.ExtendedProcessInfoTimeout);
 
                 await Task.WhenAll(processInfoTasks);
 
@@ -109,128 +97,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 default:
                     throw new ArgumentException(Strings.ErrorMessage_MultipleTargetProcesses);
             }
-        }
-
-        /// <summary>
-        /// We want to make sure we destroy files we finish streaming.
-        /// We want to make sure that we stream out files since we compress on the fly; the size cannot be known upfront.
-        /// CONSIDER The above implies knowledge of how the file is used by the rest api.
-        /// </summary>
-        private sealed class AutoDeleteFileStream : FileStream
-        {
-            public AutoDeleteFileStream(string path) : base(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete,
-                bufferSize: 4096, FileOptions.DeleteOnClose)
-            {
-            }
-
-            public override bool CanSeek => false;
-        }
-
-        private sealed class ProcessInfo : IProcessInfo
-        {
-            // String returned for a process field when its value could not be retrieved. This is the same
-            // value that is returned by the runtime when it could not determine the value for each of those fields.
-            private static readonly string ProcessFieldUnknownValue = "unknown";
-
-            public ProcessInfo(
-                IEndpointInfo endpointInfo,
-                string commandLine,
-                string processName)
-            {
-                EndpointInfo = endpointInfo;
-
-                // The GetProcessInfo command will return "unknown" for values for which it does
-                // not know the value, such as operating system and process architecture if the
-                // process is running on one that is not predefined. Mimic the same behavior here
-                // when the extra process information was not provided.
-                CommandLine = commandLine ?? ProcessFieldUnknownValue;
-                ProcessName = processName ?? ProcessFieldUnknownValue;
-            }
-
-            public static async Task<ProcessInfo> FromEndpointInfoAsync(IEndpointInfo endpointInfo)
-            {
-                using CancellationTokenSource extendedInfoCancellation = new CancellationTokenSource(ExtendedProcessInfoTimeout);
-                return await FromEndpointInfoAsync(endpointInfo, extendedInfoCancellation.Token);
-            }
-
-            // Creates a ProcessInfo object from the IEndpointInfo. Attempts to get the command line using event pipe
-            // if the endpoint information doesn't provide it. The cancelation token can be used to timebox this fallback
-            // mechansim.
-            public static async Task<ProcessInfo> FromEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken extendedInfoCancellationToken)
-            {
-                if (null == endpointInfo)
-                {
-                    throw new ArgumentNullException(nameof(endpointInfo));
-                }
-
-                var client = new DiagnosticsClient(endpointInfo.Endpoint);
-
-                string commandLine = endpointInfo.CommandLine;
-                if (string.IsNullOrEmpty(commandLine))
-                {
-                    try
-                    {
-                        var infoSettings = new EventProcessInfoPipelineSettings
-                        {
-                            Duration = Timeout.InfiniteTimeSpan,
-                        };
-
-                        await using var pipeline = new EventProcessInfoPipeline(client, infoSettings,
-                            (cmdLine, token) => { commandLine = cmdLine; return Task.CompletedTask; });
-
-                        await pipeline.RunAsync(extendedInfoCancellationToken);
-                    }
-                    catch
-                    {
-                    }
-                }
-
-                string processName = null;
-                if (!string.IsNullOrEmpty(commandLine))
-                {
-                    // Get the process name from the command line
-                    bool isWindowsProcess = false;
-                    if (string.IsNullOrEmpty(endpointInfo.OperatingSystem))
-                    {
-                        // If operating system is null, the process is likely .NET Core 3.1 (which doesn't have the GetProcessInfo command).
-                        // Since the underlying diagnostic communication channel used by the .NET runtime requires that the diagnostic process
-                        // must be running on the same type of operating system as the target process (e.g. dotnet-monitor must be running on Windows
-                        // if the target process is running on Windows), then checking the local operating system should be a sufficient heuristic
-                        // to determine the operating system of the target process.
-                        isWindowsProcess = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-                    }
-                    else
-                    {
-                        isWindowsProcess = ProcessOperatingSystemWindowsValue.Equals(endpointInfo.OperatingSystem, StringComparison.OrdinalIgnoreCase);
-                    }
-
-                    string processPath = CommandLineHelper.ExtractExecutablePath(commandLine, isWindowsProcess);
-                    if (!string.IsNullOrEmpty(processPath))
-                    {
-                        processName = Path.GetFileName(processPath);
-                        if (isWindowsProcess)
-                        {
-                            // Remove the extension on Windows to match the behavior of Process.ProcessName
-                            processName = Path.GetFileNameWithoutExtension(processName);
-                        }
-                    }
-                }
-
-                return new ProcessInfo(
-                    endpointInfo,
-                    commandLine,
-                    processName);
-            }
-
-            public IEndpointInfo EndpointInfo { get; }
-
-            public string CommandLine { get; }
-
-            public string OperatingSystem => EndpointInfo.OperatingSystem ?? ProcessFieldUnknownValue;
-
-            public string ProcessArchitecture => EndpointInfo.ProcessArchitecture ?? ProcessFieldUnknownValue;
-
-            public string ProcessName { get; }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.EventPipe;
+using Microsoft.Diagnostics.NETCore.Client;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    /// Named "ProcessInfoImpl" to disambiguate from Microsoft.Diagnostics.NETCore.client ProcessInfo
+    /// class returned from issuing GetProcesssInfo command on diagnostic pipe.
+    internal sealed class ProcessInfoImpl : IProcessInfo
+    {
+        // The amount of time to wait before cancelling get additional process information (e.g. getting
+        // the process command line if the IEndpointInfo doesn't provide it).
+        public static readonly TimeSpan ExtendedProcessInfoTimeout = TimeSpan.FromMilliseconds(1000);
+
+        // String returned for a process field when its value could not be retrieved. This is the same
+        // value that is returned by the runtime when it could not determine the value for each of those fields.
+        private static readonly string ProcessFieldUnknownValue = "unknown";
+
+        // The value of the operating system field of the ProcessInfo result when the target process is running
+        // on a Windows operating system.
+        private const string ProcessOperatingSystemWindowsValue = "windows";
+
+        public ProcessInfoImpl(
+            IEndpointInfo endpointInfo,
+            string commandLine,
+            string processName)
+        {
+            EndpointInfo = endpointInfo;
+
+            // The GetProcessInfo command will return "unknown" for values for which it does
+            // not know the value, such as operating system and process architecture if the
+            // process is running on one that is not predefined. Mimic the same behavior here
+            // when the extra process information was not provided.
+            CommandLine = commandLine ?? ProcessFieldUnknownValue;
+            ProcessName = processName ?? ProcessFieldUnknownValue;
+        }
+
+        public static async Task<IProcessInfo> FromEndpointInfoAsync(IEndpointInfo endpointInfo)
+        {
+            using CancellationTokenSource extendedInfoCancellation = new(ExtendedProcessInfoTimeout);
+            return await FromEndpointInfoAsync(endpointInfo, extendedInfoCancellation.Token);
+        }
+
+        // Creates a ProcessInfo object from the IEndpointInfo. Attempts to get the command line using event pipe
+        // if the endpoint information doesn't provide it. The cancelation token can be used to timebox this fallback
+        // mechansim.
+        public static async Task<IProcessInfo> FromEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken extendedInfoCancellationToken)
+        {
+            if (null == endpointInfo)
+            {
+                throw new ArgumentNullException(nameof(endpointInfo));
+            }
+
+            DiagnosticsClient client = new(endpointInfo.Endpoint);
+
+            string commandLine = endpointInfo.CommandLine;
+            if (string.IsNullOrEmpty(commandLine))
+            {
+                try
+                {
+                    EventProcessInfoPipelineSettings infoSettings = new()
+                    {
+                        Duration = Timeout.InfiniteTimeSpan,
+                    };
+
+                    await using EventProcessInfoPipeline pipeline = new(client, infoSettings,
+                        (cmdLine, token) => { commandLine = cmdLine; return Task.CompletedTask; });
+
+                    await pipeline.RunAsync(extendedInfoCancellationToken);
+                }
+                catch
+                {
+                }
+            }
+
+            string processName = null;
+            if (!string.IsNullOrEmpty(commandLine))
+            {
+                // Get the process name from the command line
+                bool isWindowsProcess = false;
+                if (string.IsNullOrEmpty(endpointInfo.OperatingSystem))
+                {
+                    // If operating system is null, the process is likely .NET Core 3.1 (which doesn't have the GetProcessInfo command).
+                    // Since the underlying diagnostic communication channel used by the .NET runtime requires that the diagnostic process
+                    // must be running on the same type of operating system as the target process (e.g. dotnet-monitor must be running on Windows
+                    // if the target process is running on Windows), then checking the local operating system should be a sufficient heuristic
+                    // to determine the operating system of the target process.
+                    isWindowsProcess = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                }
+                else
+                {
+                    isWindowsProcess = ProcessOperatingSystemWindowsValue.Equals(endpointInfo.OperatingSystem, StringComparison.OrdinalIgnoreCase);
+                }
+
+                string processPath = CommandLineHelper.ExtractExecutablePath(commandLine, isWindowsProcess);
+                if (!string.IsNullOrEmpty(processPath))
+                {
+                    processName = Path.GetFileName(processPath);
+                    if (isWindowsProcess)
+                    {
+                        // Remove the extension on Windows to match the behavior of Process.ProcessName
+                        processName = Path.GetFileNameWithoutExtension(processName);
+                    }
+                }
+            }
+
+            return new ProcessInfoImpl(
+                endpointInfo,
+                commandLine,
+                processName);
+        }
+
+        public IEndpointInfo EndpointInfo { get; }
+
+        public string CommandLine { get; }
+
+        public string OperatingSystem => EndpointInfo.OperatingSystem ?? ProcessFieldUnknownValue;
+
+        public string ProcessArchitecture => EndpointInfo.ProcessArchitecture ?? ProcessFieldUnknownValue;
+
+        public string ProcessName { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     /// Named "ProcessInfoImpl" to disambiguate from Microsoft.Diagnostics.NETCore.client ProcessInfo
-    /// class returned from issuing GetProcesssInfo command on diagnostic pipe.
+    /// class returned from issuing GetProcessInfo command on diagnostic pipe.
     internal sealed class ProcessInfoImpl : IProcessInfo
     {
         // The amount of time to wait before cancelling get additional process information (e.g. getting
@@ -49,9 +49,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return await FromEndpointInfoAsync(endpointInfo, extendedInfoCancellation.Token);
         }
 
-        // Creates a ProcessInfo object from the IEndpointInfo. Attempts to get the command line using event pipe
+        // Creates an IProcessInfo object from the IEndpointInfo. Attempts to get the command line using event pipe
         // if the endpoint information doesn't provide it. The cancelation token can be used to timebox this fallback
-        // mechansim.
+        // mechanism.
         public static async Task<IProcessInfo> FromEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken extendedInfoCancellationToken)
         {
             if (null == endpointInfo)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
@@ -16,6 +17,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
         public static Version RuntimeVersion =>
             s_runtimeVersionLazy.Value;
+
+        public static string HostExeNameWithoutExtension => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            Path.GetFileNameWithoutExtension(HostExePath) :
+            Path.GetFileName(HostExePath);
 
         public static string HostExePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             @"..\..\..\..\..\.dotnet\dotnet.exe" :

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Validates that a collection rule with a command line filter can be matched to the
         /// target process.
         /// </summary>
-        [ConditionalTheory(nameof(IsNotNet5OnUnix))]
+        [ConditionalTheory(nameof(IsNotNet5OrGreaterOnUnix))]
         [InlineData(DiagnosticPortConnectionMode.Listen)]
         public async Task CollectionRule_CommandLineFilterMatchTest(DiagnosticPortConnectionMode mode)
         {
@@ -246,12 +246,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     filteredTask = runner.WaitForCollectionRuleUnmatchedFiltersAsync(DefaultRuleName);
                 });
         }
-#endif
 
         // The GetProcessInfo command is not providing command line arguments (only the process name)
-        // for .NET 5 process on non-Windows when suspended. See https://github.com/dotnet/dotnet-monitor/issues/885
-        private static bool IsNotNet5OnUnix =>
-            DotNetHost.RuntimeVersion.Major != 5 ||
+        // for .NET 5+ process on non-Windows when suspended. See https://github.com/dotnet/dotnet-monitor/issues/885
+        private static bool IsNotNet5OrGreaterOnUnix =>
+            DotNetHost.RuntimeVersion.Major < 5 ||
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -124,7 +125,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Validates that a collection rule with a command line filter can be matched to the
         /// target process.
         /// </summary>
-        [Theory]
+        [ConditionalTheory(nameof(IsNotNet5OnUnix))]
         [InlineData(DiagnosticPortConnectionMode.Listen)]
         public async Task CollectionRule_CommandLineFilterMatchTest(DiagnosticPortConnectionMode mode)
         {
@@ -246,5 +247,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 });
         }
 #endif
+
+        // The GetProcessInfo command is not providing command line arguments (only the process name)
+        // for .NET 5 process on non-Windows when suspended. See https://github.com/dotnet/dotnet-monitor/issues/885
+        private static bool IsNotNet5OnUnix =>
+            DotNetHost.RuntimeVersion.Major != 5 ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -119,6 +119,132 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     ruleCompletedTask = runner.WaitForCollectionRuleCompleteAsync(DefaultRuleName);
                 });
         }
+
+        /// <summary>
+        /// Validates that a collection rule with a command line filter can be matched to the
+        /// target process.
+        /// </summary>
+        [Theory]
+        [InlineData(DiagnosticPortConnectionMode.Listen)]
+        public async Task CollectionRule_CommandLineFilterMatchTest(DiagnosticPortConnectionMode mode)
+        {
+            Task startedTask = null;
+
+            await ScenarioRunner.SingleTarget(
+                _outputHelper,
+                _httpClientFactory,
+                mode,
+                TestAppScenarios.AsyncWait.Name,
+                appValidate: async (runner, client) =>
+                {
+                    await startedTask;
+
+                    await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+                },
+                configureTool: runner =>
+                {
+                    runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddCommandLineFilter(TestAppScenarios.AsyncWait.Name);
+
+                    startedTask = runner.WaitForCollectionRuleStartedAsync(DefaultRuleName);
+                });
+        }
+
+        /// <summary>
+        /// Validates that a collection rule with a command line filter can fail to match the
+        /// target process.
+        /// </summary>
+        [Theory]
+        [InlineData(DiagnosticPortConnectionMode.Listen)]
+        public async Task CollectionRule_CommandLineFilterNoMatchTest(DiagnosticPortConnectionMode mode)
+        {
+            Task filteredTask = null;
+
+            await ScenarioRunner.SingleTarget(
+                _outputHelper,
+                _httpClientFactory,
+                mode,
+                TestAppScenarios.AsyncWait.Name,
+                appValidate: async (runner, client) =>
+                {
+                    await filteredTask;
+
+                    await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+                },
+                configureTool: runner =>
+                {
+                    // Note that the process name filter is specified as "SpinWait" whereas the
+                    // actual command line of the target process will contain "AsyncWait".
+                    runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddProcessNameFilter(TestAppScenarios.SpinWait.Name);
+
+                    filteredTask = runner.WaitForCollectionRuleUnmatchedFiltersAsync(DefaultRuleName);
+                });
+        }
+
+        /// <summary>
+        /// Validates that a collection rule with a process name filter can be matched to the
+        /// target process.
+        /// </summary>
+        [Theory]
+        [InlineData(DiagnosticPortConnectionMode.Listen)]
+        public async Task CollectionRule_ProcessNameFilterMatchTest(DiagnosticPortConnectionMode mode)
+        {
+            Task startedTask = null;
+
+            await ScenarioRunner.SingleTarget(
+                _outputHelper,
+                _httpClientFactory,
+                mode,
+                TestAppScenarios.AsyncWait.Name,
+                appValidate: async (runner, client) =>
+                {
+                    await startedTask;
+
+                    await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+                },
+                configureTool: runner =>
+                {
+                    runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddProcessNameFilter(DotNetHost.HostExeNameWithoutExtension);
+
+                    startedTask = runner.WaitForCollectionRuleStartedAsync(DefaultRuleName);
+                });
+        }
+
+        /// <summary>
+        /// Validates that a collection rule with a process name filter can fail to match the
+        /// target process.
+        /// </summary>
+        [Theory]
+        [InlineData(DiagnosticPortConnectionMode.Listen)]
+        public async Task CollectionRule_ProcessNameFilterNoMatchTest(DiagnosticPortConnectionMode mode)
+        {
+            Task filteredTask = null;
+
+            await ScenarioRunner.SingleTarget(
+                _outputHelper,
+                _httpClientFactory,
+                mode,
+                TestAppScenarios.AsyncWait.Name,
+                appValidate: async (runner, client) =>
+                {
+                    await filteredTask;
+
+                    await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+                },
+                configureTool: runner =>
+                {
+                    runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddProcessNameFilter("UmatchedName");
+
+                    filteredTask = runner.WaitForCollectionRuleUnmatchedFiltersAsync(DefaultRuleName);
+                });
+        }
 #endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
@@ -99,5 +99,27 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             using CancellationTokenSource cancellation = new(timeout);
             await runner.WaitForCollectionRuleCompleteAsync(ruleName, cancellation.Token);
         }
+
+        public static Task WaitForCollectionRuleUnmatchedFiltersAsync(this MonitorCollectRunner runner, string ruleName)
+        {
+            return runner.WaitForCollectionRuleUnmatchedFiltersAsync(ruleName, TestTimeouts.CollectionRuleFilteredTimeout);
+        }
+
+        public static async Task WaitForCollectionRuleUnmatchedFiltersAsync(this MonitorCollectRunner runner, string ruleName, TimeSpan timeout)
+        {
+            using CancellationTokenSource cancellation = new(timeout);
+            await runner.WaitForCollectionRuleUnmatchedFiltersAsync(ruleName, cancellation.Token);
+        }
+
+        public static Task WaitForCollectionRuleStartedAsync(this MonitorCollectRunner runner, string ruleName)
+        {
+            return runner.WaitForCollectionRuleStartedAsync(ruleName, TestTimeouts.CollectionRuleCompletionTimeout);
+        }
+
+        public static async Task WaitForCollectionRuleStartedAsync(this MonitorCollectRunner runner, string ruleName, TimeSpan timeout)
+        {
+            using CancellationTokenSource cancellation = new(timeout);
+            await runner.WaitForCollectionRuleStartedAsync(ruleName, cancellation.Token);
+        }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
@@ -33,5 +33,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Timeout for waiting for a collection rule to complete.
         /// </summary>
         public static readonly TimeSpan CollectionRuleCompletionTimeout = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Timeout for waiting for a collection rule to be filtered.
+        /// </summary>
+        public static readonly TimeSpan CollectionRuleFilteredTimeout = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
@@ -17,6 +18,30 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 {
     internal static partial class CollectionRuleOptionsExtensions
     {
+        public static CollectionRuleOptions AddCommandLineFilter(this CollectionRuleOptions options, string value, ProcessFilterType matchType = ProcessFilterType.Contains)
+        {
+            options.Filters.Add(new ProcessFilterDescriptor()
+            {
+                Key = ProcessFilterKey.CommandLine,
+                Value = value,
+                MatchType = matchType
+            });
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddProcessNameFilter(this CollectionRuleOptions options, string name)
+        {
+            options.Filters.Add(new ProcessFilterDescriptor()
+            {
+                Key = ProcessFilterKey.ProcessName,
+                Value = name,
+                MatchType = ProcessFilterType.Exact
+            });
+
+            return options;
+        }
+
         public static CollectionRuleOptions AddAction(this CollectionRuleOptions options, string type)
         {
             return options.AddAction(type, out _);

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -49,5 +49,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public const int CollectionRuleActionsCompleted = 39;
         public const int ApplyingCollectionRules = 40;
         public const int DiagnosticRequestCancelled = 41;
+        public const int CollectionRuleUnmatchedFilters = 42;
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -217,6 +217,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DiagnosticRequestCancelled);
 
+        private static readonly Action<ILogger, string, Exception> _collectionRuleUnmatchedFilters =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(LoggingEventIds.CollectionRuleUnmatchedFilters, "CollectionRuleUnmatchedFilters"),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_CollectionRuleUnmatchedFilters);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -389,6 +395,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void DiagnosticRequestCancelled(this ILogger logger, int processId)
         {
             _diagnosticRequestCancelled(logger, processId, null);
+        }
+
+        public static void CollectionRuleUnmatchedFilters(this ILogger logger, string ruleName)
+        {
+            _collectionRuleUnmatchedFilters(logger, ruleName, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -646,6 +646,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collection rule &apos;{ruleName}&apos; filters do not match the process..
+        /// </summary>
+        internal static string LogFormatString_CollectionRuleUnmatchedFilters {
+            get {
+                return ResourceManager.GetString("LogFormatString_CollectionRuleUnmatchedFilters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cancelled waiting for diagnostic response from runtime in process {processId}..
         /// </summary>
         internal static string LogFormatString_DiagnosticRequestCancelled {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -421,6 +421,9 @@
   <data name="LogFormatString_CollectionRuleTriggerStarted" xml:space="preserve">
     <value>Collection rule '{ruleName}' trigger '{triggerType}' started.</value>
   </data>
+  <data name="LogFormatString_CollectionRuleUnmatchedFilters" xml:space="preserve">
+    <value>Collection rule '{ruleName}' filters do not match the process.</value>
+  </data>
   <data name="LogFormatString_DiagnosticRequestCancelled" xml:space="preserve">
     <value>Cancelled waiting for diagnostic response from runtime in process {processId}.</value>
   </data>


### PR DESCRIPTION
This change filters collection rules based on the filters specified in configuration. It includes a refactor of the DiagnosticServices+ProcessInfo class to a separate ProcessInfoImpl class as well as a few basic tests to verify that the rules are able to be conditionally applied.

closes #870 