### PR TITLE
Switch to 1ES servicing pools on release/5.0

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -85,8 +85,8 @@ stages:
           - MacOSRelease
           publishUsingPipelines: true
           pool:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
   # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -38,8 +38,8 @@ jobs:
 
         # Official Build Linux Pool
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
 
       # Build OSX Pool
       ${{ if in(parameters.osGroup, 'MacOS') }}:
@@ -51,8 +51,8 @@ jobs:
           vmImage: windows-2019
 
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-359e48e-20200313130914


### PR DESCRIPTION
Per https://github.com/dotnet/core-eng/issues/14276.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1404326&view=results