### PR TITLE
Migrate to .NET 6

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <clear />
     <!-- Feeds used in Maestro/Arcade publishing -->
     <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet6" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <!-- Standard feeds -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,7 +55,6 @@
     <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>5.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationKeyPerFileVersion>5.0.2</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>5.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>5.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>REST Api surface for dotnet-monitor</Description>
     <!-- Tentatively create package so other teams can tentatively consume. -->

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>REST Api surface for dotnet-monitor</Description>
     <!-- Tentatively create package so other teams can tentatively consume. -->

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>$(DefineConstants);SCHEMAGEN</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
     {
         private readonly LoggingRunnerAdapter _adapter;
 
+        private readonly string _appPath;
+
         private readonly ITestOutputHelper _outputHelper;
 
         private readonly TaskCompletionSource<string> _readySource =
@@ -30,16 +32,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
         private readonly DotNetRunner _runner = new();
 
-        private readonly Assembly _testAssembly;
-
         private TaskCompletionSource<object> _currentCommandSource;
 
         private bool _isDiposed;
-
-        /// <summary>
-        /// The path to the application.
-        /// </summary>
-        private string AppPath => AssemblyHelper.GetAssemblyArtifactBinPath(_testAssembly, "Microsoft.Diagnostics.Monitoring.UnitTestApp");
 
         /// <summary>
         /// The mode of the diagnostic port connection. Default is <see cref="DiagnosticPortConnectionMode.Listen"/>
@@ -72,8 +67,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         {
             AppId = appId;
 
-            _testAssembly = testAssembly;
             _outputHelper = new PrefixedOutputHelper(outputHelper, FormattableString.Invariant($"[App{appId}] "));
+
+            _appPath = AssemblyHelper.GetAssemblyArtifactBinPath(
+                testAssembly,
+                "Microsoft.Diagnostics.Monitoring.UnitTestApp",
+                tfm);
 
             _runner.TargetFramework = tfm;
 
@@ -108,12 +107,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
                 throw new ArgumentNullException(nameof(ScenarioName));
             }
 
-            if (!File.Exists(AppPath))
+            if (!File.Exists(_appPath))
             {
-                throw new FileNotFoundException($"Application path could not be found.", AppPath);
+                throw new FileNotFoundException($"Application path could not be found.", _appPath);
             }
 
-            _runner.EntrypointAssemblyPath = AppPath;
+            _runner.EntrypointAssemblyPath = _appPath;
             _runner.Arguments = ScenarioName;
 
             // Enable diagnostics in case it is disabled via inheriting test environment.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -42,6 +42,18 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             throw CreateUnsupportedException(moniker);
         }
 
+        // Checks if the specified moniker is the same as the test value or if it is Current
+        // then matches the same TFM for which this assembly was built.
+        public static bool IsEffectively(this TargetFrameworkMoniker moniker, TargetFrameworkMoniker test)
+        {
+            if (TargetFrameworkMoniker.Current == test)
+            {
+                throw new ArgumentException($"Parameter {nameof(test)} cannot be TargetFrameworkMoniker.Current");
+            }
+
+            return moniker == test || (TargetFrameworkMoniker.Current == moniker && CurrentTargetFrameworkMoniker == test);
+        }
+
         public static string ToFolderName(this TargetFrameworkMoniker moniker)
         {
             switch (moniker)
@@ -60,5 +72,14 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         {
             return new ArgumentException($"Unsupported target framework moniker: {moniker:G}");
         }
+
+        private static readonly TargetFrameworkMoniker CurrentTargetFrameworkMoniker =
+#if NET6_0
+            TargetFrameworkMoniker.Net60;
+#elif NET5_0
+            TargetFrameworkMoniker.Net50;
+#elif NETCOREAPP3_1
+            TargetFrameworkMoniker.NetCoreApp31;
+#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     DotnetMonitorInfo info = await client.GetInfoAsync();
 
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
-                    Assert.Equal(Environment.Version.ToString(), info.RuntimeVersion);
+                    Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
+                    Assert.True(runtimeVersion.Major >= 6, "RuntimVersion.Major is not greater than or equal to 6.");
                     Assert.Equal(mode, info.DiagnosticPortMode);
 
                     if (mode == DiagnosticPortConnectionMode.Connect)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     DotnetMonitorInfo info = await client.GetInfoAsync();
 
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
-                    Assert.Equal(info.RuntimeVersion, Environment.Version.ToString());
-                    Assert.Equal(info.DiagnosticPortMode, mode);
+                    Assert.Equal(Environment.Version.ToString(), info.RuntimeVersion);
+                    Assert.Equal(mode, info.DiagnosticPortMode);
 
                     if (mode == DiagnosticPortConnectionMode.Connect)
                     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
-                    Assert.True(runtimeVersion.Major >= 6, "RuntimVersion.Major is not greater than or equal to 6.");
+                    Assert.True(runtimeVersion.Major >= 6, "RuntimeVersion.Major is not greater than or equal to 6.");
                     Assert.Equal(mode, info.DiagnosticPortMode);
 
                     if (mode == DiagnosticPortConnectionMode.Connect)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -62,6 +62,8 @@
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Microsoft.Diagnostics.Monitoring.WebApi.csproj" />
     <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
-                (DotNetHost.RuntimeVersion.Major == 6) ? TargetFrameworkMoniker.Net60 : TargetFrameworkMoniker.NetCoreApp31);
+                TargetFrameworkMoniker.Net60);
 
         private string SharedConfigDirectoryPath =>
             Path.Combine(_runnerTmpPath, "SharedConfig");
@@ -72,6 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             // the correct ASP.NET Core version (which can be different than the .NET
             // version, especially for prereleases).
             _runner.FrameworkReference = DotNetFrameworkReference.Microsoft_AspNetCore_App;
+            _runner.TargetFramework = TargetFrameworkMoniker.Net60;
 
             _adapter = new LoggingRunnerAdapter(_outputHelper, _runner);
             _adapter.ReceivedStandardOutputLine += StandardOutputCallback;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
-                TargetFrameworkMoniker.NetCoreApp31);
+                (DotNetHost.RuntimeVersion.Major == 6) ? TargetFrameworkMoniker.Net60 : TargetFrameworkMoniker.NetCoreApp31);
 
         private string SharedConfigDirectoryPath =>
             Path.Combine(_runnerTmpPath, "SharedConfig");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-monitor/Auth/UserAuthorizationHandler.cs
+++ b/src/Tools/dotnet-monitor/Auth/UserAuthorizationHandler.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Text;
@@ -42,6 +43,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     (context.User.Identity.AuthenticationType == AuthConstants.KerberosSchema) ||
                     (context.User.Identity.AuthenticationType == AuthConstants.NegotiateSchema))
             {
+                // Only supported on Windows
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return Task.CompletedTask;
+                }
+
                 //Negotiate, Kerberos, or NTLM.
                 //CONSIDER In the future, we may want to have configuration around a dotnet-monitor group sid instead.
                 //We cannot check the user against BUILTIN\Administrators group membership, since the browser user

--- a/src/Tools/dotnet-monitor/ConfigurationBuilderExtensions.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationBuilderExtensions.cs
@@ -4,35 +4,12 @@
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.KeyPerFile;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Threading;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ConfigurationBuilderExtensions
     {
-        // Works arounds an isssue in KeyPerFileConfigurationProvider where the change token is not signaled
-        // when the keys and values are reloaded. See https://github.com/dotnet/aspnetcore/issues/32836
-        public static IConfigurationBuilder AddKeyPerFileWithChangeTokenSupport(this IConfigurationBuilder builder, string directoryPath, bool optional, bool reloadOnChange)
-        {
-            return builder.Add(delegate (KeyPerFileConfigurationSourceWithChangeTokenSupport source)
-            {
-                if (!optional || Directory.Exists(directoryPath))
-                {
-                    source.FileProvider = new PhysicalFileProvider(directoryPath);
-                }
-                source.Optional = optional;
-                source.ReloadOnChange = reloadOnChange;
-            });
-        }
-
         public static IConfigurationBuilder ConfigureStorageDefaults(this IConfigurationBuilder builder)
         {
             return builder.AddInMemoryCollection(new Dictionary<string, string>
@@ -40,65 +17,5 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {ConfigurationPath.Combine(ConfigurationKeys.Storage, nameof(StorageOptions.DumpTempFolder)), StorageOptionsDefaults.DumpTempFolder }
             });
         }
-
-        private class KeyPerFileConfigurationSourceWithChangeTokenSupport :
-            KeyPerFileConfigurationSource,
-            IConfigurationSource
-        {
-            IConfigurationProvider IConfigurationSource.Build(IConfigurationBuilder builder)
-            {
-                return new KeyPerFileConfigurationProviderWithChangeTokenSupport(this);
-            }
-        }
-
-        private class KeyPerFileConfigurationProviderWithChangeTokenSupport :
-            KeyPerFileConfigurationProvider,
-            IDisposable
-        {
-            // KeyPerFileConfigurationProvider.Load(bool) method
-            private readonly static MethodInfo s_loadMethod = typeof(KeyPerFileConfigurationProvider).GetMethod(
-                "Load",
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                null,
-                new[] { typeof(bool) },
-                null);
-
-            private readonly IDisposable _changeTokenRegistration;
-
-            public KeyPerFileConfigurationProviderWithChangeTokenSupport(KeyPerFileConfigurationSourceWithChangeTokenSupport source)
-                : base(source)
-            {
-                Debug.Assert(null != s_loadMethod);
-                if (null != s_loadMethod)
-                {
-                    if (source.ReloadOnChange && source.FileProvider != null)
-                    {
-                        _changeTokenRegistration = ChangeToken.OnChange(
-                            () => source.FileProvider.Watch("*"),
-                            () =>
-                            {
-                                Thread.Sleep(source.ReloadDelay);
-                                Reload();
-                            });
-                    }
-                }
-            }
-
-            void IDisposable.Dispose()
-            {
-                _changeTokenRegistration?.Dispose();
-                base.Dispose();
-            }
-
-            private void Reload()
-            {
-                // Invoke KeyPerFileConfigurationProvider.Load(bool) to reload the keys and values.
-                s_loadMethod.Invoke(this, new object[] { true });
-
-                // The fix for the issue is to invoke the change token after reloading the data.
-                OnReload();
-            }
-        }
-
     }
 }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         }
                     }
 
-                    builder.AddKeyPerFileWithChangeTokenSupport(path, optional: true, reloadOnChange: true);
+                    builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ConfigPrefix);
 
                     if (authenticationOptions.KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey)

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 // Allow serialization of enum values into strings rather than numbers.
                 options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
             })
-            .SetCompatibilityVersion(CompatibilityVersion.Latest)
             .AddApplicationPart(typeof(DiagController).Assembly);
 
             services.AddControllers(options =>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
     <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
     <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
@@ -23,10 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This change migrates dotnet-monitor to run only on the .NET 6 (or higher) runtime.

Overview of changes:
- Add net6.0 TFMs and fix build.
- Update tests to support running net6.0 dotnet-monitor.
- Remove netcoreapp3.1 TFM from dotnet-monitor and tests.