### PR TITLE
Fix ordering of configuration sources

### DIFF
--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             GetEnvironmentOverrideOrValue(
                 SharedConfigDirectoryOverrideEnvironmentVariable,
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ProductFolderName):
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ProductFolderName) :
                     Path.Combine("/etc", ProductFolderName));
 
         private static readonly string SharedSettingsPath = Path.Combine(SharedConfigDirectoryPath, SettingsFileName);

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public const string ConfigPrefix = "DotnetMonitor_";
         private const string SettingsFileName = "settings.json";
+        private const string AppSettingsFileName = "appsettings.json";
         private const string ProductFolderName = "dotnet-monitor";
 
         // Allows tests to override the shared configuration directory so there
@@ -42,17 +43,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private const string UserConfigDirectoryOverrideEnvironmentVariable
             = "DotnetMonitorTestSettings__UserConfigDirectoryOverride";
 
-        // Location where shared dotnet-monitor configuration is stored.
-        // Windows: "%ProgramData%\dotnet-monitor
-        // Other: /etc/dotnet-monitor
         private static readonly string SharedConfigDirectoryPath =
             GetEnvironmentOverrideOrValue(
                 SharedConfigDirectoryOverrideEnvironmentVariable,
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ProductFolderName) :
+                    Directory.GetCurrentDirectory() :
                     Path.Combine("/etc", ProductFolderName));
 
-        private static readonly string SharedSettingsPath = Path.Combine(SharedConfigDirectoryPath, SettingsFileName);
+        private static readonly string SharedSettingsPath = Path.Combine(SharedConfigDirectoryPath, AppSettingsFileName);
 
         // Location where user's dotnet-monitor configuration is stored.
         // Windows: "%USERPROFILE%\.dotnet-monitor"

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private const string UserConfigDirectoryOverrideEnvironmentVariable
             = "DotnetMonitorTestSettings__UserConfigDirectoryOverride";
 
+        // Location where shared dotnet-monitor configuration is stored.
+        // Windows: Current Directory
+        // Other: /etc/dotnet-monitor
         private static readonly string SharedConfigDirectoryPath =
             GetEnvironmentOverrideOrValue(
                 SharedConfigDirectoryOverrideEnvironmentVariable,
@@ -143,6 +146,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             hostBuilder.UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
+                    Console.WriteLine("Curr Directory" + Directory.GetCurrentDirectory());
+
                     //Note these are in precedence order.
                     ConfigureEndpointInfoSource(builder, diagnosticPort);
                     ConfigureMetricsEndpoint(builder, metrics, metricUrls);

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -146,8 +146,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             hostBuilder.UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
-                    Console.WriteLine("Curr Directory" + Directory.GetCurrentDirectory());
-
                     //Note these are in precedence order.
                     ConfigureEndpointInfoSource(builder, diagnosticPort);
                     ConfigureMetricsEndpoint(builder, metrics, metricUrls);


### PR DESCRIPTION
It was noticed that DiagnosticPort's config wasn't being respected in `appsettings.json`; this is because the default value set in `ConfigureEndpointInfoSource` was being loaded after `appsettings.json`. This change fixes the ordering so that `appsettings.json` is automatically added as a source _after_ the defaults are set in the call to `ConfigureHostConfiguration`.

Closes #1102 