### PR TITLE
Use existing diagnostics release binaries.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,13 +4,13 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>166610c56ff732093f0145a2911d4f6c40b786da</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.21514.2">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.248003">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>84e364e79abd56d4479dae920a9f6db0803ec493</Sha>
+      <Sha>f15e60ff2091bcc54a8b8de8ce4e9d7de4c5dd62</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.0-preview.21514.2">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.248003">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>84e364e79abd56d4479dae920a9f6db0803ec493</Sha>
+      <Sha>f15e60ff2091bcc54a8b8de8ce4e9d7de4c5dd62</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,8 +34,8 @@
     <!-- dotnet/aspnetcore references -->
     <VSRedistCommonAspNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21514.23</VSRedistCommonAspNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21514.2</MicrosoftDiagnosticsMonitoringVersion>
-    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21514.2</MicrosoftDiagnosticsMonitoringEventPipeVersion>
+    <MicrosoftDiagnosticsMonitoringVersion>5.0.248003</MicrosoftDiagnosticsMonitoringVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.248003</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
     <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21514.7</VSRedistCommonNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/symstore references -->

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             {
                 CounterGroups = eventPipeCounterGroups.ToArray(),
                 Duration = Utilities.ConvertSecondsToTimeSpan(durationSeconds),
-                CounterIntervalSeconds = counterInterval
+                RefreshInterval = TimeSpan.FromSeconds(counterInterval)
             };
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/PipelineExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/PipelineExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Monitoring.EventPipe;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    internal static class PipelineExtensions
+    {
+        public static async Task<Task> StartAsync<T>(this EventSourcePipeline<T> pipeline, CancellationToken token)
+            where T : EventSourcePipelineSettings
+        {
+            Task runTask = pipeline.RunAsync(token);
+
+            // Await both the session started or the run task and return when either is completed.
+            // This works around an issue where the run task may fail but not cancel/fault the session
+            // started task. Logically, the run task will not successfully complete before the session
+            // started task. Thus, the combined task completes either when the session started task is
+            // completed OR the run task has cancelled/failed.
+            IEventSourcePipelineInternal pipelineInternal = pipeline;
+            await Task.WhenAny(pipelineInternal.SessionStarted, runTask).Unwrap();
+
+            return runTask;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
             if (profile.HasFlag(Models.TraceProfile.Metrics))
             {
-                configurations.Add(new MetricSourceConfiguration(metricsIntervalSeconds, Enumerable.Empty<string>()));
+                configurations.Add(new MetricSourceConfiguration((int)metricsIntervalSeconds, Enumerable.Empty<string>()));
             }
 
             return new AggregateSourceConfiguration(configurations.ToArray());

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetRequestDurationTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetRequestDurationTriggerFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
                 SlidingWindowDuration = options.SlidingWindowDuration ?? TimeSpan.Parse(AspNetRequestDurationOptionsDefaults.SlidingWindowDuration, CultureInfo.InvariantCulture),
             };
 
-            var aspnetTriggerSourceConfiguration = new AspNetTriggerSourceConfiguration(_counterOptions.CurrentValue.GetIntervalSeconds());
+            var aspnetTriggerSourceConfiguration = new AspNetTriggerSourceConfiguration(supportHeartbeat: true);
 
             return _eventPipeTriggerFactory.Create(endpointInfo, aspnetTriggerSourceConfiguration, _traceEventTriggerFactory, settings, callback);
         }

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
             EventCounterTriggerSettings settings = new()
             {
                 ProviderName = options.ProviderName,
-                CounterIntervalSeconds = _counterOptions.CurrentValue.GetIntervalSeconds(),
+                CounterIntervalSeconds = (int)_counterOptions.CurrentValue.GetIntervalSeconds(),
                 CounterName = options.CounterName,
                 GreaterThan = options.GreaterThan,
                 LessThan = options.LessThan,


### PR DESCRIPTION
This change uses the latest release of the dotnet/diagnostics binaries. It effectively reverts the dependencies that have been added since the latest release to the closest usage state.

Note: This change is ONLY a contingency for if we cannot get newer diagnostics binaries for the next release.