### PR TITLE
Enable publishing of nupkg to blob storage.

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -96,10 +96,9 @@
       </_VersionContainerBlobItem>
       <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism
            so that they can be retrieved from a stable location. -->
-      <!-- Enable once https://github.com/dotnet/arcade/issues/6517 is fixed. -->
-      <!-- <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
+      <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
         <ManifestArtifactData Condition="'@(_PackageArtifactData)' != ''">@(_PackageArtifactData)</ManifestArtifactData>
-      </_VersionContainerBlobItem> -->
+      </_VersionContainerBlobItem>
     </ItemGroup>
 
     <!-- Add artifact items to be pushed to blob feed -->


### PR DESCRIPTION
With https://github.com/dotnet/arcade/issues/6517 fixed, nupkg files can now be published to blob storage once again. This will allow providing dotnet-monitor to the dotnet-docker repo via blob storage rather than shipping through a separate NuGet feed.

See https://dev.azure.com/dnceng/internal/_build/results?buildId=1521464&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=6e277ba4-1c1e-552d-b96f-db0aeb4be20a as an example of the nupkg being promoted to blob storage in addition to the normal target NuGet feed.