### PR TITLE
Use a singular option for all counter intervals

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -386,19 +386,6 @@
             }
           },
           {
-            "name": "metricsIntervalSeconds",
-            "in": "query",
-            "description": "The reporting interval (in seconds) for event counters.",
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The reporting interval (in seconds) for event counters.",
-              "format": "int32",
-              "default": 1
-            }
-          },
-          {
             "name": "egressProvider",
             "in": "query",
             "description": "The egress provider to which the trace is saved.",
@@ -853,19 +840,6 @@
             }
           },
           {
-            "name": "metricsIntervalSeconds",
-            "in": "query",
-            "description": "The reporting interval (in seconds) for event counters.",
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The reporting interval (in seconds) for event counters.",
-              "format": "int32",
-              "default": 5
-            }
-          },
-          {
             "name": "egressProvider",
             "in": "query",
             "description": "The egress provider to which the metrics are saved.",
@@ -941,19 +915,6 @@
               "description": "The duration of the metrics session (in seconds).",
               "format": "int32",
               "default": 30
-            }
-          },
-          {
-            "name": "metricsIntervalSeconds",
-            "in": "query",
-            "description": "The reporting interval (in seconds) for event counters.",
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The reporting interval (in seconds) for event counters.",
-              "format": "int32",
-              "default": 5
             }
           },
           {

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -739,8 +739,13 @@
       "additionalProperties": false,
       "properties": {
         "IntervalSeconds": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Determines the metrics interval for all dotnet-monitor scenarios. This includes prometheus metrics, live metrics, triggers, and traces.",
           "format": "int32",
+          "default": 5,
           "maximum": 86400.0,
           "minimum": 1.0
         }

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -37,6 +37,17 @@
         "$ref": "#/definitions/CollectionRuleOptions"
       }
     },
+    "GlobalCounter": {
+      "default": {},
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/GlobalCounterOptions"
+        }
+      ]
+    },
     "CorsConfiguration": {
       "default": {},
       "oneOf": [
@@ -723,6 +734,18 @@
         }
       }
     },
+    "GlobalCounterOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "IntervalSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 86400.0,
+          "minimum": 1.0
+        }
+      }
+    },
     "CorsConfigurationOptions": {
       "type": "object",
       "additionalProperties": false,
@@ -932,15 +955,6 @@
             "string"
           ],
           "description": "Endpoints that expose prometheus metrics. Defaults to http://localhost:52325."
-        },
-        "UpdateIntervalSeconds": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "description": "How often metrics are collected.",
-          "format": "int32",
-          "default": 10
         },
         "MetricCount": {
           "type": [
@@ -1167,17 +1181,6 @@
               "$ref": "#/definitions/TraceProfile"
             }
           ]
-        },
-        "MetricsIntervalSeconds": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "description": "The amount of time (in seconds) between the collection of each sample of the counter. Only applicable when Profile contains Metrics.",
-          "format": "int32",
-          "default": 1,
-          "maximum": 86400.0,
-          "minimum": 1.0
         },
         "Providers": {
           "type": [
@@ -1520,17 +1523,6 @@
           "description": "The sliding time window in which the counter must maintain its value as specified by the threshold levels in GreaterThan and LessThan.",
           "format": "time-span",
           "default": "00:01:00"
-        },
-        "Frequency": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "description": "The amount of time (in seconds) between the collection of each sample of the counter.",
-          "format": "int32",
-          "default": 5,
-          "maximum": 86400.0,
-          "minimum": 1.0
         }
       }
     },

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
-    internal class MetricsOptionsDefaults
+    public class GlobalCounterOptions
     {
-        public const bool Enabled = true;
-
-        public const int MetricCount = 3;
-
-        public const bool IncludeDefaultProviders = true;
+        [Range(1, 3600 * 24)]
+        public int IntervalSeconds { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
@@ -12,6 +12,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     public class GlobalCounterOptions
     {
         [Range(1, 3600 * 24)]
-        public int IntervalSeconds { get; set; }
+        public int? IntervalSeconds { get; set; }
+    }
+
+    internal static class GlobalCounterOptionsExtensions
+    {
+        public static int GetIntervalSeconds(this GlobalCounterOptions options) =>
+            options.IntervalSeconds.GetValueOrDefault(GlobalCounterOptionsDefaults.IntervalSeconds);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text;
 
@@ -11,7 +12,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     public class GlobalCounterOptions
     {
-        [Range(1, 3600 * 24)]
+        public const int IntervalMinSeconds = 1;
+        public const int IntervalMaxSeconds = 60 * 60 * 24; // One day
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_GlobalCounterOptions_IntervalSeconds))]
+        [Range(IntervalMinSeconds, IntervalMaxSeconds)]
+        [DefaultValue(GlobalCounterOptionsDefaults.IntervalSeconds)]
         public int? IntervalSeconds { get; set; }
     }
 

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptionsDefaults.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Text;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
-    internal class MetricsOptionsDefaults
+    internal static class GlobalCounterOptionsDefaults
     {
-        public const bool Enabled = true;
-
-        public const int MetricCount = 3;
-
-        public const bool IncludeDefaultProviders = true;
+        public const int IntervalSeconds = 5;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
@@ -29,12 +29,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
-            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_UpdateIntervalSeconds))]
-        [DefaultValue(MetricsOptionsDefaults.UpdateIntervalSeconds)]
-        public int? UpdateIntervalSeconds { get; set; }
-
-        [Display(
-            ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_MetricCount))]
         [DefaultValue(MetricsOptionsDefaults.MetricCount)]
         public int? MetricCount { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -477,15 +477,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of time (in seconds) between the collection of each sample of the counter. Only applicable when Profile contains Metrics..
-        /// </summary>
-        public static string DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds {
-            get {
-                return ResourceManager.GetString("DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use a predefined set of event providers and settings to capture in the trace. More than one profile may be specified at the same time. Either Profile or Providers must be specified, but not both..
         /// </summary>
         public static string DisplayAttributeDescription_CollectTraceOptions_Profile {
@@ -680,15 +671,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         public static string DisplayAttributeDescription_EventCounterOptions_CounterName {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_CounterName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The amount of time (in seconds) between the collection of each sample of the counter..
-        /// </summary>
-        public static string DisplayAttributeDescription_EventCounterOptions_Frequency {
-            get {
-                return ResourceManager.GetString("DisplayAttributeDescription_EventCounterOptions_Frequency", resourceCulture);
             }
         }
         
@@ -897,15 +879,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         public static string DisplayAttributeDescription_MetricsOptions_Providers {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_MetricsOptions_Providers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to How often metrics are collected..
-        /// </summary>
-        public static string DisplayAttributeDescription_MetricsOptions_UpdateIntervalSeconds {
-            get {
-                return ResourceManager.GetString("DisplayAttributeDescription_MetricsOptions_UpdateIntervalSeconds", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -748,6 +748,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Determines the metrics interval for all dotnet-monitor scenarios. This includes prometheus metrics, live metrics, triggers, and traces..
+        /// </summary>
+        public static string DisplayAttributeDescription_GlobalCounterOptions_IntervalSeconds {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_GlobalCounterOptions_IntervalSeconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Gets or sets JsonWriterOptions..
         /// </summary>
         public static string DisplayAttributeDescription_JsonConsoleFormatterOptions_WriterOptions {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -289,10 +289,6 @@
     <value>The name of the egress provider to which the trace is egressed.</value>
     <comment>The description provided for the Egress parameter on CollectTraceOptions.</comment>
   </data>
-  <data name="DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds" xml:space="preserve">
-    <value>The amount of time (in seconds) between the collection of each sample of the counter. Only applicable when Profile contains Metrics.</value>
-    <comment>The description provided for the MetricsIntervalSeconds parameter on CollectTraceOptions.</comment>
-  </data>
   <data name="DisplayAttributeDescription_CollectTraceOptions_Profile" xml:space="preserve">
     <value>Use a predefined set of event providers and settings to capture in the trace. More than one profile may be specified at the same time. Either Profile or Providers must be specified, but not both.</value>
     <comment>The description provided for the Profile parameter on CollectTraceOptions.</comment>
@@ -385,10 +381,6 @@
     <value>The name of the counter to monitor.</value>
     <comment>The description provided for the CounterName parameter on EventCounterOptions.</comment>
   </data>
-  <data name="DisplayAttributeDescription_EventCounterOptions_Frequency" xml:space="preserve">
-    <value>The amount of time (in seconds) between the collection of each sample of the counter.</value>
-    <comment>The description provided for the Frequency parameter on EventCounterOptions.</comment>
-  </data>
   <data name="DisplayAttributeDescription_EventCounterOptions_GreaterThan" xml:space="preserve">
     <value>The threshold level the counter must maintain (or higher) for the specified duration. Either GreaterThan or LessThan (or both) must be specified.</value>
     <comment>The description provided for the GreaterThan parameter on EventCounterOptions.</comment>
@@ -480,10 +472,6 @@
   <data name="DisplayAttributeDescription_MetricsOptions_Providers" xml:space="preserve">
     <value>Providers for custom metrics.</value>
     <comment>The description provided for the Providers parameter on MetricsOptions.</comment>
-  </data>
-  <data name="DisplayAttributeDescription_MetricsOptions_UpdateIntervalSeconds" xml:space="preserve">
-    <value>How often metrics are collected.</value>
-    <comment>The description provided for the UpdateIntervalSeconds parameter on MetricsOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_MonitorApiKeyOptions_PublicKey" xml:space="preserve">
     <value>The public key used to sign the JWT (JSON Web Token) used for authentication. This field is a JSON Web Key serialized as JSON encoded with base64Url encoding. The JWK must have a kty field of RSA or EC and should not have the private key information.</value>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -544,4 +544,7 @@
     <value>Wait for the current action to complete before starting the next action.</value>
     <comment>The description provided for the WaitForCompletion parameter on CollectionRuleActionOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_GlobalCounterOptions_IntervalSeconds" xml:space="preserve">
+    <value>Determines the metrics interval for all dotnet-monitor scenarios. This includes prometheus metrics, live metrics, triggers, and traces.</value>
+  </data>
 </root>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         /// <param name="uid">The Runtime instance cookie used to identify the target process.</param>
         /// <param name="name">Process name used to identify the target process.</param>
         /// <param name="durationSeconds">The duration of the metrics session (in seconds).</param>
-        /// <param name="metricsIntervalSeconds">The reporting interval (in seconds) for event counters.</param>
         /// <param name="egressProvider">The egress provider to which the metrics are saved.</param>
         [HttpGet("livemetrics", Name = nameof(CaptureMetrics))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJsonSequence)]
@@ -45,8 +44,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             string name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
-            [FromQuery][Range(1, int.MaxValue)]
-            int metricsIntervalSeconds = 5,
             [FromQuery]
             string egressProvider = null)
         {
@@ -60,9 +57,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 {
                     var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);
                     EventPipeCounterPipelineSettings settings = EventCounterSettingsFactory.CreateSettings(
+                        _counterOptions.CurrentValue,
                         includeDefaults: true,
-                        durationSeconds: durationSeconds,
-                        refreshInterval: metricsIntervalSeconds);
+                        durationSeconds: durationSeconds);
 
                     await using EventCounterPipeline eventCounterPipeline = new EventCounterPipeline(client,
                         settings,
@@ -89,7 +86,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         /// <param name="uid">The Runtime instance cookie used to identify the target process.</param>
         /// <param name="name">Process name used to identify the target process.</param>
         /// <param name="durationSeconds">The duration of the metrics session (in seconds).</param>
-        /// <param name="metricsIntervalSeconds">The reporting interval (in seconds) for event counters.</param>
         /// <param name="egressProvider">The egress provider to which the metrics are saved.</param>
         [HttpPost("livemetrics", Name = nameof(CaptureMetricsCustom))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJsonSequence)]
@@ -108,8 +104,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             string name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
-            [FromQuery][Range(1, int.MaxValue)]
-            int metricsIntervalSeconds = 5,
             [FromQuery]
             string egressProvider = null)
         {
@@ -123,8 +117,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 {
                     var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);
                     EventPipeCounterPipelineSettings settings = EventCounterSettingsFactory.CreateSettings(
+                        _counterOptions.CurrentValue,
                         durationSeconds,
-                        metricsIntervalSeconds,
                         configuration);
 
                     await using EventCounterPipeline eventCounterPipeline = new EventCounterPipeline(client,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             {
                 TimeSpan duration = Utilities.ConvertSecondsToTimeSpan(durationSeconds);
 
-                var aggregateConfiguration = Utilities.GetTraceConfiguration(profile, _counterOptions.CurrentValue.IntervalSeconds);
+                var aggregateConfiguration = Utilities.GetTraceConfiguration(profile, _counterOptions.CurrentValue.GetIntervalSeconds());
 
                 return StartTrace(processInfo, aggregateConfiguration, duration, egressProvider);
             }, processKey, Utilities.ArtifactType_Trace);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                     if (!CounterValidator.ValidateProviders(_counterOptions.CurrentValue,
                         provider, out string errorMessage))
                     {
-                        throw new InvalidOperationException(errorMessage);
+                        throw new ValidationException(errorMessage);
                     }
                 }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             {
                 foreach(Models.EventPipeProvider provider in configuration.Providers)
                 {
-                    if (!CounterValidator.ValidateProviders(_counterOptions.CurrentValue,
+                    if (!CounterValidator.ValidateProvider(_counterOptions.CurrentValue,
                         provider, out string errorMessage))
                     {
                         throw new ValidationException(errorMessage);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
@@ -17,26 +17,25 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     /// </summary>
     internal static class EventCounterSettingsFactory
     {
-        public static EventPipeCounterPipelineSettings CreateSettings(bool includeDefaults,
-            int durationSeconds,
-            int refreshInterval)
+        public static EventPipeCounterPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, bool includeDefaults,
+            int durationSeconds)
         {
-            return CreateSettings(includeDefaults, durationSeconds, refreshInterval, () => new List<EventPipeCounterGroup>(0));
+            return CreateSettings(includeDefaults, durationSeconds, counterOptions.IntervalSeconds, () => new List<EventPipeCounterGroup>(0));
         }
 
-        public static EventPipeCounterPipelineSettings CreateSettings(MetricsOptions options)
+        public static EventPipeCounterPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, MetricsOptions options)
         {
             return CreateSettings(options.IncludeDefaultProviders.GetValueOrDefault(MetricsOptionsDefaults.IncludeDefaultProviders),
-                Timeout.Infinite, options.UpdateIntervalSeconds.GetValueOrDefault(MetricsOptionsDefaults.UpdateIntervalSeconds),
+                Timeout.Infinite, counterOptions.IntervalSeconds,
                 () => ConvertCounterGroups(options.Providers));
         }
 
-        public static EventPipeCounterPipelineSettings CreateSettings(int durationSeconds, int refreshInterval,
+        public static EventPipeCounterPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, int durationSeconds,
             Models.EventMetricsConfiguration configuration)
         {
             return CreateSettings(configuration.IncludeDefaultProviders,
                 durationSeconds,
-                refreshInterval,
+                counterOptions.IntervalSeconds,
                 () => ConvertCounterGroups(configuration.Providers));
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public static EventPipeCounterPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, bool includeDefaults,
             int durationSeconds)
         {
-            return CreateSettings(includeDefaults, durationSeconds, counterOptions.IntervalSeconds, () => new List<EventPipeCounterGroup>(0));
+            return CreateSettings(includeDefaults, durationSeconds, counterOptions.GetIntervalSeconds(), () => new List<EventPipeCounterGroup>(0));
         }
 
         public static EventPipeCounterPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, MetricsOptions options)
         {
             return CreateSettings(options.IncludeDefaultProviders.GetValueOrDefault(MetricsOptionsDefaults.IncludeDefaultProviders),
-                Timeout.Infinite, counterOptions.IntervalSeconds,
+                Timeout.Infinite, counterOptions.GetIntervalSeconds(),
                 () => ConvertCounterGroups(options.Providers));
         }
 
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             return CreateSettings(configuration.IncludeDefaultProviders,
                 durationSeconds,
-                counterOptions.IntervalSeconds,
+                counterOptions.GetIntervalSeconds(),
                 () => ConvertCounterGroups(configuration.Providers));
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -88,6 +88,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Custom trace metric provider &apos;{0}&apos; must use the global counter interval &apos;{1}&apos;.
+        /// </summary>
+        internal static string ErrorMessage_InvalidMetricInterval {
+            get {
+                return ResourceManager.GetString("ErrorMessage_InvalidMetricInterval", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Metrics was not enabled..
         /// </summary>
         internal static string ErrorMessage_MetricsDisabled {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -129,6 +129,9 @@
     <value>Invalid metric count.</value>
     <comment>Gets a string similar to "Invalid metric count.".</comment>
   </data>
+  <data name="ErrorMessage_InvalidMetricInterval" xml:space="preserve">
+    <value>Custom trace metric provider '{0}' must use the global counter interval '{1}'</value>
+  </data>
   <data name="ErrorMessage_MetricsDisabled" xml:space="preserve">
     <value>Metrics was not enabled.</value>
     <comment>Gets a string similar to "Metrics was not enabled.".</comment>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
 
             if (provider.Arguments?.TryGetValue("EventCounterIntervalSec", out string intervalValue) == true)
             {
-                if (int.TryParse(intervalValue, out int intervalSeconds) &&
+                if (float.TryParse(intervalValue, out float intervalSeconds) &&
                     intervalSeconds != counterOptions.GetIntervalSeconds())
                 {
                     errorMessage = string.Format(CultureInfo.CurrentCulture,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
 {
     internal static class CounterValidator
     {
-        public static bool ValidateProviders(GlobalCounterOptions counterOptions,
+        public static bool ValidateProvider(GlobalCounterOptions counterOptions,
             EventPipeProvider provider,
             out string errorMessage)
         {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
@@ -18,15 +18,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
         {
             errorMessage = null;
 
-            if (provider.Arguments.TryGetValue("EventCounterIntervalSec", out string intervalValue))
+            if (provider.Arguments?.TryGetValue("EventCounterIntervalSec", out string intervalValue) == true)
             {
                 if (int.TryParse(intervalValue, out int intervalSeconds) &&
-                    intervalSeconds != counterOptions.IntervalSeconds)
+                    intervalSeconds != counterOptions.GetIntervalSeconds())
                 {
                     errorMessage = string.Format(CultureInfo.CurrentCulture,
                         Strings.ErrorMessage_InvalidMetricInterval,
                         provider.Name,
-                        counterOptions.IntervalSeconds);
+                        counterOptions.GetIntervalSeconds());
                     return false;
                 }
             }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
+{
+    internal static class CounterValidator
+    {
+        public static bool ValidateProviders(GlobalCounterOptions counterOptions,
+            EventPipeProvider provider,
+            out string errorMessage)
+        {
+            errorMessage = null;
+
+            if (provider.Arguments.TryGetValue("EventCounterIntervalSec", out string intervalValue))
+            {
+                if (int.TryParse(intervalValue, out int intervalSeconds) &&
+                    intervalSeconds != counterOptions.IntervalSeconds)
+                {
+                    errorMessage = string.Format(CultureInfo.CurrentCulture,
+                        Strings.ErrorMessage_InvalidMetricInterval,
+                        provider.Name,
+                        counterOptions.IntervalSeconds);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -564,11 +564,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     string[] failures = ex.Failures.ToArray();
                     Assert.Equal(4, failures.Length);
                     VerifyEnumDataTypeMessage<TraceProfile>(failures, 0, nameof(CollectTraceOptions.Profile));
-                    VerifyRangeMessage<int>(failures, 2, nameof(CollectTraceOptions.BufferSizeMegabytes),
+                    VerifyRangeMessage<int>(failures, 1, nameof(CollectTraceOptions.BufferSizeMegabytes),
                         ActionOptionsConstants.BufferSizeMegabytes_MinValue_String, ActionOptionsConstants.BufferSizeMegabytes_MaxValue_String);
-                    VerifyRangeMessage<TimeSpan>(failures, 3, nameof(CollectTraceOptions.Duration),
+                    VerifyRangeMessage<TimeSpan>(failures, 2, nameof(CollectTraceOptions.Duration),
                         ActionOptionsConstants.Duration_MinValue, ActionOptionsConstants.Duration_MaxValue);
-                    VerifyRequiredMessage(failures, 4, nameof(CollectTraceOptions.Egress));
+                    VerifyRequiredMessage(failures, 3, nameof(CollectTraceOptions.Egress));
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -146,7 +146,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             const double ExpectedGreaterThan = 0.5;
             const double ExpectedLessThan = 0.75;
             TimeSpan ExpectedDuration = TimeSpan.FromSeconds(30);
-            const int ExpectedFrequency = 5;
 
             return ValidateSuccess(
                 rootOptions =>
@@ -159,7 +158,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     eventCounterOptions.GreaterThan = ExpectedGreaterThan;
                     eventCounterOptions.LessThan = ExpectedLessThan;
                     eventCounterOptions.SlidingWindowDuration = ExpectedDuration;
-                    eventCounterOptions.Frequency = ExpectedFrequency;
                 },
                 ruleOptions =>
                 {
@@ -169,7 +167,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Equal(ExpectedGreaterThan, eventCounterOptions.GreaterThan);
                     Assert.Equal(ExpectedLessThan, eventCounterOptions.LessThan);
                     Assert.Equal(ExpectedDuration, eventCounterOptions.SlidingWindowDuration);
-                    Assert.Equal(ExpectedFrequency, eventCounterOptions.Frequency);
                 });
         }
 
@@ -183,7 +180,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                         .SetEventCounterTrigger(out EventCounterOptions eventCounterOptions);
 
                     eventCounterOptions.SlidingWindowDuration = TimeSpan.FromSeconds(-1);
-                    eventCounterOptions.Frequency = -1;
                 },
                 ex =>
                 {
@@ -191,13 +187,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     // Property validation failures will short-circuit the remainder of the validation
                     // rules, thus only observe 4 errors when one might expect 5 (the fifth being that
                     // either GreaterThan or LessThan should be specified).
-                    Assert.Equal(4, failures.Length);
+                    Assert.Equal(3, failures.Length);
                     VerifyRequiredMessage(failures, 0, nameof(EventCounterOptions.ProviderName));
                     VerifyRequiredMessage(failures, 1, nameof(EventCounterOptions.CounterName));
                     VerifyRangeMessage<TimeSpan>(failures, 2, nameof(EventCounterOptions.SlidingWindowDuration),
                         TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue);
-                    VerifyRangeMessage<int>(failures, 3, nameof(EventCounterOptions.Frequency),
-                        TriggerOptionsConstants.Frequency_MinValue_String, TriggerOptionsConstants.Frequency_MaxValue_String);
                 });
         }
 
@@ -488,7 +482,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             const TraceProfile ExpectedProfile = TraceProfile.Logs;
             const string ExpectedEgressProvider = "TmpEgressProvider";
             TimeSpan ExpectedDuration = TimeSpan.FromSeconds(45);
-            const int ExpectedMetricsIntervalSeconds = 3;
 
             return ValidateSuccess(
                 rootOptions =>
@@ -498,7 +491,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                         .AddCollectTraceAction(ExpectedProfile, ExpectedEgressProvider, out CollectTraceOptions collectTraceOptions);
 
                     collectTraceOptions.Duration = ExpectedDuration;
-                    collectTraceOptions.MetricsIntervalSeconds = ExpectedMetricsIntervalSeconds;
 
                     rootOptions.AddFileSystemEgress(ExpectedEgressProvider, "/tmp");
                 },
@@ -507,7 +499,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     CollectTraceOptions collectTraceOptions = ruleOptions.VerifyCollectTraceAction(0, ExpectedProfile, ExpectedEgressProvider);
 
                     Assert.Equal(ExpectedDuration, collectTraceOptions.Duration);
-                    Assert.Equal(ExpectedMetricsIntervalSeconds, collectTraceOptions.MetricsIntervalSeconds);
                 });
         }
 
@@ -567,15 +558,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                     collectTraceOptions.BufferSizeMegabytes = 2048;
                     collectTraceOptions.Duration = TimeSpan.FromDays(7);
-                    collectTraceOptions.MetricsIntervalSeconds = (int)TimeSpan.FromDays(3).TotalSeconds;
                 },
                 ex =>
                 {
                     string[] failures = ex.Failures.ToArray();
-                    Assert.Equal(5, failures.Length);
+                    Assert.Equal(4, failures.Length);
                     VerifyEnumDataTypeMessage<TraceProfile>(failures, 0, nameof(CollectTraceOptions.Profile));
-                    VerifyRangeMessage<int>(failures, 1, nameof(CollectTraceOptions.MetricsIntervalSeconds),
-                        ActionOptionsConstants.MetricsIntervalSeconds_MinValue_String, ActionOptionsConstants.MetricsIntervalSeconds_MaxValue_String);
                     VerifyRangeMessage<int>(failures, 2, nameof(CollectTraceOptions.BufferSizeMegabytes),
                         ActionOptionsConstants.BufferSizeMegabytes_MinValue_String, ActionOptionsConstants.BufferSizeMegabytes_MaxValue_String);
                     VerifyRangeMessage<TimeSpan>(failures, 3, nameof(CollectTraceOptions.Duration),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     string[] failures = ex.Failures.ToArray();
                     // Property validation failures will short-circuit the remainder of the validation
-                    // rules, thus only observe 4 errors when one might expect 5 (the fifth being that
+                    // rules, thus only observe 3 errors when one might expect 4 (the fourth being that
                     // either GreaterThan or LessThan should be specified).
                     Assert.Equal(3, failures.Length);
                     VerifyRequiredMessage(failures, 0, nameof(EventCounterOptions.ProviderName));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public Task CollectionRulePipeline_ActionCountLimitSlidingDurationTest(TargetFrameworkMoniker appTfm)
         {
             const int ExpectedActionExecutionCount = 3;
-            TimeSpan SlidingWindowDuration = TimeSpan.FromSeconds(3);
+            TimeSpan SlidingWindowDuration = TimeSpan.FromSeconds(5);
 
             ManualTriggerService triggerService = new();
             CallbackActionService callbackService = new(_outputHelper);
@@ -284,7 +284,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                     await startedTask.WithCancellation(cancellationSource.Token);
 
-                    await ManualTriggerBurstAsync(triggerService);
+                    await ManualTriggerBurstAsync(triggerService, count: 5);
 
                     // Action list should have been executed the expected number of times
                     VerifyExecutionCount(callbackService, ExpectedActionExecutionCount);
@@ -292,7 +292,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     // Wait for existing execution times to fall out of sliding window.
                     await Task.Delay(SlidingWindowDuration * 1.2);
 
-                    await ManualTriggerBurstAsync(triggerService);
+                    await ManualTriggerBurstAsync(triggerService, count: 5);
 
                     // Expect total action invocation count to be twice the limit
                     VerifyExecutionCount(callbackService, 2 * ExpectedActionExecutionCount);
@@ -325,9 +325,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.Equal(expectedCount, service.ExecutionTimestamps.Count);
         }
 
-        private async Task ManualTriggerBurstAsync(ManualTriggerService service)
+        private async Task ManualTriggerBurstAsync(ManualTriggerService service, int count = 10)
         {
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < count; i++)
             {
                 service.NotifySubscribers();
                 await Task.Delay(TimeSpan.FromMilliseconds(100));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 })
                 .ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
                 {
+                    services.ConfigureGlobalCounter(context.Configuration);
                     services.ConfigureCollectionRules();
                     services.ConfigureEgress();
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -6,6 +6,8 @@ using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -42,11 +44,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             CollectionRuleActionBase<CollectTraceOptions>
         {
             private readonly IServiceProvider _serviceProvider;
+            private readonly IOptionsMonitor<GlobalCounterOptions> _counterOptions;
 
             public CollectTraceAction(IServiceProvider serviceProvider, IEndpointInfo endpointInfo, CollectTraceOptions options)
                 : base(endpointInfo, options)
             {
                 _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+                _counterOptions = _serviceProvider.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
             }
 
             protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
@@ -61,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 if (Options.Profile.HasValue)
                 {
                     TraceProfile profile = Options.Profile.Value;
-                    int metricsIntervalSeconds = Options.MetricsIntervalSeconds.GetValueOrDefault(CollectTraceOptionsDefaults.MetricsIntervalSeconds);
+                    int metricsIntervalSeconds = _counterOptions.CurrentValue.IntervalSeconds;
 
                     configuration = Utils.GetTraceConfiguration(profile, metricsIntervalSeconds);
                 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 if (Options.Profile.HasValue)
                 {
                     TraceProfile profile = Options.Profile.Value;
-                    int metricsIntervalSeconds = _counterOptions.CurrentValue.IntervalSeconds;
+                    int metricsIntervalSeconds = _counterOptions.CurrentValue.GetIntervalSeconds();
 
                     configuration = Utils.GetTraceConfiguration(profile, metricsIntervalSeconds);
                 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
@@ -16,10 +16,5 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 
         public const string Duration_MaxValue = "1.00:00:00"; // 1 day
         public const string Duration_MinValue = "00:00:01"; // 1 second
-
-        public const int MetricsIntervalSeconds_MaxValue = 24 * 60 * 60; // 1 day
-        public static readonly string MetricsIntervalSeconds_MaxValue_String = MetricsIntervalSeconds_MaxValue.ToString(CultureInfo.InvariantCulture);
-        public const int MetricsIntervalSeconds_MinValue = 1; // 1 second
-        public static readonly string MetricsIntervalSeconds_MinValue_String = MetricsIntervalSeconds_MinValue.ToString(CultureInfo.InvariantCulture);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
                     if (!CounterValidator.ValidateProviders(counterOptions.CurrentValue,
                         provider, out string errorMessage))
                     {
-                        results.Add(new ValidationResult(errorMessage, new[] { providerContext.MemberName }));
+                        results.Add(new ValidationResult(errorMessage, new[] { nameof(EventPipeProvider.Arguments) }));
                     }
 
                     index++;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
                     Validator.TryValidateObject(provider, providerContext, results, validateAllProperties: true);
 
                     IOptionsMonitor<GlobalCounterOptions> counterOptions = validationContext.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
-                    if (!CounterValidator.ValidateProviders(counterOptions.CurrentValue,
+                    if (!CounterValidator.ValidateProvider(counterOptions.CurrentValue,
                         provider, out string errorMessage))
                     {
                         results.Add(new ValidationResult(errorMessage, new[] { nameof(EventPipeProvider.Arguments) }));

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Diagnostics.Monitoring.WebApi.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
@@ -49,6 +53,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
                     providerContext.MemberName = nameof(Providers) + "[" + index.ToString(CultureInfo.InvariantCulture) + "]";
 
                     Validator.TryValidateObject(provider, providerContext, results, validateAllProperties: true);
+
+                    IOptionsMonitor<GlobalCounterOptions> counterOptions = validationContext.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
+                    if (!CounterValidator.ValidateProviders(counterOptions.CurrentValue,
+                        provider, out string errorMessage))
+                    {
+                        results.Add(new ValidationResult(errorMessage, new[] { providerContext.MemberName }));
+                    }
 
                     index++;
                 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
@@ -26,13 +26,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
-            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_MetricsIntervalSeconds))]
-        [Range(ActionOptionsConstants.MetricsIntervalSeconds_MinValue, ActionOptionsConstants.MetricsIntervalSeconds_MaxValue)]
-        [DefaultValue(CollectTraceOptionsDefaults.MetricsIntervalSeconds)]
-        public int? MetricsIntervalSeconds { get; set; }
-
-        [Display(
-            ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_Providers))]
         public List<EventPipeProvider> Providers { get; set; }
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptionsDefaults.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {
     internal static class CollectTraceOptionsDefaults
     {
-        public const int MetricsIntervalSeconds = 1;
         public const bool RequestRundown = true;
         public const int BufferSizeMegabytes = 256;
         public const string Duration = "00:00:30";

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
@@ -42,12 +42,5 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [Range(typeof(TimeSpan), TriggerOptionsConstants.SlidingWindowDuration_MinValue, TriggerOptionsConstants.SlidingWindowDuration_MaxValue)]
         [DefaultValue(EventCounterOptionsDefaults.SlidingWindowDuration)]
         public TimeSpan? SlidingWindowDuration { get; set; }
-
-        [Display(
-            ResourceType = typeof(OptionsDisplayStrings),
-            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_Frequency))]
-        [Range(TriggerOptionsConstants.CounterFrequency_MinValue, TriggerOptionsConstants.CounterFrequency_MaxValue)]
-        [DefaultValue(EventCounterOptionsDefaults.Frequency)]
-        public int? Frequency { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
@@ -7,6 +7,5 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     internal static class EventCounterOptionsDefaults
     {
         public const string SlidingWindowDuration = TriggerOptionsConstants.SlidingWindowDuration_Default;
-        public const int Frequency = 5;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
@@ -9,11 +9,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
     // Constants for trigger options allowing reuse among multiple trigger and for tests to verify ranges.
     internal static class TriggerOptionsConstants
     {
-        public const int CounterFrequency_MaxValue = 24*60*60; // 1 day
-        public static readonly string Frequency_MaxValue_String = CounterFrequency_MaxValue.ToString(CultureInfo.InvariantCulture);
-        public const int CounterFrequency_MinValue = 1; // 1 second
-        public static readonly string Frequency_MinValue_String = CounterFrequency_MinValue.ToString(CultureInfo.InvariantCulture);
-
         public const string SlidingWindowDuration_Default = "00:01:00"; // 1 minute
         public const string SlidingWindowDuration_MaxValue = "1.00:00:00"; // 1 day
         public const string SlidingWindowDuration_MinValue = "00:00:01"; // 1 second

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;
+using Microsoft.Extensions.Options;
 using System;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
@@ -18,13 +19,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
     {
         private readonly EventPipeTriggerFactory _eventPipeTriggerFactory;
         private readonly ITraceEventTriggerFactory<EventCounterTriggerSettings> _traceEventTriggerFactory;
+        private readonly IOptionsMonitor<GlobalCounterOptions> _counterOptions;
 
         public EventCounterTriggerFactory(
+            IOptionsMonitor<GlobalCounterOptions> counterOptions,
             EventPipeTriggerFactory eventPipeTriggerFactory,
             ITraceEventTriggerFactory<EventCounterTriggerSettings> traceEventTriggerFactory)
         {
             _eventPipeTriggerFactory = eventPipeTriggerFactory;
             _traceEventTriggerFactory = traceEventTriggerFactory;
+            _counterOptions = counterOptions;
         }
 
         /// <inheritdoc/>
@@ -33,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
             EventCounterTriggerSettings settings = new()
             {
                 ProviderName = options.ProviderName,
-                CounterIntervalSeconds = options.Frequency.GetValueOrDefault(EventCounterOptionsDefaults.Frequency),
+                CounterIntervalSeconds = _counterOptions.CurrentValue.IntervalSeconds,
                 CounterName = options.CounterName,
                 GreaterThan = options.GreaterThan,
                 LessThan = options.LessThan,

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
             EventCounterTriggerSettings settings = new()
             {
                 ProviderName = options.ProviderName,
-                CounterIntervalSeconds = _counterOptions.CurrentValue.IntervalSeconds,
+                CounterIntervalSeconds = _counterOptions.CurrentValue.GetIntervalSeconds(),
                 CounterName = options.CounterName,
                 GreaterThan = options.GreaterThan,
                 LessThan = options.LessThan,

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
 
             //No sensitive information
+            ProcessChildSection(configuration, ConfigurationKeys.GlobalCounter, includeChildSections: true);
             ProcessChildSection(configuration, ConfigurationKeys.CollectionRules, includeChildSections: true);
             ProcessChildSection(configuration, ConfigurationKeys.CorsConfiguration, includeChildSections: true);
             ProcessChildSection(configuration, ConfigurationKeys.DiagnosticPort, includeChildSections: true);

--- a/src/Tools/dotnet-monitor/ConfigurationKeys.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationKeys.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public const string DefaultProcess = nameof(DefaultProcess);
 
         public const string Logging = nameof(Logging);
+
+        public const string GlobalCounter = nameof(RootOptions.GlobalCounter);
     }
 }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     //Note these are in precedence order.
                     ConfigureEndpointInfoSource(builder, diagnosticPort);
                     ConfigureMetricsEndpoint(builder, metrics, metricUrls);
+                    ConfigureGlobalMetrics(builder);
                     builder.ConfigureStorageDefaults();
 
                     builder.AddCommandLine(new[] { "--urls", ConfigurationHelper.JoinValue(urls) });
@@ -236,6 +237,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(ConfigurationKeys.DiagnosticPort));
                     services.AddSingleton<IValidateOptions<DiagnosticPortOptions>, DiagnosticPortValidateOptions>();
 
+                    services.ConfigureGlobalCounter(context.Configuration);
+
                     services.AddSingleton<IEndpointInfoSource, FilteredEndpointInfoSource>();
                     services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
                     services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
@@ -313,9 +316,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             {
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.Enabled)), enableMetrics.ToString()},
-                {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.UpdateIntervalSeconds)), MetricsOptionsDefaults.UpdateIntervalSeconds.ToString()},
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.MetricCount)), MetricsOptionsDefaults.MetricCount.ToString()},
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.IncludeDefaultProviders)), MetricsOptionsDefaults.IncludeDefaultProviders.ToString()}
+            });
+        }
+
+        private static void ConfigureGlobalMetrics(IConfigurationBuilder builder)
+        {
+            builder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                {ConfigurationPath.Combine(ConfigurationKeys.GlobalCounter, nameof(GlobalCounterOptions.IntervalSeconds)), GlobalCounterOptionsDefaults.IntervalSeconds.ToString() }
             });
         }
 

--- a/src/Tools/dotnet-monitor/RootOptions.cs
+++ b/src/Tools/dotnet-monitor/RootOptions.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public IDictionary<string, CollectionRuleOptions> CollectionRules { get; }
             = new Dictionary<string, CollectionRuleOptions>(0);
 
+        public GlobalCounterOptions GlobalCounter { get; set; }
+
         public CorsConfigurationOptions CorsConfiguration { get; set; }
 
         public DiagnosticPortOptions DiagnosticPort { get; set; }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ServiceCollectionExtensions
     {
+        public static IServiceCollection ConfigureGlobalCounter(this IServiceCollection services, IConfiguration configuration)
+        {
+            return ConfigureOptions<GlobalCounterOptions>(services, configuration, ConfigurationKeys.GlobalCounter);
+        }
+
         public static IServiceCollection ConfigureMetrics(this IServiceCollection services, IConfiguration configuration)
         {
             return ConfigureOptions<MetricsOptions>(services, configuration, ConfigurationKeys.Metrics);


### PR DESCRIPTION
- [x] Prometheus metrics
- [x] EventCounter trigger
- [x] Trace
- [x] Custom trace
- [x] Live metrics
- [x] Custom live metrics
- [x] trace action
- [x] custom trace action

Not done:

- [ ] Asp.net duration heartbeat. Hardcoded in diagnostics repo
- [x] Make sure unit tests work
- [ ] Documentation changes