### PR TITLE
Write logger entries to ITestOutputHelper.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
@@ -83,9 +83,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 .ConfigureLogging( loggingBuilder =>
                 {
                     loggingCallback?.Invoke(loggingBuilder);
+
+                    loggingBuilder.Services.AddSingleton<ILoggerProvider, TestOutputLoggerProvider>();
                 })
                 .ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
                 {
+                    services.AddSingleton<ITestOutputHelper>(outputHelper);
                     services.AddSingleton(RealSystemClock.Instance);
                     services.ConfigureGlobalCounter(context.Configuration);
                     services.AddSingleton<OperationTrackerService>();

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestOutputLogger.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestOutputLogger.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    internal sealed class TestOutputLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentDictionary<string, TestOutputLogger> _loggers = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ITestOutputHelper _outputHelper;
+
+        public TestOutputLoggerProvider(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _loggers.GetOrAdd(categoryName, (name, helper) => new TestOutputLogger(helper, name), _outputHelper);
+        }
+
+        public void Dispose()
+        {
+            _loggers.Clear();
+        }
+    }
+
+    internal sealed class TestOutputLogger : ILogger
+    {
+        private readonly string _categoryName;
+        private readonly ITestOutputHelper _outputHelper;
+
+        public TestOutputLogger(ITestOutputHelper outputHelper, string categoryName)
+        {
+            _categoryName = categoryName;
+            _outputHelper = outputHelper;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            _outputHelper.WriteLine($"[Logger:{_categoryName}][Id:{eventId.Id}] {formatter(state, exception)}");
+        }
+    }
+}


### PR DESCRIPTION
These changes take the log entries and write them to ITestOutputHelper so that the entries are in the test output. This will help diagnose test failures around components that log their state.