### PR TITLE
Fix help text for generatekey's output parameter

### DIFF
--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The format to display the output in. Valid values are Json, Text, and EnvVar..
+        ///   Looks up a localized string similar to The format to display the output in. This option is useful for printing the information in a format to be copy/pasted into the system of your choice..
         /// </summary>
         internal static string HelpDescription_OutputFormat {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The format to display the output in. This option is useful for printing the information in a format to be copy/pasted into the system of your choice..
+        ///   Looks up a localized string similar to The output format of the API Key configuration..
         /// </summary>
         internal static string HelpDescription_OutputFormat {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -352,7 +352,7 @@
     <comment>Gets the string to display in help that explains what the '--urls' option does.</comment>
   </data>
   <data name="HelpDescription_OutputFormat" xml:space="preserve">
-    <value>The format to display the output in. Valid values are Json, Text, and EnvVar.</value>
+    <value>The format to display the output in. This option is useful for printing the information in a format to be copy/pasted into the system of your choice.</value>
     <comment>Gets the string to display in help that explains what the '--output' option does.</comment>
   </data>
   <data name="LogFormatString_ActionSettingsTokenizationNotSupported" xml:space="preserve">

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -352,7 +352,7 @@
     <comment>Gets the string to display in help that explains what the '--urls' option does.</comment>
   </data>
   <data name="HelpDescription_OutputFormat" xml:space="preserve">
-    <value>The format to display the output in. This option is useful for printing the information in a format to be copy/pasted into the system of your choice.</value>
+    <value>The output format of the API Key configuration.</value>
     <comment>Gets the string to display in help that explains what the '--output' option does.</comment>
   </data>
   <data name="LogFormatString_ActionSettingsTokenizationNotSupported" xml:space="preserve">


### PR DESCRIPTION
Corrects an error in the `generatekey` command's `output` parameter help text. 

Old output of `dotnet monitor generatekey --help`:
```
generatekey:
  Generate api key and hash for authentication.

Usage:
  dotnet-monitor generatekey [options]

Options:
  -o, --output <Cmd|Json|PowerShell|Shell|Text>    The format to display the output in. Valid values are Json, Text,
                                                   and EnvVar. [default: Json]
  -?, -h, --help                                   Show help and usage information
```

New output of `dotnet monitor generatekey --help`:
```
generatekey:
  Generate api key and hash for authentication.

Usage:
  dotnet-monitor generatekey [options]

Options:
  -o, --output <Cmd|Json|PowerShell|Shell|Text>    The format to display the output in. This option is useful for
                                                   printing the information in a format to be copy/pasted into the
                                                   system of your choice. [default: Json]
  -?, -h, --help                                   Show help and usage information
```

Closes #1119 