### PR TITLE
[release/6.0] Push command line url parameters to lowest precedence.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,6 +43,7 @@
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
+    <MicrosoftExtensionsHostingVersion>6.0.0</MicrosoftExtensionsHostingVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21522.10</VSRedistCommonNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/symstore references -->

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         /// </summary>
         [Theory]
         [InlineData(ConfigurationLevel.None)]
-        [InlineData(ConfigurationLevel.DotnetEnvironment)]
         [InlineData(ConfigurationLevel.HostBuilderSettingsUrl)]
+        [InlineData(ConfigurationLevel.DotnetEnvironment)]
         [InlineData(ConfigurationLevel.AspnetEnvironment)]
         [InlineData(ConfigurationLevel.AppSettings)]
         [InlineData(ConfigurationLevel.UserSettings)]
@@ -141,14 +141,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             {
                 Assert.Null(configuredUrls);
             }
-            else if (level == ConfigurationLevel.DotnetEnvironment)
-            {
-                // Not sure this was the intent that setting DOTNET_Urls via environment yields no
-                // configured URLS, however, this does not happen because the --urls command line
-                // parameter always supercedes this environment variable (again, not sure this was
-                // intended either).
-                Assert.Null(configuredUrls);
-            }
             else
             {
                 Assert.Equal(Enum.GetName(typeof(ConfigurationLevel), level), configuredUrls);
@@ -160,8 +152,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public enum ConfigurationLevel
         {
             None,
-            DotnetEnvironment,
             HostBuilderSettingsUrl,
+            DotnetEnvironment,
             AspnetEnvironment,
             AppSettings,
             UserSettings,

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static IHostBuilder CreateHostBuilder(HostBuilderSettings settings)
         {
-            return Host.CreateDefaultBuilder()
-                .UseContentRoot(settings.ContentRootDirectory)
+            return new HostBuilder()
                 .ConfigureHostConfiguration((IConfigurationBuilder builder) =>
                 {
                     //Note these are in precedence order.
@@ -33,6 +32,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     builder.AddCommandLine(new[] { "--urls", ConfigurationHelper.JoinValue(settings.Urls ?? Array.Empty<string>()) });
                 })
+                .ConfigureDefaults(args: null)
+                .UseContentRoot(settings.ContentRootDirectory)
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
                     string userSettingsPath = Path.Combine(settings.UserConfigDirectory, SettingsFileName);
@@ -83,8 +84,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         //3) Environment variables (ASPNETCORE_URLS, then DOTNETCORE_URLS)
 
                         //Our precedence
-                        //1) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
-                        //2) Command line arguments (these have defaults) --urls, --metricUrls
+                        //1) Command line arguments (these have defaults) --urls, --metricUrls
+                        //2) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
                         //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
 
                         string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Backport of #1382 to release/6.0

This also requires taking a dependency on the 6.0.0 version of Microsoft.Extensions.Hosting in which the `IHostBuilder ConfigureDefaults(this IHostBuilder builder, params string[] args)` method was introduced. Without this dependency, the code would need to be rewritten in such as way that the in-memory collections are inserted _before_ the sources that were already added from prior invocations of `IHostBuilder IHostBuilder.ConfigureHostConfiguration(Action<IConfigurationBuilder> configureDelegate)`.