### PR TITLE
Use ConfigurationJsonWriter to write authentication key generation output

### DIFF
--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress, configOnly: true).Build();
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter writer = new ConfigurationJsonWriter(Console.OpenStandardOutput());
-            writer.Write(configuration, full: level == ConfigDisplayLevel.Full);
+            writer.Write(configuration, full: level == ConfigDisplayLevel.Full, skipNotPresent: false);
             
             return Task.FromResult(0);
         }

--- a/src/Tools/dotnet-monitor/DisposableHelper.cs
+++ b/src/Tools/dotnet-monitor/DisposableHelper.cs
@@ -51,18 +51,30 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         }
 
         /// <summary>
+        /// Calls <see cref="IDisposable.Dispose"/> on object if object
+        /// implements <see cref="IDisposable"/> interface.
+        /// </summary>
+        public static void Dispose(object obj)
+        {
+            if (obj is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Checks if the object implements <see cref="IAsyncDisposable"/>
         /// or <see cref="IDisposable"/> and calls the corresponding dispose method.
         /// </summary>
         public static async ValueTask DisposeAsync(object obj)
         {
-            if (obj is IAsyncDisposable asyncDisposableAction)
+            if (obj is IAsyncDisposable asyncDisposable)
             {
-                await asyncDisposableAction.DisposeAsync();
+                await asyncDisposable.DisposeAsync();
             }
-            else if (obj is IDisposable disposableAction)
+            else
             {
-                disposableAction.Dispose();
+                Dispose(obj);
             }
         }
     }


### PR DESCRIPTION
The `generatekey` command currently writes out an empty CollectionRules property, e.g.:

```
Settings in Json format:
{
  "Authentication": {
    "MonitorApiKey": {
      "Subject": "...",
      "PublicKey": "..."
    }
  },
  "CollectionRules": {}
}
```

This occurs because it the RootOptions object has a non-null CollectionRules property and the JsonSerializer will write out non-null values.

This change fixes this by using ConfigurationJsonWriter instead of JsonSerializer to write out the relevant properties. This writer has been updated to allow not writing out anything for configuration sections that do not have data.