### PR TITLE
Convert LoggingEventIds to enum

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
@@ -20,27 +20,27 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         public Task WaitForCollectionRuleActionsCompletedAsync(string ruleName, CancellationToken token)
         {
-            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleActionsCompleted, ruleName, token);
+            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleActionsCompleted.Id(), ruleName, token);
         }
 
         public Task WaitForCollectionRuleCompleteAsync(string ruleName, CancellationToken token)
         {
-            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleCompleted, ruleName, token);
+            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleCompleted.Id(), ruleName, token);
         }
 
         public Task WaitForCollectionRuleUnmatchedFiltersAsync(string ruleName, CancellationToken token)
         {
-            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleUnmatchedFilters, ruleName, token);
+            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleUnmatchedFilters.Id(), ruleName, token);
         }
 
         public Task WaitForCollectionRuleStartedAsync(string ruleName, CancellationToken token)
         {
-            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleStarted, ruleName, token);
+            return WaitForCollectionRuleEventAsync(LoggingEventIds.CollectionRuleStarted.Id(), ruleName, token);
         }
 
         public Task WaitForCollectionRulesStoppedAsync(CancellationToken token)
         {
-            return WaitForEventAsync(LoggingEventIds.CollectionRulesStopped, token);
+            return WaitForEventAsync(LoggingEventIds.CollectionRulesStopped.Id(), token);
         }
 
         private async Task WaitForCollectionRuleEventAsync(int eventId, string ruleName, CancellationToken token)
@@ -48,7 +48,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             TaskCompletionSource<object> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             CollectionRuleKey eventKey = new(eventId, ruleName);
-            CollectionRuleKey failedKey = new(LoggingEventIds.CollectionRuleFailed, ruleName);
+            CollectionRuleKey failedKey = new(LoggingEventIds.CollectionRuleFailed.Id(), ruleName);
 
             AddCollectionRuleCallback(eventKey, tcs);
             AddCollectionRuleCallback(failedKey, tcs);
@@ -87,13 +87,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 CollectionRuleKey key = new(logEvent.EventId, ruleName);
                 switch (logEvent.EventId)
                 {
-                    case LoggingEventIds.CollectionRuleActionsCompleted:
-                    case LoggingEventIds.CollectionRuleCompleted:
-                    case LoggingEventIds.CollectionRuleUnmatchedFilters:
-                    case LoggingEventIds.CollectionRuleStarted:
+                    case (int)LoggingEventIds.CollectionRuleActionsCompleted:
+                    case (int)LoggingEventIds.CollectionRuleCompleted:
+                    case (int)LoggingEventIds.CollectionRuleUnmatchedFilters:
+                    case (int)LoggingEventIds.CollectionRuleStarted:
                         CompleteCollectionRuleCallbacks(key);
                         break;
-                    case LoggingEventIds.CollectionRuleFailed:
+                    case (int)LoggingEventIds.CollectionRuleFailed:
                         FailCollectionRuleCallbacks(key, logEvent.Exception);
                         break;
                 }
@@ -102,7 +102,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             {
                 switch (logEvent.EventId)
                 {
-                    case LoggingEventIds.CollectionRulesStopped:
+                    case (int)LoggingEventIds.CollectionRulesStopped:
                         CompleteEventCallbacks(logEvent.EventId);
                         break;
                 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
@@ -85,24 +85,24 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             if (logEvent.State.TryGetValue("ruleName", out string ruleName))
             {
                 CollectionRuleKey key = new(logEvent.EventId, ruleName);
-                switch (logEvent.EventId)
+                switch ((LoggingEventIds)logEvent.EventId)
                 {
-                    case (int)LoggingEventIds.CollectionRuleActionsCompleted:
-                    case (int)LoggingEventIds.CollectionRuleCompleted:
-                    case (int)LoggingEventIds.CollectionRuleUnmatchedFilters:
-                    case (int)LoggingEventIds.CollectionRuleStarted:
+                    case LoggingEventIds.CollectionRuleActionsCompleted:
+                    case LoggingEventIds.CollectionRuleCompleted:
+                    case LoggingEventIds.CollectionRuleUnmatchedFilters:
+                    case LoggingEventIds.CollectionRuleStarted:
                         CompleteCollectionRuleCallbacks(key);
                         break;
-                    case (int)LoggingEventIds.CollectionRuleFailed:
+                    case LoggingEventIds.CollectionRuleFailed:
                         FailCollectionRuleCallbacks(key, logEvent.Exception);
                         break;
                 }
             }
             else
             {
-                switch (logEvent.EventId)
+                switch ((LoggingEventIds)logEvent.EventId)
                 {
-                    case (int)LoggingEventIds.CollectionRulesStopped:
+                    case LoggingEventIds.CollectionRulesStopped:
                         CompleteEventCallbacks(logEvent.EventId);
                         break;
                 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -222,21 +222,21 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         {
             switch (logEvent.EventId)
             {
-                case LoggingEventIds.BoundDefaultAddress:
+                case (int)LoggingEventIds.BoundDefaultAddress:
                     if (logEvent.State.TryGetValue("address", out string defaultAddress))
                     {
                         _outputHelper.WriteLine("Default Address: {0}", defaultAddress);
                         Assert.True(_defaultAddressSource.TrySetResult(defaultAddress));
                     }
                     break;
-                case LoggingEventIds.BoundMetricsAddress:
+                case (int)LoggingEventIds.BoundMetricsAddress:
                     if (logEvent.State.TryGetValue("address", out string metricsAddress))
                     {
                         _outputHelper.WriteLine("Metrics Address: {0}", metricsAddress);
                         Assert.True(_metricsAddressSource.TrySetResult(metricsAddress));
                     }
                     break;
-                case LoggingEventIds.LogTempApiKey:
+                case (int)LoggingEventIds.LogTempApiKey:
                     if (logEvent.State.TryGetValue("MonitorApiKey", out string monitorApiKey))
                     {
                         _outputHelper.WriteLine("MonitorApiKey: {0}", monitorApiKey);
@@ -250,7 +250,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         {
             switch (logEvent.EventId)
             {
-                case LoggingEventIds.NotifyPrivateKey:
+                case (int)LoggingEventIds.NotifyPrivateKey:
                     if (logEvent.State.TryGetValue("fieldName", out string fieldName))
                     {
                         _outputHelper.WriteLine("Private Key data detected in field: {0}", fieldName);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -220,23 +220,23 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         private void HandleStartupEvent(ConsoleLogEvent logEvent)
         {
-            switch (logEvent.EventId)
+            switch ((LoggingEventIds)logEvent.EventId)
             {
-                case (int)LoggingEventIds.BoundDefaultAddress:
+                case LoggingEventIds.BoundDefaultAddress:
                     if (logEvent.State.TryGetValue("address", out string defaultAddress))
                     {
                         _outputHelper.WriteLine("Default Address: {0}", defaultAddress);
                         Assert.True(_defaultAddressSource.TrySetResult(defaultAddress));
                     }
                     break;
-                case (int)LoggingEventIds.BoundMetricsAddress:
+                case LoggingEventIds.BoundMetricsAddress:
                     if (logEvent.State.TryGetValue("address", out string metricsAddress))
                     {
                         _outputHelper.WriteLine("Metrics Address: {0}", metricsAddress);
                         Assert.True(_metricsAddressSource.TrySetResult(metricsAddress));
                     }
                     break;
-                case (int)LoggingEventIds.LogTempApiKey:
+                case LoggingEventIds.LogTempApiKey:
                     if (logEvent.State.TryGetValue("MonitorApiKey", out string monitorApiKey))
                     {
                         _outputHelper.WriteLine("MonitorApiKey: {0}", monitorApiKey);
@@ -248,9 +248,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         private void HandleGenericLogEvent(ConsoleLogEvent logEvent)
         {
-            switch (logEvent.EventId)
+            switch ((LoggingEventIds)logEvent.EventId)
             {
-                case (int)LoggingEventIds.NotifyPrivateKey:
+                case LoggingEventIds.NotifyPrivateKey:
                     if (logEvent.State.TryGetValue("fieldName", out string fieldName))
                     {
                         _outputHelper.WriteLine("Private Key data detected in field: {0}", fieldName);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -63,9 +63,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 analyzer.SubstituteOptionValues(new Dictionary<string, CollectionRuleActionResult>(), 1, settings);
 
                 Assert.Equal(3, record.Events.Count);
-                Assert.Equal(LoggingEventIds.InvalidActionReferenceToken, record.Events[0].EventId.Id);
-                Assert.Equal(LoggingEventIds.InvalidActionReference, record.Events[1].EventId.Id);
-                Assert.Equal(LoggingEventIds.InvalidActionResultReference, record.Events[2].EventId.Id);
+                Assert.Equal(LoggingEventIds.InvalidActionReferenceToken.Id(), record.Events[0].EventId.Id);
+                Assert.Equal(LoggingEventIds.InvalidActionReference.Id(), record.Events[1].EventId.Id);
+                Assert.Equal(LoggingEventIds.InvalidActionResultReference.Id(), record.Events[2].EventId.Id);
 
             }, serviceCollection =>
             {

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -2,64 +2,82 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
+using System;
+
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
     // The existing EventIds must not be duplicated, reused, or repurposed.
     // New logging events must use the next available EventId.
-    internal static class LoggingEventIds
+    internal enum LoggingEventIds
     {
-        public const int EgressProviderAdded = 1;
-        public const int EgressProviderInvalidOptions = 2;
-        public const int EgressProviderInvalidType = 3;
-        public const int EgressProviderValidatingOptions = 4;
-        public const int EgressCopyActionStreamToEgressStream = 5;
-        public const int EgressProviderOptionsValidationFailure = 6;
-        public const int EgressProviderOptionValue = 7;
-        public const int EgressStreamOptionValue = 8;
-        public const int EgressProviderFileName = 9;
-        public const int EgressProvideUnableToFindPropertyKey = 10;
-        public const int EgressProviderInvokeStreamAction = 11;
-        public const int EgressProviderSavedStream = 12;
-        public const int NoAuthentication = 13;
-        public const int InsecureAutheticationConfiguration = 14;
-        public const int UnableToListenToAddress = 15;
-        public const int BoundDefaultAddress = 16;
-        public const int BoundMetricsAddress = 17;
-        public const int OptionsValidationFailure = 18;
-        public const int RunningElevated = 19;
-        public const int DisabledNegotiateWhileElevated = 20;
-        public const int ApiKeyValidationFailure = 21;
-        public const int ApiKeyAuthenticationOptionsChanged = 22;
-        public const int LogTempApiKey = 23;
-        public const int DuplicateEgressProviderIgnored = 24;
-        public const int ApiKeyAuthenticationOptionsValidated = 25;
-        public const int NotifyPrivateKey = 26;
-        public const int DuplicateCollectionRuleActionIgnored = 27;
-        public const int DuplicateCollectionRuleTriggerIgnored = 28;
-        public const int CollectionRuleStarted = 29;
-        public const int CollectionRuleFailed = 30;
-        public const int CollectionRuleCompleted = 31;
-        public const int CollectionRulesStarted = 32;
-        public const int CollectionRuleActionStarted = 33;
-        public const int CollectionRuleActionCompleted = 34;
-        public const int CollectionRuleTriggerStarted = 35;
-        public const int CollectionRuleTriggerCompleted = 36;
-        public const int CollectionRuleActionsThrottled = 37;
-        public const int CollectionRuleActionFailed = 38;
-        public const int CollectionRuleActionsCompleted = 39;
-        public const int CollectionRulesStarting = 40;
-        public const int DiagnosticRequestCancelled = 41;
-        public const int CollectionRuleUnmatchedFilters = 42;
-        public const int CollectionRuleConfigurationChanged = 43;
-        public const int CollectionRulesStopping = 44;
-        public const int CollectionRulesStopped = 45;
-        public const int CollectionRuleCancelled = 46;
-        public const int DiagnosticRequestFailed = 47;
-        public const int InvalidActionReferenceToken = 48;
-        public const int InvalidActionReference = 49;
-        public const int InvalidActionResultReference = 50;
-        public const int ActionSettingsTokenizationNotSupported = 51;
-        public const int EndpointTimeout = 52;
-        public const int LoadingProfiler = 53;
+        EgressProviderAdded = 1,
+        EgressProviderInvalidOptions = 2,
+        EgressProviderInvalidType = 3,
+        EgressProviderValidatingOptions = 4,
+        EgressCopyActionStreamToEgressStream = 5,
+        EgressProviderOptionsValidationFailure = 6,
+        EgressProviderOptionValue = 7,
+        EgressStreamOptionValue = 8,
+        EgressProviderFileName = 9,
+        EgressProvideUnableToFindPropertyKey = 10,
+        EgressProviderInvokeStreamAction = 11,
+        EgressProviderSavedStream = 12,
+        NoAuthentication = 13,
+        InsecureAutheticationConfiguration = 14,
+        UnableToListenToAddress = 15,
+        BoundDefaultAddress = 16,
+        BoundMetricsAddress = 17,
+        OptionsValidationFailure = 18,
+        RunningElevated = 19,
+        DisabledNegotiateWhileElevated = 20,
+        ApiKeyValidationFailure = 21,
+        ApiKeyAuthenticationOptionsChanged = 22,
+        LogTempApiKey = 23,
+        DuplicateEgressProviderIgnored = 24,
+        ApiKeyAuthenticationOptionsValidated = 25,
+        NotifyPrivateKey = 26,
+        DuplicateCollectionRuleActionIgnored = 27,
+        DuplicateCollectionRuleTriggerIgnored = 28,
+        CollectionRuleStarted = 29,
+        CollectionRuleFailed = 30,
+        CollectionRuleCompleted = 31,
+        CollectionRulesStarted = 32,
+        CollectionRuleActionStarted = 33,
+        CollectionRuleActionCompleted = 34,
+        CollectionRuleTriggerStarted = 35,
+        CollectionRuleTriggerCompleted = 36,
+        CollectionRuleActionsThrottled = 37,
+        CollectionRuleActionFailed = 38,
+        CollectionRuleActionsCompleted = 39,
+        CollectionRulesStarting = 40,
+        DiagnosticRequestCancelled = 41,
+        CollectionRuleUnmatchedFilters = 42,
+        CollectionRuleConfigurationChanged = 43,
+        CollectionRulesStopping = 44,
+        CollectionRulesStopped = 45,
+        CollectionRuleCancelled = 46,
+        DiagnosticRequestFailed = 47,
+        InvalidActionReferenceToken = 48,
+        InvalidActionReference = 49,
+        InvalidActionResultReference = 50,
+        ActionSettingsTokenizationNotSupported = 51,
+        EndpointTimeout = 52,
+        LoadingProfiler = 53,
+    }
+
+    internal static class LoggingEventIdsExtensions
+    {
+        public static EventId EventId(this LoggingEventIds enumVal)
+        {
+            string name = Enum.GetName(typeof(LoggingEventIds), enumVal);
+            int id = enumVal.Id();
+            return new EventId(id, name);
+        }
+        public static int Id(this LoggingEventIds enumVal)
+        {
+            int id = (int)enumVal;
+            return id;
+        }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -15,277 +15,277 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         private static readonly Action<ILogger, string, Exception> _egressProviderInvalidOptions =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.EgressProviderInvalidOptions, "EgressProviderInvalidOptions"),
+                eventId: LoggingEventIds.EgressProviderInvalidOptions.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_EgressProviderInvalidOptions);
 
         private static readonly Action<ILogger, int, Exception> _egressCopyActionStreamToEgressStream =
             LoggerMessage.Define<int>(
-                eventId: new EventId(LoggingEventIds.EgressCopyActionStreamToEgressStream, "EgressCopyActionStreamToEgressStream"),
+                eventId: LoggingEventIds.EgressCopyActionStreamToEgressStream.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_EgressCopyActionStreamToEgressStream);
 
         private static readonly Action<ILogger, string, string, Exception> _egressProviderOptionsValidationFailure =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.EgressProviderOptionsValidationFailure, "EgressProviderOptionsValidationFailure"),
+                eventId: LoggingEventIds.EgressProviderOptionsValidationFailure.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_EgressProviderOptionsValidationError);
 
         private static readonly Action<ILogger, string, string, Exception> _egressProviderUnableToFindPropertyKey =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.EgressProvideUnableToFindPropertyKey, "EgressProvideUnableToFindPropertyKey"),
+                eventId: LoggingEventIds.EgressProvideUnableToFindPropertyKey.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_EgressProvideUnableToFindPropertyKey);
 
         private static readonly Action<ILogger, string, Exception> _egressProviderInvokeStreamAction =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.EgressProviderInvokeStreamAction, "EgressProviderInvokeStreamAction"),
+                eventId: LoggingEventIds.EgressProviderInvokeStreamAction.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_EgressProviderInvokeStreamAction);
 
         private static readonly Action<ILogger, string, string, Exception> _egressProviderSavedStream =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.EgressProviderSavedStream, "EgressProviderSavedStream"),
+                eventId: LoggingEventIds.EgressProviderSavedStream.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_EgressProviderSavedStream);
 
         private static readonly Action<ILogger, Exception> _noAuthentication =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.NoAuthentication, "NoAuthentication"),
+                eventId: LoggingEventIds.NoAuthentication.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_NoAuthentication);
 
         private static readonly Action<ILogger, Exception> _insecureAuthenticationConfiguration =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.InsecureAutheticationConfiguration, "InsecureAutheticationConfiguration"),
+                eventId: LoggingEventIds.InsecureAutheticationConfiguration.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_InsecureAutheticationConfiguration);
 
         private static readonly Action<ILogger, string, Exception> _unableToListenToAddress =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.UnableToListenToAddress, "UnableToListenToAddress"),
+                eventId: LoggingEventIds.UnableToListenToAddress.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_UnableToListenToAddress);
 
         private static readonly Action<ILogger, string, Exception> _boundDefaultAddress =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.BoundDefaultAddress, "BoundDefaultAddress"),
+                eventId: LoggingEventIds.BoundDefaultAddress.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_BoundDefaultAddress);
 
         private static readonly Action<ILogger, string, Exception> _boundMetricsAddress =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.BoundMetricsAddress, "BoundMetricsAddress"),
+                eventId: LoggingEventIds.BoundMetricsAddress.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_BoundMetricsAddress);
 
         private static readonly Action<ILogger, string, Exception> _optionsValidationFalure =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.OptionsValidationFailure, "OptionsValidationFailure"),
+                eventId: LoggingEventIds.OptionsValidationFailure.EventId(),
                 logLevel: LogLevel.Critical,
                 formatString: Strings.LogFormatString_OptionsValidationFailure);
 
         private static readonly Action<ILogger, Exception> _runningElevated =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.RunningElevated, "RunningElevated"),
+                eventId: LoggingEventIds.RunningElevated.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_RunningElevated);
 
         private static readonly Action<ILogger, Exception> _disabledNegotiateWhileElevated =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.DisabledNegotiateWhileElevated, "DisabledNegotiateWhileElevated"),
+                eventId: LoggingEventIds.DisabledNegotiateWhileElevated.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DisabledNegotiateWhileElevated);
 
         private static readonly Action<ILogger, string, string, Exception> _apiKeyValidationFailure =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.ApiKeyValidationFailure, "ApiKeyValidationFailure"),
+                eventId: LoggingEventIds.ApiKeyValidationFailure.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ApiKeyValidationFailure);
 
         private static readonly Action<ILogger, string, string, string, string, Exception> _logTempKey =
             LoggerMessage.Define<string, string, string, string>(
-                eventId: new EventId(LoggingEventIds.LogTempApiKey, "LogTempApiKey"),
+                eventId: LoggingEventIds.LogTempApiKey.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_LogTempApiKey);
 
         private static readonly Action<ILogger, string, string, string, Exception> _duplicateEgressProviderIgnored =
             LoggerMessage.Define<string, string, string>(
-                eventId: new EventId(LoggingEventIds.DuplicateEgressProviderIgnored, "DuplicateEgressProviderIgnored"),
+                eventId: LoggingEventIds.DuplicateEgressProviderIgnored.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateEgressProviderIgnored);
 
         private static readonly Action<ILogger, string, Exception> _apiKeyAuthenticationOptionsValidated =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.ApiKeyAuthenticationOptionsValidated, "ApiKeyAuthenticationOptionsValidated"),
+                eventId: LoggingEventIds.ApiKeyAuthenticationOptionsValidated.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ApiKeyAuthenticationOptionsValidated);
 
         private static readonly Action<ILogger, string, Exception> _notifyPrivateKey =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.NotifyPrivateKey, "NotifyPrivateKey"),
+                eventId: LoggingEventIds.NotifyPrivateKey.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_NotifyPrivateKey);
 
         private static readonly Action<ILogger, string, Exception> _duplicateCollectionRuleActionIgnored =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.DuplicateCollectionRuleActionIgnored, "DuplicateCollectionRuleActionIgnored"),
+                eventId: LoggingEventIds.DuplicateCollectionRuleActionIgnored.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateCollectionRuleActionIgnored);
 
         private static readonly Action<ILogger, string, Exception> _duplicateCollectionRuleTriggerIgnored =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.DuplicateCollectionRuleTriggerIgnored, "DuplicateCollectionRuleTriggerIgnored"),
+                eventId: LoggingEventIds.DuplicateCollectionRuleTriggerIgnored.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateCollectionRuleTriggerIgnored);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleStarted =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleStarted, "CollectionRuleStarted"),
+                eventId: LoggingEventIds.CollectionRuleStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleStarted);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleFailed =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleFailed, "CollectionRuleFailed"),
+                eventId: LoggingEventIds.CollectionRuleFailed.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_CollectionRuleFailed);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleCompleted =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleCompleted, "CollectionRuleCompleted"),
+                eventId: LoggingEventIds.CollectionRuleCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleCompleted);
 
         private static readonly Action<ILogger, Exception> _collectionRulesStarted =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.CollectionRulesStarted, "CollectionRulesStarted"),
+                eventId: LoggingEventIds.CollectionRulesStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStarted);
 
         private static readonly Action<ILogger, string, string, Exception> _collectionRuleActionStarted =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleActionStarted, "CollectionRuleActionStarted"),
+                eventId: LoggingEventIds.CollectionRuleActionStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionStarted);
 
         private static readonly Action<ILogger, string, string, Exception> _collectionRuleActionCompleted =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleActionCompleted, "CollectionRuleActionCompleted"),
+                eventId: LoggingEventIds.CollectionRuleActionCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionCompleted);
 
         private static readonly Action<ILogger, string, string, Exception> _collectionRuleTriggerStarted =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleTriggerStarted, "CollectionRuleTriggerStarted"),
+                eventId: LoggingEventIds.CollectionRuleTriggerStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleTriggerStarted);
 
         private static readonly Action<ILogger, string, string, Exception> _collectionRuleTriggerCompleted =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleTriggerCompleted, "CollectionRuleTriggerCompleted"),
+                eventId: LoggingEventIds.CollectionRuleTriggerCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleTriggerCompleted);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleActionsThrottled =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleActionsThrottled, "CollectionRuleActionsThrottled"),
+                eventId: LoggingEventIds.CollectionRuleActionsThrottled.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_CollectionRuleActionsThrottled);
 
         private static readonly Action<ILogger, string, string, Exception> _collectionRuleActionFailed =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleActionFailed, "CollectionRuleActionFailed"),
+                eventId: LoggingEventIds.CollectionRuleActionFailed.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_CollectionRuleActionFailed);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleActionsCompleted =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleActionsCompleted, "CollectionRuleActionsCompleted"),
+                eventId: LoggingEventIds.CollectionRuleActionsCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionsCompleted);
 
         private static readonly Action<ILogger, Exception> _collectionRulesStarting =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.CollectionRulesStarting, "CollectionRulesStarting"),
+                eventId: LoggingEventIds.CollectionRulesStarting.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStarting);
 
         private static readonly Action<ILogger, int, Exception> _diagnosticRequestCancelled =
             LoggerMessage.Define<int>(
-                eventId: new EventId(LoggingEventIds.DiagnosticRequestCancelled, "DiagnosticRequestCancelled"),
+                eventId: LoggingEventIds.DiagnosticRequestCancelled.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DiagnosticRequestCancelled);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleUnmatchedFilters =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleUnmatchedFilters, "CollectionRuleUnmatchedFilters"),
+                eventId: LoggingEventIds.CollectionRuleUnmatchedFilters.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleUnmatchedFilters);
 
         private static readonly Action<ILogger, Exception> _collectionRuleConfigurationChanged =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.CollectionRuleConfigurationChanged, "CollectionRuleConfigurationChanged"),
+                eventId: LoggingEventIds.CollectionRuleConfigurationChanged.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleConfigurationChanged);
 
         private static readonly Action<ILogger, Exception> _collectionRulesStopping =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.CollectionRulesStopping, "CollectionRulesStopping"),
+                eventId: LoggingEventIds.CollectionRulesStopping.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStopping);
 
         private static readonly Action<ILogger, Exception> _collectionRulesStopped =
             LoggerMessage.Define(
-                eventId: new EventId(LoggingEventIds.CollectionRulesStopped, "CollectionRulesStopped"),
+                eventId: LoggingEventIds.CollectionRulesStopped.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStopped);
 
         private static readonly Action<ILogger, string, Exception> _collectionRuleCancelled =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.CollectionRuleCancelled, "CollectionRuleCancelled"),
+                eventId: LoggingEventIds.CollectionRuleCancelled.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleCancelled);
 
         private static readonly Action<ILogger, int, Exception> _diagnosticRequestFailed =
             LoggerMessage.Define<int>(
-                eventId: new EventId(LoggingEventIds.DiagnosticRequestFailed, "DiagnosticRequestFailed"),
+                eventId: LoggingEventIds.DiagnosticRequestFailed.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_DiagnosticRequestFailed);
 
         private static readonly Action<ILogger, string, string, Exception> _invalidActionReferenceToken =
             LoggerMessage.Define<string, string>(
-                eventId: new EventId(LoggingEventIds.InvalidActionReferenceToken, "InvalidActionReferenceToken"),
+                eventId: LoggingEventIds.InvalidActionReferenceToken.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_InvalidToken);
 
         private static readonly Action<ILogger, string, Exception> _invalidActionReference =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.InvalidActionReference, "InvalidActionReference"),
+                eventId: LoggingEventIds.InvalidActionReference.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_InvalidActionReference);
 
         private static readonly Action<ILogger, string, Exception> _invalidActionResultReference =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.InvalidActionResultReference, "InvalidActionResultReference"),
+                eventId: LoggingEventIds.InvalidActionResultReference.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_InvalidActionResultReference);
 
         private static readonly Action<ILogger, string, Exception> _actionSettingsTokenizationNotSupported =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.ActionSettingsTokenizationNotSupported, "ActionSettingsTokenizationNotSupported"),
+                eventId: LoggingEventIds.ActionSettingsTokenizationNotSupported.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_ActionSettingsTokenizationNotSupported);
 
         private static readonly Action<ILogger, string, Exception> _endpointTimeout =
             LoggerMessage.Define<string>(
-                eventId: new EventId(LoggingEventIds.EndpointTimeout, "EndpointTimeout"),
+                eventId: LoggingEventIds.EndpointTimeout.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_EndpointTimeout);
 
         private static readonly Action<ILogger, Guid, string, int, Exception> _loadingProfiler =
             LoggerMessage.Define<Guid, string, int>(
-                eventId: new EventId(LoggingEventIds.LoadingProfiler, "LoadingProfiler"),
+                eventId: LoggingEventIds.LoadingProfiler.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_LoadingProfiler);
 


### PR DESCRIPTION
Let's convert the huge list of constants in [LoggingEventIds.cs](https://github.com/dotnet/dotnet-monitor/blob/main/src/Tools/dotnet-monitor/LoggingEventIds.cs) to an enum to these 2 advantages:
- Compiler will enforce that we don't accidently introduce duplicate IDs, this is very common because we always append to this list and just use the next number
- Avoid having an extra point where we define the ID and a string representing the event. We can just ask the runtime for the enum name and so the code will always match the event names produced at runtime.

The motivation for this is to avoid having to worry about and verify that we don't introduce conflicting IDs in 2 PRs that add an event to this list.