### PR TITLE
Remove collection rules when process is no longer detected.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
@@ -132,5 +132,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             using CancellationTokenSource cancellation = new(timeout);
             await runner.WaitForCollectionRuleStartedAsync(ruleName, cancellation.Token);
         }
+
+        public static Task WaitForCollectionRulesStoppedAsync(this MonitorCollectRunner runner)
+        {
+            return runner.WaitForCollectionRulesStoppedAsync(TestTimeouts.CollectionRuleCompletionTimeout);
+        }
+
+        public static async Task WaitForCollectionRulesStoppedAsync(this MonitorCollectRunner runner, TimeSpan timeout)
+        {
+            using CancellationTokenSource cancellation = new(timeout);
+            await runner.WaitForCollectionRulesStoppedAsync(cancellation.Token);
+        }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleEndpointInfoSourceCallbacks.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleEndpointInfoSourceCallbacks.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         public Task OnRemovedEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return _service.RemoveRules(endpointInfo, cancellationToken);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static readonly Action<ILogger, Exception> _collectionRulesStopped =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.CollectionRulesStopping, "CollectionRulesStopped"),
+                eventId: new EventId(LoggingEventIds.CollectionRulesStopped, "CollectionRulesStopped"),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStopped);
 


### PR DESCRIPTION
The change removes collection rules associated with a process when that process is no longer detected (e.g. it exited, crashed, etc). A test has been added to verify that removal is detectable.

closes #962