### PR TITLE
Separate runtime package version from runtime framework version.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,6 +14,10 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rtm.21523.4">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>7c57ecbdfee67ad544bd655a757e03145f6122a2</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21526.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f08de5892cab40c9a0e94dcc54b4537763420494</Sha>
@@ -25,6 +29,10 @@
     <Dependency Name="Microsoft.FileFormats" Version="1.0.251801">
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>14e48c616b8579f0c5f4d296c10b2c66e707c297</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rtm.21518.12">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>5a23dc38e94484ee69f660ef5ffbc92d7b372bc7</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rtm.21523.4">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,11 +32,13 @@
     <!-- dotnet/arcade references -->
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.21526.1</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
+    <MicrosoftAspNetCoreAppRuntimewinx64Version>6.0.0-rtm.21523.4</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <VSRedistCommonAspNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21523.4</VSRedistCommonAspNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21525.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21525.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
+    <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-rtm.21518.12</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21518.12</VSRedistCommonNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.251801</MicrosoftFileFormatsVersion>
@@ -46,8 +48,8 @@
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.11</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
-    <MicrosoftNETCoreApp60Version>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreApp60Version>
-    <MicrosoftAspNetCoreApp60Version>$(VSRedistCommonAspNetCoreSharedFrameworkx6460Version)</MicrosoftAspNetCoreApp60Version>
+    <MicrosoftNETCoreApp60Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp60Version>
+    <MicrosoftAspNetCoreApp60Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp60Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>

--- a/global.json
+++ b/global.json
@@ -5,12 +5,12 @@
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",
         "$(MicrosoftAspNetCoreApp50Version)",
-        "$(MicrosoftAspNetCoreApp60Version)"
+        "$(VSRedistCommonAspNetCoreSharedFrameworkx6460Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp31Version)",
         "$(MicrosoftNETCoreApp50Version)",
-        "$(MicrosoftNETCoreApp60Version)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6460Version)"
       ]
     }
   },


### PR DESCRIPTION
As the 6.0 runtime approaches GA, the framework version is changed to 6.0.0 whereas the package version still contains the "-rtm.#" label. This change allows the installation of the package version to be separate from the framework version used when specifying the `--fx-version` parameter to the `dotnet` executable.

This should unblock insertion PRs such as #1057