### PR TITLE
Increase default HTTP API timeout to 30 seconds.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Default timeout for HTTP API calls
         /// </summary>
-        public static readonly TimeSpan HttpApi = TimeSpan.FromSeconds(15);
+        public static readonly TimeSpan HttpApi = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Timeout for waiting for a collection rule to complete.


### PR DESCRIPTION
See #1024 for an example of why this increase is needed.