### PR TITLE
Remove netstandard2.0 outputs and PackageReferences.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,10 +57,6 @@
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>3.1.17</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>3.1.10</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
-    <MicrosoftAspNetCoreHttpVersion>2.1.22</MicrosoftAspNetCoreHttpVersion>
-    <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
-    <MicrosoftAspNetCoreServerKestrelCoreVersion>2.1.7</MicrosoftAspNetCoreServerKestrelCoreVersion>
-    <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.0</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
@@ -69,14 +65,10 @@
     <MicrosoftIdentityModelTokensVersion>6.11.1</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
-    <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemIdentityModelTokensJwtVersion>6.11.1</SystemIdentityModelTokensJwtVersion>
-    <SystemIOPipelinesVersion>4.5.1</SystemIOPipelinesVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
-    <SystemThreadingChannelsVersion>5.0.0</SystemThreadingChannelsVersion>
     <!-- Third-party references -->
     <NJsonSchemaVersion>10.3.11</NJsonSchemaVersion>
     <SwashbuckleAspNetCoreSwaggerGenVersion>5.6.3</SwashbuckleAspNetCoreSwaggerGenVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsShippingAssembly>true</IsShippingAssembly>
     <OutputType>Library</OutputType>
   </PropertyGroup>
@@ -14,10 +14,6 @@
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.Tool.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi.UnitTests" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>;1591;1701</NoWarn>
-    <Description>REST Api surface for dotnet-monitor</Description>
+    <Description>Web Api surface for dotnet-monitor</Description>
     <!-- Tentatively create package so other teams can tentatively consume. -->
     <IsPackable>true</IsPackable>
     <IsShippingAssembly>true</IsShippingAssembly>
@@ -20,23 +20,6 @@
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' != ''">
     <ProjectReference Include="$(DIAGNOSTICS_REPO_ROOT)\src\Microsoft.Diagnostics.Monitoring.EventPipe\Microsoft.Diagnostics.Monitoring.EventPipe.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!--
-      AspNetCore references use version ranges in order to allow package references to this
-      WebApi package to use newer versions but not reference anything newer than .NET Core 2.1
-    -->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="[$(MicrosoftAspNetCoreMvcVersion),2.2.0)" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="$(MicrosoftBclHashCodeVersion)" />
-    <!--
-      Upgraded packages to avoid insecure versions; these are not directly referenced by the code.
-    -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[$(MicrosoftAspNetCoreHttpVersion),2.2.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[$(MicrosoftAspNetCoreServerKestrelCoreVersion),2.2.0)" />
-    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
-    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
@@ -47,11 +47,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 }
                 context.HttpContext.Response.Headers["Content-Type"] = _contentType;
 
-#if !NETSTANDARD2_0
                 context.HttpContext.Features.Get<AspNetCore.Http.Features.IHttpResponseBodyFeature>()?.DisableBuffering();
-#else
-                context.HttpContext.Features.Get<AspNetCore.Http.Features.IHttpBufferingFeature>()?.DisableResponseBuffering();
-#endif
 
                 await _action(context.HttpContext.Response.Body, token);
 


### PR DESCRIPTION
With 2.1 out of support, there's little reason to keep the netstandard build outputs. Removing these simplifies the necessary assembly references in the Options and WebApi projects.

closes #1270