### PR TITLE
Prevent warning on retries of copying locked files in dotnet-monitor.

### DIFF
--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -13,6 +13,17 @@
     <!-- This forces the creation of a checksum file and uploads it to blob storage
          using this name as part of the blob relative path. -->
     <BlobGroupPrefix>monitor</BlobGroupPrefix>
+    <!-- File locking warnings (that are typically resolved with automatic retries) are failing builds
+         quite frequently with messages such as:
+         
+         error MSB3026: (NETCORE_ENGINEERING_TELEMETRY=Build) Could not copy "...\dotnet-monitor.dll" to
+         "...\dotnet-monitor.dll". Beginning retry 1 in 1000ms. The process cannot access the file
+         '...\dotnet-monitor.dll' because it is being used by another process.
+         
+         work around this problem by telling the compiler to not warn about the issue. A file lock that
+         actually prevents the build from completing correctly should still fail the compilation with
+         an MSB3027 error. -->
+    <NoWarn>$(NoWarn);MSB3026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port #1032 to `release/6.0` branch.