### PR TITLE
Fix logging message for exit code in AppRunner

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
                 await _runner.WaitForExitAsync(token).ConfigureAwait(false);
                 exitCode = _runner.ExitCode;
             }
-            _outputHelper.WriteLine("Exit Code: {0}", _exitCode);
+            _outputHelper.WriteLine("Exit Code: {0}", exitCode);
             _exitCode = exitCode;
             return exitCode.Value;
         }


### PR DESCRIPTION
Fix logging message for exit code in `AppRunner`. Current code causes null to always be printed.