### PR TITLE
Add net7.0 TFM to dotnet-monitor.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,18 @@
     -->
     <BlobGroupBuildQuality>daily</BlobGroupBuildQuality>
   </PropertyGroup>
+  <PropertyGroup Label="TargetFrameworks">
+    <!-- The TFMs of the dotnet-monitor tool.  -->
+    <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
+    <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
+    <ToolTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(ToolTargetFrameworks);net7.0</ToolTargetFrameworks>
+    <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
+    <TestTargetFrameworks>netcoreapp3.1;net5.0;net6.0</TestTargetFrameworks>
+    <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
+    <TestTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(TestTargetFrameworks);net7.0</TestTargetFrameworks>
+    <!-- The TFM for generating schema.json and OpenAPI docs. -->
+    <SchemaTargetFramework>net6.0</SchemaTargetFramework>
+  </PropertyGroup>
   <PropertyGroup Label="Arcade">
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>false</UsingToolNetFrameworkReferenceAssemblies>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-alpha.1.22054.5",
+    "dotnet": "7.0.100-alpha.1.22068.3",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",

--- a/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <!--
+      Ideally, this would be TestTargetFrameworks, but some of the test
+      assemblies have a binary dependency on the older TFMs.
+      -->
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsShippingAssembly>true</IsShippingAssembly>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <!--
+      Ideally, this would be TestTargetFrameworks, but some of the test
+      assemblies have a binary dependency on the older TFMs.
+      -->
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>Web Api surface for dotnet-monitor</Description>
     <!-- Tentatively create package so other teams can tentatively consume. -->

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
     <DefineConstants>$(DefineConstants);SCHEMAGEN</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 return TargetFrameworkMoniker.Net50;
 #elif NET6_0
                 return TargetFrameworkMoniker.Net60;
+#elif NET7_0
+                return TargetFrameworkMoniker.Net70;
 #endif
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -14,9 +14,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly string NetCore31VersionString = "$MicrosoftNetCoreApp31Version$";
         public static readonly string NetCore50VersionString = "$MicrosoftNetCoreApp50Version$";
         public static readonly string NetCore60VersionString = "$MicrosoftNetCoreApp60Version$";
+        public static readonly string NetCore70VersionString = "$MicrosoftNetCoreApp70Version$";
 
         public static readonly string AspNetCore31VersionString = "$MicrosoftAspNetCoreApp31Version$";
         public static readonly string AspNetCore50VersionString = "$MicrosoftAspNetCoreApp50Version$";
         public static readonly string AspNetCore60VersionString = "$MicrosoftAspNetCoreApp60Version$";
+        public static readonly string AspNetCore70VersionString = "$MicrosoftAspNetCoreApp70Version$";
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -11,9 +11,11 @@
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftNETCoreApp50Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</NetCoreAppVersion>
+    <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net7.0'">$(MicrosoftNETCoreApp70Version)</NetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftAspNetCoreApp31Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftAspNetCoreApp50Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftAspNetCoreApp60Version)</AspNetCoreAppVersion>
+    <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net7.0'">$(MicrosoftAspNetCoreApp70Version)</AspNetCoreAppVersion>
   </PropertyGroup>
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
@@ -24,9 +26,11 @@
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp31Version$', '$(MicrosoftNETCoreApp31Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp50Version$', '$(MicrosoftNETCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp60Version$', '$(MicrosoftNETCoreApp60Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp70Version$', '$(MicrosoftNETCoreApp70Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp31Version$', '$(MicrosoftAspNetCoreApp31Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp50Version$', '$(MicrosoftAspNetCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp60Version$', '$(MicrosoftAspNetCoreApp60Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp70Version$', '$(MicrosoftAspNetCoreApp70Version)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Microsoft.Diagnostics.Monitoring.TestCommon.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Microsoft.Diagnostics.Monitoring.TestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
                     // parameter from having the correct effect of using the exact framework version
                     // that we want. Disabling this forced version usage for ASP.NET 6+ applications
                     // until it can be resolved.
-                    if (!TargetFramework.IsEffectively(TargetFrameworkMoniker.Net60))
+                    if (!TargetFramework.IsEffectively(TargetFrameworkMoniker.Net60) &&
+                        !TargetFramework.IsEffectively(TargetFrameworkMoniker.Net70))
                     {
                         frameworkVersion = TargetFramework.GetAspNetCoreFrameworkVersionString();
                     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         Current,
         NetCoreApp31,
         Net50,
-        Net60
+        Net60,
+        Net70
     }
 
     public static class TargetFrameworkMonikerExtensions
@@ -34,6 +35,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return DotNetHost.AspNetCore50VersionString;
                 case TargetFrameworkMoniker.Net60:
                     return DotNetHost.AspNetCore60VersionString;
+                case TargetFrameworkMoniker.Net70:
+                    return DotNetHost.AspNetCore70VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -50,6 +53,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return DotNetHost.NetCore50VersionString;
                 case TargetFrameworkMoniker.Net60:
                     return DotNetHost.NetCore60VersionString;
+                case TargetFrameworkMoniker.Net70:
+                    return DotNetHost.NetCore70VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -76,6 +81,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return "netcoreapp3.1";
                 case TargetFrameworkMoniker.Net60:
                     return "net6.0";
+                case TargetFrameworkMoniker.Net70:
+                    return "net7.0";
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -97,7 +104,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         }
 
         private static readonly TargetFrameworkMoniker CurrentTargetFrameworkMoniker =
-#if NET6_0
+#if NET7_0
+            TargetFrameworkMoniker.Net70;
+#elif NET6_0
             TargetFrameworkMoniker.Net60;
 #elif NET5_0
             TargetFrameworkMoniker.Net50;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -53,7 +53,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
 
+#if NET7_OR_GREATER
+                    Version currentAspNetVersion = TargetFrameworkMoniker.Current.GetAspNetCoreFrameworkVersion();
+#else
                     Version currentAspNetVersion = TargetFrameworkMoniker.Net60.GetAspNetCoreFrameworkVersion();
+#endif
                     Assert.Equal(currentAspNetVersion.Major, runtimeVersion.Major);
                     Assert.Equal(currentAspNetVersion.Minor, runtimeVersion.Minor);
                     Assert.Equal(currentAspNetVersion.Revision, runtimeVersion.Revision);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
 
-#if NET7_OR_GREATER
+#if NET7_0_OR_GREATER
                     Version currentAspNetVersion = TargetFrameworkMoniker.Current.GetAspNetCoreFrameworkVersion();
 #else
                     Version currentAspNetVersion = TargetFrameworkMoniker.Net60.GetAspNetCoreFrameworkVersion();

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -49,7 +49,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
-                TargetFrameworkMoniker.Net60);
+#if NET7_0_OR_GREATER
+                TargetFrameworkMoniker.Net70
+#else
+                TargetFrameworkMoniker.Net60
+#endif
+                );
 
         private string SharedConfigDirectoryPath =>
             Path.Combine(TempPath, "SharedConfig");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-        <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Microsoft.Diagnostics.Monitoring.WebApi.csproj" />
-        <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Microsoft.Diagnostics.Monitoring.WebApi.csproj" />
+    <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
     <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>


### PR DESCRIPTION
These changes add the net7.0 TFM to all projects, including dotnet-monitor. The functional tests will use the net6.0 variant for testing netcoreapp3.1, net5.0, and net6.0 apps whereas the net7.0 variant will be used with the net7.0 apps (future changes can be made to test across targets).

I've centralized the TFM specifications for the projects so that it'll be easier to add and remove TFMs in the future.

Finally, the SDK is updated to bring in runtimes that contain fixes for some configuration bugs that were introduced in prior versions of the .NET 7 SDK.

closes #1269
