### PR TITLE
Use RTM versioning and release blob group.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,9 @@
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>6.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <!-- Enable for final build -->
+    <!-- <DotNetFinalVersionKind>release</DotNetFinalVersionKind> -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!--
       Build quality notion for blob group naming, similar to aka.ms channel build quality in Arcade:
@@ -11,7 +12,7 @@
       - 'prerelease': allows the blob group release name to use prerelease version information.
       - 'release': sets the blob group release name to 'release'.
     -->
-    <BlobGroupBuildQuality>prerelease</BlobGroupBuildQuality>
+    <BlobGroupBuildQuality>release</BlobGroupBuildQuality>
   </PropertyGroup>
   <PropertyGroup Label="Arcade">
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
Version numbers will look like `6.0.0-rtm.21520.2`; note there is no iteration for RTM.

For the final build, the `DotNetFinalVersionKind` property will be set to `true` to produce the `6.0.0` package and assembly info version for dotnet-monitor.