### PR TITLE
[release/6.0] Adds internal/release/ to publish branches

### DIFF
--- a/eng/PrepareRelease.yml
+++ b/eng/PrepareRelease.yml
@@ -2,7 +2,7 @@ stages:
 - stage: PrepareReleaseStage
   displayName: Release Preparation
   dependsOn:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:
     - publish_using_darc
   jobs:
   - job: PrepareReleaseJob
@@ -10,7 +10,7 @@ stages:
     pool: 
       vmImage: windows-latest
     variables:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:
       - group: DotNet-Diagnostics-Storage
       - group: DotNet-DotNetStage-Storage
       - group: Release-Pipeline
@@ -23,7 +23,7 @@ stages:
         packageType: runtime
         version: 3.1.x
         installationPath: '$(Build.Repository.LocalPath)\.dotnet'
-    - ${{ if not(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+    - ${{ if not(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/')))) }}:
       - script: '$(Build.SourcesDirectory)\dotnet.cmd build $(Build.Repository.LocalPath)\eng\release\DiagnosticsReleaseTool\DiagnosticsReleaseTool.csproj -c Release /bl'
         workingDirectory: '$(System.ArtifactsDirectory)\'
         displayName: 'Build Manifest generation and asset publishing tool'
@@ -32,7 +32,7 @@ stages:
           targetPath: '$(System.ArtifactsDirectory)\'
           publishLocation: 'pipeline'
           artifact: 'DiagnosticsReleaseToolBin'
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:
       - task: PowerShell@2
         displayName: 'DARC Gather build'
         inputs:
@@ -66,8 +66,9 @@ stages:
           targetPath: '$(System.ArtifactsDirectory)\ReleaseStaging'
           publishLocation: 'pipeline'
           artifact: 'MonitorRelease'
-      - task: tagBuildOrRelease@0      
-        displayName: 'Tag Build with Monitor Release'
-        inputs:
-          type: 'Build'
-          tags: 'MonitorRelease'
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
+        - task: tagBuildOrRelease@0
+          displayName: 'Tag Build with Monitor Release'
+          inputs:
+            type: 'Build'
+            tags: 'MonitorRelease'


### PR DESCRIPTION
* Adds `internal/release/` to publish branches so the yaml pipeline will correctly publish bits during the build.

(cherry picked from commit 53c9fa2a0a75827aeda7542be69ca1dd30478e15)