### PR TITLE
Update Alpine image to latest

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -60,7 +60,7 @@ jobs:
       container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2
 
     ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-WithNode-20210714125437-9b5bbc2
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20211214164112-c401c85
 
     ${{ if ne(parameters.dependsOn, '') }}:
       dependsOn: ${{ parameters.dependsOn }}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DistroInformation.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DistroInformation.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    public static class DistroInformation
+    {
+        private const string LinuxReleaseFilePath = "/etc/os-release";
+        private const string AlpineLinuxIdLine = "ID=alpine";
+
+        public static bool IsAlpineLinux
+        {
+            get
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    return false;
+
+                if (!File.Exists(LinuxReleaseFilePath))
+                    return false;
+
+                string releaseInfo = null;
+                try
+                {
+                    releaseInfo = File.ReadAllText(LinuxReleaseFilePath);
+                }
+                catch
+                {
+                }
+
+                return !string.IsNullOrWhiteSpace(releaseInfo) &&
+                    releaseInfo.Contains(AlpineLinuxIdLine);
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -45,6 +45,17 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 #endif
         public Task DumpTest(DiagnosticPortConnectionMode mode, DumpType type)
         {
+#if !NET6_0_OR_GREATER
+            // Capturing non-full dumps via diagnostic command works inconsistently
+            // on Alpine for .NET 5 and lower (the dump command will return successfully, but)
+            // the dump file will not exist). Only test other dump types on .NET 6+
+            if (DistroInformation.IsAlpineLinux && type != DumpType.Full)
+            {
+                _outputHelper.WriteLine("Skipped on Alpine for .NET 5 and lower.");
+                return Task.CompletedTask;
+            }
+#endif
+
             return ScenarioRunner.SingleTarget(
                 _outputHelper,
                 _httpClientFactory,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionTestsHelper.cs
@@ -47,9 +47,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             foreach (TargetFrameworkMoniker tfm in tfmsToTest)
             {
                 yield return new object[] { tfm, DumpType.Full };
-                yield return new object[] { tfm, DumpType.WithHeap };
-                yield return new object[] { tfm, DumpType.Triage };
-                yield return new object[] { tfm, DumpType.Mini };
+                // Capturing non-full dumps via diagnostic command works inconsistently
+                // on Alpine for .NET 5 and lower (the dump command will return successfully, but)
+                // the dump file will not exist). Only test other dump types on .NET 6+
+                if (!DistroInformation.IsAlpineLinux || tfm == TargetFrameworkMoniker.Net60)
+                {
+                    yield return new object[] { tfm, DumpType.WithHeap };
+                    yield return new object[] { tfm, DumpType.Triage };
+                    yield return new object[] { tfm, DumpType.Mini };
+                }
             }
         }
 

--- a/src/Tools/dotnet-monitor/RuntimeInfo.cs
+++ b/src/Tools/dotnet-monitor/RuntimeInfo.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {


### PR DESCRIPTION
The Alpine image currently used is very old and no longer supported. It also doesn't seem to work with .NET 7 runtimes. Update the image to 3.14 since that the earliest Alpine image in support as provided by dotnet-docker (which also happens to be the latest version until 3.15 images are shipped in the near future).

Note: May need to adjust dump tests on Alpine to only capture full dumps (see https://github.com/dotnet/dotnet-monitor/issues/674#issuecomment-920189864)