### PR TITLE
Push command line url parameters to lowest precedence.

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         /// </summary>
         [Theory]
         [InlineData(ConfigurationLevel.None)]
-        [InlineData(ConfigurationLevel.DotnetEnvironment)]
         [InlineData(ConfigurationLevel.HostBuilderSettingsUrl)]
+        [InlineData(ConfigurationLevel.DotnetEnvironment)]
         [InlineData(ConfigurationLevel.AspnetEnvironment)]
         [InlineData(ConfigurationLevel.AppSettings)]
         [InlineData(ConfigurationLevel.UserSettings)]
@@ -141,14 +141,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             {
                 Assert.Null(configuredUrls);
             }
-            else if (level == ConfigurationLevel.DotnetEnvironment)
-            {
-                // Not sure this was the intent that setting DOTNET_Urls via environment yields no
-                // configured URLS, however, this does not happen because the --urls command line
-                // parameter always supercedes this environment variable (again, not sure this was
-                // intended either).
-                Assert.Null(configuredUrls);
-            }
             else
             {
                 Assert.Equal(Enum.GetName(level), configuredUrls);
@@ -160,8 +152,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public enum ConfigurationLevel
         {
             None,
-            DotnetEnvironment,
             HostBuilderSettingsUrl,
+            DotnetEnvironment,
             AspnetEnvironment,
             AppSettings,
             UserSettings,

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static IHostBuilder CreateHostBuilder(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, AuthConfiguration authenticationOptions)
         {
-            return Host.CreateDefaultBuilder()
-                .UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
+            return new HostBuilder()
                 .ConfigureHostConfiguration((IConfigurationBuilder builder) =>
                 {
                     //Note these are in precedence order.
@@ -73,6 +72,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     builder.AddCommandLine(new[] { "--urls", ConfigurationHelper.JoinValue(urls) });
                 })
+                .ConfigureDefaults(args: null)
+                .UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
                     builder.AddJsonFile(UserSettingsPath, optional: true, reloadOnChange: true);

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         //3) Environment variables (ASPNETCORE_URLS, then DOTNETCORE_URLS)
 
                         //Our precedence
-                        //1) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
-                        //2) Command line arguments (these have defaults) --urls, --metricUrls
+                        //1) Command line arguments (these have defaults) --urls, --metricUrls
+                        //2) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
                         //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
 
                         string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);


### PR DESCRIPTION
This change pushes the command line url parameters to the lowest possible precedence so that DOTNET_* environment variables (e.g. DOTNET_Urls) can override them.

cc @wiktork 