### PR TITLE
[main] Allow access to private feeds for internal builds.

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -101,6 +101,24 @@ jobs:
       - scriptExt: '.sh'
 
     steps:
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - ${{ if eq(parameters.osGroup, 'Windows') }}:
+        - task: PowerShell@2
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - ${{ if ne(parameters.osGroup, 'Windows') }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
     - script: >-
         $(Build.SourcesDirectory)/build$(scriptExt)
         -ci


### PR DESCRIPTION
Port of #1163 from `release/6.0` to `main` branch.

(cherry picked from commit f1bd67df92b707d787dd54fdd8cdfdd2f0fb493a)