### PR TITLE
[main] Add netcoreapp3.1 to dotnet-monitor

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -42,6 +42,15 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0558f85d950fee2838bf02b9ba1f20d67f00b504</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.FileFormats" Version="1.0.250401">
     <Dependency Name="Microsoft.FileFormats" Version="1.0.252801">
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>b659197e9065269ac3a7d7a2c7135db785521f1d</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,6 +12,22 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>5af66d87c1b1e96cebadfad242aa883821deeb77</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,11 @@
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21529.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21529.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
+    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.0</MicrosoftExtensionsConfigurationKeyPerFileVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
+    <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21522.10</VSRedistCommonNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.252801</MicrosoftFileFormatsVersion>
@@ -60,8 +64,6 @@
     <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>5.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>5.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>5.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftIdentityModelTokensVersion>6.11.1</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
@@ -84,6 +86,5 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
-    <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,9 +38,11 @@
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21529.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21529.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.0</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
     <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21522.10</VSRedistCommonNetCoreSharedFrameworkx6460Version>
@@ -63,8 +65,6 @@
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>5.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftIdentityModelTokensVersion>6.11.1</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -34,7 +34,8 @@ jobs:
       # Public Linux Build Pool
       ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          vmImage: ubuntu-20.04
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
@@ -48,7 +49,8 @@ jobs:
       # Public Windows Build Pool
       ${{ if eq(parameters.osGroup, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          vmImage: windows-2019
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Internal

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     {
                         await _counterPipeline.DisposeAsync();
                     }
-                    await Task.Delay(5000);
+                    await Task.Delay(5000, stoppingToken);
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>REST Api surface for dotnet-monitor</Description>
     <!-- Tentatively create package so other teams can tentatively consume. -->

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -14,5 +14,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly string NetCore31VersionString = "$MicrosoftNetCoreApp31Version$";
         public static readonly string NetCore50VersionString = "$MicrosoftNetCoreApp50Version$";
         public static readonly string NetCore60VersionString = "$MicrosoftNetCoreApp60Version$";
+
+        public static readonly string AspNetCore31VersionString = "$MicrosoftAspNetCoreApp31Version$";
+        public static readonly string AspNetCore50VersionString = "$MicrosoftAspNetCoreApp50Version$";
+        public static readonly string AspNetCore60VersionString = "$MicrosoftAspNetCoreApp60Version$";
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -24,6 +24,9 @@
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp31Version$', '$(MicrosoftNETCoreApp31Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp50Version$', '$(MicrosoftNETCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp60Version$', '$(MicrosoftNETCoreApp60Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp31Version$', '$(MicrosoftAspNetCoreApp31Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp50Version$', '$(MicrosoftAspNetCoreApp50Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp60Version$', '$(MicrosoftAspNetCoreApp60Version)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -136,11 +136,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
                     // until it can be resolved.
                     if (!TargetFramework.IsEffectively(TargetFrameworkMoniker.Net60))
                     {
-                        frameworkVersion = TargetFramework.GetAspNetCoreFrameworkVersion();
+                        frameworkVersion = TargetFramework.GetAspNetCoreFrameworkVersionString();
                     }
                     break;
                 case DotNetFrameworkReference.Microsoft_NetCore_App:
-                    frameworkVersion = TargetFramework.GetNetCoreAppFrameworkVersion();
+                    frameworkVersion = TargetFramework.GetNetCoreAppFrameworkVersionString();
                     break;
                 default:
                     throw new InvalidOperationException($"Unsupported framework reference: {FrameworkReference}");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
@@ -16,17 +17,28 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
     public static class TargetFrameworkMonikerExtensions
     {
-        public static string GetAspNetCoreFrameworkVersion(this TargetFrameworkMoniker moniker)
+        public static Version GetAspNetCoreFrameworkVersion(this TargetFrameworkMoniker moniker)
+        {
+            return ParseVersionRemoveLabel(moniker.GetAspNetCoreFrameworkVersionString());
+        }
+
+        public static string GetAspNetCoreFrameworkVersionString(this TargetFrameworkMoniker moniker)
         {
             switch (moniker)
             {
                 case TargetFrameworkMoniker.Current:
                     return DotNetHost.CurrentAspNetCoreVersionString;
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return DotNetHost.AspNetCore31VersionString;
+                case TargetFrameworkMoniker.Net50:
+                    return DotNetHost.AspNetCore50VersionString;
+                case TargetFrameworkMoniker.Net60:
+                    return DotNetHost.AspNetCore60VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
 
-        public static string GetNetCoreAppFrameworkVersion(this TargetFrameworkMoniker moniker)
+        public static string GetNetCoreAppFrameworkVersionString(this TargetFrameworkMoniker moniker)
         {
             switch (moniker)
             {
@@ -71,6 +83,17 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         private static ArgumentException CreateUnsupportedException(TargetFrameworkMoniker moniker)
         {
             return new ArgumentException($"Unsupported target framework moniker: {moniker:G}");
+        }
+
+        private static Version ParseVersionRemoveLabel(string versionString)
+        {
+            Assert.NotNull(versionString);
+            int prereleaseLabelIndex = versionString.IndexOf('-');
+            if (prereleaseLabelIndex >= 0)
+            {
+                versionString = versionString.Substring(0, prereleaseLabelIndex);
+            }
+            return Version.Parse(versionString);
         }
 
         private static readonly TargetFrameworkMoniker CurrentTargetFrameworkMoniker =

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -52,7 +52,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
-                    Assert.True(runtimeVersion.Major >= 6, "RuntimeVersion.Major is not greater than or equal to 6.");
+
+                    Version currentAspNetVersion = TargetFrameworkMoniker.Current.GetAspNetCoreFrameworkVersion();
+                    Assert.Equal(currentAspNetVersion.Major, runtimeVersion.Major);
+                    Assert.Equal(currentAspNetVersion.Minor, runtimeVersion.Minor);
+                    Assert.Equal(currentAspNetVersion.Revision, runtimeVersion.Revision);
+
                     Assert.Equal(mode, info.DiagnosticPortMode);
 
                     if (mode == DiagnosticPortConnectionMode.Connect)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Tests that all log events are collected if log level set to Trace.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Tests that log events with level at or above the specified level are collected.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -118,7 +118,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Test that log events with a category that doesn't have a specified level are collected
         /// at the log level specified in the request body.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Test that LogLevel.None is not supported as the level query parameter.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -195,7 +195,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Test that LogLevel.None is not supported as the default log level in the request body.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -231,7 +231,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Test that log events are collected for the categories and levels specified by the application.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -265,7 +265,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Test that log events are collected for the categories and levels specified by the application.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -304,7 +304,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Test that log events are collected for the categories and levels specified by the application
         /// and for the categories and levels specified in the filter specs.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -348,7 +348,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Test that log events are collected for wildcard categories.
         /// </summary>
-        [ConditionalTheory(nameof(SkipOnWindowsNetCore31))]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
 #if NET5_0_OR_GREATER
@@ -463,16 +463,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             await LogsTestUtilities.ValidateLogsEquality(holder.Stream, callback, logFormat, _outputHelper);
         }
 
-        public static bool SkipOnWindowsNetCore31
+        public static bool IsNotWindowsNetCore31
         {
             get
             {
                 // Skip logs tests for .NET Core 3.1 on Windows; these tests sporadically
                 // fail frequently causing insertions and builds with unrelated changes to
                 // fail. See https://github.com/dotnet/dotnet-monitor/issues/807 for details.
-                return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                    DotNetHost.RuntimeVersion.Major != 3 ||
-                    DotNetHost.RuntimeVersion.Minor != 1;
+                return !TestConditions.IsWindows || !TestConditions.IsNetCore31;
             }
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -63,8 +63,6 @@
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Microsoft.Diagnostics.Monitoring.WebApi.csproj" />
     <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Tests that multiple processes are discoverable by dotnet-monitor.
         /// Also tests for correct behavior in response to queries with different/multiple process identifiers.
         /// </summary>
-        [Theory]
+        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect)]
 #if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen)]
@@ -304,6 +304,18 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsException.StatusCode);
             Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsException.Details.Status);
 #endif
+        }
+
+        public static bool IsNotWindowsNetCore31
+        {
+            get
+            {
+                /// Disabled on Windows .NET Core 3.1; process enumeration frequent hangs when running in connect mode.
+                /// Additional logging shows that some discovered processes on the test machines are not responding on their
+                /// diagnostic pipe and the named pipe implementation is not responding to cancellation.
+                /// See https://github.com/dotnet/diagnostics/issues/2711
+                return !TestConditions.IsWindows || !TestConditions.IsNetCore31;
+            }
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -46,14 +46,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         protected Task<int> RunnerExitedTask => _runner.ExitedTask;
 
         /// <summary>
-        /// The path to dotnet-monitor. It is currently only built for the
-        /// netcoreapp3.1 target framework.
+        /// The path to dotnet-monitor. The tool is currently built for netcoreapp3.1 and net6.0.
+        /// For netcoreapp3.1 and net5.0 testing, use the netcoreapp3.1 version. For net6.0+,
+        /// use the net6.0 version.
         /// </summary>
         private static string DotNetMonitorPath =>
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
+#if NET6_0_OR_GREATER
                 TargetFrameworkMoniker.Net60);
+#else
+                TargetFrameworkMoniker.NetCoreApp31);
+#endif
 
         private string SharedConfigDirectoryPath =>
             Path.Combine(_runnerTmpPath, "SharedConfig");
@@ -72,7 +77,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             // the correct ASP.NET Core version (which can be different than the .NET
             // version, especially for prereleases).
             _runner.FrameworkReference = DotNetFrameworkReference.Microsoft_AspNetCore_App;
-            _runner.TargetFramework = TargetFrameworkMoniker.Net60;
 
             _adapter = new LoggingRunnerAdapter(_outputHelper, _runner);
             _adapter.ReceivedStandardOutputLine += StandardOutputCallback;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             }
         }
 
+        public static bool IsNetCore31 => DotNetHost.BuiltTargetFrameworkMoniker == TargetFrameworkMoniker.NetCoreApp31;
+
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
@@ -94,10 +94,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         {
             if (_dependencies.TryGetValue(actionIndex, out Dictionary<string, PropertyDependency> properties))
             {
-                return properties
-                    .SelectMany(p => p.Value.ActionDependencies)
-                    .DistinctBy(a => a.Action.Name, StringComparer.Ordinal)
-                    .Select(a => a.Action).ToArray();
+                HashSet<string> actionNames = new(StringComparer.Ordinal);
+                List<CollectionRuleActionOptions> actionOptions = new();
+
+                foreach (ActionDependency dependency in properties.SelectMany(p => p.Value.ActionDependencies))
+                {
+                    if (actionNames.Add(dependency.Action.Name))
+                    {
+                        actionOptions.Add(dependency.Action);
+                    }
+                }
+
+                return actionOptions;
             }
             return Array.Empty<CollectionRuleActionOptions>();
         }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -90,6 +90,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         .OptionsValidationFailure(ex);
                     return -1;
                 }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    // The host will throw a OperationCanceledException if it cannot shut down the
+                    // hosted services gracefully within the shut down timeout period. Handle the
+                    // exception and let the tool exit gracefully.
+                    return 0;
+                }
                 finally
                 {
                     if (host is IAsyncDisposable asyncDisposable)

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -13,17 +13,6 @@
     <!-- This forces the creation of a checksum file and uploads it to blob storage
          using this name as part of the blob relative path. -->
     <BlobGroupPrefix>monitor</BlobGroupPrefix>
-    <!-- File locking warnings (that are typically resolved with automatic retries) are failing builds
-         quite frequently with messages such as:
-         
-         error MSB3026: (NETCORE_ENGINEERING_TELEMETRY=Build) Could not copy "...\dotnet-monitor.dll" to
-         "...\dotnet-monitor.dll". Beginning retry 1 in 1000ms. The process cannot access the file
-         '...\dotnet-monitor.dll' because it is being used by another process.
-         
-         work around this problem by telling the compiler to not warn about the issue. A file lock that
-         actually prevents the build from completing correctly should still fail the compilation with
-         an MSB3027 error. -->
-    <NoWarn>$(NoWarn);MSB3026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
     <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
@@ -35,8 +35,11 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">


### PR DESCRIPTION
This cherry-picks the commits from #1080 from `release/6.0` to `main` with one additional change to remove the NoWarn for MSB3026 since it doesn't occur anymore with this changes.