### PR TITLE
Use newer System.Private.Uri library.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,6 +67,7 @@
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemIdentityModelTokensJwtVersion>6.11.1</SystemIdentityModelTokensJwtVersion>
     <SystemIOPipelinesVersion>4.5.1</SystemIOPipelinesVersion>
+    <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <SystemThreadingChannelsVersion>5.0.0</SystemThreadingChannelsVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,5 +23,9 @@
     <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=3m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
+  </ItemGroup>
+
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
 </Project>


### PR DESCRIPTION
Use newer System.Private.Uri to avoid restoring the 4.3.0 version so that component scanning doesn't pick it up. See dotnet/announcements#97 for the issue that upgrading addresses. From what I can see, this change does not affect the build output.