### PR TITLE
[main] Pass additional installation feed for internal builds.

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -74,9 +74,17 @@ jobs:
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
     - _SignType: test
+    - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
     - _InternalSignArgs: ''
     - _InternalPublishArgs: ''
+
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - group: DotNet-MSRC-Storage
+      - _InternalInstallArgs: >-
+          /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
+          /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - _InternalBuildArgs: >-
           -pack
@@ -107,6 +115,7 @@ jobs:
         -test
         -configuration ${{ parameters.configuration }}
         -prepareMachine
+        $(_InternalInstallArgs)
         $(_InternalBuildArgs)
         $(_InternalSignArgs)
         $(_InternalPublishArgs)


### PR DESCRIPTION
Port of #1169 from `release/6.0` branch to `main` branch.

(cherry picked from commit 8dda983a3ecde881d6464b969dd049e1831464bf)