### PR TITLE
Respect binding to metric endpoint configuration

### DIFF
--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -283,6 +283,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     var metricsOptions = new MetricsOptions();
                     context.Configuration.Bind(ConfigurationKeys.Metrics, metricsOptions);
 
+                    string metricHostingUrls = metricsOptions.Endpoints;
+                    metricUrls = ConfigurationHelper.SplitValue(metricHostingUrls);
+
                     //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
                     options.Configure(context.Configuration.GetSection("Kestrel")).Load();
 


### PR DESCRIPTION
Port #1042 to `release/6.0` branch.