### PR TITLE
Restart collection rules when configuration changes.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -256,8 +256,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [InlineData(DiagnosticPortConnectionMode.Listen)]
         public async Task CollectionRule_ConfigurationChangeTest(DiagnosticPortConnectionMode mode)
         {
-            string firstRuleName = "FirstRule";
-            string secondRuleName = "SecondRule";
+            const string firstRuleName = "FirstRule";
+            const string secondRuleName = "SecondRule";
 
             DiagnosticPortHelper.Generate(
                 mode,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 {
                     Enabled = false
                 }
-            }, Timeout.InfiniteTimeSpan);
+            });
 
             await toolRunner.StartAsync();
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
     {
         private readonly ConcurrentDictionary<CollectionRuleKey, List<TaskCompletionSource<object>>> _collectionRuleCallbacks = new();
 
+        public Task WaitForCollectionRuleActionsCompletedAsync(string ruleName, CancellationToken token)
+        {
+            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleActionsCompleted, ruleName, token);
+        }
+
         public Task WaitForCollectionRuleCompleteAsync(string ruleName, CancellationToken token)
         {
             return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleCompleted, ruleName, token);
@@ -60,6 +65,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 CollectionRuleKey key = new(logEvent.EventId, ruleName);
                 switch (logEvent.EventId)
                 {
+                    case LoggingEventIds.CollectionRuleActionsCompleted:
                     case LoggingEventIds.CollectionRuleCompleted:
                     case LoggingEventIds.CollectionRuleUnmatchedFilters:
                     case LoggingEventIds.CollectionRuleStarted:

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             }
         }
 
-        public async Task WriteUserSettingsAsync(RootOptions options, CancellationToken token)
+        public async Task WriteUserSettingsAsync(RootOptions options)
         {
             using FileStream stream = new(UserSettingsFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
 
@@ -184,12 +184,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             await JsonSerializer.SerializeAsync(stream, options, serializerOptions).ConfigureAwait(false);
 
             _outputHelper.WriteLine("Wrote user settings.");
-        }
-
-        public async Task WriteUserSettingsAsync(RootOptions options, TimeSpan timeout)
-        {
-            using CancellationTokenSource cancellation = new(timeout);
-            await WriteUserSettingsAsync(options, cancellation.Token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
@@ -89,6 +89,17 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             await runner.StartAsync(cancellation.Token);
         }
 
+        public static Task WaitForCollectionRuleActionsCompletedAsync(this MonitorCollectRunner runner, string ruleName)
+        {
+            return runner.WaitForCollectionRuleActionsCompletedAsync(ruleName, TestTimeouts.CollectionRuleActionsCompletedTimeout);
+        }
+
+        public static async Task WaitForCollectionRuleActionsCompletedAsync(this MonitorCollectRunner runner, string ruleName, TimeSpan timeout)
+        {
+            using CancellationTokenSource cancellation = new(timeout);
+            await runner.WaitForCollectionRuleActionsCompletedAsync(ruleName, cancellation.Token);
+        }
+
         public static Task WaitForCollectionRuleCompleteAsync(this MonitorCollectRunner runner, string ruleName)
         {
             return runner.WaitForCollectionRuleCompleteAsync(ruleName, TestTimeouts.CollectionRuleCompletionTimeout);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         public static readonly TimeSpan CollectionRuleFilteredTimeout = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// Timeout for waiting for a collection rule to be filtered.
+        /// Timeout for waiting for a collection rule to run its action list to completion.
         /// </summary>
         public static readonly TimeSpan CollectionRuleActionsCompletedTimeout = TimeSpan.FromSeconds(30);
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
@@ -38,5 +38,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Timeout for waiting for a collection rule to be filtered.
         /// </summary>
         public static readonly TimeSpan CollectionRuleFilteredTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Timeout for waiting for a collection rule to be filtered.
+        /// </summary>
+        public static readonly TimeSpan CollectionRuleActionsCompletedTimeout = TimeSpan.FromSeconds(30);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,8 +30,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         private readonly List<Task> _runTasks = new();
         private readonly ICollectionRuleTriggerOperations _triggerOperations;
 
-        private CancellationTokenSource _shutdownTokenSource;
         private long _disposalState;
+        private CancellationTokenSource _shutdownTokenSource;
 
         public CollectionRuleContainer(
             IServiceProvider serviceProvider,
@@ -63,6 +64,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             CancellationToken token)
         {
             DisposableHelper.ThrowIfDisposed<CollectionRuleContainer>(ref _disposalState);
+
+            Debug.Assert(null == _shutdownTokenSource, "Collection rules were previously started without stopping.");
 
             _shutdownTokenSource = new();
 

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -94,7 +94,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         private async Task ReapplyRulesAsync(CancellationToken token)
         {
+            // Indicates that rules changed while handling a previous change.
+            // Used to indicate that the next iteration should not wait for
+            // another configuration change since a change was already detected.
             bool rulesChanged = false;
+
             while (!token.IsCancellationRequested)
             {
                 if (!rulesChanged)
@@ -107,9 +111,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                     // Wait for the rules to be changed
                     await rulesChangedTaskSource.Task;
-
-                    rulesChanged = false;
                 }
+
+                rulesChanged = false;
 
                 _logger.CollectionRuleConfigurationChanged();
 

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
 using Microsoft.Extensions.Logging;
@@ -14,9 +15,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 {
     internal class CollectionRuleService : IAsyncDisposable
     {
+        private readonly CancellationTokenSource _disposalSource = new();
         private readonly List<CollectionRuleContainer> _containers = new();
         private readonly ILogger<CollectionRuleService> _logger;
         private readonly CollectionRulesConfigurationProvider _provider;
+        private readonly Task _reapplyRulesTask;
         private readonly IServiceProvider _serviceProvider;
 
         private long _disposalState;
@@ -30,17 +33,31 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+            CancellationToken disposalToken = _disposalSource.Token;
+            _reapplyRulesTask = Task.Run(() => ReapplyRulesAsync(disposalToken), disposalToken).SafeAwait();
         }
 
         public async ValueTask DisposeAsync()
         {
             if (DisposableHelper.CanDispose(ref _disposalState))
             {
-                foreach (CollectionRuleContainer container in _containers)
+                CollectionRuleContainer[] containers;
+                lock (_containers)
+                {
+                    containers = _containers.ToArray();
+                }
+
+                _disposalSource.SafeCancel();
+
+                await _reapplyRulesTask;
+
+                foreach (CollectionRuleContainer container in containers)
                 {
                     await container.DisposeAsync();
                 }
-                _containers.Clear();
+
+                _disposalSource.Dispose();
             }
         }
 
@@ -55,42 +72,109 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                 throw new ArgumentNullException(nameof(endpointInfo));
             }
 
+            IProcessInfo processInfo = await ProcessInfoImpl.FromEndpointInfoAsync(endpointInfo);
+
             IReadOnlyCollection<string> ruleNames = _provider.GetCollectionRuleNames();
+
+            CollectionRuleContainer container = new(
+                _serviceProvider,
+                _logger,
+                processInfo);
+
+            lock (_containers)
+            {
+                _containers.Add(container);
+            }
 
             if (ruleNames.Count > 0)
             {
-                KeyValueLogScope logScope = new();
-                logScope.AddCollectionRuleEndpointInfo(endpointInfo);
-                // Constrain the scope of the log scope to just the log call so that the log scope
-                // is not captured by the rule execution method.
-                using (_logger.BeginScope(logScope))
+                await container.StartRulesAsync(ruleNames, token);
+            }
+        }
+
+        private async Task ReapplyRulesAsync(CancellationToken token)
+        {
+            bool rulesChanged = false;
+            while (!token.IsCancellationRequested)
+            {
+                if (!rulesChanged)
                 {
-                    _logger.ApplyingCollectionRules();
+                    using EventTaskSource<EventHandler> rulesChangedTaskSource = new(
+                        callback => (s, e) => callback(),
+                        handler => _provider.RulesChanged += handler,
+                        handler => _provider.RulesChanged -= handler,
+                        token);
+
+                    // Wait for the rules to be changed
+                    await rulesChangedTaskSource.Task;
+
+                    rulesChanged = false;
                 }
 
-                IProcessInfo processInfo = await ProcessInfoImpl.FromEndpointInfoAsync(endpointInfo);
+                _logger.CollectionRuleConfigurationChanged();
 
-                CollectionRuleContainer container = new(
-                    _serviceProvider,
-                    _logger,
-                    processInfo);
-                _containers.Add(container);
-
-                List<Task> startTasks = new List<Task>(ruleNames.Count);
-                foreach (string ruleName in ruleNames)
+                // Get a copy of the container list to avoid having to
+                // lock the entire list during stop and restart of all containers.
+                CollectionRuleContainer[] containers;
+                lock (_containers)
                 {
-                    // Start running the rule and wrap running task
-                    // in a safe awaitable task so that shutdown isn't
-                    // failed due to failing or cancelled pipelines.
-                    startTasks.Add(container.StartRuleAsync(ruleName, token).SafeAwait());
+                    containers = _containers.ToArray();
                 }
 
-                // Wait for all start tasks to complete before finishing rule application
-                await Task.WhenAll(startTasks);
-
-                using (_logger.BeginScope(logScope))
+                // Stop all rules for all processes
+                List<Task> tasks = new(_containers.Count);
+                foreach (CollectionRuleContainer container in containers)
                 {
-                    _logger.CollectionRulesStarted();
+                    tasks.Add(Task.Run(() => container.StopRulesAsync(token), token).SafeAwait());
+                }
+
+                await Task.WhenAll(tasks);
+
+                tasks.Clear();
+
+                using CancellationTokenSource rulesChangedCancellationSource = new();
+                using CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+                    rulesChangedCancellationSource.Token,
+                    token);
+                CancellationToken linkedToken = linkedSource.Token;
+
+                EventHandler rulesChangedHandler = (s, e) =>
+                {
+                    // Remember that the rules were changed (so that the next iteration doesn't
+                    // have to wait for them to change again) and signal cancellation due to the
+                    // change.
+                    rulesChanged = true;
+                    rulesChangedCancellationSource.SafeCancel();
+                };
+
+                // Apply new rules to existing processes. This can be cancelled if the rules change
+                // again while attempting to apply the old rules; in this case, loop around again to
+                // stop any rules that are in flight and apply the new rules again.
+                try
+                {
+                    _provider.RulesChanged += rulesChangedHandler;
+
+                    IReadOnlyCollection<string> ruleNames = _provider.GetCollectionRuleNames();
+
+                    if (ruleNames.Count > 0)
+                    {
+                        foreach (CollectionRuleContainer container in containers)
+                        {
+                            tasks.Add(Task.Run(() => container.StartRulesAsync(ruleNames, linkedToken), linkedToken).SafeAwait());
+                        }
+
+                        await Task.WhenAll(tasks);
+                    }
+                }
+                catch (OperationCanceledException) when (rulesChangedCancellationSource.IsCancellationRequested)
+                {
+                    // Catch exception if due to rule change.
+                }
+                finally
+                {
+                    _provider.RulesChanged -= rulesChangedHandler;
+
+                    tasks.Clear();
                 }
             }
         }

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationChangeTokenSource.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
+{
+    /// <summary>
+    /// Raises a notification that the CollectionRuleOptions may have changed.
+    /// </summary>
+    internal sealed class CollectionRulesConfigurationChangeTokenSource :
+        ConfigurationChangeTokenSource<CollectionRuleOptions>
+    {
+        public CollectionRulesConfigurationChangeTokenSource(CollectionRulesConfigurationProvider provider)
+            : base(provider.Configuration)
+        {
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/DynamicNamedOptionsCache.cs
+++ b/src/Tools/dotnet-monitor/DynamicNamedOptionsCache.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Diagnostics;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
+namespace Microsoft.Diagnostics.Tools.Monitor
 {
     /// <summary>
     /// Custom <see cref="IOptionsMonitorCache{TOptions}"/> to override behavior
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
     /// on all of the names in the cache (e.g. <see cref="TryRemove(string)"/> on the default name signals
     /// that all of the named options should be cleared.
     /// </remarks>
-    internal sealed class EgressOptionsCache<TOptions> :
+    internal sealed class DynamicNamedOptionsCache<TOptions> :
         OptionsCache<TOptions>
         where TOptions : class
     {

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -53,5 +53,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public const int CollectionRuleConfigurationChanged = 43;
         public const int CollectionRulesStopping = 44;
         public const int CollectionRulesStopped = 45;
+        public const int CollectionRuleCancelled = 46;
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -47,8 +47,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public const int CollectionRuleActionsThrottled = 37;
         public const int CollectionRuleActionFailed = 38;
         public const int CollectionRuleActionsCompleted = 39;
-        public const int ApplyingCollectionRules = 40;
+        public const int CollectionRulesStarting = 40;
         public const int DiagnosticRequestCancelled = 41;
         public const int CollectionRuleUnmatchedFilters = 42;
+        public const int CollectionRuleConfigurationChanged = 43;
+        public const int CollectionRulesStopping = 44;
+        public const int CollectionRulesStopped = 45;
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -241,6 +241,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStopped);
 
+        private static readonly Action<ILogger, string, Exception> _collectionRuleCancelled =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(LoggingEventIds.CollectionRuleCancelled, "CollectionRuleCancelled"),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_CollectionRuleCancelled);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -433,6 +439,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void CollectionRulesStopped(this ILogger logger)
         {
             _collectionRulesStopped(logger, null);
+        }
+
+        public static void CollectionRuleCancelled(this ILogger logger, string ruleName)
+        {
+            _collectionRuleCancelled(logger, ruleName, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -205,11 +205,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionsCompleted);
 
-        private static readonly Action<ILogger, Exception> _applyingCollectionRules =
+        private static readonly Action<ILogger, Exception> _collectionRulesStarting =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.ApplyingCollectionRules, "ApplyingCollectionRules"),
+                eventId: new EventId(LoggingEventIds.CollectionRulesStarting, "CollectionRulesStarting"),
                 logLevel: LogLevel.Information,
-                formatString: Strings.LogFormatString_ApplyingCollectionRules);
+                formatString: Strings.LogFormatString_CollectionRulesStarting);
 
         private static readonly Action<ILogger, int, Exception> _diagnosticRequestCancelled =
             LoggerMessage.Define<int>(
@@ -222,6 +222,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 eventId: new EventId(LoggingEventIds.CollectionRuleUnmatchedFilters, "CollectionRuleUnmatchedFilters"),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleUnmatchedFilters);
+
+        private static readonly Action<ILogger, Exception> _collectionRuleConfigurationChanged =
+            LoggerMessage.Define(
+                eventId: new EventId(LoggingEventIds.CollectionRuleConfigurationChanged, "CollectionRuleConfigurationChanged"),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_CollectionRuleConfigurationChanged);
+
+        private static readonly Action<ILogger, Exception> _collectionRulesStopping =
+            LoggerMessage.Define(
+                eventId: new EventId(LoggingEventIds.CollectionRulesStopping, "CollectionRulesStopping"),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_CollectionRulesStopping);
+
+        private static readonly Action<ILogger, Exception> _collectionRulesStopped =
+            LoggerMessage.Define(
+                eventId: new EventId(LoggingEventIds.CollectionRulesStopping, "CollectionRulesStopped"),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_CollectionRulesStopped);
 
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
@@ -387,9 +405,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _collectionRuleActionsCompleted(logger, ruleName, null);
         }
 
-        public static void ApplyingCollectionRules(this ILogger logger)
+        public static void CollectionRulesStarting(this ILogger logger)
         {
-            _applyingCollectionRules(logger, null);
+            _collectionRulesStarting(logger, null);
         }
 
         public static void DiagnosticRequestCancelled(this ILogger logger, int processId)
@@ -400,6 +418,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void CollectionRuleUnmatchedFilters(this ILogger logger, string ruleName)
         {
             _collectionRuleUnmatchedFilters(logger, ruleName, null);
+        }
+
+        public static void CollectionRuleConfigurationChanged(this ILogger logger)
+        {
+            _collectionRuleConfigurationChanged(logger, null);
+        }
+
+        public static void CollectionRulesStopping(this ILogger logger)
+        {
+            _collectionRulesStopping(logger, null);
+        }
+
+        public static void CollectionRulesStopped(this ILogger logger)
+        {
+            _collectionRulesStopped(logger, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System;
 
@@ -99,6 +100,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             services.AddSingleton<ActionListExecutor>();
             services.AddSingleton<CollectionRuleService>();
+            services.AddHostedServiceForwarder<CollectionRuleService>();
             services.AddSingleton<IEndpointInfoSourceCallbacks, CollectionRuleEndpointInfoSourceCallbacks>();
 
             return services;
@@ -205,6 +207,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private static void AddSingletonForwarder<TService, TImplementation>(this IServiceCollection services) where TImplementation : class, TService where TService : class
         {
             services.AddSingleton<TService, TImplementation>(sp => sp.GetRequiredService<TImplementation>());
+        }
+
+        private static void AddHostedServiceForwarder<THostedService>(this IServiceCollection services) where THostedService : class, IHostedService
+        {
+            services.AddHostedService<THostedService>(sp => sp.GetRequiredService<THostedService>());
         }
     }
 }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -84,13 +84,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.AddSingleton<ITraceEventTriggerFactory<AspNetRequestCountTriggerSettings>, Monitoring.EventPipe.Triggers.AspNet.AspNetRequestCountTriggerFactory>();
             services.AddSingleton<ITraceEventTriggerFactory<AspNetRequestStatusTriggerSettings>, Monitoring.EventPipe.Triggers.AspNet.AspNetRequestStatusTriggerFactory>();
 
-
             services.AddSingleton<CollectionRulesConfigurationProvider>();
             services.AddSingleton<ICollectionRuleActionOperations, CollectionRuleActionOperations>();
             services.AddSingleton<ICollectionRuleTriggerOperations, CollectionRuleTriggerOperations>();
 
             services.AddSingleton<IConfigureOptions<CollectionRuleOptions>, CollectionRuleConfigureNamedOptions>();
             services.AddSingleton<IValidateOptions<CollectionRuleOptions>, DataAnnotationValidateOptions<CollectionRuleOptions>>();
+
+            // Register change sources for the options type
+            services.AddSingleton<IOptionsChangeTokenSource<CollectionRuleOptions>, CollectionRulesConfigurationChangeTokenSource>();
+
+            // Add custom options cache to override behavior of default named options
+            services.AddSingleton<IOptionsMonitorCache<CollectionRuleOptions>, DynamicNamedOptionsCache<CollectionRuleOptions>>();
 
             services.AddSingleton<ActionListExecutor>();
             services.AddSingleton<CollectionRuleService>();
@@ -188,7 +193,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.AddSingleton<IOptionsChangeTokenSource<TOptions>, EgressProviderConfigurationChangeTokenSource<TOptions>>();
 
             // Add custom options cache to override behavior of default named options
-            services.AddSingleton<IOptionsMonitorCache<TOptions>, EgressOptionsCache<TOptions>>();
+            services.AddSingleton<IOptionsMonitorCache<TOptions>, DynamicNamedOptionsCache<TOptions>>();
 
             // Add egress provider and internal provider wrapper
             services.AddSingleton<IEgressProvider<TOptions>, TProvider>();

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -520,15 +520,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Applying collection rules..
-        /// </summary>
-        internal static string LogFormatString_ApplyingCollectionRules {
-            get {
-                return ResourceManager.GetString("LogFormatString_ApplyingCollectionRules", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Bound default address: {address}.
         /// </summary>
         internal static string LogFormatString_BoundDefaultAddress {
@@ -601,6 +592,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collection rule configuration changed..
+        /// </summary>
+        internal static string LogFormatString_CollectionRuleConfigurationChanged {
+            get {
+                return ResourceManager.GetString("LogFormatString_CollectionRuleConfigurationChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Collection rule &apos;{ruleName}&apos; failed..
         /// </summary>
         internal static string LogFormatString_CollectionRuleFailed {
@@ -615,6 +615,33 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string LogFormatString_CollectionRulesStarted {
             get {
                 return ResourceManager.GetString("LogFormatString_CollectionRulesStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starting collection rules..
+        /// </summary>
+        internal static string LogFormatString_CollectionRulesStarting {
+            get {
+                return ResourceManager.GetString("LogFormatString_CollectionRulesStarting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All collection rules have stopped..
+        /// </summary>
+        internal static string LogFormatString_CollectionRulesStopped {
+            get {
+                return ResourceManager.GetString("LogFormatString_CollectionRulesStopped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stopping collection rules..
+        /// </summary>
+        internal static string LogFormatString_CollectionRulesStopping {
+            get {
+                return ResourceManager.GetString("LogFormatString_CollectionRulesStopping", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -583,6 +583,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collection rule &apos;{ruleName}&apos; cancelled..
+        /// </summary>
+        internal static string LogFormatString_CollectionRuleCancelled {
+            get {
+                return ResourceManager.GetString("LogFormatString_CollectionRuleCancelled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Collection rule &apos;{ruleName}&apos; completed..
         /// </summary>
         internal static string LogFormatString_CollectionRuleCompleted {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -400,6 +400,9 @@
   <data name="LogFormatString_CollectionRuleActionsThrottled" xml:space="preserve">
     <value>Collection rule '{ruleName}' actions throttled due to action limits.</value>
   </data>
+  <data name="LogFormatString_CollectionRuleCancelled" xml:space="preserve">
+    <value>Collection rule '{ruleName}' cancelled.</value>
+  </data>
   <data name="LogFormatString_CollectionRuleCompleted" xml:space="preserve">
     <value>Collection rule '{ruleName}' completed.</value>
   </data>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -373,9 +373,6 @@
 1. apiAuthenticationConfigKey: The string key of ApiAuthentication object in configuration.
 2. validationFailure: The error message of why the provided ApiAuthentication object is invalid.</comment>
   </data>
-  <data name="LogFormatString_ApplyingCollectionRules" xml:space="preserve">
-    <value>Applying collection rules.</value>
-  </data>
   <data name="LogFormatString_BoundDefaultAddress" xml:space="preserve">
     <value>Bound default address: {address}</value>
     <comment>Gets the format string that is printed in the 16:BoundDefaultAddress event.
@@ -406,11 +403,23 @@
   <data name="LogFormatString_CollectionRuleCompleted" xml:space="preserve">
     <value>Collection rule '{ruleName}' completed.</value>
   </data>
+  <data name="LogFormatString_CollectionRuleConfigurationChanged" xml:space="preserve">
+    <value>Collection rule configuration changed.</value>
+  </data>
   <data name="LogFormatString_CollectionRuleFailed" xml:space="preserve">
     <value>Collection rule '{ruleName}' failed.</value>
   </data>
   <data name="LogFormatString_CollectionRulesStarted" xml:space="preserve">
     <value>All collection rules started.</value>
+  </data>
+  <data name="LogFormatString_CollectionRulesStarting" xml:space="preserve">
+    <value>Starting collection rules.</value>
+  </data>
+  <data name="LogFormatString_CollectionRulesStopped" xml:space="preserve">
+    <value>All collection rules have stopped.</value>
+  </data>
+  <data name="LogFormatString_CollectionRulesStopping" xml:space="preserve">
+    <value>Stopping collection rules.</value>
   </data>
   <data name="LogFormatString_CollectionRuleStarted" xml:space="preserve">
     <value>Collection rule '{ruleName}' started.</value>


### PR DESCRIPTION
This change plumbs through the ability to stop and restart collection rules on all processes when the collection rule configuration changes.

~~TODO: Add functional test that verifies that a rule change is actually reflected in the tool and can be observed.~~ Done

closes #657 