### PR TITLE
[release/6.0] Enable publishing of nupkg to blob storage.

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -96,10 +96,9 @@
       </_VersionContainerBlobItem>
       <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism
            so that they can be retrieved from a stable location. -->
-      <!-- Enable once https://github.com/dotnet/arcade/issues/6517 is fixed. -->
-      <!-- <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
+      <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
         <ManifestArtifactData Condition="'@(_PackageArtifactData)' != ''">@(_PackageArtifactData)</ManifestArtifactData>
-      </_VersionContainerBlobItem> -->
+      </_VersionContainerBlobItem>
     </ItemGroup>
 
     <!-- Add artifact items to be pushed to blob feed -->


### PR DESCRIPTION
(cherry picked from commit 5cb0a7b0fef906263d315cb32ccc8498e09680d9)