### PR TITLE
Port DiagnosticsReleaseTool fix to main

### DIFF
--- a/eng/release/DiagnosticsReleaseTool/Core/FileMetadata.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/FileMetadata.cs
@@ -72,7 +72,7 @@ namespace ReleaseTool.Core
 
         public override string ToString()
         {
-            return $"Class: {Class}, Category: {AssetCategory}, CDN: {ShouldPublishToCdn}, RID: {Rid}";
+            return $"Class: {Class}, Category: {AssetCategory}, CDN: {ShouldPublishToCdn}, RID: {Rid}, Sha512: {Sha512}";
         }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Core/Release.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/Release.cs
@@ -254,8 +254,10 @@ namespace ReleaseTool.Core
                                     return -1;
                                 }
                             }
-                            relativePublishPathsToHash.Add(dstPath, fileMetadata.Sha512);
-
+                            else
+                            {
+                                relativePublishPathsToHash.Add(dstPath, fileMetadata.Sha512);
+                            }
                             _logger.LogTrace("[{buildFilePath}, {worker}, {layoutInd}: {srcPath} -> {dstPath}, {fileMetadata}] adding layout to release data.", file.FullName, worker.GetType().FullName, i, srcPath, dstPath, fileMetadata);
                             _filesToRelease.Add(new FileReleaseData(fileMap, fileMetadata));
                         }


### PR DESCRIPTION
Ports the following PRs (made to `release/6.x`) into main:
- #1350
- #1351
- #1358
- #1359

This fixes a bug in the release tool that caused it to error when duplicate files exist in the DARC drop.

@hoyosjs let me know if we should also port this over to the Diagnositcs repo. It should be safe for you but it does change one of the core assumptions (that there won't be duplicate files in the DARC drop).