### PR TITLE
Update dependency flowed runtimes to 7.0.0 versions.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,17 +5,10 @@
   </solution>
   <packageSources>
     <clear />
-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-pub-dotnet-aspnetcore-2d82d2c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-2d82d2cc/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-aspnetcore -->
-    <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-cfb9e77" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-cfb9e770/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-runtime -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- Feeds used in Maestro/Arcade publishing -->
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <!-- Standard feeds -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,27 +12,11 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>9087fd931ded784281af0806d734d7c95d237d06</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.KeyPerFile" Version="6.0.2">
-      <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2d82d2cc6338b6e720da3d7cd77df680c0bdbf5f</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="6.0.0">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="System.Text.Json" Version="6.0.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>cfb9e77032ad77f703ff8cc69bdc778daa184363</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.2">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="7.0.0-alpha.1.21620.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2d82d2cc6338b6e720da3d7cd77df680c0bdbf5f</Sha>
+      <Sha>a3adc142f403cfa3f69d11b9f75c3daa4425d1b4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21620.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -42,29 +26,21 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2af5dda2d48417982a6b90bf28e8b9a9b57f5ad4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="6.0.0">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.FileFormats" Version="1.0.260601">
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>3cb08015ea49f070b1e8b036d0a74ce57ba0863f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.2">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-alpha.1.21620.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>cfb9e77032ad77f703ff8cc69bdc778daa184363</Sha>
+      <Sha>834b278911962102919b3a7dec22ca6cb26bfa8a</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.2-servicing.21616.6">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0" Version="7.0.0-alpha.1.21620.3">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2d82d2cc6338b6e720da3d7cd77df680c0bdbf5f</Sha>
+      <Sha>a3adc142f403cfa3f69d11b9f75c3daa4425d1b4</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.2-servicing.21608.7">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-alpha.1.21620.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>cfb9e77032ad77f703ff8cc69bdc778daa184363</Sha>
+      <Sha>834b278911962102919b3a7dec22ca6cb26bfa8a</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,20 +32,14 @@
     <!-- dotnet/arcade references -->
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.21620.2</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
-    <MicrosoftAspNetCoreAppRuntimewinx64Version>6.0.2</MicrosoftAspNetCoreAppRuntimewinx64Version>
-    <VSRedistCommonAspNetCoreSharedFrameworkx6460Version>6.0.2-servicing.21616.6</VSRedistCommonAspNetCoreSharedFrameworkx6460Version>
+    <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-alpha.1.21620.3</MicrosoftAspNetCoreAppRuntimewinx64Version>
+    <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-alpha.1.21620.3</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.21613.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.21613.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.2</MicrosoftExtensionsConfigurationKeyPerFileVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>6.0.2</MicrosoftNETCoreAppRuntimewinx64Version>
-    <SystemTextJsonVersion>6.0.1</SystemTextJsonVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.2-servicing.21608.7</VSRedistCommonNetCoreSharedFrameworkx6460Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-alpha.1.21620.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-alpha.1.21620.1</VSRedistCommonNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.260601</MicrosoftFileFormatsVersion>
   </PropertyGroup>
@@ -54,8 +48,10 @@
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.13</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
-    <MicrosoftNETCoreApp60Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp60Version>
-    <MicrosoftAspNetCoreApp60Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp60Version>
+    <MicrosoftNETCoreApp60Version>6.0.1</MicrosoftNETCoreApp60Version>
+    <MicrosoftAspNetCoreApp60Version>6.0.1</MicrosoftAspNetCoreApp60Version>
+    <MicrosoftNETCoreApp70Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp70Version>
+    <MicrosoftAspNetCoreApp70Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp70Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>
@@ -65,6 +61,11 @@
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.0</MicrosoftExtensionsConfigurationKeyPerFileVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftIdentityModelTokensVersion>6.11.1</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
@@ -74,6 +75,7 @@
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>5.0.0</SystemThreadingChannelsVersion>
     <!-- Third-party references -->
     <NJsonSchemaVersion>10.3.11</NJsonSchemaVersion>

--- a/global.json
+++ b/global.json
@@ -5,12 +5,14 @@
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",
         "$(MicrosoftAspNetCoreApp50Version)",
-        "$(VSRedistCommonAspNetCoreSharedFrameworkx6460Version)"
+        "$(MicrosoftAspNetCoreApp60Version)",
+        "$(VSRedistCommonAspNetCoreSharedFrameworkx6470Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp31Version)",
         "$(MicrosoftNETCoreApp50Version)",
-        "$(VSRedistCommonNetCoreSharedFrameworkx6460Version)"
+        "$(MicrosoftNETCoreApp60Version)",
+        "$(VSRedistCommonNetCoreSharedFrameworkx6470Version)"
       ]
     }
   },


### PR DESCRIPTION
This change installs the .NET 7 versions of runtime and aspnet frameworks. All other packages have been kept back at currently shipping versions. This change does not impact the functionality of the tool nor change the target framework support matrix at this time.