### PR TITLE
Use latest .NET 7.0 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100",
+    "dotnet": "7.0.100-alpha.1.22054.5",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",


### PR DESCRIPTION
This will allow the repo to build net7.0 TFM assemblies in future changes.

close #1268