### PR TITLE
Add common release scripts

### DIFF
--- a/eng/release/Scripts/GetBarId.ps1
+++ b/eng/release/Scripts/GetBarId.ps1
@@ -15,7 +15,7 @@ $tagsUri = "${env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${env:SYSTEM_TEAMPROJECT}/_
 $buildData = Invoke-RestMethod `
     -Uri $tagsUri `
     -Method 'GET' `
-    -Headers @{ 'accept' = 'application/json'; 'Authorization' = 'Bearer ' + $env:System_AccessToken }
+    -Headers @{ 'accept' = 'application/json'; 'Authorization' = "Bearer ${env:System_AccessToken}" }
 
 Write-Verbose 'BuildData:'
 $buildDataJson = $buildData | ConvertTo-Json

--- a/eng/release/Scripts/GetBarId.ps1
+++ b/eng/release/Scripts/GetBarId.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][string] $BuildId,
+    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+if ([String]::IsNullOrEmpty($env:System_AccessToken)) {
+    Write-Error 'System access token missing, this script needs access.'
+}
+
+$tagsUri = "${env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${env:SYSTEM_TEAMPROJECT}/_apis/build/builds/$BuildId/tags?api-version=6.0"
+$buildData = Invoke-RestMethod `
+    -Uri $tagsUri `
+    -Method 'GET' `
+    -Headers @{ 'accept' = 'application/json'; 'Authorization' = 'Bearer ' + $env:System_AccessToken }
+
+Write-Verbose 'BuildData:'
+$buildDataJson = $buildData | ConvertTo-Json
+Write-Verbose $buildDataJson
+
+$barId = -1;
+$buildData.Value | Foreach-Object {
+    if ($_.StartsWith('BAR ID - ')) {
+        if ($barId -ne -1) {
+            Write-Error 'Multiple BAR IDs found in tags.'
+        }
+        $barId = $_.SubString(9)
+    }
+}
+
+if ($barId -eq -1) {
+    Write-Error 'Failed to get BAR ID from tags.'
+}
+
+Write-Verbose "BAR ID: $barId"
+
+if ($TaskVariableName) {
+    & $PSScriptRoot\SetTaskVariable.ps1 `
+        -Name $TaskVariableName `
+        -Value $barId
+}
+
+Write-Ouptut $barId

--- a/eng/release/Scripts/GetBarId.ps1
+++ b/eng/release/Scripts/GetBarId.ps1
@@ -43,4 +43,4 @@ if ($TaskVariableName) {
         -Value $barId
 }
 
-Write-Ouptut $barId
+Write-Output $barId

--- a/eng/release/Scripts/GetReleaseVersion.ps1
+++ b/eng/release/Scripts/GetReleaseVersion.ps1
@@ -1,0 +1,39 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][string] $BarId,
+    [Parameter(Mandatory=$true)][string] $MaestroToken,
+    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
+    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null,
+    [Parameter(Mandatory=$false)][switch] $IncludeV
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$releaseData = Invoke-RestMethod `
+    -Uri "$MaestroApiEndPoint/api/assets?buildId=$BarId&name=dotnet-monitor&api-version=2020-02-20" `
+    -Method 'GET' `
+    -Headers @{ 'accept' = 'application/json'; 'Authorization' = "Bearer $MaestroToken" }
+
+Write-Verbose 'ReleaseData:'
+$releaseDataJson = $releaseData | ConvertTo-Json
+Write-Verbose $releaseDataJson
+
+if ($releaseData.Length -ne 1) {
+    Write-Error 'Unable to obtain release version'
+}
+
+$version = $releaseData[0].Version
+if ($IncludeV) {
+    $version = "v$version"
+}
+
+Write-Verbose "Release Version: $version"
+
+if ($TaskVariableName) {
+    & $PSScriptRoot\SetTaskVariable.ps1 `
+        -Name $TaskVariableName `
+        -Value $version
+}
+
+Write-Output $version

--- a/eng/release/Scripts/GetReleaseVersion.ps1
+++ b/eng/release/Scripts/GetReleaseVersion.ps1
@@ -3,6 +3,7 @@ Param(
     [Parameter(Mandatory=$true)][string] $BarId,
     [Parameter(Mandatory=$true)][string] $MaestroToken,
     [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
+    [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2020-02-20',
     [Parameter(Mandatory=$false)][string] $TaskVariableName = $null,
     [Parameter(Mandatory=$false)][switch] $IncludeV
 )
@@ -11,7 +12,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
 $releaseData = Invoke-RestMethod `
-    -Uri "$MaestroApiEndPoint/api/assets?buildId=$BarId&name=dotnet-monitor&api-version=2020-02-20" `
+    -Uri "$MaestroApiEndPoint/api/assets?buildId=$BarId&name=dotnet-monitor&api-version=$MaestroApiVersion" `
     -Method 'GET' `
     -Headers @{ 'accept' = 'application/json'; 'Authorization' = "Bearer $MaestroToken" }
 

--- a/eng/release/Scripts/SetTaskVariable.ps1
+++ b/eng/release/Scripts/SetTaskVariable.ps1
@@ -1,0 +1,10 @@
+param(
+    [Parameter(Mandatory=$true)][string] $Name,
+    [Parameter(Mandatory=$false)][string] $Value
+)
+
+$ErrorActionPreference = 'Stop'
+$VerbosePreference = 'Continue'
+Set-StrictMode -Version 2.0
+
+Write-Host "##vso[task.setvariable variable=$Name]$Value"


### PR DESCRIPTION
This change adds the Get BAR ID and Get Release Version inline scripts from the release definition into the repo with several improvements:
- Caller can decide if it wants verbose information (e.g. release data and versions) by using the -Verbose flag.
- Caller can decide whether to push final output value into a task variable.
- Use standard error stream for reporting errors and failing the script immediately.
- Allows calling script via file path so that script parameters are printed into task output.
- Allows reuse among multiple build tasks.

cc @kelltrick, @hoyosjs