### PR TITLE
Allow access to private feeds for internal builds.

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -101,6 +101,24 @@ jobs:
       - scriptExt: '.sh'
 
     steps:
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - ${{ if eq(parameters.agentOs, 'Windows') }}:
+        - task: PowerShell@2
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - ${{ if ne(parameters.agentOs, 'Windows') }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
     - script: >-
         $(Build.SourcesDirectory)/build$(scriptExt)
         -ci

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -102,7 +102,7 @@ jobs:
 
     steps:
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - ${{ if eq(parameters.agentOs, 'Windows') }}:
+      - ${{ if eq(parameters.osGroup, 'Windows') }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials
           inputs:
@@ -110,7 +110,7 @@ jobs:
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - ${{ if ne(parameters.agentOs, 'Windows') }}:
+      - ${{ if ne(parameters.osGroup, 'Windows') }}:
         - task: Bash@3
           displayName: Setup Private Feeds Credentials
           inputs:


### PR DESCRIPTION
Adding this step allows access to private feeds that require credentials. See the following example build demonstrating what it is changing in the NuGet.config file: https://dev.azure.com/dnceng/internal/_build/results?buildId=1489686&view=logs&j=1994a01f-c112-51c5-af4f-f0bea4551182&t=e14f3dce-491b-58da-8687-15b613994bfa