### PR TITLE
Config Show: Array properties without indices

### DIFF
--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -197,14 +197,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             _writer.WritePropertyName(section.Key);
 
-            bool parentIsCR = section.Key.Equals(ConfigurationKeys.CollectionRules);
-
             IEnumerable<IConfigurationSection> children = section.GetChildren();
 
             //If we do not traverse the child sections, the caller is responsible for creating the value
             if (includeChildSections && children.Any())
             {
                 bool isSequentialIndices = CheckForSequentialIndices(children);
+
+                bool parentIsCR = section.Key.Equals(ConfigurationKeys.CollectionRules);
 
                 if (isSequentialIndices && !parentIsCR)
                 {

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -222,7 +222,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     }
                     else
                     {
-                        WriteValue(section.Value, redact);
+                        _writer.WriteStartArray();
+
+                        foreach (IConfigurationSection child in children)
+                        {
+                            WriteValue(child.Value, redact);
+                        }
+
+                        _writer.WriteEndArray();
                     }
                 }
                 else

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -8,6 +8,7 @@ using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -259,7 +260,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             foreach (IConfigurationSection child in children)
             {
-                if (!child.Key.Equals(indexValue.ToString()))
+                if (!child.Key.Equals(indexValue.ToString(CultureInfo.InvariantCulture)))
                 {
                     return false;
                 }
@@ -291,5 +292,4 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
     }
-
 }

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -209,28 +209,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                 if (isSequentialIndices && !parentIsCR)
                 {
-                    if (children.First().GetChildren().Any())
-                    {
-                        _writer.WriteStartArray();
+                    _writer.WriteStartArray();
 
-                        foreach (IConfigurationSection child in children)
+                    foreach (IConfigurationSection child in children)
+                    {
+                        if (child.GetChildren().Any())
                         {
                             ProcessChildren(child, includeChildSections, redact);
                         }
-
-                        _writer.WriteEndArray();
-                    }
-                    else
-                    {
-                        _writer.WriteStartArray();
-
-                        foreach (IConfigurationSection child in children)
+                        else
                         {
                             WriteValue(child.Value, redact);
                         }
-
-                        _writer.WriteEndArray();
                     }
+
+                    _writer.WriteEndArray();
                 }
                 else
                 {


### PR DESCRIPTION
By default, `Config Show` lists the indices of elements in an array. This change counteracts that behavior by printing `Config Show` using the expected format (no indices).

I've currently only wired up three scenarios to take advantage of this code (CollectionRules, Metrics, and DefaultProcess), because they appeared to be the ones that were affected; however, this could easily be extended with the addition of a parameter to any of the other configuration elements.

The least elegant part of this solution is determining the type of actions/triggers in order to get their available properties; I'll leave a few comments in the review where people can weigh in if they have any thoughts on whether it's fine as-is or if there's a better way.

I tested this against the scenarios in my Collection Rule Examples PR as well as a few custom scenarios and it appears to work consistently, but it's possible there's edge cases I've overlooked in the testing, so let me know if anything looks amiss.

Closes #1054 