### PR TITLE
Ensure dumps folder exist before issuing dump command.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -38,7 +38,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 throw new ArgumentNullException(nameof(endpointInfo));
             }
 
-            string dumpFilePath = Path.Combine(_storageOptions.CurrentValue.DumpTempFolder, FormattableString.Invariant($"{Guid.NewGuid()}_{endpointInfo.ProcessId}"));
+            string dumpTempFolder = _storageOptions.CurrentValue.DumpTempFolder;
+
+            // Ensure folder exists before issue command.
+            if (!Directory.Exists(dumpTempFolder))
+            {
+                Directory.CreateDirectory(dumpTempFolder);
+            }
+
+            string dumpFilePath = Path.Combine(dumpTempFolder, FormattableString.Invariant($"{Guid.NewGuid()}_{endpointInfo.ProcessId}"));
             DumpType dumpType = MapDumpType(mode);
 
             IDisposable operationRegistration = null;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
@@ -10,6 +11,7 @@ using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Extensions.DependencyInjection;
+using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -72,6 +74,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     {
                         runner.Environment.Add(DumpTestUtilities.EnableElfDumpOnMacOS, "1");
                     }
+                },
+                configureTool: runner =>
+                {
+                    string dumpTempFolder = Path.Combine(runner.TempPath, "Dumps");
+
+                    // The dump temp folder should not exist in order to test that capturing dumps into the folder
+                    // will work since dotnet-monitor should ensure the folder is created before issuing the dump command.
+                    Assert.False(Directory.Exists(dumpTempFolder), "The dump temp folder should not exist.");
+
+                    runner.ConfigurationFromEnvironment.SetDumpTempFolder(dumpTempFolder);
                 });
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -43,6 +43,18 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             return options;
         }
 
+        public static RootOptions SetDumpTempFolder(this RootOptions options, string directoryPath)
+        {
+            if (null == options.Storage)
+            {
+                options.Storage = new StorageOptions();
+            }
+
+            options.Storage.DumpTempFolder = directoryPath;
+
+            return options;
+        }
+
         /// <summary>
         /// Sets API Key authentication. Use this overload for most operations, unless specifically testing Authentication or Authorization.
         /// </summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         private readonly LoggingRunnerAdapter _adapter;
 
-        private readonly string _runnerTmpPath =
-            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
-
         private bool _isDisposed;
 
         /// <summary>
@@ -61,13 +58,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 #endif
 
         private string SharedConfigDirectoryPath =>
-            Path.Combine(_runnerTmpPath, "SharedConfig");
+            Path.Combine(TempPath, "SharedConfig");
 
         private string UserConfigDirectoryPath =>
-            Path.Combine(_runnerTmpPath, "UserConfig");
+            Path.Combine(TempPath, "UserConfig");
 
         private string UserSettingsFilePath =>
             Path.Combine(UserConfigDirectoryPath, "settings.json");
+
+        public string TempPath { get; } =
+            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
 
         public MonitorRunner(ITestOutputHelper outputHelper)
         {
@@ -103,11 +103,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             try
             {
-                Directory.Delete(_runnerTmpPath, recursive: true);
+                Directory.Delete(TempPath, recursive: true);
             }
             catch (Exception ex)
             {
-                _outputHelper.WriteLine("Unable to delete '{0}': {1}", _runnerTmpPath, ex);
+                _outputHelper.WriteLine("Unable to delete '{0}': {1}", TempPath, ex);
             }
         }
 


### PR DESCRIPTION
If some folder segment in the dumps directory path doesn't exist, the `/dump` endpoint will fail, returning an HTTP 400 with an error message of `WriteDumpAsync failed - HRESULT: 0x00000000`. The logs in `dotnet monitor` show this error too but there's no indication what the issue is.

This is fixed by ensuring that the directory exists before issuing the dump command.

closes #1216 