### PR TITLE
Config Show - List configuration sources

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -188,6 +188,12 @@ The output of the command should resemble the following JSON object:
 }
 ```
 
+To view the loaded configuration providers, run the following command:
+
+```cmd
+dotnet monitor config show --showSources
+```
+
 ## Diagnostic Port Configuration
 
 `dotnet monitor` communicates via .NET processes through their diagnostic port. In the default configuration, .NET processes listen on a platform native transport (named pipes on Windows/Unix-domain sockets on \*nix) in a well-known location.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -191,7 +191,7 @@ The output of the command should resemble the following JSON object:
 To view the loaded configuration providers, run the following command:
 
 ```cmd
-dotnet monitor config show --showSources
+dotnet monitor config show --show-sources
 ```
 
 ## Diagnostic Port Configuration

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 {
@@ -15,12 +16,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         // Although the "noHttpEgress" parameter is unused, it keeps the entire command parameter set a superset
         // of the "collect" command so that users can take the same arguments from "collect" and use it on "config show"
         // to get the same configuration without telling them to drop specific command line arguments.
-        public static void Invoke(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, ConfigDisplayLevel level)
+        public static void Invoke(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, ConfigDisplayLevel level, bool showSources)
         {
-            Write(Console.OpenStandardOutput(), urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, level);
+            Write(Console.OpenStandardOutput(), urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, level, showSources);
         }
 
-        public static void Write(Stream stream, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, ConfigDisplayLevel level)
+        public static void Write(Stream stream, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, ConfigDisplayLevel level, bool showSources)
         {
             IAuthConfiguration authConfiguration = HostBuilderHelper.CreateAuthConfiguration(noAuth, tempApiKey);
             HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(urls, metricUrls, metrics, diagnosticPort, authConfiguration);
@@ -28,6 +29,30 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter jsonWriter = new ConfigurationJsonWriter(stream);
             jsonWriter.Write(configuration, full: level == ConfigDisplayLevel.Full, skipNotPresent: false);
+
+            if (showSources)
+            {
+                WriteConfigurationProviders(stream, configuration);
+            }
+        }
+
+        private static void WriteConfigurationProviders(Stream stream, IConfiguration configuration)
+        {
+            var configurationProviders = ((IConfigurationRoot)configuration).Providers.Reverse();
+
+            StreamWriter writer = new StreamWriter(stream);
+
+            writer.WriteLine("ConfigurationProviders (High to Low Priority):");
+
+
+            foreach (var provider in configurationProviders)
+            {
+                writer.WriteLine(" - " + provider.ToString());
+            }
+
+            writer.WriteLine();
+
+            writer.Flush();
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 {
@@ -32,26 +31,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 
             if (showSources)
             {
-                WriteConfigurationProviders(stream, configuration);
+                jsonWriter.WriteProviders(configuration);
             }
-        }
-
-        private static void WriteConfigurationProviders(Stream stream, IConfiguration configuration)
-        {
-            var configurationProviders = ((IConfigurationRoot)configuration).Providers.Reverse();
-
-            StreamWriter writer = new StreamWriter(stream);
-
-            writer.WriteLine("Configuration Providers (High to Low Priority):");
-
-            foreach (var provider in configurationProviders)
-            {
-                writer.WriteLine(" - " + provider.ToString());
-            }
-
-            writer.WriteLine();
-
-            writer.Flush();
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -27,12 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             IHost host = HostBuilderHelper.CreateHostBuilder(settings).Build();
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter jsonWriter = new ConfigurationJsonWriter(stream);
-            jsonWriter.Write(configuration, full: level == ConfigDisplayLevel.Full, skipNotPresent: false);
-
-            if (showSources)
-            {
-                jsonWriter.WriteProviders(configuration);
-            }
+            jsonWriter.Write(configuration, full: level == ConfigDisplayLevel.Full, skipNotPresent: false, showSources);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             IHost host = HostBuilderHelper.CreateHostBuilder(settings).Build();
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter jsonWriter = new ConfigurationJsonWriter(stream);
-            jsonWriter.Write(configuration, full: level == ConfigDisplayLevel.Full, skipNotPresent: false, showSources);
+            jsonWriter.Write(configuration, full: level == ConfigDisplayLevel.Full, skipNotPresent: false, showSources: showSources);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 
             StreamWriter writer = new StreamWriter(stream);
 
-            writer.WriteLine("ConfigurationProviders (High to Low Priority):");
-
+            writer.WriteLine("Configuration Providers (High to Low Priority):");
 
             foreach (var provider in configurationProviders)
             {

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -199,11 +199,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void ProcessSection(IConfigurationSection section, bool includeChildSections = true, bool redact = false, bool showSources = false)
         {
-            _writer.WritePropertyName(section.Key);
-
             IEnumerable<IConfigurationSection> children = section.GetChildren();
 
             bool canWriteChildren = CanWriteChildren(section, children);
+
+            if (!canWriteChildren)
+            {
+                string comment = GetConfigurationProvider(section, showSources);
+
+                if (comment.Length > 0)
+                {
+                    _writer.WriteCommentValue(comment);
+                }
+            }
+
+            _writer.WritePropertyName(section.Key);
 
             //If we do not traverse the child sections, the caller is responsible for creating the value
             if (includeChildSections && canWriteChildren)
@@ -226,7 +236,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         {
                             WriteValue(child.Value, redact);
 
-                            string comment = GetConfigurationProvider(section, showSources);
+                            string comment = GetConfigurationProvider(child, showSources);
 
                             if (comment.Length > 0)
                             {
@@ -245,12 +255,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             else if (!canWriteChildren)
             {
                 WriteValue(section.Value, redact);
-                string comment = GetConfigurationProvider(section, showSources);
-
-                if (comment.Length > 0)
-                {
-                    _writer.WriteCommentValue(comment);
-                }
             }
         }
 

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -199,21 +199,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void ProcessSection(IConfigurationSection section, bool includeChildSections = true, bool redact = false, bool showSources = false)
         {
+            _writer.WritePropertyName(section.Key);
+
             IEnumerable<IConfigurationSection> children = section.GetChildren();
 
             bool canWriteChildren = CanWriteChildren(section, children);
-
-            if (!canWriteChildren)
-            {
-                string comment = GetConfigurationProvider(section, showSources);
-
-                if (comment.Length > 0)
-                {
-                    _writer.WriteCommentValue(comment);
-                }
-            }
-
-            _writer.WritePropertyName(section.Key);
 
             //If we do not traverse the child sections, the caller is responsible for creating the value
             if (includeChildSections && canWriteChildren)
@@ -255,6 +245,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             else if (!canWriteChildren)
             {
                 WriteValue(section.Value, redact);
+
+                string comment = GetConfigurationProvider(section, showSources);
+
+                if (comment.Length > 0)
+                {
+                    _writer.WriteCommentValue(comment);
+                }
             }
         }
 

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -22,14 +22,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal sealed class ConfigurationJsonWriter : IDisposable
     {
         private readonly Utf8JsonWriter _writer;
+        private IConfiguration _configuration;
         public ConfigurationJsonWriter(Stream outputStream)
         {
             JsonWriterOptions options = new() { Indented = true };
             _writer = new Utf8JsonWriter(outputStream, options);
         }
 
-        public void Write(IConfiguration configuration, bool full, bool skipNotPresent)
+        public void Write(IConfiguration configuration, bool full, bool skipNotPresent, bool showSources=false)
         {
+            _configuration = configuration;
             //Note that we avoid IConfigurationRoot.GetDebugView because it shows everything
             //CONSIDER Should we show this in json, since it cannot represent complete configuration?
             //CONSIDER Should we convert number based names to arrays?
@@ -38,24 +40,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             using (new JsonObjectContext(_writer))
             {
-                ProcessChildSection(configuration, WebHostDefaults.ServerUrlsKey, skipNotPresent);
-                IConfigurationSection kestrel = ProcessChildSection(configuration, "Kestrel", skipNotPresent, includeChildSections: false);
+                ProcessChildSection(configuration, WebHostDefaults.ServerUrlsKey, skipNotPresent, showSources: showSources);
+                IConfigurationSection kestrel = ProcessChildSection(configuration, "Kestrel", skipNotPresent, includeChildSections: false, showSources: showSources);
                 if (kestrel != null)
                 {
                     using (new JsonObjectContext(_writer))
                     {
-                        IConfigurationSection certificates = ProcessChildSection(kestrel, "Certificates", skipNotPresent, includeChildSections: false);
+                        IConfigurationSection certificates = ProcessChildSection(kestrel, "Certificates", skipNotPresent, includeChildSections: false, showSources: showSources);
                         if (certificates != null)
                         {
                             using (new JsonObjectContext(_writer))
                             {
-                                IConfigurationSection defaultCert = ProcessChildSection(certificates, "Default", skipNotPresent, includeChildSections: false);
+                                IConfigurationSection defaultCert = ProcessChildSection(certificates, "Default", skipNotPresent, includeChildSections: false, showSources: showSources);
                                 if (defaultCert != null)
                                 {
                                     using (new JsonObjectContext(_writer))
                                     {
-                                        ProcessChildSection(defaultCert, "Path", skipNotPresent, includeChildSections: false);
-                                        ProcessChildSection(defaultCert, "Password", skipNotPresent, includeChildSections: false, redact: !full);
+                                        ProcessChildSection(defaultCert, "Path", skipNotPresent, includeChildSections: false, showSources: showSources);
+                                        ProcessChildSection(defaultCert, "Password", skipNotPresent, includeChildSections: false, redact: !full, showSources: showSources);
                                     }
                                 }
                             }
@@ -64,47 +66,47 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
 
                 //No sensitive information
-                ProcessChildSection(configuration, ConfigurationKeys.GlobalCounter, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.CollectionRules, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.CorsConfiguration, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.DiagnosticPort, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.Metrics, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.Storage, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.DefaultProcess, skipNotPresent, includeChildSections: true);
-                ProcessChildSection(configuration, ConfigurationKeys.Logging, skipNotPresent, includeChildSections: true);
+                ProcessChildSection(configuration, ConfigurationKeys.GlobalCounter, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.CollectionRules, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.CorsConfiguration, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.DiagnosticPort, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.Metrics, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.Storage, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.DefaultProcess, skipNotPresent, includeChildSections: true, showSources: showSources);
+                ProcessChildSection(configuration, ConfigurationKeys.Logging, skipNotPresent, includeChildSections: true, showSources: showSources);
 
                 if (full)
                 {
-                    ProcessChildSection(configuration, ConfigurationKeys.Authentication, skipNotPresent, includeChildSections: true);
-                    ProcessChildSection(configuration, ConfigurationKeys.Egress, skipNotPresent, includeChildSections: true);
+                    ProcessChildSection(configuration, ConfigurationKeys.Authentication, skipNotPresent, includeChildSections: true, showSources: showSources);
+                    ProcessChildSection(configuration, ConfigurationKeys.Egress, skipNotPresent, includeChildSections: true, showSources: showSources);
                 }
                 else
                 {
-                    IConfigurationSection auth = ProcessChildSection(configuration, ConfigurationKeys.Authentication, skipNotPresent, includeChildSections: false);
+                    IConfigurationSection auth = ProcessChildSection(configuration, ConfigurationKeys.Authentication, skipNotPresent, includeChildSections: false, showSources: showSources);
                     if (null != auth)
                     {
                         using (new JsonObjectContext(_writer))
                         {
-                            IConfigurationSection monitorApiKey = ProcessChildSection(auth, ConfigurationKeys.MonitorApiKey, skipNotPresent, includeChildSections: false);
+                            IConfigurationSection monitorApiKey = ProcessChildSection(auth, ConfigurationKeys.MonitorApiKey, skipNotPresent, includeChildSections: false, showSources: showSources);
                             if (null != monitorApiKey)
                             {
                                 using (new JsonObjectContext(_writer))
                                 {
-                                    ProcessChildSection(monitorApiKey, nameof(MonitorApiKeyOptions.Subject), skipNotPresent, includeChildSections: false, redact: false);
+                                    ProcessChildSection(monitorApiKey, nameof(MonitorApiKeyOptions.Subject), skipNotPresent, includeChildSections: false, redact: false, showSources: showSources);
                                     // The PublicKey should only ever contain the public key, however we expect that accidents may occur and we should
                                     // redact this field in the event the JWK contains the private key information.
-                                    ProcessChildSection(monitorApiKey, nameof(MonitorApiKeyOptions.PublicKey), skipNotPresent, includeChildSections: false, redact: true);
+                                    ProcessChildSection(monitorApiKey, nameof(MonitorApiKeyOptions.PublicKey), skipNotPresent, includeChildSections: false, redact: true, showSources: showSources);
                                 }
                             }
                         }
                     }
 
-                    IConfigurationSection egress = ProcessChildSection(configuration, ConfigurationKeys.Egress, skipNotPresent, includeChildSections: false);
+                    IConfigurationSection egress = ProcessChildSection(configuration, ConfigurationKeys.Egress, skipNotPresent, includeChildSections: false, showSources: showSources);
                     if (egress != null)
                     {
                         using (new JsonObjectContext(_writer))
                         {
-                            ProcessEgressSection(egress, skipNotPresent);
+                            ProcessEgressSection(egress, skipNotPresent, showSources: showSources);
                         }
                     }
                 }
@@ -127,18 +129,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _writer.WriteCommentValue(providersOutput.ToString());
         }
 
-        private void ProcessEgressSection(IConfiguration egress, bool skipNotPresent)
+        private void ProcessEgressSection(IConfiguration egress, bool skipNotPresent, bool showSources=false)
         {
             IList<string> processedSectionPaths = new List<string>();
 
             // Redact all the properties since they could include secrets such as storage keys
-            IConfigurationSection propertiesSection = ProcessChildSection(egress, nameof(EgressOptions.Properties), skipNotPresent, includeChildSections: true, redact: true);
+            IConfigurationSection propertiesSection = ProcessChildSection(egress, nameof(EgressOptions.Properties), skipNotPresent, includeChildSections: true, redact: true, showSources: showSources);
             if (null != propertiesSection)
             {
                 processedSectionPaths.Add(propertiesSection.Path);
             }
 
-            IConfigurationSection azureBlobProviderSection = ProcessChildSection(egress, nameof(EgressOptions.AzureBlobStorage), skipNotPresent, includeChildSections: false);
+            IConfigurationSection azureBlobProviderSection = ProcessChildSection(egress, nameof(EgressOptions.AzureBlobStorage), skipNotPresent, includeChildSections: false, showSources: showSources);
             if (azureBlobProviderSection != null)
             {
                 processedSectionPaths.Add(azureBlobProviderSection.Path);
@@ -150,20 +152,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         _writer.WritePropertyName(optionsSection.Key);
                         using (new JsonObjectContext(_writer))
                         {
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.AccountUri), skipNotPresent, includeChildSections: false);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.BlobPrefix), skipNotPresent, includeChildSections: false);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.ContainerName), skipNotPresent, includeChildSections: false);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.CopyBufferSize), skipNotPresent, includeChildSections: false);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.SharedAccessSignature), skipNotPresent, includeChildSections: false, redact: true);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.AccountKey), skipNotPresent, includeChildSections: false, redact: true);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.SharedAccessSignatureName), skipNotPresent, includeChildSections: false, redact: false);
-                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.AccountKeyName), skipNotPresent, includeChildSections: false, redact: false);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.AccountUri), skipNotPresent, includeChildSections: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.BlobPrefix), skipNotPresent, includeChildSections: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.ContainerName), skipNotPresent, includeChildSections: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.CopyBufferSize), skipNotPresent, includeChildSections: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.SharedAccessSignature), skipNotPresent, includeChildSections: false, redact: true, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.AccountKey), skipNotPresent, includeChildSections: false, redact: true, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.SharedAccessSignatureName), skipNotPresent, includeChildSections: false, redact: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(AzureBlobEgressProviderOptions.AccountKeyName), skipNotPresent, includeChildSections: false, redact: false, showSources: showSources);
                         }
                     }
                 }
             }
 
-            IConfigurationSection fileSystemProviderSection = ProcessChildSection(egress, nameof(EgressOptions.FileSystem), skipNotPresent, includeChildSections: false);
+            IConfigurationSection fileSystemProviderSection = ProcessChildSection(egress, nameof(EgressOptions.FileSystem), skipNotPresent, includeChildSections: false, showSources: showSources);
             if (fileSystemProviderSection != null)
             {
                 processedSectionPaths.Add(fileSystemProviderSection.Path);
@@ -175,9 +177,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         _writer.WritePropertyName(optionsSection.Key);
                         using (new JsonObjectContext(_writer))
                         {
-                            ProcessChildSection(optionsSection, nameof(FileSystemEgressProviderOptions.DirectoryPath), skipNotPresent, includeChildSections: false);
-                            ProcessChildSection(optionsSection, nameof(FileSystemEgressProviderOptions.IntermediateDirectoryPath), skipNotPresent, includeChildSections: false);
-                            ProcessChildSection(optionsSection, nameof(FileSystemEgressProviderOptions.CopyBufferSize), skipNotPresent, includeChildSections: false);
+                            ProcessChildSection(optionsSection, nameof(FileSystemEgressProviderOptions.DirectoryPath), skipNotPresent, includeChildSections: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(FileSystemEgressProviderOptions.IntermediateDirectoryPath), skipNotPresent, includeChildSections: false, showSources: showSources);
+                            ProcessChildSection(optionsSection, nameof(FileSystemEgressProviderOptions.CopyBufferSize), skipNotPresent, includeChildSections: false, showSources: showSources);
                         }
                     }
                 }
@@ -188,12 +190,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             {
                 if (!processedSectionPaths.Contains(childSection.Path))
                 {
-                    ProcessChildSection(egress, childSection.Key, skipNotPresent, includeChildSections: true, redact: true);
+                    ProcessChildSection(egress, childSection.Key, skipNotPresent, includeChildSections: true, redact: true, showSources: showSources);
                 }
             }
         }
 
-        private IConfigurationSection ProcessChildSection(IConfiguration parentSection, string key, bool skipNotPresent, bool includeChildSections = true, bool redact = false)
+        private IConfigurationSection ProcessChildSection(IConfiguration parentSection, string key, bool skipNotPresent, bool includeChildSections = true, bool redact = false, bool showSources=false)
         {
             IConfigurationSection section = parentSection.GetSection(key);
             if (!section.Exists())
@@ -206,12 +208,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 return null;
             }
 
-            ProcessSection(section, includeChildSections, redact);
+            ProcessSection(section, includeChildSections, redact, showSources: showSources);
 
             return section;
         }
 
-        private void ProcessSection(IConfigurationSection section, bool includeChildSections = true, bool redact = false)
+        private void ProcessSection(IConfigurationSection section, bool includeChildSections = true, bool redact = false, bool showSources = false)
         {
             _writer.WritePropertyName(section.Key);
 
@@ -234,11 +236,33 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         if (child.GetChildren().Any())
                         {
-                            ProcessChildren(child, includeChildSections, redact);
+                            ProcessChildren(child, includeChildSections, redact,  showSources: showSources);
                         }
                         else
                         {
                             WriteValue(child.Value, redact);
+
+                            if (showSources)
+                            {
+                                var configurationProviders = ((IConfigurationRoot)_configuration).Providers.Reverse();
+
+                                StringBuilder comment = new StringBuilder();
+
+                                foreach (var provider in configurationProviders)
+                                {
+                                    provider.TryGet(section.Path, out string value);
+
+                                    if (!string.IsNullOrEmpty(value))
+                                    {
+                                        comment.Append(provider.ToString());
+                                    }
+                                }
+
+                                if (comment.Length > 0)
+                                {
+                                    _writer.WriteCommentValue(comment.ToString());
+                                }
+                            }
                         }
                     }
 
@@ -246,12 +270,34 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
                 else
                 {
-                    ProcessChildren(section, includeChildSections, redact);
+                    ProcessChildren(section, includeChildSections, redact, showSources: showSources);
                 }
             }
             else if (!canWriteChildren)
             {
                 WriteValue(section.Value, redact);
+
+                if (showSources)
+                {
+                    var configurationProviders = ((IConfigurationRoot)_configuration).Providers.Reverse();
+
+                    StringBuilder comment = new StringBuilder();
+
+                    foreach (var provider in configurationProviders)
+                    {
+                        provider.TryGet(section.Path, out string value);
+
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            comment.Append(provider.ToString());
+                        }
+                    }
+
+                    if (comment.Length > 0)
+                    {
+                        _writer.WriteCommentValue(comment.ToString());
+                    }
+                }
             }
         }
 
@@ -272,13 +318,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _writer.WriteStringValue(valueToWrite);
         }
 
-        private void ProcessChildren(IConfigurationSection section, bool includeChildSections, bool redact)
+        private void ProcessChildren(IConfigurationSection section, bool includeChildSections, bool redact, bool showSources)
         {
             using (new JsonObjectContext(_writer))
             {
                 foreach (IConfigurationSection child in section.GetChildren())
                 {
-                    ProcessSection(child, includeChildSections, redact);
+                    ProcessSection(child, includeChildSections, redact, showSources: showSources);
                 }
             }
         }

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _writer = new Utf8JsonWriter(outputStream, options);
         }
 
-        public void Write(IConfiguration configuration, bool full, bool skipNotPresent, bool showSources=false)
+        public void Write(IConfiguration configuration, bool full, bool skipNotPresent, bool showSources = false)
         {
             _configuration = configuration;
             //Note that we avoid IConfigurationRoot.GetDebugView because it shows everything
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
-        private void ProcessEgressSection(IConfiguration egress, bool skipNotPresent, bool showSources=false)
+        private void ProcessEgressSection(IConfiguration egress, bool skipNotPresent, bool showSources = false)
         {
             IList<string> processedSectionPaths = new List<string>();
 
@@ -179,7 +179,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
-        private IConfigurationSection ProcessChildSection(IConfiguration parentSection, string key, bool skipNotPresent, bool includeChildSections = true, bool redact = false, bool showSources=false)
+        private IConfigurationSection ProcessChildSection(IConfiguration parentSection, string key, bool skipNotPresent, bool includeChildSections = true, bool redact = false, bool showSources = false)
         {
             IConfigurationSection section = parentSection.GetSection(key);
             if (!section.Exists())
@@ -230,6 +230,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                             if (comment.Length > 0)
                             {
+                                // TODO: Comments are currently written after Key/Value pairs due to a limitation in System.Text.Json
+                                // that prevents comments from being directly after commas
                                 _writer.WriteCommentValue(comment);
                             }
                         }
@@ -250,6 +252,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                 if (comment.Length > 0)
                 {
+                    // TODO: Comments are currently written after Key/Value pairs due to a limitation in System.Text.Json
+                    // that prevents comments from being directly after commas
                     _writer.WriteCommentValue(comment);
                 }
             }
@@ -261,7 +265,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             {
                 var configurationProviders = ((IConfigurationRoot)_configuration).Providers.Reverse();
 
-                StringBuilder comment = new StringBuilder();
+                string comment = string.Empty;
 
                 foreach (var provider in configurationProviders)
                 {
@@ -269,15 +273,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     if (!string.IsNullOrEmpty(value))
                     {
-                        comment.Append(provider.ToString());
+                        comment = provider.ToString();
                         break;
                     }
                 }
 
-                return comment.ToString();
+                return comment;
             }
 
-            return "";
+            return string.Empty;
         }
 
         private bool CanWriteChildren(IConfigurationSection section, IEnumerable<IConfigurationSection> children)

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
@@ -108,6 +109,22 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     }
                 }
             }
+        }
+
+        public void WriteProviders(IConfiguration configuration)
+        {
+            var configurationProviders = ((IConfigurationRoot)configuration).Providers.Reverse();
+
+            StringBuilder providersOutput = new StringBuilder();
+
+            providersOutput.AppendLine(Strings.Message_ShowSources);
+
+            foreach (var provider in configurationProviders)
+            {
+                providersOutput.AppendLine(" - " + provider.ToString());
+            }
+
+            _writer.WriteCommentValue(providersOutput.ToString());
         }
 
         private void ProcessEgressSection(IConfiguration egress, bool skipNotPresent)

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option ShowSources() =>
             new Option(
-                alias: "--showSources",
+                alias: "--show-sources",
                 description: Strings.HelpDescription_OptionShowSources)
             {
                 Argument = new Argument<bool>(name: "showSources", getDefaultValue: () => false)

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     // Handler
                     CommandHandler.Create(ConfigShowCommandHandler.Invoke),
                     SharedOptions(),
-                    ConfigLevel()
+                    ConfigLevel(),
+                    ShowSources()
                 }
             };
 
@@ -129,6 +130,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 description: Strings.HelpDescription_OptionLevel)
             {
                 Argument = new Argument<ConfigDisplayLevel>(name: "level", getDefaultValue: () => ConfigDisplayLevel.Redacted)
+            };
+
+        private static Option ShowSources() =>
+            new Option(
+                alias: "--sources",
+                description: Strings.HelpDescription_OptionShowSources)
+            {
+                Argument = new Argument<bool>(name: "sources", getDefaultValue: () => true)
             };
 
         public static Task<int> Main(string[] args)

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -134,10 +134,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option ShowSources() =>
             new Option(
-                alias: "--sources",
+                alias: "--showSources",
                 description: Strings.HelpDescription_OptionShowSources)
             {
-                Argument = new Argument<bool>(name: "sources", getDefaultValue: () => true)
+                Argument = new Argument<bool>(name: "showSources", getDefaultValue: () => false)
             };
 
         public static Task<int> Main(string[] args)

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -493,6 +493,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show loaded configuration providers from high to low priority.
+        /// </summary>
+        internal static string HelpDescription_OptionShowSources {
+            get {
+                return ResourceManager.GetString("HelpDescription_OptionShowSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Generates a new MonitorApiKey for each launch of the process..
         /// </summary>
         internal static string HelpDescription_OptionTempApiKey {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1015,6 +1015,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Configuration Providers (High to Low Priority):.
+        /// </summary>
+        internal static string Message_ShowSources {
+            get {
+                return ResourceManager.GetString("Message_ShowSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to :NOT PRESENT:.
         /// </summary>
         internal static string Placeholder_NotPresent {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -621,6 +621,10 @@
     <value>Settings in {0} format:</value>
     <comment>Gets a header string for the configuration output of GenerateApiKeyCommand.</comment>
   </data>
+  <data name="Message_ShowSources" xml:space="preserve">
+    <value>Configuration Providers (High to Low Priority):</value>
+    <comment>Gets the string for displaying the configuration providers with the --show-sources flag.</comment>
+  </data>
   <data name="Placeholder_NotPresent" xml:space="preserve">
     <value>:NOT PRESENT:</value>
     <comment>Gets a string similar to ":NOT PRESENT:".</comment>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -355,6 +355,10 @@
     <value>Turn off HTTP response egress</value>
     <comment>Gets the string to display in help that explains what the '--no-http-egress' option does.</comment>
   </data>
+  <data name="HelpDescription_OptionShowSources" xml:space="preserve">
+    <value>Show loaded configuration providers from high to low priority</value>
+    <comment>Gets the string to display in help that explains what the '--sources' option does.</comment>
+  </data>
   <data name="HelpDescription_OptionTempApiKey" xml:space="preserve">
     <value>Generates a new MonitorApiKey for each launch of the process.</value>
     <comment>Gets the string to display in help that explains what the '--temp-apikey' option does.</comment>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -357,7 +357,7 @@
   </data>
   <data name="HelpDescription_OptionShowSources" xml:space="preserve">
     <value>Show loaded configuration providers from high to low priority</value>
-    <comment>Gets the string to display in help that explains what the '--sources' option does.</comment>
+    <comment>Gets the string to display in help that explains what the '--show-sources' option does.</comment>
   </data>
   <data name="HelpDescription_OptionTempApiKey" xml:space="preserve">
     <value>Generates a new MonitorApiKey for each launch of the process.</value>


### PR DESCRIPTION
With the addition of the `--show-sources` flag, users can now view the configuration sources that `dotnet monitor` is using to generate the configuration for debugging purposes. NOTE: this does not show which parts of the configuration are associated with each provider - if we'd rather invest in trying to do that, we can close this PR and I can work on a different solution.

Closes #277 