### PR TITLE
Remove task reference from BuildId parameter

### DIFF
--- a/eng/PrepareRelease.yml
+++ b/eng/PrepareRelease.yml
@@ -38,7 +38,7 @@ stages:
           targetType: filePath
           filePath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
           arguments: >-
-            -BarBuildId "$(setReleaseVars.BARBuildId)" 
+            -BarBuildId "$(BARBuildId)" 
             -AzdoToken "$(dn-bot-dotnet-all-scopes)" 
             -MaestroToken "$(MaestroAccessToken)" 
             -GitHubToken "$(BotAccount-dotnet-bot-repo-PAT)" 


### PR DESCRIPTION
Maestro vars are no longer isoutput=true, and should not be referenced with the task name.