### PR TITLE
Remove Restricted Characters From Collection Rule Keys (: and #)

### DIFF
--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
             BoundedChannelOptions containersToRemoveChannelOptions = new(PendingRemovalChannelCapacity)
@@ -141,11 +142,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             {
                 if (!rulesChanged)
                 {
-                    using EventTaskSource<EventHandler> rulesChangedTaskSource = new(
-                        callback => (s, e) => callback(),
-                        handler => _provider.RulesChanged += handler,
-                        handler => _provider.RulesChanged -= handler,
-                        token);
+                    using EventTaskSource<EventHandler> rulesChangedTaskSource = CreateRulesChangedETS(token);
 
                     // Wait for the rules to be changed
                     await rulesChangedTaskSource.Task;
@@ -219,6 +216,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                     tasks.Clear();
                 }
             }
+        }
+
+        private EventTaskSource<EventHandler> CreateRulesChangedETS(CancellationToken token)
+        {
+            return new(callback => (s, e) => callback(),
+                handler => _provider.RulesChanged += handler,
+                handler => _provider.RulesChanged -= handler,
+                token);
         }
 
         private async Task StopAndDisposeContainerAsync(CancellationToken token)

--- a/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public const string ConfigPrefix = "DotnetMonitor_";
         private const string SettingsFileName = "settings.json";
+        private const string InternalSettingsFileName = "internal_settings.json";
         private const string ProductFolderName = "dotnet-monitor";
 
         // Allows tests to override the shared configuration directory so there
@@ -42,11 +43,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         // is better control and access of what is visible during test.
         private const string UserConfigDirectoryOverrideEnvironmentVariable
             = "DotnetMonitorTestSettings__UserConfigDirectoryOverride";
-
-        // Allows tests to override the user configuration directory so there
-        // is better control and access of what is visible during test.
-        private const string UserConfigSettingsDirectoryOverrideEnvironmentVariable
-            = "DotnetMonitorTestSettings__UserConfigSettingsDirectoryOverride";
 
         // Location where shared dotnet-monitor configuration is stored.
         // Windows: "%ProgramData%\dotnet-monitor
@@ -70,15 +66,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "." + ProductFolderName) :
                     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ProductFolderName));
 
-        internal static readonly string UserSettingsPath =
-            GetEnvironmentOverrideOrValue(
-                UserConfigSettingsDirectoryOverrideEnvironmentVariable,
-                Path.Combine(UserConfigDirectoryPath, SettingsFileName));
+        private static readonly string UserSettingsPath = Path.Combine(UserConfigDirectoryPath, SettingsFileName);
 
-        internal static readonly string InternalUserSettingsPath =
-            GetEnvironmentOverrideOrValue(
-                UserConfigSettingsDirectoryOverrideEnvironmentVariable,
-                Path.Combine(UserConfigDirectoryPath, Guid.NewGuid().ToString()));
+        internal static readonly string InternalUserSettingsPath = Path.Combine(UserConfigDirectoryPath, InternalSettingsFileName);
 
         public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress)
         {


### PR DESCRIPTION
Currently, the `:` and `#` symbols are accepted in collection rule keys; however, a colon is interpreted in configuration as a divider, resulting in invalid configuration and collection rules that don't work. This change automatically converts all colons and pound signs to the `_` character behind the scenes using a secondary configuration file. Note: I'm currently using a file named `internal_settings.json`, but I wasn't sure if this was the preferred approach (for example, we could also generate a temporary file with a GUID as a name, but that would require us to do clean-up every time `dotnet monitor` closes to avoid dead files from sitting around).

To avoid breaking people's existing rules, this will not be done if this would cause a naming collision (i.e. a rule named test:1 and test_1 exist, and the conversion would result in two rules with the same name). It also will only change an illegal rule if there is only one instance of the name in the file, which means there are still technically edge cases where a colon will result in the current failing state.

Below are examples of the existing behavior when using colons:
![ColonSeparationBug_ConfigShow](https://user-images.githubusercontent.com/85592574/144520933-a52cf260-dedc-4f4b-88ea-6f7ba95c975c.png)
![ColonSeparationBug_CollectionRulesStart](https://user-images.githubusercontent.com/85592574/144520953-22a9c5a9-8ae3-4eeb-bfbd-ec3f84ee9ede.png)

Tests will be coming for `config show` in a later PR; I'm planning to add test cases to check that these characters are being correctly handled.