### PR TITLE
Do not attempt to prune processes during tracing

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IDumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IDumpService.cs
@@ -11,9 +11,5 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     internal interface IDumpService
     {
         Task<Stream> DumpAsync(IEndpointInfo endpointInfo, Models.DumpType mode, CancellationToken token);
-
-        bool IsExecutingOperation(IEndpointInfo endpointInfo);
-
-        void EndpointRemoved(IEndpointInfo endpointInfo);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OperationTrackerService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OperationTrackerService.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    internal sealed class OperationTrackerService
+    {
+        private readonly ConcurrentDictionary<IEndpointInfo, OperationsTracker> _operations = new();
+
+        private sealed class OperationsTracker : IDisposable
+        {
+            private int _count = 0;
+
+            public IDisposable Register()
+            {
+                Interlocked.Increment(ref _count);
+                return this;
+            }
+
+            public bool IsExecutingOperation => 0 != Interlocked.CompareExchange(ref _count, 0, 0);
+
+            public void Dispose() => Interlocked.Decrement(ref _count);
+        }
+
+        public bool IsExecutingOperation(IEndpointInfo endpointInfo)
+        {
+            return GetOperationsTracker(endpointInfo).IsExecutingOperation;
+        }
+
+        public IDisposable Register(IEndpointInfo endpointInfo)
+        {
+            return GetOperationsTracker(endpointInfo).Register();
+        }
+
+        public void EndpointRemoved(IEndpointInfo endpointInfo)
+        {
+            _operations.TryRemove(endpointInfo, out _);
+        }
+
+        private OperationsTracker GetOperationsTracker(IEndpointInfo endpointInfo)
+        {
+            return _operations.GetOrAdd(endpointInfo, _ => new OperationsTracker());
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -161,9 +161,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public async Task ServerSourceNoPruneDuringDumpTest(TargetFrameworkMoniker appTfm)
         {
             EndpointInfoSourceCallback callback = new(_outputHelper);
-            var operatonTrackerService = new OperationTrackerService();
-            MockDumpService dumpService = new(operatonTrackerService);
-            await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback, dumpService, operatonTrackerService);
+            var operationTrackerService = new OperationTrackerService();
+            MockDumpService dumpService = new(operationTrackerService);
+            await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback, dumpService, operationTrackerService);
 
             AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, appTfm);
 
@@ -244,7 +244,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 }
                 finally
                 {
-                    operationRegistration.Dispose();
+                    operationRegistration?.Dispose();
                 }
             }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointUtilities.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 callbacks.Add(sourceCallback);
                 if (null != dumpService)
                 {
-                    callbacks.Add(new DumpServiceEndpointInfoSourceCallback(operationTrackerService));
+                    callbacks.Add(new OperationTrackerServiceEndpointInfoSourceCallback(operationTrackerService));
                 }
             }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointUtilities.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             _outputHelper = outputHelper;
         }
 
-        public async Task<ServerSourceHolder> StartServerAsync(EndpointInfoSourceCallback sourceCallback = null, IDumpService dumpService = null)
+        public async Task<ServerSourceHolder> StartServerAsync(EndpointInfoSourceCallback sourceCallback = null, IDumpService dumpService = null,
+            OperationTrackerService operationTrackerService = null)
         {
             DiagnosticPortHelper.Generate(DiagnosticPortConnectionMode.Listen, out _, out string transportName);
             _outputHelper.WriteLine("Starting server endpoint info source at '" + transportName + "'.");
@@ -39,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 callbacks.Add(sourceCallback);
                 if (null != dumpService)
                 {
-                    callbacks.Add(new DumpServiceEndpointInfoSourceCallback(dumpService));
+                    callbacks.Add(new DumpServiceEndpointInfoSourceCallback(operationTrackerService));
                 }
             }
 
@@ -50,7 +51,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     EndpointName = transportName
                 });
 
-            ServerEndpointInfoSource source = new(portOptions, callbacks, dumpService);
+            ServerEndpointInfoSource source = new(portOptions, callbacks, operationTrackerService);
 
             await source.StartAsync(CancellationToken.None);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
@@ -86,9 +86,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 .ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
                 {
                     services.ConfigureGlobalCounter(context.Configuration);
+                    services.AddSingleton<OperationTrackerService>();
                     services.ConfigureCollectionRules();
                     services.ConfigureEgress();
-
+;
                     services.AddSingleton<IDumpService, DumpService>();
                     services.ConfigureStorage(context.Configuration);
                     servicesCallback?.Invoke(services);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     services.AddSingleton<OperationTrackerService>();
                     services.ConfigureCollectionRules();
                     services.ConfigureEgress();
-;
+
                     services.AddSingleton<IDumpService, DumpService>();
                     services.ConfigureStorage(context.Configuration);
                     servicesCallback?.Invoke(services);

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -87,15 +87,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 EgressOperation egressOperation = new EgressOperation(
                     async (outputStream, token) =>
                     {
-                        IDisposable operationRegistration = _operationTrackerService.Register(EndpointInfo);
-                        try
-                        {
-                            await TraceUtilities.CaptureTraceAsync(startCompletionSource, EndpointInfo, configuration, duration, outputStream, token);
-                        }
-                        finally
-                        {
-                            operationRegistration.Dispose();
-                        }
+                        using IDisposable operationRegistration = _operationTrackerService.Register(EndpointInfo);
+                        await TraceUtilities.CaptureTraceAsync(startCompletionSource, EndpointInfo, configuration, duration, outputStream, token);
                     },
                     egressProvider,
                     fileName,

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(ConfigurationKeys.DiagnosticPort));
                     services.AddSingleton<IValidateOptions<DiagnosticPortOptions>, DiagnosticPortValidateOptions>();
+                    services.AddSingleton<OperationTrackerService>();
 
                     services.ConfigureGlobalCounter(context.Configuration);
 

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.AddHostedServiceForwarder<ServerEndpointInfoSource>();
                     services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
                     services.AddSingleton<IDumpService, DumpService>();
-                    services.AddSingleton<IEndpointInfoSourceCallbacks, DumpServiceEndpointInfoSourceCallback>();
+                    services.AddSingleton<IEndpointInfoSourceCallbacks, OperationTrackerServiceEndpointInfoSourceCallback>();
                     services.AddSingleton<RequestLimitTracker>();
                     services.ConfigureOperationStore();
                     services.ConfigureEgress();

--- a/src/Tools/dotnet-monitor/DumpServiceEndpointInfoSourceCallback.cs
+++ b/src/Tools/dotnet-monitor/DumpServiceEndpointInfoSourceCallback.cs
@@ -9,13 +9,14 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
+    //TODO Rename this
     internal sealed class DumpServiceEndpointInfoSourceCallback : IEndpointInfoSourceCallbacks
     {
-        private readonly IDumpService _dumpService;
+        private readonly OperationTrackerService _operationTrackerService;
 
-        public DumpServiceEndpointInfoSourceCallback(IDumpService dumpService)
+        public DumpServiceEndpointInfoSourceCallback(OperationTrackerService operationTrackerService)
         {
-            _dumpService = dumpService ?? throw new ArgumentNullException(nameof(dumpService));
+            _operationTrackerService = operationTrackerService ?? throw new ArgumentNullException(nameof(operationTrackerService));
         }
 
         public Task OnAddedEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken cancellationToken)
@@ -30,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public Task OnRemovedEndpointInfoAsync(IEndpointInfo endpointInfo, CancellationToken cancellationToken)
         {
-            _dumpService.EndpointRemoved(endpointInfo);
+            _operationTrackerService.EndpointRemoved(endpointInfo);
 
             return Task.CompletedTask;
         }

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private readonly IEnumerable<IEndpointInfoSourceCallbacks> _callbacks;
         private readonly DiagnosticPortOptions _portOptions;
 
-        private readonly IDumpService _dumpService;
+        private readonly OperationTrackerService _operationTrackerService;
 
         /// <summary>
         /// Constructs a <see cref="ServerEndpointInfoSource"/> that aggregates diagnostic endpoints
@@ -51,10 +51,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public ServerEndpointInfoSource(
             IOptions<DiagnosticPortOptions> portOptions,
             IEnumerable<IEndpointInfoSourceCallbacks> callbacks = null,
-            IDumpService dumpService = null)
+            OperationTrackerService operationTrackerService = null)
         {
             _callbacks = callbacks ?? Enumerable.Empty<IEndpointInfoSourceCallbacks>();
-            _dumpService = dumpService;
+            _operationTrackerService = operationTrackerService;
             _portOptions = portOptions.Value;
 
             BoundedChannelOptions channelOptions = new(PendingRemovalChannelCapacity)
@@ -253,7 +253,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             // If a dump operation is in progress, the runtime is likely to not respond to
             // diagnostic requests. Do not check for responsiveness while the dump operation
             // is in progress.
-            if (_dumpService?.IsExecutingOperation(info) == true)
+            if (_operationTrackerService?.IsExecutingOperation(info) == true)
             {
                 return true;
             }

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -59,5 +59,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public const int InvalidActionReference = 49;
         public const int InvalidActionResultReference = 50;
         public const int ActionSettingsTokenizationNotSupported = 51;
+        public const int EndpointTimeout = 52;
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -277,6 +277,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             logLevel: LogLevel.Error,
             formatString: Strings.LogFormatString_ActionSettingsTokenizationNotSupported);
 
+        private static readonly Action<ILogger, string, Exception> _endpointTimeout =
+            LoggerMessage.Define<string>(
+                eventId: new EventId(LoggingEventIds.EndpointTimeout, "EndpointTimeout"),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_EndpointTimeout);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -499,6 +505,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void ActionSettingsTokenizationNotSupported(this ILogger logger, string settingsType)
         {
             _actionSettingsTokenizationNotSupported(logger, settingsType, null);
+        }
+
+        public static void EndpointTimeout(this ILogger logger, string processId)
+        {
+            _endpointTimeout(logger, processId, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/OperationTrackerServiceEndpointInfoSourceCallback.cs
+++ b/src/Tools/dotnet-monitor/OperationTrackerServiceEndpointInfoSourceCallback.cs
@@ -9,12 +9,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
-    //TODO Rename this
-    internal sealed class DumpServiceEndpointInfoSourceCallback : IEndpointInfoSourceCallbacks
+    internal sealed class OperationTrackerServiceEndpointInfoSourceCallback : IEndpointInfoSourceCallbacks
     {
         private readonly OperationTrackerService _operationTrackerService;
 
-        public DumpServiceEndpointInfoSourceCallback(OperationTrackerService operationTrackerService)
+        public OperationTrackerServiceEndpointInfoSourceCallback(OperationTrackerService operationTrackerService)
         {
             _operationTrackerService = operationTrackerService ?? throw new ArgumentNullException(nameof(operationTrackerService));
         }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -817,6 +817,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected timeout from process {processId}. Process will no longer be monitored..
+        /// </summary>
+        internal static string LogFormatString_EndpointTimeout {
+            get {
+                return ResourceManager.GetString("LogFormatString_EndpointTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments..
         /// </summary>
         internal static string LogFormatString_InsecureAutheticationConfiguration {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -512,6 +512,9 @@
 1. providerType: Type of the provider
 2. keyName: Name of the property that could not be found</comment>
   </data>
+  <data name="LogFormatString_EndpointTimeout" xml:space="preserve">
+    <value>Unexpected timeout from process {processId}. Process will no longer be monitored.</value>
+  </data>
   <data name="LogFormatString_InsecureAutheticationConfiguration" xml:space="preserve">
     <value>WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.</value>
     <comment>Gets the format string that is printed in the 14:InsecureAutheticationConfiguration event.


### PR DESCRIPTION
It appears that the event pipe is not responsive during rundown, which causes our pruning mechanism to remove processes (similar to dumps). Possibly related to https://github.com/dotnet/runtime/issues/1892.

- The pruning algorithm should probably do multiple attempts over a period of time to see if the process is really to be removed.
- The real fix should make rundown more configurable. We are defaulting to true in some cases we may not need.
- There may be other affected artifacts (gcdump/logs).
- We should converge the OperationTrackerService and the RequestLimitTracker at some point.