### PR TITLE
Resolving File Name Collisions

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public static string GetFileNameTimeStampUtcNow()
         {
-            return DateTime.UtcNow.ToString("yyyyMMdd_HHmmssfff");
+            return DateTime.UtcNow.ToString("yyyyMMdd_HHmmss_fff");
         }
 
         public static KeyValueLogScope CreateArtifactScope(string artifactType, IEndpointInfo endpointInfo)


### PR DESCRIPTION
I wasn't entirely sure where we landed on this (other than not using the GUIDs, which may have been an eyesore), so I tried what someone suggested of including milliseconds in the names of the artifacts. In my basic testing (using the same repro as the issue and a few other similar examples), there were no collisions. **This isn't a perfect solution**, since there's still a very slim possibility of collision, but it greatly reduces the likelihood of this occurring.

Closes #1064 