### PR TITLE
Publish nupkgs to blob storage.

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -39,8 +39,8 @@
     <PropertyGroup>
       <_BlobGroupFilePath>%(PackageFile.FullPath).blobgroup</_BlobGroupFilePath>
       <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
-      <_VersionFilePath>%(PackageFile.FullPath).version</_VersionFilePath>
       <_BuildVersionFileFilePath>%(PackageFile.FullPath).buildversionfile</_BuildVersionFileFilePath>
+      <_PackageVersionFileFilePath>%(PackageFile.FullPath).versionfile</_PackageVersionFileFilePath>
     </PropertyGroup>
 
     <Error Condition="Exists('$(_BlobGroupFilePath)') and !Exists('$(_ChecksumFilePath)')"
@@ -54,9 +54,14 @@
     <ReadLinesFromFile File="$(_BuildVersionFileFilePath)" Condition="Exists('$(_BuildVersionFileFilePath)')">
       <Output TaskParameter="Lines" PropertyName="_BuildVersionFileName"/>
     </ReadLinesFromFile>
+    <!-- Read in package version file name, if it exists -->
+    <ReadLinesFromFile File="$(_PackageVersionFileFilePath)" Condition="Exists('$(_PackageVersionFileFilePath)')">
+      <Output TaskParameter="Lines" PropertyName="_PackageVersionFileName"/>
+    </ReadLinesFromFile>
 
     <PropertyGroup>
       <_BuildVersionFilePath>%(PackageFile.RootDir)%(PackageFile.Directory)$(_BuildVersionFileName)</_BuildVersionFilePath>
+      <_PackageVersionFilePath>%(PackageFile.RootDir)%(PackageFile.Directory)$(_PackageVersionFileName)</_PackageVersionFilePath>
     </PropertyGroup>
 
     <!-- Read in build version, if it exists -->
@@ -79,14 +84,14 @@
       <_BlobGroupBlobItem Include="$(_BuildVersionFilePath)" Condition="Exists('$(_BuildVersionFilePath)')" >
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_BlobGroupBlobItem>
+      <_BlobGroupBlobItem Include="$(_PackageVersionFilePath)" Condition="Exists('$(_PackageVersionFilePath)')">
+        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
+      </_BlobGroupBlobItem>
     </ItemGroup>
 
     <!-- Capture items that need to be published under the build version container. -->
     <ItemGroup>
       <_VersionContainerBlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
-        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
-      </_VersionContainerBlobItem>
-      <_VersionContainerBlobItem Include="$(_VersionFilePath)" Condition="Exists('$(_VersionFilePath)')">
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_VersionContainerBlobItem>
       <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -40,6 +40,7 @@
       <_BlobGroupFilePath>%(PackageFile.FullPath).blobgroup</_BlobGroupFilePath>
       <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
       <_VersionFilePath>%(PackageFile.FullPath).version</_VersionFilePath>
+      <_BuildVersionFileFilePath>%(PackageFile.FullPath).buildversionfile</_BuildVersionFileFilePath>
     </PropertyGroup>
 
     <Error Condition="Exists('$(_BlobGroupFilePath)') and !Exists('$(_ChecksumFilePath)')"
@@ -49,26 +50,62 @@
     <ReadLinesFromFile File="$(_BlobGroupFilePath)" Condition="Exists('$(_BlobGroupFilePath)')">
       <Output TaskParameter="Lines" PropertyName="_BlobGroupName"/>
     </ReadLinesFromFile>
+    <!-- Read in build version file name, if it exists -->
+    <ReadLinesFromFile File="$(_BuildVersionFileFilePath)" Condition="Exists('$(_BuildVersionFileFilePath)')">
+      <Output TaskParameter="Lines" PropertyName="_BuildVersionFileName"/>
+    </ReadLinesFromFile>
+
+    <PropertyGroup>
+      <_BuildVersionFilePath>%(PackageFile.RootDir)%(PackageFile.Directory)$(_BuildVersionFileName)</_BuildVersionFilePath>
+    </PropertyGroup>
+
+    <!-- Read in build version, if it exists -->
+    <ReadLinesFromFile File="$(_BuildVersionFilePath)" Condition="Exists('$(_BuildVersionFilePath)')">
+      <Output TaskParameter="Lines" PropertyName="_BuildVersion"/>
+    </ReadLinesFromFile>
 
     <!-- Calculate manifest artifact data for each file type. -->
     <ItemGroup>
       <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageFile.IsShipping)' != 'true'" />
     </ItemGroup>
-
-    <!-- Capture each blob item to upload to blob feed -->
     <ItemGroup>
-      <_BlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
+      <_PackageArtifactData Include="@(_CommonArtifactData)" />
+      <!-- Set Category to OTHER so that packages are also published to blob storage. -->
+      <_PackageArtifactData Include="Category=OTHER" />
+    </ItemGroup>
+
+    <!-- Capture items that need to be published under the blob group. -->
+    <ItemGroup>
+      <_BlobGroupBlobItem Include="$(_BuildVersionFilePath)" Condition="Exists('$(_BuildVersionFilePath)')" >
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
-      </_BlobItem>
-      <_BlobItem Include="$(_VersionFilePath)" Condition="Exists('$(_VersionFilePath)')">
+      </_BlobGroupBlobItem>
+    </ItemGroup>
+
+    <!-- Capture items that need to be published under the build version container. -->
+    <ItemGroup>
+      <_VersionContainerBlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
-      </_BlobItem>
+      </_VersionContainerBlobItem>
+      <_VersionContainerBlobItem Include="$(_VersionFilePath)" Condition="Exists('$(_VersionFilePath)')">
+        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
+      </_VersionContainerBlobItem>
+      <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism
+           so that they can be retrieved from a stable location. -->
+      <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
+        <ManifestArtifactData Condition="'@(_PackageArtifactData)' != ''">@(_PackageArtifactData)</ManifestArtifactData>
+      </_VersionContainerBlobItem>
     </ItemGroup>
 
     <!-- Add artifact items to be pushed to blob feed -->
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(_BlobItem)" Condition="'$(_BlobGroupName)' != ''">
-        <RelativeBlobPath>diagnostics/$(_BlobGroupName)/%(_BlobItem.Filename)%(_BlobItem.Extension)</RelativeBlobPath>
+      <ItemsToPushToBlobFeed Include="@(_BlobGroupBlobItem)" Condition="'$(_BlobGroupName)' != ''">
+        <!-- Place blobs into versioned container so that stable package versions do not collide. -->
+        <RelativeBlobPath>diagnostics/monitor$(_BlobGroupName)/%(_BlobGroupBlobItem.Filename)%(_BlobGroupBlobItem.Extension)</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
+      </ItemsToPushToBlobFeed>
+      <ItemsToPushToBlobFeed Include="@(_VersionContainerBlobItem)" Condition="'$(_BuildVersion)' != ''">
+        <!-- Place blobs into versioned container so that stable package versions do not collide. -->
+        <RelativeBlobPath>diagnostics/monitor/$(_BuildVersion)/%(_VersionContainerBlobItem.Filename)%(_VersionContainerBlobItem.Extension)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPushToBlobFeed>
     </ItemGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -96,9 +96,10 @@
       </_VersionContainerBlobItem>
       <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism
            so that they can be retrieved from a stable location. -->
-      <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
+      <!-- Enable once https://github.com/dotnet/arcade/issues/6517 is fixed. -->
+      <!-- <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
         <ManifestArtifactData Condition="'@(_PackageArtifactData)' != ''">@(_PackageArtifactData)</ManifestArtifactData>
-      </_VersionContainerBlobItem>
+      </_VersionContainerBlobItem> -->
     </ItemGroup>
 
     <!-- Add artifact items to be pushed to blob feed -->

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
@@ -6,6 +6,9 @@ namespace DiagnosticsReleaseTool.Util
     {
         public const string ProductName = "dotnet-monitor";
         public const string RepositoryName = "https://github.com/dotnet/dotnet-monitor";
-        internal static bool IsDockerUtilityFile(FileInfo arg) => arg.FullName.EndsWith(".nupkg.sha512") || arg.FullName.EndsWith(".nupkg.version");
+        internal static bool IsDockerUtilityFile(FileInfo arg) =>
+            arg.FullName.EndsWith(".nupkg.sha512")
+            || arg.FullName.EndsWith(".nupkg.version")
+            || arg.FullName.EndsWith(".nupkg.buildversion");
     }
 }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -77,10 +77,9 @@
         stable package versions.
         -->
       <_BuildVersion>$(_OriginalVersionPrefix)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_BuildVersion>
-      <!-- Name of the build version file. -->
-      <_BuildVersionFileName>$(PackageId).$(_BuildVersion).nupkg.buildversion</_BuildVersionFileName>
       <!-- Name of the package file. Used as a prefix for the following files. -->
       <_PackageFileName>$(PackageId).$(PackageVersion).nupkg</_PackageFileName>
+      <_PackageWithBuildVersionFileName>$(PackageId).$(_BuildVersion).nupkg</_PackageWithBuildVersionFileName>
     </PropertyGroup>
     <!-- A file that contains the blob group so that publishing can use it in the blob path calculation. -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).blobgroup"
@@ -88,10 +87,21 @@
                       Overwrite="true" />
 
     <!--
-      A file that contains the version of the nuget package.
-      Example name: dotnet-monitor.7.0.0.nupkg.version
+      A file that contains the name of another file that contains the package version. It effectively
+      states that "for a given package and version, the named file contains the package version". This
+      file is used by publishing to determine which package version file to upload to blob storage. The
+      file itself is not uploaded to blob storage.
+      Example name: dotnet-monitor.7.0.0.nupkg.versionfile
       -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).version"
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).versionfile"
+                      Lines="$(_PackageWithBuildVersionFileName).version"
+                      Overwrite="true" />
+
+    <!--
+      A file that contains the version of the nuget package.
+      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
+      -->
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageWithBuildVersionFileName).version"
                       Lines="$(PackageVersion)"
                       Overwrite="true" />
 
@@ -103,7 +113,7 @@
       Example name: dotnet-monitor.7.0.0.nupkg.buildversionfile
       -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).buildversionfile"
-                      Lines="$(_BuildVersionFileName)"
+                      Lines="$(_PackageWithBuildVersionFileName).buildversion"
                       Overwrite="true" />
 
     <!--
@@ -111,7 +121,7 @@
       version in order to avoid collisions when uploaded to blob storage.
       Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
       -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_BuildVersionFileName)"
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageWithBuildVersionFileName).buildversion"
                       Lines="$(_BuildVersion)"
                       Overwrite="true" />
   </Target>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,20 +14,20 @@
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
   <Target Name="GeneratePackageArtifactFiles"
           AfterTargets="Pack"
-          Condition="'$(IsPackable)' == 'true' and '$(BlobGroupPrefix)' != ''">
+          Condition="'$(IsPackable)' == 'true' and '$(PublishToBlob)' == 'true'">
     <PropertyGroup>
       <!--
         These properties take a package version and transform it into a blob group name so that
         all builds from the same product and release version are grouped together. This code has
-        to consider when the version is a release version (e.g. 6.0.0) or has a prerelease label
-        (e.g. 6.0.0-preview.8). The former is transformed into '$(BlobGroupPrefix)5.0/release' whereas
-        the latter is transformed into '$(BlobGroupPrefix)5.0/preview.1'. It also accounts for the
+        to consider when the version is a release version (e.g. 7.0.0) or has a prerelease label
+        (e.g. 7.0.0-preview.1). The former is transformed into '7.0/release' whereas
+        the latter is transformed into '7.0/preview.1'. It also accounts for the
         BlobGroupBuildQuality defined in Version.props, which determines if the prerelease information
         should be used in the final blob group name.
         -->
       <_PreReleaseSeperatorIndex>$(PackageVersion.IndexOf('-'))</_PreReleaseSeperatorIndex>
       
-      <!-- Prerelease: '6.0.0-preview.8' -> '6.0.0' and 'preview.8' -->
+      <!-- Prerelease: '7.0.0-preview.8' -> '7.0.0' and 'preview.8' -->
       <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring(0, $(_PreReleaseSeperatorIndex)))</_BlobGroupVersion>
       <_BlobGroupPreRelease Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring($([MSBuild]::Add($(_PreReleaseSeperatorIndex), 1))))</_BlobGroupPreRelease>
       
@@ -65,19 +65,54 @@
     <Error Text="Unable to calculate _BlobGroupReleaseName" Condition="'$(_BlobGroupReleaseName)' == ''" />
     <PropertyGroup>
       <!--
-        Combine all parts to create blob group name. For example (with BlobGroupPrefix = 'monitor'):
-        Daily: '6.0.0-preview.1.12345' -> 'monitor6.0/daily'
-        Prerelease: '6.0.0-preview.1.12345' -> 'monitor6.0/preview.1'
-        Release: '6.0.0' -> 'monitor6.0/release'
+        Combine all parts to create blob group name.
+        Daily: '7.0.0-preview.1.12345' -> '7.0/daily'
+        Prerelease: '7.0.0-preview.1.12345' -> '7.0/preview.1'
+        Release: '7.0.0' -> '7.0/release'
         -->
-      <_BlobGroupName>$(BlobGroupPrefix)$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>
+      <_BlobGroupName>$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>
+      <!--
+        This computes the original version without considering the effect of DotNetFinalVersionKind.
+        This can be used to uniquely identify a version of a specific build even if the build produces
+        stable package versions.
+        -->
+      <_BuildVersion>$(_OriginalVersionPrefix)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_BuildVersion>
+      <!-- Name of the build version file. -->
+      <_BuildVersionFileName>$(PackageId).$(_BuildVersion).nupkg.buildversion</_BuildVersionFileName>
+      <!-- Name of the package file. Used as a prefix for the following files. -->
+      <_PackageFileName>$(PackageId).$(PackageVersion).nupkg</_PackageFileName>
     </PropertyGroup>
     <!-- A file that contains the blob group so that publishing can use it in the blob path calculation. -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.blobgroup"
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).blobgroup"
                       Lines="$(_BlobGroupName)"
                       Overwrite="true" />
-    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.version"
+
+    <!--
+      A file that contains the version of the nuget package.
+      Example name: dotnet-monitor.7.0.0.nupkg.version
+      -->
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).version"
                       Lines="$(PackageVersion)"
+                      Overwrite="true" />
+
+    <!--
+      A file that contains the name of another file that contains the build version. It effectively
+      states that "for a given package and version, the named file contains the build version". This
+      file is used by publishing to determine which build version file to upload to blob storage. The
+      file itself is not uploaded to blob storage.
+      Example name: dotnet-monitor.7.0.0.nupkg.buildversionfile
+      -->
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).buildversionfile"
+                      Lines="$(_BuildVersionFileName)"
+                      Overwrite="true" />
+
+    <!--
+      A file that contains the build version of the package. The name of this file contains the build
+      version in order to avoid collisions when uploaded to blob storage.
+      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
+      -->
+    <WriteLinesToFile File="$(PackageOutputPath)\$(_BuildVersionFileName)"
+                      Lines="$(_BuildVersion)"
                       Overwrite="true" />
   </Target>
 

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -10,9 +10,7 @@
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <RollForward>Major</RollForward>
-    <!-- This forces the creation of a checksum file and uploads it to blob storage
-         using this name as part of the blob relative path. -->
-    <BlobGroupPrefix>monitor</BlobGroupPrefix>
+    <PublishToBlob>true</PublishToBlob>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These changes facilitate the ability to publish the dotnet-monitor nupkg file to the dotnet blob storage account in addition to the default behavior of publishing to each channel's nuget feed.

The files that are created as part of the pack step are:
| File Name | Description | Blob Sub Path |
|---|---|---|
| `dotnet-monitor.<PackageVersion>.nupkg` | The nupkg built by the standard .NET build targets | `diagnostics/monitor/<BuildVersion>/dotnet-monitor.<PackageVersion>.nupkg` |
| `dotnet-monitor.<PackageVersion>.nupkg.blobgroup` | Contains which sub-container the files should be published to in blob storage e.g. `7.0/daily`, used by publishing | N/A |
| `dotnet-monitor.<PackageVersion>.nupkg.buildversionfile` | Contains the name of build version file, used by publishing | N/A |
| `dotnet-monitor.<BuildVersion>.nupkg.buildversion` | Contains the build version of the package | `diagnostics/monitor<BlobGroup>/dotnet-monitor.<BuildVersion>.nupkg.buildversion` |
| `dotnet-monitor.<PackageVersion>.nupkg.versionfile` | Contains the name of package version file, used by publishing | N/A |
| `dotnet-monitor.<PackageVersion>.nupkg.version` | The version of the nupkg | `diagnostics/monitor/<BuildVersion>/dotnet-monitor.<PackageVersion>.nupkg.version` |

The files that are created as part of the publish step are:
| File Name | Description | Blob Sub Path |
|---|---|---|
| `dotnet-monitor.<PackageVersion>.nupkg.sha512` | The SHA512 hash value of the nupkg | `diagnostics/monitor/<BuildVersion>/dotnet-monitor.<PackageVersion>.nupkg.sha512` |

Concrete examples of the publish step are:
`dotnet-monitor.7.0.0.nupkg` -> `diagnostics/monitor/7.0.0-rtm.21555.3/dotnet-monitor.7.0.0.nupkg`
`dotnet-monitor.7.0.0.nupkg.buildversion` -> `diagnostics/monitor7.0/release/dotnet-monitor.7.0.0-rtm.21555.3.nupkg.buildversion`
`dotnet-monitor.7.0.0.nupkg.version` -> `diagnostics/monitor/monitor7.0/release/dotnet-monitor.7.0.0-rtm.21555.3.nupkg.version`
`dotnet-monitor.7.0.0.nupkg.sha512` -> `diagnostics/monitor/7.0.0-rtm.21555.3/dotnet-monitor.7.0.0.nupkg.sha512`

The build version and package version files are published under the blob group container to allow dotnet-docker to find the latest build and package version within a version bubble (major.minor). The remaining files are published under a container named with the build version; this allows multiple builds of the same stable version to be produced without interfering with each other.

The dotnet-docker workflow will be updated to look for the *.buildversion file using the shortened aka.ms link URL which will point to the latest build version file within each version bubble: `https://aka.ms/dotnet/diagnostics/monitor7.0/release/dotnet-monitor.buildversion`. The build number in the file informs dotnet-docker which build version to look up the nupkg file and checksum file.