### PR TITLE
Allow action completion to be deferred.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionListExecutorTests.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
@@ -51,18 +52,34 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger);
 
-                await executor.ExecuteActions(context, cancellationTokenSource.Token);
+                bool calledStartCallback = false;
+                Action startCallback = () => calledStartCallback = true;
+
+                await executor.ExecuteActions(context, startCallback, cancellationTokenSource.Token);
+
+                Assert.True(calledStartCallback, "Expected start callback to have been invoked.");
             });
         }
 
         [Fact]
-        public async Task ActionListExecutor_SecondActionFail()
+        public Task ActionListExecutor_SecondActionFail_DeferredCompletion()
+        {
+            return ActionListExecutor_SecondActionFail(waitForCompletion: false);
+        }
+
+        [Fact]
+        public Task ActionListExecutor_SecondActionFail_WaitedCompletion()
+        {
+            return ActionListExecutor_SecondActionFail(waitForCompletion: true);
+        }
+
+        private async Task ActionListExecutor_SecondActionFail(bool waitForCompletion)
         {
             await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
             {
                 rootOptions.CreateCollectionRule(DefaultRuleName)
-                    .AddExecuteActionAppAction(new string[] { "ZeroExitCode" })
-                    .AddExecuteActionAppAction(new string[] { "NonzeroExitCode" })
+                    .AddExecuteActionAppAction(waitForCompletion, new string[] { "ZeroExitCode" })
+                    .AddExecuteActionAppAction(waitForCompletion, new string[] { "NonzeroExitCode" })
                     .SetStartupTrigger();
             }, async host =>
             {
@@ -75,23 +92,51 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger);
 
+                bool calledStartCallback = false;
+                Action startCallback = () => calledStartCallback = true;
+
                 CollectionRuleActionExecutionException actionExecutionException = await Assert.ThrowsAsync<CollectionRuleActionExecutionException>(
-                    () => executor.ExecuteActions(context, cancellationTokenSource.Token));
+                    () => executor.ExecuteActions(context, startCallback, cancellationTokenSource.Token));
 
                 Assert.Equal(1, actionExecutionException.ActionIndex);
 
                 Assert.Equal(string.Format(Strings.ErrorMessage_NonzeroExitCode, "1"), actionExecutionException.Message);
+
+                if (waitForCompletion)
+                {
+                    // The action failure occurs in completion and the actions were specified to have
+                    // to wait for completion before executing the next action, thus the start callback
+                    // should not have been invoked.
+                    Assert.False(calledStartCallback, "Expected start callback to not have been invoked.");
+                }
+                else
+                {
+                    // The action failure occurs in completion but all actions were started, thus
+                    // the start callback should have been invoked.
+                    Assert.True(calledStartCallback, "Expected start callback to have been invoked.");
+                }
             });
         }
 
         [Fact]
-        public async Task ActionListExecutor_FirstActionFail()
+        public Task ActionListExecutor_FirstActionFail_DeferredCompletion()
+        {
+            return ActionListExecutor_FirstActionFail(waitForCompletion: false);
+        }
+
+        [Fact]
+        public Task ActionListExecutor_FirstActionFail_WaitedCompletion()
+        {
+            return ActionListExecutor_FirstActionFail(waitForCompletion: true);
+        }
+
+        private async Task ActionListExecutor_FirstActionFail(bool waitForCompletion)
         {
             await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
             {
                 rootOptions.CreateCollectionRule(DefaultRuleName)
-                    .AddExecuteActionAppAction(new string[] { "NonzeroExitCode" })
-                    .AddExecuteActionAppAction(new string[] { "ZeroExitCode" })
+                    .AddExecuteActionAppAction(waitForCompletion, new string[] { "NonzeroExitCode" })
+                    .AddExecuteActionAppAction(waitForCompletion, new string[] { "ZeroExitCode" })
                     .SetStartupTrigger();
             }, async host =>
             {
@@ -104,12 +149,29 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger);
 
+                bool calledStartCallback = false;
+                Action startCallback = () => calledStartCallback = true;
+
                 CollectionRuleActionExecutionException actionExecutionException = await Assert.ThrowsAsync<CollectionRuleActionExecutionException>(
-                    () => executor.ExecuteActions(context, cancellationTokenSource.Token));
+                    () => executor.ExecuteActions(context, startCallback, cancellationTokenSource.Token));
 
                 Assert.Equal(0, actionExecutionException.ActionIndex);
 
                 Assert.Equal(string.Format(Strings.ErrorMessage_NonzeroExitCode, "1"), actionExecutionException.Message);
+
+                if (waitForCompletion)
+                {
+                    // The action failure occurs in completion and the actions were specified to have
+                    // to wait for completion before executing the next action, thus the start callback
+                    // should not have been invoked.
+                    Assert.False(calledStartCallback, "Expected start callback to not have been invoked.");
+                }
+                else
+                {
+                    // The action failure occurs in completion but all actions were started, thus
+                    // the start callback should have been invoked.
+                    Assert.True(calledStartCallback, "Expected start callback to have been invoked.");
+                }
             });
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -389,14 +389,17 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                             logger);
 
                         TaskCompletionSource<object> startedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                        int startedCount = 0;
 
                         await using CollectionRulePipeline pipeline = new(
                             actionListExecutor,
                             triggerOperations,
                             context,
-                            () => startedSource.TrySetResult(null));
+                            () => { startedSource.TrySetResult(null); startedCount++; });
 
                         await pipelineCallback(runner, pipeline, startedSource.Task);
+
+                        Assert.Equal(1, startedCount);
                     },
                     servicesCallback);
             });

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             return options;
         }
 
-        public static CollectionRuleOptions AddExecuteAction(this CollectionRuleOptions options, string path, string arguments = null)
+        public static CollectionRuleOptions AddExecuteAction(this CollectionRuleOptions options, string path, string arguments = null, bool? waitForCompletion = null)
         {
             options.AddAction(KnownCollectionRuleActions.Execute, out CollectionRuleActionOptions actionOptions);
 
@@ -144,6 +144,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             executeOptions.Path = path;
 
             actionOptions.Settings = executeOptions;
+            actionOptions.WaitForCompletion = waitForCompletion;
 
             return options;
         }
@@ -151,6 +152,13 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
         public static CollectionRuleOptions AddExecuteActionAppAction(this CollectionRuleOptions options, params string[] args)
         {
             options.AddExecuteAction(DotNetHost.HostExePath, ExecuteActionTestHelper.GenerateArgumentsString(args));
+
+            return options;
+        }
+
+        public static CollectionRuleOptions AddExecuteActionAppAction(this CollectionRuleOptions options, bool waitForCompletion, params string[] args)
+        {
+            options.AddExecuteAction(DotNetHost.HostExePath, ExecuteActionTestHelper.GenerateArgumentsString(args), waitForCompletion);
 
             return options;
         }

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         // Ensures that the start callback is only invoked once.
         private void InvokeStartCallback()
         {
-            if (_invokedStartCallback)
+            if (!_invokedStartCallback)
             {
                 _startCallback?.Invoke();
                 _invokedStartCallback = true;

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         // Operations for getting trigger information.
         private readonly ICollectionRuleTriggerOperations _triggerOperations;
 
+        // Flag used to guard against multiple invocations of _startCallback.
+        private bool _invokedStartCallback = false;
+
         public CollectionRulePipeline(
             ActionListExecutor actionListExecutor,
             ICollectionRuleTriggerOperations triggerOperations,
@@ -110,7 +113,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                         if (trigger is not ICollectionRuleStartupTrigger)
                         {
                             // Signal that the pipeline trigger is initialized.
-                            _startCallback?.Invoke();
+                            InvokeStartCallback();
                         }
 
                         // Wait for the trigger to be satisfied.
@@ -164,7 +167,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                         {
                             // Intentionally not using the linkedToken. Allow the action list to execute gracefully
                             // unless forced by a caller to cancel or stop the running of the pipeline.
-                            await _actionListExecutor.ExecuteActions(_context, token);
+                            await _actionListExecutor.ExecuteActions(_context, InvokeStartCallback, token);
 
                             actionsCompleted = true;
                         }
@@ -200,7 +203,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                     if (trigger is ICollectionRuleStartupTrigger)
                     {
                         // Signal that the pipeline trigger is initialized.
-                        _startCallback?.Invoke();
+                        InvokeStartCallback();
 
                         // Complete the pipeline since the action list is only executed once
                         // for collection rules with startup triggers.
@@ -225,6 +228,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         public new Task StopAsync(CancellationToken token)
         {
             return base.StopAsync(token);
+        }
+
+        // Ensures that the start callback is only invoked once.
+        private void InvokeStartCallback()
+        {
+            if (_invokedStartCallback)
+            {
+                _startCallback?.Invoke();
+                _invokedStartCallback = true;
+            }
         }
     }
 }


### PR DESCRIPTION
This change allows action completion to be deferred by default such that all actions are startup asynchronously (but in order), signal startup has completed, and then wait for completion on all deferred action completions. Actions can opt into synchronous completion by setting the WaitForCompletion property to true e.g.

```json
{
  "Type": "CollectTrace",
  "Settings": { ... },
  "WaitForCompletion": true
}
```