### PR TITLE
Do not write BOM for logs.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EncodingCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EncodingCache.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal static class EncodingCache
     {
-        public static readonly Encoding UTF8NoBOM =
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+        // Encode UTF8 without BOM and write "?" as fallback replacement.
+        public static readonly Encoding UTF8NoBOMNoThrow =
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 }
             }
 
-            using var writer = new StreamWriter(outputStream, EncodingCache.UTF8NoBOM, bufferSize: 1024, leaveOpen: true);
+            using var writer = new StreamWriter(outputStream, EncodingCache.UTF8NoBOMNoThrow, bufferSize: 1024, leaveOpen: true);
             writer.NewLine = "\n";
 
             foreach (var metricGroup in copy)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             // Matches the format of SimpleConsoleFormatter as much as possible
 
-            using var writer = new StreamWriter(outputStream, EncodingCache.UTF8NoBOM, 1024, leaveOpen: true) { NewLine = "\n" };
+            using var writer = new StreamWriter(outputStream, EncodingCache.UTF8NoBOMNoThrow, 1024, leaveOpen: true) { NewLine = "\n" };
 
             // Format (based on simple console format):
             // Note: This deviates slightly from the simple console format in that the event name


### PR DESCRIPTION
Currently, each log entry within the `/logs` output has a BOM at the beginning of the entry, which is not allowed. This change removes the BOM from being emitted.

I've tested that the following routes return their respective data with BOM using curl that writes the output directly to disk and using a hex editor to check the delimiters:
- `/metrics`
- `/logs`
- `/logs` with `Accept: application/json-seq`
- `/logs` with `Accept: application/x-ndjson`