### PR TITLE
Update setup and documentation pages to encourage using latest versions.

### DIFF
--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -96,7 +96,7 @@ spec:
       secretName: apikey
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor
+    image: mcr.microsoft.com/dotnet/monitor:6.0
     volumeMounts:
       - name: apikey
         mountPath: /etc/dotnet-monitor

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -96,7 +96,7 @@ spec:
       secretName: apikey
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor:6.0.0-preview.8
+    image: mcr.microsoft.com/dotnet/dotnet-monitor
     volumeMounts:
       - name: apikey
         mountPath: /etc/dotnet-monitor

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -61,7 +61,7 @@ spec:
       secretName: apikey
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor
+    image: mcr.microsoft.com/dotnet/monitor:6.0
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor
@@ -88,7 +88,7 @@ spec:
       name: my-configmap
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor
+    image: mcr.microsoft.com/dotnet/monitor:6.0
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor
@@ -108,7 +108,7 @@ spec:
             name: my-configmap
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor
+    image: mcr.microsoft.com/dotnet/monitor:6.0
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -61,7 +61,7 @@ spec:
       secretName: apikey
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor:6.0.0
+    image: mcr.microsoft.com/dotnet/dotnet-monitor
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor
@@ -88,7 +88,7 @@ spec:
       name: my-configmap
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor:6.0.0
+    image: mcr.microsoft.com/dotnet/dotnet-monitor
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor
@@ -108,7 +108,7 @@ spec:
             name: my-configmap
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/dotnet-monitor:6.0.0
+    image: mcr.microsoft.com/dotnet/dotnet-monitor
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor

--- a/documentation/setup.md
+++ b/documentation/setup.md
@@ -9,44 +9,52 @@
 
 The `dotnet monitor` global tool requires a .NET 3.1 or newer SDK installed as a pre-requisite. If you do not have a new enough SDK, you can install a new one from the [Download .NET webpage](https://dotnet.microsoft.com/download).
 
-The latest public preview of `dotnet monitor` is available on Nuget. You can download the latest version using the following command:
+You can download the latest version using the following command:
 
 ```cmd
-dotnet tool install -g dotnet-monitor --version 6.0.0
+dotnet tool install -g dotnet-monitor
 ```
 
 If you already have `dotnet monitor` installed and want to update:
 
 ```cmd
-dotnet tool update -g dotnet-monitor --version 6.0.0
+dotnet tool update -g dotnet-monitor
 ```
 
 ### Container image
 
-The latest public preview of the `dotnet monitor` container image is available on MCR. You can pull the latest image using the following command:
+You can pull the latest image using the following command:
 
 ```cmd
-docker pull mcr.microsoft.com/dotnet/monitor:6.0.0
+docker pull mcr.microsoft.com/dotnet/monitor
 ```
 
 ### Working with CI builds
 
 In addition to public previews, we also publish last-known-good (LKG) builds for the next release of `dotnet monitor`.
 
-The LKG build of `dotnet monitor` is available on a private package feed. You can download the latest version of the .NET global tool using the following command:
+The LKG build of `dotnet monitor` is available on a private package feed. You can download the latest prerelease version of the .NET global tool using the following command:
 
 ```cmd
-dotnet tool install -g dotnet-monitor --add-source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-tools/nuget/v3/index.json --version 6.0.0
+dotnet tool install -g dotnet-monitor --add-source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-tools/nuget/v3/index.json --prerelease
 ```
 
 If you already have `dotnet monitor` installed and want to update:
 
 ```cmd
-dotnet tool update -g dotnet-monitor --add-source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-tools/nuget/v3/index.json --version 6.0.0
+dotnet tool update -g dotnet-monitor --add-source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-tools/nuget/v3/index.json --prerelease
 ```
 
 The LKG build of `dotnet monitor` is also available as a container image. You can pull the image using the following command:
 
 ```cmd
-docker pull mcr.microsoft.com/dotnet/nightly/monitor:6.0.0
+docker pull mcr.microsoft.com/dotnet/nightly/monitor
 ```
+
+### Official Releases and Previews
+
+The official releases and previews are:
+- Documented on the [Releases](./releases.md) page.
+- Announced on the GitHub [Releases](https://github.com/dotnet/dotnet-monitor/releases) tab.
+- Published to [nuget.org](https://www.nuget.org/packages/dotnet-monitor/).
+- Published to the Microsoft Container Registry ([tag list](https://mcr.microsoft.com/v2/dotnet/monitor/tags/list)).

--- a/documentation/setup.md
+++ b/documentation/setup.md
@@ -26,7 +26,7 @@ dotnet tool update -g dotnet-monitor
 You can pull the latest image using the following command:
 
 ```cmd
-docker pull mcr.microsoft.com/dotnet/monitor
+docker pull mcr.microsoft.com/dotnet/monitor:6.0
 ```
 
 ### Working with CI builds


### PR DESCRIPTION
Remove the fixed versions of the releases to encourage using the latest versions. Customers can look up exact versions from the sources cited in the existing documentation on the docker.md page as well as in the new section at the bottom of the setup.md page.