### PR TITLE
Add MachineJson output format for key generation

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [InlineData(OutputFormat.Cmd)]
         [InlineData(OutputFormat.PowerShell)]
         [InlineData(OutputFormat.Shell)]
+        [InlineData(OutputFormat.MachineJson)]
         public async Task GenerateKey(OutputFormat? format)
         {
             using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TestTimeouts.OperationTimeout);
@@ -47,9 +48,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             string tokenStr = await toolRunner.GetBearerToken(cancellationToken);
             Assert.NotNull(tokenStr);
 
-            string formatStr = await toolRunner.GetFormat(cancellationToken);
-            Assert.NotNull(formatStr);
-            Assert.Equal(toolRunner.FormatUsed.ToString(), formatStr);
+            // MachineJson doesn't have a format string header
+            if (format != OutputFormat.MachineJson)
+            {
+                string formatStr = await toolRunner.GetFormat(cancellationToken);
+                Assert.NotNull(formatStr);
+                Assert.Equal(toolRunner.FormatUsed.ToString(), formatStr);
+            }
 
             string subject = await toolRunner.GetSubject(cancellationToken);
             Assert.NotNull(subject);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
@@ -2,16 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Dia2Lib;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Tools.Monitor;
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Dia2Lib;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Tools.Monitor;
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +30,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly Regex _bearerTokenRegex = 
             new Regex("^Authorization: Bearer (?<token>[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+)$", RegexOptions.Compiled);
+        private readonly Regex _authorizationHeaderRegex =
+            new Regex("^Bearer (?<token>[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+)$", RegexOptions.Compiled);
 
         // Completion source containing the format type emitted by the generatekey command
         private readonly TaskCompletionSource<string> _formatHeaderSource =
@@ -40,7 +45,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         private readonly Dictionary<OutputFormat, Regex> _subjectRegexMap =
             new Dictionary<OutputFormat, Regex>()
             {
-                { OutputFormat.Json, new Regex("\\\"Subject\\\":\\s*\\\"(?<subject>[0-9a-zA-Z-_!@#\\$%\\^&\\*\\(\\)\\{\\}\\[\\]|\\,\\.;:/]+)\\\"", RegexOptions.Compiled) },
+                { OutputFormat.MachineJson, null },
+                { OutputFormat.Json, null },
                 { OutputFormat.Text, new Regex("Subject:\\s*(?<subject>[0-9a-zA-Z-_!@#\\$%\\^&\\*\\(\\)\\{\\}\\[\\]|\\,\\.;:/]+)\\Z", RegexOptions.Compiled) },
                 { OutputFormat.Cmd, new Regex("set\\s*Authentication__MonitorApiKey__Subject=(?<subject>[0-9a-zA-Z-_!@#\\$%\\^&\\*\\(\\)\\{\\}\\[\\]|\\,\\.;:/]+)\\Z", RegexOptions.Compiled) },
                 { OutputFormat.PowerShell, new Regex("\\$env\\:Authentication__MonitorApiKey__Subject\\s*=\\s*\\\"(?<subject>[0-9a-zA-Z-_!@#\\$%\\^&\\*\\(\\)\\{\\}\\[\\]|\\,\\.;:/]+)\\\"", RegexOptions.Compiled) },
@@ -53,18 +59,22 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         private readonly Dictionary<OutputFormat, Regex> _publicKeyRegexMap =
             new Dictionary<OutputFormat, Regex>()
             {
-                { OutputFormat.Json, new Regex("\\\"PublicKey\\\":\\s*\\\"(?<publickey>[a-zA-Z0-9_-]{2,}?)\\\"", RegexOptions.Compiled) },
+                { OutputFormat.MachineJson, null },
+                { OutputFormat.Json, null },
                 { OutputFormat.Text, new Regex("Public Key:\\s(?<publickey>[a-zA-Z0-9_-]{2,}?)\\Z", RegexOptions.Compiled) },
                 { OutputFormat.Cmd, new Regex("set\\s*Authentication__MonitorApiKey__PublicKey=(?<publickey>[a-zA-Z0-9_-]{2,}?)\\Z", RegexOptions.Compiled) },
                 { OutputFormat.PowerShell, new Regex("\\$env\\:Authentication__MonitorApiKey__PublicKey\\s*=\\s*\\\"(?<publickey>[a-zA-Z0-9_-]{2,}?)\\\"", RegexOptions.Compiled) },
                 { OutputFormat.Shell, new Regex("export\\s*Authentication__MonitorApiKey__PublicKey=\\\"(?<publickey>[a-zA-Z0-9_-]{2,}?)\\\"", RegexOptions.Compiled) },
             };
 
-        // Completion source containing the full output in the specified format (this is everything after the _formatHeaderRegex line)
+        // Completion source containing the output in the specified format (this is everything after the _formatHeaderRegex line)
         private readonly TaskCompletionSource<string> _outputSource =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private StringBuilder _outputBuilder = new();
+
+        // String builder that has the full output this will include any headers
+        private StringBuilder _fullOutputBuilder = new();
 
         /// <summary>
         /// Gets the expected default <see cref="OutputFormat"/> when no --output parameter is specified at the command line.
@@ -153,10 +163,28 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 Assert.True(_subjectSource.TrySetResult(parsedOpts?.Authentication?.MonitorApiKey?.Subject));
                 Assert.True(_publicKeySource.TrySetResult(parsedOpts?.Authentication?.MonitorApiKey?.PublicKey));
             }
+            else if (FormatUsed == OutputFormat.MachineJson)
+            {
+                MachineOutputFormat parsedPayload = JsonSerializer.Deserialize<MachineOutputFormat>(_fullOutputBuilder.ToString());
+
+                Assert.NotNull(parsedPayload);
+
+                Match tokenMatch = _authorizationHeaderRegex.Match(parsedPayload.AuthorizationHeader);
+                if (tokenMatch.Success)
+                {
+                    string tokenValue = tokenMatch.Groups["token"].Value;
+                    _outputHelper.WriteLine($"Found Bearer Token: {tokenValue}");
+                    Assert.True(_bearerTokenTaskSource.TrySetResult(tokenValue));
+                }
+
+                Assert.True(_subjectSource.TrySetResult(parsedPayload.Authentication?.MonitorApiKey?.Subject));
+                Assert.True(_publicKeySource.TrySetResult(parsedPayload.Authentication?.MonitorApiKey?.PublicKey));
+            }
         }
 
         protected override void StandardOutputCallback(string line)
         {
+            _fullOutputBuilder.AppendLine(line);
             if (_formatHeaderSource.Task.IsCompletedSuccessfully)
             {
                 _outputBuilder.AppendLine(line);
@@ -178,29 +206,35 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 Assert.True(_formatHeaderSource.TrySetResult(formatValue));
             }
 
-            Match subjectMatch = _subjectRegexMap[FormatUsed].Match(line);
-            if (subjectMatch.Success)
+            if (_subjectRegexMap[FormatUsed] != null)
             {
-                string subjectValue = subjectMatch.Groups["subject"].Value;
-                _outputHelper.WriteLine($"Subject: {subjectValue}");
-
-                // for Json we will parse the whole blob and set the value that way
-                if (FormatUsed != OutputFormat.Json)
+                Match subjectMatch = _subjectRegexMap[FormatUsed].Match(line);
+                if (subjectMatch.Success)
                 {
-                    Assert.True(_subjectSource.TrySetResult(subjectValue));
+                    string subjectValue = subjectMatch.Groups["subject"].Value;
+                    _outputHelper.WriteLine($"Subject: {subjectValue}");
+
+                    // for Json we will parse the whole blob and set the value that way
+                    if (FormatUsed != OutputFormat.Json)
+                    {
+                        Assert.True(_subjectSource.TrySetResult(subjectValue));
+                    }
                 }
             }
 
-            Match publicKeyMatch = _publicKeyRegexMap[FormatUsed].Match(line);
-            if (publicKeyMatch.Success)
+            if (_publicKeyRegexMap[FormatUsed] != null)
             {
-                string publicKeyValue = publicKeyMatch.Groups["publickey"].Value;
-                _outputHelper.WriteLine($"Public Key: {publicKeyValue}");
-
-                // for Json we will parse the whole blob and set the value that way
-                if (FormatUsed != OutputFormat.Json)
+                Match publicKeyMatch = _publicKeyRegexMap[FormatUsed].Match(line);
+                if (publicKeyMatch.Success)
                 {
-                    Assert.True(_publicKeySource.TrySetResult(publicKeyValue));
+                    string publicKeyValue = publicKeyMatch.Groups["publickey"].Value;
+                    _outputHelper.WriteLine($"Public Key: {publicKeyValue}");
+
+                    // for Json we will parse the whole blob and set the value that way
+                    if (FormatUsed != OutputFormat.Json)
+                    {
+                        Assert.True(_publicKeySource.TrySetResult(publicKeyValue));
+                    }
                 }
             }
         }
@@ -228,6 +262,20 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         public Task<string> GetPublicKey(CancellationToken token)
         {
             return _publicKeySource.Task.WithCancellation(token);
+        }
+
+        /// <summary>
+        /// Expected output format for <see cref="OutputFormat.MachineJson" />
+        /// </summary>
+        /// <remarks>
+        /// This is intentionally a second copy of the class so that any changes to the first copy will cause a test failure.
+        /// We shouldn't change this format; if you find yourself here editing this, 
+        /// be careful of any downstream dependencies that are depending on this remaining stable.
+        /// </remarks>
+        internal class MachineOutputFormat
+        {
+            public AuthenticationOptions Authentication { get; set; }
+            public string AuthorizationHeader { get; set; }
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             }
             else if (FormatUsed == OutputFormat.MachineJson)
             {
-                MachineOutputFormat parsedPayload = JsonSerializer.Deserialize<MachineOutputFormat>(_fullOutputBuilder.ToString());
+                ExpectedMachineOutputFormat parsedPayload = JsonSerializer.Deserialize<ExpectedMachineOutputFormat>(_fullOutputBuilder.ToString());
 
                 Assert.NotNull(parsedPayload);
 
@@ -262,14 +262,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         }
 
         /// <summary>
-        /// Expected output format for <see cref="OutputFormat.MachineJson" />
+        /// Expected output format for <see cref="OutputFormat.MachineJson" />.
         /// </summary>
         /// <remarks>
-        /// This is intentionally a second copy of the class so that any changes to the first copy will cause a test failure.
-        /// We shouldn't change this format; if you find yourself here editing this, 
+        /// This is intentionally a second copy of the class used to generate the output, 
+        /// Microsoft.Diagnostics.Tools.Monitor.Commands.GenerateApiKeyCommandHandler.MachineOutputForma.
+        /// This is separate so that any breaking changes to the first copy will cause a test failure.
+        /// We shouldn't break this format; if you find yourself here editing this, 
         /// be careful of any downstream dependencies that are depending on this remaining stable.
         /// </remarks>
-        internal class MachineOutputFormat
+        internal class ExpectedMachineOutputFormat
         {
             public AuthenticationOptions Authentication { get; set; }
             public string AuthorizationHeader { get; set; }

--- a/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
@@ -136,8 +136,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         /// Represents the output format for <see cref="OutputFormat.MachineJson" />.
         /// </summary>
         /// <remarks>
-        /// This is intentionally a second copy of the class so that any changes to the first copy will cause a test failure.
-        /// We shouldn't change this format; if you find yourself here editing this, 
+        /// This is the first copy of this class, the testing companion is
+        /// Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners.MonitorGenerateKeyRunner.ExpectedMachineOutputFormat
+        /// ExpectedMachineOutputFormat. Any breaking changes here will cause a test failure.
+        /// If you find yourself here editing this, 
         /// be careful of any downstream dependencies that are depending on this remaining stable.
         /// </remarks>
         internal class MachineOutputFormat

--- a/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
@@ -12,6 +12,7 @@ using System.CommandLine;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,13 +29,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         {
             GeneratedJwtKey newJwt = GeneratedJwtKey.Create();
 
-            StringBuilder outputBldr = new StringBuilder();
-
-            outputBldr.AppendLine(Strings.Message_GenerateApiKey);
-            outputBldr.AppendLine();
-            outputBldr.AppendLine(string.Format(Strings.Message_GeneratedAuthorizationHeader, HeaderNames.Authorization, AuthConstants.ApiKeySchema, newJwt.Token));
-            outputBldr.AppendLine();
-
             RootOptions opts = new()
             {
                 Authentication = new AuthenticationOptions()
@@ -47,56 +41,77 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 }
             };
 
-            outputBldr.AppendFormat(CultureInfo.CurrentCulture, Strings.Message_SettingsDump, output);
-            outputBldr.AppendLine();
-            switch (output)
+            StringBuilder outputBldr = new StringBuilder();
+
+            if (output == OutputFormat.MachineJson)
             {
-                case OutputFormat.Json:
-                    {
-                        // Create configuration from object model.
-                        MemoryConfigurationSource source = new();
-                        source.InitialData = opts.ToConfigurationValues();
-                        ConfigurationBuilder builder = new();
-                        builder.Add(source);
-                        IConfigurationRoot configuration = builder.Build();
+                // For MachineJson, we don't do any decorations and the entire output payload is a single json blob
+                MachineOutputFormat result = new MachineOutputFormat()
+                {
+                    Authentication = opts.Authentication,
+                    AuthorizationHeader = $"{AuthConstants.ApiKeySchema} {newJwt.Token}" // This is the actual format of the HTTP header and should not be localized
+                };
+                outputBldr.AppendLine(JsonSerializer.Serialize(result, result.GetType(), new JsonSerializerOptions() { WriteIndented = true, IncludeFields = true }));
+            }
+            else
+            {
+                outputBldr.AppendLine(Strings.Message_GenerateApiKey);
+                outputBldr.AppendLine();
+                outputBldr.AppendLine(string.Format(Strings.Message_GeneratedAuthorizationHeader, HeaderNames.Authorization, AuthConstants.ApiKeySchema, newJwt.Token));
+                outputBldr.AppendLine();
 
-                        try
+                outputBldr.AppendFormat(CultureInfo.CurrentCulture, Strings.Message_SettingsDump, output);
+                outputBldr.AppendLine();
+                switch (output)
+                {
+                    case OutputFormat.Json:
                         {
-                            // Write configuration into stream
-                            using MemoryStream stream = new();
-                            using (ConfigurationJsonWriter writer = new(stream))
+                            // Create configuration from object model.
+                            MemoryConfigurationSource source = new();
+                            source.InitialData = opts.ToConfigurationValues();
+                            ConfigurationBuilder builder = new();
+                            builder.Add(source);
+                            IConfigurationRoot configuration = builder.Build();
+
+                            try
                             {
-                                writer.Write(configuration, full: true, skipNotPresent: true);
-                            }
+                                // Write configuration into stream
+                                using MemoryStream stream = new();
+                                using (ConfigurationJsonWriter writer = new(stream))
+                                {
+                                    writer.Write(configuration, full: true, skipNotPresent: true);
+                                }
 
-                            // Write stream content as test into builder.
-                            stream.Position = 0;
-                            using StreamReader reader = new(stream);
-                            outputBldr.AppendLine(reader.ReadToEnd());
+                                // Write stream content as test into builder.
+                                stream.Position = 0;
+                                using StreamReader reader = new(stream);
+                                outputBldr.AppendLine(reader.ReadToEnd());
+                            }
+                            finally
+                            {
+                                DisposableHelper.Dispose(configuration);
+                            }
                         }
-                        finally
+                        break;
+                    case OutputFormat.Text:
+                        outputBldr.AppendLine(string.Format(Strings.Message_GeneratekeySubject, newJwt.Subject));
+                        outputBldr.AppendLine(string.Format(Strings.Message_GeneratekeyPublicKey, newJwt.PublicKey));
+                        break;
+                    case OutputFormat.Cmd:
+                    case OutputFormat.PowerShell:
+                    case OutputFormat.Shell:
+                        IDictionary<string, string> optList = opts.ToEnvironmentConfiguration();
+                        foreach ((string name, string value) in optList)
                         {
-                            DisposableHelper.Dispose(configuration);
+                            outputBldr.AppendFormat(CultureInfo.InvariantCulture, GetFormatString(output), name, value);
+                            outputBldr.AppendLine();
                         }
-                    }
-                    break;
-                case OutputFormat.Text:
-                    outputBldr.AppendLine(string.Format(Strings.Message_GeneratekeySubject, newJwt.Subject));
-                    outputBldr.AppendLine(string.Format(Strings.Message_GeneratekeyPublicKey, newJwt.PublicKey));
-                    break;
-                case OutputFormat.Cmd:
-                case OutputFormat.PowerShell:
-                case OutputFormat.Shell:
-                    IDictionary<string, string> optList = opts.ToEnvironmentConfiguration();
-                    foreach ((string name, string value) in optList)
-                    {
-                        outputBldr.AppendFormat(CultureInfo.InvariantCulture, GetFormatString(output), name, value);
-                        outputBldr.AppendLine();
-                    }
-                    break;
+                        break;
+                }
+
+                outputBldr.AppendLine();
             }
 
-            outputBldr.AppendLine();
             console.Out.Write(outputBldr.ToString());
 
             return Task.FromResult(0);
@@ -115,6 +130,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 default:
                     throw new InvalidOperationException(string.Format(Strings.ErrorMessage_UnknownFormat, output));
             }
+        }
+
+        /// <summary>
+        /// Represents the output format for <see cref="OutputFormat.MachineJson" />.
+        /// </summary>
+        /// <remarks>
+        /// This is intentionally a second copy of the class so that any changes to the first copy will cause a test failure.
+        /// We shouldn't change this format; if you find yourself here editing this, 
+        /// be careful of any downstream dependencies that are depending on this remaining stable.
+        /// </remarks>
+        internal class MachineOutputFormat
+        {
+            public AuthenticationOptions Authentication { get; set; }
+            public string AuthorizationHeader { get; set; }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/OutputFormat.cs
+++ b/src/Tools/dotnet-monitor/OutputFormat.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         Cmd,
         Shell,
         PowerShell,
-        MachineJson
+        MachineJson,
     }
 }

--- a/src/Tools/dotnet-monitor/OutputFormat.cs
+++ b/src/Tools/dotnet-monitor/OutputFormat.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         Cmd,
         Shell,
         PowerShell,
+        MachineJson
     }
 }


### PR DESCRIPTION
Adds new `OutputFormat` called `MachineJson` which will cause `generatekey` to write out only a single json object. This is designed to be machine consumable and parsable.

`dotnet monitor generatekey --output MachineJson`
```json
{
  "Authentication": {
    "MonitorApiKey": {
      "Subject": "68b75a98-c440-4b87-8abc-42c81a06fdce",
      "PublicKey": "eyJBZGRpdGlvbmFsRGF0YSI6e30sIkNydiI6IlAtMzg0IiwiS2V5T3BzIjpbXSwiS3R5IjoiRUMiLCJYIjoiWG80NTFxdm9JRC1pS0ltLVRfZ2pTZVZteEhabC1RV1VpbnczWG1fUS1CTEM3c0ptSTVSTllSYzc2RlVDeldSZyIsIlg1YyI6W10sIlkiOiJoQWRPWENiczFhVHl6R1JTRVFET1FYUUsyUElrVGs1aVBSZWQ4YTBYbUNOQ2xmdTgwTmg3bGtSRFB0TllvZE5fIiwiS2V5U2l6ZSI6Mzg0LCJIYXNQcml2YXRlS2V5IjpmYWxzZSwiQ3J5cHRvUHJvdmlkZXJGYWN0b3J5Ijp7IkNyeXB0b1Byb3ZpZGVyQ2FjaGUiOnt9LCJDYWNoZVNpZ25hdHVyZVByb3ZpZGVycyI6dHJ1ZSwiU2lnbmF0dXJlUHJvdmlkZXJPYmplY3RQb29sQ2FjaGVTaXplIjozMn19"
    }
  },
  "AuthorizationHeader": "Bearer eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vZG90bmV0L2RvdG5ldC1tb25pdG9yIiwiaXNzIjoiaHR0cHM6Ly9naXRodWIuY29tL2RvdG5ldC9kb3RuZXQtbW9uaXRvci9nZW5lcmF0ZWtleStNb25pdG9yQXBpS2V5Iiwic3ViIjoiNjhiNzVhOTgtYzQ0MC00Yjg3LThhYmMtNDJjODFhMDZmZGNlIn0.FLIdB0w9YUemIc_XqGhHwMMUF4eHvPW0QgDh3CmiyieghLAL0pLGKkDBXVItvroqvp1Vsk3MkJTDl3bzWfF23iF-cDwxXuV4j4YjI0SACHBM2OhNNee_LWcXNowHQfHv"
}
```

Resolves #1428