### PR TITLE
Use .NET 6 GA SDK

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,8 @@
     <add key="darc-pub-dotnet-runtime-4822e3c-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-4822e3c3-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <!-- Temporary until .NET 6 GA to get Microsoft.WindowsDesktop.App.Runtime.* packages -->
+    <add key="darc-pub-dotnet-windowsdesktop-f22ff8b3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-windowsdesktop-f22ff8b3/nuget/v3/index.json" />
     <!-- Feeds used in Maestro/Arcade publishing -->
     <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet6" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet6/nuget/v3/index.json" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.2.21505.57",
+    "dotnet": "6.0.100",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -13,17 +13,9 @@
     <!-- This forces the creation of a checksum file and uploads it to blob storage
          using this name as part of the blob relative path. -->
     <BlobGroupPrefix>monitor</BlobGroupPrefix>
-    <!-- File locking warnings (that are typically resolved with automatic retries) are failing builds
-         quite frequently with messages such as:
-         
-         error MSB3026: (NETCORE_ENGINEERING_TELEMETRY=Build) Could not copy "...\dotnet-monitor.dll" to
-         "...\dotnet-monitor.dll". Beginning retry 1 in 1000ms. The process cannot access the file
-         '...\dotnet-monitor.dll' because it is being used by another process.
-         
-         work around this problem by telling the compiler to not warn about the issue. A file lock that
-         actually prevents the build from completing correctly should still fail the compilation with
-         an MSB3027 error. -->
-    <NoWarn>$(NoWarn);MSB3026</NoWarn>
+    <!-- Temporarily pin netcoreapp3.1 runtime framework version until .NET 6 GA.
+         This will allow the tool to be built without the unreleased minimum runtime framework versions. -->
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">3.1.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change builds the product with the .NET 6.0.100 SDK, which allows the framework references of the dotnet-monitor tool to be based on the 6.0.0 packages and frameworks.