### PR TITLE
Add Get+Set Environment Variable Actions

### DIFF
--- a/documentation/collectionrules.md
+++ b/documentation/collectionrules.md
@@ -57,6 +57,9 @@ The following are the currently available actions:
 | [CollectLogs](./configuration.md#collectlogs-action) | Collects logs from the target process. |
 | [CollectTrace](./configuration.md#collecttrace-action) | Collects an event trace of the target process. |
 | [Execute](./configuration.md#execute-action) | Executes an external executable with command line parameters. |
+| [LoadProfiler](./configuration.md#loadprofiler-action) | Loads an ICorProfilerCallback implementation into the target process. |
+| [SetEnvironmentVariable](./configuration.md#setenvironmentvaraible-action) | Sets an environment variable value in the target process. |
+| [GetEnvironmentVariable](./configuration.md#Getenvironmentvaraible-action) | Gets an environment variable value from the target process. |
 
 ## Limits
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -802,11 +802,11 @@ No outputs
 
 ##### Example
 
-Usage that sets a parameter to the profiler you loaded. In this case, your profiler might be looking for an account key defined in `MyProfiler_ApiKey` which is used to communicate to some outside system.
+Usage that sets a parameter to the profiler you loaded. In this case, your profiler might be looking for an account key defined in `MyProfiler_AccountId` which is used to communicate to some outside system.
 
 ```json
 {
-  "Name": "MyProfiler_ApiKey",
+  "Name": "MyProfiler_AccountId",
   "Value": "8fb138d2c44e4aea8545cc2df541ed4c"
 }
 ```

--- a/documentation/releaseNotes/releaseNotes.md
+++ b/documentation/releaseNotes/releaseNotes.md
@@ -1,6 +1,6 @@
 Today we are releasing the next preview of the `dotnet monitor` tool. This release includes:
 
-- ⚠️ [Here is a breaking change we did and it's work item] (#737)
-- [Here is a new feature we added and it's work item] (#737)
+- Load a profiler via a collection rule action (#781)
+- Get or Set an environment via a collection rule action (#1176)
 
 \*⚠️ **_indicates a breaking change_**

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -713,6 +713,32 @@
               "$ref": "#/definitions/LoadProfilerOptions"
             }
           }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "SetEnvironmentVariable"
+            },
+            "Settings": {
+              "$ref": "#/definitions/SetEnvironmentVariableOptions"
+            }
+          }
+        },
+        {
+          "required": [
+            "Settings"
+          ],
+          "properties": {
+            "Type": {
+              "const": "GetEnvironmentVariable"
+            },
+            "Settings": {
+              "$ref": "#/definitions/GetEnvironmentVariableOptions"
+            }
+          }
         }
       ]
     },
@@ -1064,7 +1090,9 @@
         "CollectLogs",
         "CollectTrace",
         "Execute",
-        "LoadProfiler"
+        "LoadProfiler",
+        "SetEnvironmentVariable",
+        "GetEnvironmentVariable"
       ]
     },
     "CollectDumpOptions": {
@@ -1385,6 +1413,41 @@
           "type": "string",
           "description": "The class identifier (or CLSID, typically a GUID) of the ICorProfilerCallback implementation. This is typically the same value that would be set as the CORECLR_PROFILER environment variable.",
           "format": "guid",
+          "minLength": 1
+        }
+      }
+    },
+    "SetEnvironmentVariableOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Name"
+      ],
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "The name of the environment variable to set.",
+          "minLength": 1
+        },
+        "Value": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The value of the environment variable to set."
+        }
+      }
+    },
+    "GetEnvironmentVariableOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Name"
+      ],
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "The name of the environment variable to get.",
           "minLength": 1
         }
       }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -757,6 +757,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The name of the environment variable to get..
+        /// </summary>
+        public static string DisplayAttributeDescription_GetEnvironmentVariableOptions_Name {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_GetEnvironmentVariableOptions_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines the metrics interval for all dotnet-monitor scenarios. This includes prometheus metrics, live metrics, triggers, and traces..
         /// </summary>
         public static string DisplayAttributeDescription_GlobalCounterOptions_IntervalSeconds {
@@ -1014,6 +1023,24 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         public static string DisplayAttributeDescription_ProcessFilterType_Exact {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_ProcessFilterType_Exact", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the environment variable to set..
+        /// </summary>
+        public static string DisplayAttributeDescription_SetEnvironmentVariableOptions_Name {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_SetEnvironmentVariableOptions_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value of the environment variable to set..
+        /// </summary>
+        public static string DisplayAttributeDescription_SetEnvironmentVariableOptions_Value {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_SetEnvironmentVariableOptions_Value", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -559,4 +559,16 @@
     <value>The class identifier (or CLSID, typically a GUID) of the ICorProfilerCallback implementation. This is typically the same value that would be set as the CORECLR_PROFILER environment variable.</value>
     <comment>The description provided for the ProfilerGuid parameter on LoadProfilerOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_SetEnvironmentVariableOptions_Name" xml:space="preserve">
+    <value>The name of the environment variable to set.</value>
+    <comment>The description provided for the Name parameter on SetEnvironmentVariableOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_SetEnvironmentVariableOptions_Value" xml:space="preserve">
+    <value>The value of the environment variable to set.</value>
+    <comment>The description provided for the Value parameter on SetEnvironmentVariableOptions.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_GetEnvironmentVariableOptions_Name" xml:space="preserve">
+    <value>The name of the environment variable to get.</value>
+    <comment>The description provided for the Name parameter on GetEnvironmentVariableOptions.</comment>
+  </data>
 </root>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -23,7 +23,9 @@
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectTraceOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptions.cs" Link="Options\CollectionRules\Actions\ExecuteOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptionsDefaults.cs" Link="Options\CollectionRules\Actions\ExecuteOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\GetEnvironmentVariableOptions.cs" Link="Options\CollectionRules\Actions\GetEnvironmentVariableOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\LoadProfilerOptions.cs" Link="Options\CollectionRules\Actions\LoadProfilerOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\SetEnvironmentVariableOptions.cs" Link="Options\CollectionRules\Actions\SetEnvironmentVariableOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptions.cs" Link="Options\CollectionRules\CollectionRuleActionOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptionsDefaults.cs" Link="Options\CollectionRules\CollectionRuleActionOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptions.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptions.cs" />

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -120,6 +120,8 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
             AddCollectionRuleActionSchema<CollectTraceOptions>(context, actionTypeSchema, KnownCollectionRuleActions.CollectTrace);
             AddCollectionRuleActionSchema<ExecuteOptions>(context, actionTypeSchema, KnownCollectionRuleActions.Execute);
             AddCollectionRuleActionSchema<LoadProfilerOptions>(context, actionTypeSchema, KnownCollectionRuleActions.LoadProfiler);
+            AddCollectionRuleActionSchema<SetEnvironmentVariableOptions>(context, actionTypeSchema, KnownCollectionRuleActions.SetEnvironmentVariable);
+            AddCollectionRuleActionSchema<GetEnvironmentVariableOptions>(context, actionTypeSchema, KnownCollectionRuleActions.GetEnvironmentVariable);
 
             JsonSchema triggerTypeSchema = new JsonSchema();
             triggerTypeSchema.Type = JsonObjectType.String;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
@@ -52,5 +52,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         /// Default logs collection duration.
         /// </summary>
         public static readonly TimeSpan LogsDuration = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Default timeout for environment variable manipulation.
+        /// </summary>
+        public static readonly TimeSpan EnvVarsTimeout = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunnerExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -122,6 +123,15 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         {
             using CancellationTokenSource cancellation = new(timeout);
             await runner.StartAsync(cancellation.Token).ConfigureAwait(false);
+        }
+
+        public static async Task<string> GetEnvironmentVariable(this AppRunner runner, string name, TimeSpan timeout)
+        {
+            using CancellationTokenSource cancellation = new(timeout);
+            ConfiguredTaskAwaitable<string> getVarTask = runner.WaitForEnvironmentVariable(name, cancellation.Token).ConfigureAwait(false);
+            await runner.SendCommandAsync(TestAppScenarios.Commands.PrintEnvironmentVariables).ConfigureAwait(false);
+            string result = await getVarTask;
+            return result;
         }
 
         public static Task<int> WaitForExitAsync(this AppRunner runner)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppLogEventIds.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppLogEventIds.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    public enum TestAppLogEventIds
+    {
+        ScenarioState = 1,
+        ReceivedCommand = 2,
+        EnvironmentVariable = 3,
+    }
+    public static class TestAppLogEventIdExtensions
+    {
+        public static EventId EventId(this TestAppLogEventIds enumVal)
+        {
+            string name = Enum.GetName(typeof(TestAppLogEventIds), enumVal);
+            int id = enumVal.Id();
+            return new EventId(id, name);
+        }
+        public static int Id(this TestAppLogEventIds enumVal)
+        {
+            int id = (int)enumVal;
+            return id;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         {
             public const string EndScenario = nameof(EndScenario);
             public const string StartScenario = nameof(StartScenario);
+            public const string PrintEnvironmentVariables = nameof(PrintEnvironmentVariables);
         }
 
         public enum SenarioState
@@ -27,6 +28,18 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             public static class Commands
             {
                 public const string Continue = nameof(Continue);
+            }
+        }
+
+        public static class EnvironmentVariables
+        {
+            public const string Name = nameof(EnvironmentVariables);
+            public const string IncrementVariableName = nameof(IncrementVariableName);
+
+            public static class Commands
+            {
+                public const string IncVar = nameof(IncVar);
+                public const string ShutdownScenario = nameof(ShutdownScenario);
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -25,7 +25,9 @@
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\CollectTraceOptionsDefaults.cs" Link="Options\CollectionRules\Actions\CollectTraceOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptions.cs" Link="Options\CollectionRules\Actions\ExecuteOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\ExecuteOptionsDefaults.cs" Link="Options\CollectionRules\Actions\ExecuteOptionsDefaults.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\GetEnvironmentVariableOptions.cs" Link="Options\CollectionRules\Actions\GetEnvironmentVariableOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\LoadProfilerOptions.cs" Link="Options\CollectionRules\Actions\LoadProfilerOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\Actions\SetEnvironmentVariableOptions.cs" Link="Options\CollectionRules\Actions\SetEnvironmentVariableOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptions.cs" Link="Options\CollectionRules\CollectionRuleActionOptions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleActionOptionsDefaults.cs" Link="Options\CollectionRules\CollectionRuleActionOptionsDefaults.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\CollectionRules\Options\CollectionRuleLimitsOptions.cs" Link="Options\CollectionRules\CollectionRuleLimitsOptions.cs" />

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionTestsHelper.cs
@@ -22,10 +22,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
     internal static class ActionTestsHelper
     {
         public static TargetFrameworkMoniker[] tfmsToTest = new TargetFrameworkMoniker[] { TargetFrameworkMoniker.Net50, TargetFrameworkMoniker.Net60 };
+        public static TargetFrameworkMoniker[] tfms6PlusToTest = new TargetFrameworkMoniker[] { TargetFrameworkMoniker.Net60 };
 
         public static IEnumerable<object[]> GetTfms()
         {
             foreach (TargetFrameworkMoniker tfm in tfmsToTest)
+            {
+                yield return new object[] { tfm };
+            }
+        }
+
+        public static IEnumerable<object[]> Get6PlusTfms()
+        {
+            foreach (TargetFrameworkMoniker tfm in tfms6PlusToTest)
             {
                 yield return new object[] { tfm };
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -774,7 +774,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                         .AddLoadProfilerAction(
                         configureOptions: opts =>
                         {
-                            opts.Path = String.Empty;
+                            opts.Path = string.Empty;
                             opts.Clsid = ExpectedClsid;
                         });
                 },
@@ -826,6 +826,156 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     string[] failures = ex.Failures.ToArray();
                     Assert.Single(failures);
                     VerifyRequiredGuidMessage(failures, 0, nameof(LoadProfilerOptions.Clsid));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_SetEnvironmentVariable_MinimumOptions()
+        {
+            const string VariableName = "MyProfiler_OptionA";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddSetEnvironmentVariableAction(VariableName);
+                },
+                ruleOptions =>
+                {
+                    Assert.Single(ruleOptions.Actions);
+                    ruleOptions.VerifySetEnvironmentVariableAction(0, VariableName, null);
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_SetEnvironmentVariable_RoundTrip()
+        {
+            const string VariableName = "MyProfiler_OptionA";
+            const string VariableValue = "MyValue!@#$%^&*()_+-{}{]|";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddSetEnvironmentVariableAction(VariableName, VariableValue);
+                },
+                ruleOptions =>
+                {
+                    Assert.Single(ruleOptions.Actions);
+                    ruleOptions.VerifySetEnvironmentVariableAction(0, VariableName, VariableValue);
+                });
+        }
+
+        [Fact]
+        public async Task CollectionRuleOptions_SetEnvironmentVariable_NamePropertyValidation()
+        {
+            await ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddSetEnvironmentVariableAction(null);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(SetEnvironmentVariableOptions.Name));
+                });
+
+            await ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddSetEnvironmentVariableAction(string.Empty);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(SetEnvironmentVariableOptions.Name));
+                });
+
+            await ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddSetEnvironmentVariableAction("    ");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(SetEnvironmentVariableOptions.Name));
+                });
+        }
+
+        [Fact]
+        public Task CollectionRuleOptions_GetEnvironmentVariable_RoundTrip()
+        {
+            const string VariableName = "MyGettingVar";
+
+            return ValidateSuccess(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddGetEnvironmentVariableAction(VariableName);
+                },
+                ruleOptions =>
+                {
+                    Assert.Single(ruleOptions.Actions);
+                    ruleOptions.VerifyGetEnvironmentVariableAction(0, VariableName);
+                });
+        }
+
+        [Fact]
+        public async Task CollectionRuleOptions_GetEnvironmentVariable_NamePropertyValidation()
+        {
+            await ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddGetEnvironmentVariableAction(null);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(GetEnvironmentVariableOptions.Name));
+                });
+
+            await ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddGetEnvironmentVariableAction(string.Empty);
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(GetEnvironmentVariableOptions.Name));
+                });
+
+            await ValidateFailure(
+                rootOptions =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddGetEnvironmentVariableAction("    ");
+                },
+                ex =>
+                {
+                    string[] failures = ex.Failures.ToArray();
+                    Assert.Single(failures);
+                    VerifyRequiredMessage(failures, 0, nameof(GetEnvironmentVariableOptions.Name));
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EnvironmentVariableActionTests.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    public class EnvironmentVariableActionTests
+    {
+        private readonly ITestOutputHelper _outputHelper;
+        private readonly EndpointUtilities _endpointUtilities;
+
+        private const string DefaultRuleName = "StartupRule";
+        private const string DefaultVarName = "MyCustomVariable";
+        private const string DefaultVarValue = "TheValueStoredIn the environment";
+
+        public EnvironmentVariableActionTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+            _endpointUtilities = new(_outputHelper);
+        }
+
+        /// <summary>
+        /// Test that the <see cref="SetEnvironmentVariableActionFactory.SetEnvironmentVariableAction"/> works correctly.
+        /// </summary>
+        /// <remarks>
+        /// The required APIs only exist on .NET 6.0+
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(ActionTestsHelper.Get6PlusTfms), MemberType = typeof(ActionTestsHelper))]
+        public async Task TestSetEnvVar(TargetFrameworkMoniker tfm)
+        {
+            await TestHostHelper.CreateCollectionRulesHost(
+                outputHelper: _outputHelper,
+                setup: (Tools.Monitor.RootOptions rootOptions) =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddSetEnvironmentVariableAction(DefaultVarName, DefaultVarValue);
+                },
+                hostCallback: async (Extensions.Hosting.IHost host) =>
+                {
+                    SetEnvironmentVariableOptions setOpts = ActionTestsHelper.GetActionOptions<SetEnvironmentVariableOptions>(host, DefaultRuleName, 0);
+
+                    ICollectionRuleActionOperations actionOperationsService = host.Services.GetService<ICollectionRuleActionOperations>();
+                    Assert.True(actionOperationsService.TryCreateFactory(KnownCollectionRuleActions.SetEnvironmentVariable, out ICollectionRuleActionFactoryProxy setFactory));
+
+                    EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
+                    await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
+
+                    AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                    runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
+
+                    Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+
+                    await runner.ExecuteAsync(async () =>
+                    {
+                        IEndpointInfo endpointInfo = await newEndpointInfoTask;
+
+                        ICollectionRuleAction setAction = setFactory.Create(endpointInfo, setOpts);
+
+                        await ActionTestsHelper.ExecuteAndDisposeAsync(setAction, CommonTestTimeouts.EnvVarsTimeout);
+
+                        Assert.Equal(DefaultVarValue, await runner.GetEnvironmentVariable(DefaultVarName, CommonTestTimeouts.EnvVarsTimeout));
+
+                        await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.ShutdownScenario);
+                    });
+                });
+        }
+
+        /// <summary>
+        /// Test that the <see cref="GetEnvironmentVariableActionFactory.GetEnvironmentVariableAction"/> works correctly.
+        /// </summary>
+        /// <remarks>
+        /// The required APIs only exist on .NET 6.0+
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(ActionTestsHelper.Get6PlusTfms), MemberType = typeof(ActionTestsHelper))]
+        public async Task TestGetEnvVar(TargetFrameworkMoniker tfm)
+        {
+            await TestHostHelper.CreateCollectionRulesHost(
+                outputHelper: _outputHelper,
+                setup: (Tools.Monitor.RootOptions rootOptions) =>
+                {
+                    rootOptions.CreateCollectionRule(DefaultRuleName)
+                        .SetStartupTrigger()
+                        .AddGetEnvironmentVariableAction(TestAppScenarios.EnvironmentVariables.IncrementVariableName);
+                },
+                hostCallback: async (Extensions.Hosting.IHost host) =>
+                {
+                    GetEnvironmentVariableOptions getOpts = ActionTestsHelper.GetActionOptions<GetEnvironmentVariableOptions>(host, DefaultRuleName, 0);
+
+                    ICollectionRuleActionOperations actionOperationsService = host.Services.GetService<ICollectionRuleActionOperations>();
+                    Assert.True(actionOperationsService.TryCreateFactory(KnownCollectionRuleActions.GetEnvironmentVariable, out ICollectionRuleActionFactoryProxy getFactory));
+
+                    EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
+                    await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
+
+                    AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                    runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
+
+                    Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+
+                    await runner.ExecuteAsync(async () =>
+                    {
+                        IEndpointInfo endpointInfo = await newEndpointInfoTask;
+
+                        ICollectionRuleAction getAction = getFactory.Create(endpointInfo, getOpts);
+
+                        await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.IncVar);
+                        Assert.Equal("1", await runner.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName, CommonTestTimeouts.EnvVarsTimeout));
+
+                        await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.IncVar);
+                        Assert.Equal("2", await runner.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName, CommonTestTimeouts.EnvVarsTimeout));
+
+                        CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(getAction, CommonTestTimeouts.EnvVarsTimeout);
+                        Assert.Equal("2", result.OutputValues[CollectionRuleActionConstants.EnvironmentVariableValueName]);
+
+                        await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.IncVar);
+                        Assert.Equal("3", await runner.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName, CommonTestTimeouts.EnvVarsTimeout));
+
+                        await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.ShutdownScenario);
+                    });
+                });
+        }
+
+        /// <summary>
+        /// Test that the <see cref="SetEnvironmentVariableActionFactory.SetEnvironmentVariableAction"/> to 
+        /// <see cref="GetEnvironmentVariableActionFactory.GetEnvironmentVariableAction"/> round trip works correctly.
+        /// </summary>
+        /// <remarks>
+        /// The required APIs only exist on .NET 6.0+
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(ActionTestsHelper.Get6PlusTfms), MemberType = typeof(ActionTestsHelper))]
+        public async Task TestEnvVarRoundTrip(TargetFrameworkMoniker tfm)
+        {
+            await TestHostHelper.CreateCollectionRulesHost(
+                outputHelper: _outputHelper,
+                setup: (Tools.Monitor.RootOptions rootOptions) =>
+                {
+                rootOptions.CreateCollectionRule(DefaultRuleName)
+                    .SetStartupTrigger()
+                    .AddSetEnvironmentVariableAction(DefaultVarName, DefaultVarValue)
+                    .AddGetEnvironmentVariableAction(DefaultVarName);
+                },
+                hostCallback: async (Extensions.Hosting.IHost host) =>
+                {
+                    SetEnvironmentVariableOptions setOpts = ActionTestsHelper.GetActionOptions<SetEnvironmentVariableOptions>(host, DefaultRuleName, 0);
+                    GetEnvironmentVariableOptions getOpts = ActionTestsHelper.GetActionOptions<GetEnvironmentVariableOptions>(host, DefaultRuleName, 1);
+
+                    ICollectionRuleActionOperations actionOperationsService = host.Services.GetService<ICollectionRuleActionOperations>();
+                    Assert.True(actionOperationsService.TryCreateFactory(KnownCollectionRuleActions.SetEnvironmentVariable, out ICollectionRuleActionFactoryProxy setFactory));
+                    Assert.True(actionOperationsService.TryCreateFactory(KnownCollectionRuleActions.GetEnvironmentVariable, out ICollectionRuleActionFactoryProxy getFactory));
+
+                    EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
+                    await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
+
+                    AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                    runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
+
+                    Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+
+                    await runner.ExecuteAsync(async () =>
+                        {
+                            IEndpointInfo endpointInfo = await newEndpointInfoTask;
+
+                            ICollectionRuleAction setAction = setFactory.Create(endpointInfo, setOpts);
+                            ICollectionRuleAction getAction = getFactory.Create(endpointInfo, getOpts);
+
+                            await ActionTestsHelper.ExecuteAndDisposeAsync(setAction, CommonTestTimeouts.EnvVarsTimeout);
+                            CollectionRuleActionResult getResult = await ActionTestsHelper.ExecuteAndDisposeAsync(getAction, CommonTestTimeouts.EnvVarsTimeout);
+
+                            await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.ShutdownScenario);
+
+                            Assert.True(getResult.OutputValues.TryGetValue(CollectionRuleActionConstants.EnvironmentVariableValueName, out string value));
+                            Assert.Equal(DefaultVarValue, value);
+                        });
+                });
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.cs
@@ -168,6 +168,35 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
                 });
         }
 
+        public static CollectionRuleOptions AddSetEnvironmentVariableAction(this CollectionRuleOptions options, string name, string value = null)
+        {
+            return options.AddAction(
+                 KnownCollectionRuleActions.SetEnvironmentVariable,
+                 callback: actionOptions =>
+                 {
+                     SetEnvironmentVariableOptions setEnvOpts = new()
+                     {
+                         Name = name,
+                         Value = value,
+                     };
+                     actionOptions.Settings = setEnvOpts;
+                 });
+        }
+
+        public static CollectionRuleOptions AddGetEnvironmentVariableAction(this CollectionRuleOptions options, string name)
+        {
+            return options.AddAction(
+                 KnownCollectionRuleActions.GetEnvironmentVariable,
+                 callback: actionOptions =>
+                 {
+                     GetEnvironmentVariableOptions getEnvOpts = new()
+                     {
+                         Name = name,
+                     };
+                     actionOptions.Settings = getEnvOpts;
+                 });
+        }
+
         public static CollectionRuleOptions SetActionLimits(this CollectionRuleOptions options, int? count = null, TimeSpan? slidingWindowDuration = null)
         {
             if (null == options.Limits)
@@ -339,6 +368,26 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 
             Assert.Equal(expectedPath, opts.Path);
             Assert.Equal(expectecClsid, opts.Clsid);
+
+            return opts;
+        }
+
+        public static SetEnvironmentVariableOptions VerifySetEnvironmentVariableAction(this CollectionRuleOptions ruleOptions, int actionIndex, string expectedName, string expectedValue)
+        {
+            SetEnvironmentVariableOptions opts = ruleOptions.VerifyAction<SetEnvironmentVariableOptions>(
+                actionIndex, KnownCollectionRuleActions.SetEnvironmentVariable);
+
+            Assert.Equal(expectedName, opts.Name);
+            Assert.Equal(expectedValue, opts.Value);
+
+            return opts;
+        }
+        public static GetEnvironmentVariableOptions VerifyGetEnvironmentVariableAction(this CollectionRuleOptions ruleOptions, int actionIndex, string expectedName)
+        {
+            GetEnvironmentVariableOptions opts = ruleOptions.VerifyAction<GetEnvironmentVariableOptions>(
+                actionIndex, KnownCollectionRuleActions.GetEnvironmentVariable);
+
+            Assert.Equal(expectedName, opts.Name);
 
             return opts;
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/AppCommands.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/AppCommands.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
+{
+    internal static class AppCommands
+    {
+        public static async Task<bool> TryProcessAppCommand(string potentialCommand, ILogger logger)
+        {
+            switch (potentialCommand)
+            {
+                case TestAppScenarios.Commands.PrintEnvironmentVariables:
+                    await PrintEnvironmentVariables(logger);
+                    return true;
+            }
+            return false;
+        }
+
+        private static Task PrintEnvironmentVariables(ILogger logger)
+        {
+            IDictionary vars = Environment.GetEnvironmentVariables();
+            foreach (DictionaryEntry entry in vars)
+            {
+                logger.EnvironmentVariable((string)entry.Key, (string)entry.Value);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/LoggingExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/LoggingExtensions.cs
@@ -12,15 +12,21 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
     {
         private static readonly Action<ILogger, TestAppScenarios.SenarioState, Exception> _scenarioState =
             LoggerMessage.Define<TestAppScenarios.SenarioState>(
-                eventId: new EventId(1, "ScenarioState"),
+                eventId: TestAppLogEventIds.ScenarioState.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: "State: {state}");
 
         private static readonly Action<ILogger, string, bool, Exception> _receivedCommand =
             LoggerMessage.Define<string, bool>(
-                eventId: new EventId(2, "ReceivedCommand"),
+                eventId: TestAppLogEventIds.ReceivedCommand.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: "Received command: {command}; Expected: {expected}");
+
+        private static readonly Action<ILogger, string, string, Exception> _environmentVariable =
+            LoggerMessage.Define<string, string>(
+                eventId: TestAppLogEventIds.EnvironmentVariable.EventId(),
+                logLevel: LogLevel.Information,
+                formatString: "Environment Variable: {name} = {value}");
 
         public static void ScenarioState(this ILogger logger, TestAppScenarios.SenarioState state)
         {
@@ -30,6 +36,11 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
         public static void ReceivedCommand(this ILogger logger, string command, bool expected)
         {
             _receivedCommand(logger, command, expected, null);
+        }
+
+        public static void EnvironmentVariable(this ILogger logger, string name, string value)
+        {
+            _environmentVariable(logger, name, value, null);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
                 .AddCommand(AsyncWaitScenario.Command())
                 .AddCommand(LoggerScenario.Command())
                 .AddCommand(SpinWaitScenario.Command())
+                .AddCommand(EnvironmentVariablesScenario.Command())
                 .UseDefaults()
                 .Build()
                 .InvokeAsync(args);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
                     // We successfully received an app-level command and processed it.
                     // Restart the loop and wait for the command the scenario is expecting.
                     receivedExpected = false;
-                    // Still acknoledge this command and say it was expected
+                    // Still acknowledge this command and say it was expected
                     logger.ReceivedCommand(line, expected: true);
                     continue;
                 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
@@ -6,6 +6,8 @@ using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -58,17 +60,38 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
 
         public static async Task WaitForCommandAsync(string expectedCommand, ILogger logger)
         {
+            await WaitForCommandAsync(new string[] { expectedCommand }, logger);
+        }
+
+        public static async Task<string> WaitForCommandAsync(string[] expectedCommands, ILogger logger)
+        {
             logger.ScenarioState(TestAppScenarios.SenarioState.Waiting);
 
             bool receivedExpected = false;
-            string line;
+            string line, commandReceived = null;
 
             while (!receivedExpected && null != (line = await Console.In.ReadLineAsync()))
             {
-                receivedExpected = string.Equals(expectedCommand, line, StringComparison.Ordinal);
+                if (await AppCommands.TryProcessAppCommand(line, logger))
+                {
+                    // We successfully received an app-level command and processed it.
+                    // Restart the loop and wait for the command the scenario is expecting.
+                    receivedExpected = false;
+                    // Still acknoledge this command and say it was expected
+                    logger.ReceivedCommand(line, expected: true);
+                    continue;
+                }
+
+                receivedExpected = expectedCommands.Contains(line, StringComparer.Ordinal);
+                if (receivedExpected)
+                {
+                    commandReceived = line;
+                }
 
                 logger.ReceivedCommand(line, receivedExpected);
             }
+
+            return commandReceived;
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/EnvironmentVariablesScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/EnvironmentVariablesScenario.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System;
+using System.Collections;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
+{
+    /// <summary>
+    /// Prints out the environment variables.
+    /// </summary>
+    internal class EnvironmentVariablesScenario
+    {
+        public static Command Command()
+        {
+            Command command = new(TestAppScenarios.EnvironmentVariables.Name);
+            command.Handler = CommandHandler.Create((Func<CancellationToken, Task<int>>)ExecuteAsync);
+            return command;
+        }
+
+        public static Task<int> ExecuteAsync(CancellationToken token)
+        {
+            string[] acceptableCommands = new string[]
+            {
+                TestAppScenarios.EnvironmentVariables.Commands.IncVar,
+                TestAppScenarios.EnvironmentVariables.Commands.ShutdownScenario,
+            };
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                while (true)
+                {
+                    string command = await ScenarioHelpers.WaitForCommandAsync(acceptableCommands, logger);
+
+                    switch (command)
+                    {
+                        case TestAppScenarios.EnvironmentVariables.Commands.IncVar:
+                            string currValue = Environment.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName) ?? "0";
+                            if (!int.TryParse(currValue, out int oldValue))
+                            {
+                                oldValue = 0;
+                            }
+                            string newValue = (oldValue + 1).ToString();
+                            Environment.SetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName, newValue);
+                            break;
+                        case TestAppScenarios.EnvironmentVariables.Commands.ShutdownScenario:
+                            return 0;
+                    }
+                }
+            }, token);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionConstants.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
     internal static class CollectionRuleActionConstants
     {
         public const string EgressPathOutputValueName = "EgressPath";
+        public const string EnvironmentVariableValueName = "Value";
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
@@ -65,7 +65,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
                     _logger.GettingEnvironmentVariable(_options.Name, _endpointInfo.ProcessId);
                     Dictionary<string, string> envBlock = await client.GetProcessEnvironmentAsync(token);
-                    envBlock.TryGetValue(Options.Name, out string value);
+                    if (!envBlock.TryGetValue(Options.Name, out string value))
+                    {
+                        InvalidOperationException innerEx =
+                            new InvalidOperationException(
+                                string.Format(
+                                    Strings.ErrorMessage_NoEnvironmentVariable,
+                                    Options.Name));
+                        throw new CollectionRuleActionException(innerEx);
+                    }
 
                     if (!startCompletionSource.TrySetResult(null))
                     {

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
+{
+    internal sealed partial class GetEnvironmentVariableActionFactory :
+        ICollectionRuleActionFactory<GetEnvironmentVariableOptions>
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<GetEnvironmentVariableActionFactory> _logger;
+
+        public GetEnvironmentVariableActionFactory(IServiceProvider serviceProvider, ILogger<GetEnvironmentVariableActionFactory> logger)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, GetEnvironmentVariableOptions options)
+        {
+            if (null == options)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ValidationContext context = new(options, _serviceProvider, items: null);
+            Validator.ValidateObject(options, context, validateAllProperties: true);
+
+            return new GetEnvironmentVariableAction(_logger, endpointInfo, options);
+        }
+
+        internal sealed partial class GetEnvironmentVariableAction :
+            CollectionRuleActionBase<GetEnvironmentVariableOptions>
+        {
+            private readonly IEndpointInfo _endpointInfo;
+            private readonly ILogger _logger;
+            private readonly GetEnvironmentVariableOptions _options;
+
+            public GetEnvironmentVariableAction(ILogger logger, IEndpointInfo endpointInfo, GetEnvironmentVariableOptions options)
+                : base(endpointInfo, options)
+            {
+                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                _endpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
+                _options = options ?? throw new ArgumentNullException(nameof(options));
+            }
+
+            protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
+                TaskCompletionSource<object> startCompletionSource,
+                CancellationToken token)
+            {
+                try
+                {
+                    DiagnosticsClient client = new DiagnosticsClient(_endpointInfo.Endpoint);
+
+                    _logger.GettingEnvironmentVariable(_options.Name, _endpointInfo.ProcessId);
+                    Dictionary<string, string> envBlock = await client.GetProcessEnvironmentAsync(token);
+                    envBlock.TryGetValue(Options.Name, out string value);
+
+                    if (!startCompletionSource.TrySetResult(null))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    return new CollectionRuleActionResult()
+                    {
+                        OutputValues = new Dictionary<string, string>()
+                        {
+                            { CollectionRuleActionConstants.EnvironmentVariableValueName, value ?? string.Empty }
+                        }
+                    };
+                }
+                catch (Exception ex)
+                {
+                    throw new CollectionRuleActionException(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.Logging;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
+{
+    internal sealed partial class SetEnvironmentVariableActionFactory :
+        ICollectionRuleActionFactory<SetEnvironmentVariableOptions>
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<SetEnvironmentVariableActionFactory> _logger;
+
+        public SetEnvironmentVariableActionFactory(IServiceProvider serviceProvider, ILogger<SetEnvironmentVariableActionFactory> logger)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, SetEnvironmentVariableOptions options)
+        {
+            if (null == options)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ValidationContext context = new(options, _serviceProvider, items: null);
+            Validator.ValidateObject(options, context, validateAllProperties: true);
+
+            return new SetEnvironmentVariableAction(_logger, endpointInfo, options);
+        }
+
+        internal sealed partial class SetEnvironmentVariableAction :
+            CollectionRuleActionBase<SetEnvironmentVariableOptions>
+        {
+            private readonly IEndpointInfo _endpointInfo;
+            private readonly ILogger _logger;
+            private readonly SetEnvironmentVariableOptions _options;
+
+            public SetEnvironmentVariableAction(ILogger logger, IEndpointInfo endpointInfo, SetEnvironmentVariableOptions options)
+                : base(endpointInfo, options)
+            {
+                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                _endpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
+                _options = options ?? throw new ArgumentNullException(nameof(options));
+            }
+
+            protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
+                TaskCompletionSource<object> startCompletionSource,
+                CancellationToken token)
+            {
+                try
+                {
+                    DiagnosticsClient client = new DiagnosticsClient(_endpointInfo.Endpoint);
+
+                    _logger.SettingEnvironmentVariable(_options.Name, _endpointInfo.ProcessId);
+                    await client.SetEnvironmentVariableAsync(_options.Name, _options.Value, token);
+
+                    if (!startCompletionSource.TrySetResult(null))
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    return new CollectionRuleActionResult();
+                }
+                catch (Exception ex)
+                {
+                    throw new CollectionRuleActionException(ex);
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         public SetEnvironmentVariableActionFactory(IServiceProvider serviceProvider, ILogger<SetEnvironmentVariableActionFactory> logger)
         {
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _logger = logger ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public ICollectionRuleAction Create(IEndpointInfo endpointInfo, SetEnvironmentVariableOptions options)

--- a/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleActions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleActions.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         public const string CollectTrace = nameof(CollectTrace);
         public const string Execute = nameof(Execute);
         public const string LoadProfiler = nameof(LoadProfiler);
+        public const string SetEnvironmentVariable = nameof(SetEnvironmentVariable);
+        public const string GetEnvironmentVariable = nameof(GetEnvironmentVariable);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    /// <summary>
+    /// Options for the <see cref="CollectionRules.Actions.GetEnvironmentVariableAction"/> action.
+    /// </summary>
+    [DebuggerDisplay("GetEnvironmentVariable")]
+    internal class GetEnvironmentVariableOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_GetEnvironmentVariableOptions_Name))]
+        [Required]
+        public string Name { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    /// <summary>
+    /// Options for the <see cref="CollectionRules.Actions.SetEnvironmentVariableAction"/> action.
+    /// </summary>
+    [DebuggerDisplay("SetEnvironmentVariable")]
+    internal class SetEnvironmentVariableOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_SetEnvironmentVariableOptions_Name))]
+        [Required]
+        public string Name { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_SetEnvironmentVariableOptions_Value))]
+        public string Value { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         ActionSettingsTokenizationNotSupported = 51,
         EndpointTimeout = 52,
         LoadingProfiler = 53,
+        SetEnvironmentVariable = 54,
+        GetEnvironmentVariable = 55,
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -289,6 +289,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_LoadingProfiler);
 
+        private static readonly Action<ILogger, string, int, Exception> _setEnvironmentVariable =
+            LoggerMessage.Define<string, int>(
+                eventId: LoggingEventIds.SetEnvironmentVariable.EventId(),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_SetEnvironmentVariable);
+
+        private static readonly Action<ILogger, string, int, Exception> _getEnvironmentVariable =
+            LoggerMessage.Define<string, int>(
+                eventId: LoggingEventIds.GetEnvironmentVariable.EventId(),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_GetEnvironmentVariable);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -521,6 +533,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void LoadingProfiler(this ILogger logger, Guid profilerGuid, string path, int processId)
         {
             _loadingProfiler(logger, profilerGuid, path, processId, null);
+        }
+
+        public static void SettingEnvironmentVariable(this ILogger logger, string variableName, int processId)
+        {
+            _setEnvironmentVariable(logger, variableName, processId, null);
+        }
+
+        public static void GettingEnvironmentVariable(this ILogger logger, string variableName, int processId)
+        {
+            _getEnvironmentVariable(logger, variableName, processId, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.RegisterCollectionRuleAction<CollectTraceActionFactory, CollectTraceOptions>(KnownCollectionRuleActions.CollectTrace);
             services.RegisterCollectionRuleAction<ExecuteActionFactory, ExecuteOptions>(KnownCollectionRuleActions.Execute);
             services.RegisterCollectionRuleAction<LoadProfilerActionFactory, LoadProfilerOptions>(KnownCollectionRuleActions.LoadProfiler);
+            services.RegisterCollectionRuleAction<SetEnvironmentVariableActionFactory, SetEnvironmentVariableOptions>(KnownCollectionRuleActions.SetEnvironmentVariable);
+            services.RegisterCollectionRuleAction<GetEnvironmentVariableActionFactory, GetEnvironmentVariableOptions>(KnownCollectionRuleActions.GetEnvironmentVariable);
 
             services.RegisterCollectionRuleTrigger<CollectionRules.Triggers.AspNetRequestCountTriggerFactory, AspNetRequestCountOptions>(KnownCollectionRuleTriggers.AspNetRequestCount);
             services.RegisterCollectionRuleTrigger<CollectionRules.Triggers.AspNetRequestDurationTriggerFactory, AspNetRequestDurationOptions>(KnownCollectionRuleTriggers.AspNetRequestDuration);

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -835,6 +835,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Getting the environment variable {variableName} from process {processId}..
+        /// </summary>
+        internal static string LogFormatString_GetEnvironmentVariable {
+            get {
+                return ResourceManager.GetString("LogFormatString_GetEnvironmentVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments..
         /// </summary>
         internal static string LogFormatString_InsecureAutheticationConfiguration {
@@ -871,7 +880,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Loading the startup profiler with id {profilerGuid} from {path} into process with id {processId}..
+        ///   Looks up a localized string similar to Loading the profiler with CLSID {clsid} from {path} into process {processId}..
         /// </summary>
         internal static string LogFormatString_LoadingProfiler {
             get {
@@ -921,6 +930,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string LogFormatString_RunningElevated {
             get {
                 return ResourceManager.GetString("LogFormatString_RunningElevated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Setting the environment variable {variableName} in process {processId}..
+        /// </summary>
+        internal static string LogFormatString_SetEnvironmentVariable {
+            get {
+                return ResourceManager.GetString("LogFormatString_SetEnvironmentVariable", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -268,6 +268,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The environment block does not contain the &apos;{0}&apos; variable..
+        /// </summary>
+        internal static string ErrorMessage_NoEnvironmentVariable {
+            get {
+                return ResourceManager.GetString("ErrorMessage_NoEnvironmentVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The process exited with exit code {0}.
         /// </summary>
         internal static string ErrorMessage_NonzeroExitCode {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -521,6 +521,13 @@
   <data name="LogFormatString_EndpointTimeout" xml:space="preserve">
     <value>Unexpected timeout from process {processId}. Process will no longer be monitored.</value>
   </data>
+  <data name="LogFormatString_GetEnvironmentVariable" xml:space="preserve">
+    <value>Getting the environment variable {variableName} from process {processId}.</value>
+    <comment>Gets the format string that is printed in the 55:GetEnvironmentVariable event.
+2 Format parameterts:
+1. variableName: The name of the environment variable being read
+2. processId: The id of the process to which the variable is being read</comment>
+  </data>
   <data name="LogFormatString_InsecureAutheticationConfiguration" xml:space="preserve">
     <value>WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.</value>
     <comment>Gets the format string that is printed in the 14:InsecureAutheticationConfiguration event.
@@ -570,6 +577,13 @@
     <value>The process was launched elevated and will have access to all processes on the system. Do not run elevated unless you need to monitor processes launched by another user (e.g., IIS worker processes)</value>
     <comment>Gets the format string that is printed in the 19:RunningElevated event.
 0 Format Parameters</comment>
+  </data>
+  <data name="LogFormatString_SetEnvironmentVariable" xml:space="preserve">
+    <value>Setting the environment variable {variableName} in process {processId}.</value>
+    <comment>Gets the format string that is printed in the 54:SetEnvironmentVariable event.
+2 Format parameterts:
+1. variableName: The name of the environment variable being set
+2. processId: The id of the process to which the variable is being set</comment>
   </data>
   <data name="LogFormatString_UnableToListenToAddress" xml:space="preserve">
     <value>Unable to listen to {url}. Dotnet-monitor functionality will be limited.</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -232,6 +232,12 @@
 1. value: The value of the string that could not be parsed.
 2. errorMessage: Additional error message text.</comment>
   </data>
+  <data name="ErrorMessage_NoEnvironmentVariable" xml:space="preserve">
+    <value>The environment block does not contain the '{0}' variable.</value>
+    <comment>Gets the format string for an error when the given environment variable does not exist.
+1 Format Parameter:
+0. variableName: The name of the environment variable that is missing</comment>
+  </data>
   <data name="ErrorMessage_NonzeroExitCode" xml:space="preserve">
     <value>The process exited with exit code {0}</value>
     <comment>{0} = Nonzero exit code.</comment>


### PR DESCRIPTION
- Adds the `GetEnvironmentAction` to available collection rule actions. Get allow users to get an environment variable value and use it in a future action. Set allows a user to specify an environment variable in a process connecting to dotnet-monitor. Set is primarily intended for use with the `LoadProfiler` action to configure the profiler being loaded
- Adds the `SetEnvironmentVariable` to available collection rule actions. Set is primarily intended for use with the `LoadProfiler` action to configure the profiler being loaded. However, this may be used generically to set any environment variable in the process. This should be used from a "startup" trigger to ensure the variable is present as soon as possible in the target process.
- Adds tests for the above action. This required adding a "Command Complete" signal sent from our test app to signal when all information (environment variables) have been sent back over the pipe.
- Adds documentation for the above new actions.

resolves #1176 