### PR TITLE
Pass additional installation feed for internal builds.

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -74,9 +74,16 @@ jobs:
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
     - _SignType: test
+    - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
     - _InternalSignArgs: ''
     - _InternalPublishArgs: ''
+
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - _InternalInstallArgs: >-
+          -RuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet
+          -RuntimeSourceFeedKey $(dotnetclimsrc-read-sas-token-base64)
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - _InternalBuildArgs: >-
           -pack
@@ -125,6 +132,7 @@ jobs:
         -test
         -configuration ${{ parameters.configuration }}
         -prepareMachine
+        $(_InternalInstallArgs)
         $(_InternalBuildArgs)
         $(_InternalSignArgs)
         $(_InternalPublishArgs)


### PR DESCRIPTION
Internal builds are available on a different feed than the standard feeds that the dotnet-install script knows. Pass the additional feed location and SAS token to access the feed to install the frameworks.