### PR TITLE
Disable response compression

### DIFF
--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -187,7 +187,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 app.UseCors(builder => builder.WithOrigins(corsConfiguration.GetOrigins()).AllowAnyHeader().AllowAnyMethod());
             }
 
-            app.UseResponseCompression();
+            // Disable response compression due to ASP.NET 6.0 bug:
+            // https://github.com/dotnet/aspnetcore/issues/36960
+            //app.UseResponseCompression();
 
             //Note this must be after UseRouting but before UseEndpoints
             app.UseMiddleware<RequestLimitMiddleware>();


### PR DESCRIPTION
Disabling due to https://github.com/dotnet/aspnetcore/issues/36960 since Preview 8 will likely ship on top of ASP.NET 6.0 RC 1.