### PR TITLE
Release tool updates

### DIFF
--- a/eng/release/DiagnosticsReleaseTool/Common/BlobLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/BlobLayoutWorker.cs
@@ -5,7 +5,7 @@ namespace ReleaseTool.Core
     public sealed class BlobLayoutWorker : PassThroughLayoutWorker
     {
         public BlobLayoutWorker(string stagingPath) : base(
-            shouldHandleFileFunc: static file => true,
+            shouldHandleFileFunc: static _ => true,
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Blob),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Blob),
             stagingPath

--- a/eng/release/DiagnosticsReleaseTool/Common/BlobLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/BlobLayoutWorker.cs
@@ -1,0 +1,14 @@
+using System.IO;
+
+namespace ReleaseTool.Core
+{
+    public sealed class BlobLayoutWorker : PassThroughLayoutWorker
+    {
+        public BlobLayoutWorker(string stagingPath) : base(
+            shouldHandleFileFunc: static file => true,
+            getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Blob),
+            getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Blob),
+            stagingPath
+        ){}
+    }
+}

--- a/eng/release/DiagnosticsReleaseTool/Common/ChecksumLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/ChecksumLayoutWorker.cs
@@ -1,0 +1,14 @@
+using System.IO;
+
+namespace ReleaseTool.Core
+{
+    public sealed class ChecksumLayoutWorker : PassThroughLayoutWorker
+    {
+        public ChecksumLayoutWorker(string stagingPath) : base(
+            shouldHandleFileFunc: static file => file.Extension == ".sha512",
+            getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Checksum),
+            getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Checksum),
+            stagingPath
+        ){}
+    }
+}

--- a/eng/release/DiagnosticsReleaseTool/Common/NugetLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/NugetLayoutWorker.cs
@@ -1,11 +1,12 @@
+using System;
 using System.IO;
 
 namespace ReleaseTool.Core
 {
     public sealed class NugetLayoutWorker : PassThroughLayoutWorker
     {
-        public NugetLayoutWorker(string stagingPath) : base(
-            shouldHandleFileFunc: static file => file.Extension == ".nupkg" && file.Directory.Name == "packages",
+        public NugetLayoutWorker(string stagingPath, Func<FileInfo, bool> additionalFileConstraint = null) : base(
+            shouldHandleFileFunc: file => file.Extension == ".nupkg" && (null == additionalFileConstraint || additionalFileConstraint(file)),
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Nuget),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Nuget),
             stagingPath

--- a/eng/release/DiagnosticsReleaseTool/Common/NugetLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/NugetLayoutWorker.cs
@@ -5,7 +5,7 @@ namespace ReleaseTool.Core
     public sealed class NugetLayoutWorker : PassThroughLayoutWorker
     {
         public NugetLayoutWorker(string stagingPath) : base(
-            shouldHandleFileFunc: static file => file.Extension == ".nupkg" && !file.Name.EndsWith(".symbols.nupkg"),
+            shouldHandleFileFunc: static file => file.Extension == ".nupkg" && file.Directory.Name == "packages",
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Nuget),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Nuget),
             stagingPath

--- a/eng/release/DiagnosticsReleaseTool/Common/SkipPublisher.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/SkipPublisher.cs
@@ -1,0 +1,27 @@
+﻿using ReleaseTool.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ReleaseTool.Core
+{
+    internal class SkipPublisher : IPublisher
+    {
+        private readonly HashSet<string> _relativeOutputPaths = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Dispose()
+        {
+        }
+
+        public Task<string> PublishFileAsync(FileMapping fileData, CancellationToken ct)
+        {
+            if (!_relativeOutputPaths.Add(fileData.RelativeOutputPath))
+            {
+                throw new InvalidOperationException($"File {fileData.LocalSourcePath} was already published to {fileData.RelativeOutputPath}.");
+            }
+
+            return Task.FromResult(fileData.RelativeOutputPath);
+        }
+    }
+}

--- a/eng/release/DiagnosticsReleaseTool/Core/FileMetadata.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/FileMetadata.cs
@@ -7,6 +7,7 @@ namespace ReleaseTool.Core
         Blob,
         Nuget,
         SymbolPackage,
+        Checksum,
         Unknown
     }
 
@@ -66,6 +67,7 @@ namespace ReleaseTool.Core
             FileClass.Blob => "BlobAssets",
             FileClass.Nuget => "NugetAssets",
             FileClass.SymbolPackage => "SymbolNugetAssets",
+            FileClass.Checksum => "ChecksumAssets",
             FileClass.Unknown => "UnknownAssets",
             _ => "UnknownAssets"
         };

--- a/eng/release/DiagnosticsReleaseTool/Core/Release.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/Release.cs
@@ -224,14 +224,6 @@ namespace ReleaseTool.Core
 
                     if (layoutResult.Status == LayoutResultStatus.FileHandled)
                     {
-                        if (isProcessed)
-                        {
-                            // TODO: Might be worth to relax this limitation. It just needs to turn the
-                            //      source -> fileData relationship to something like source -> List<FileData>).
-                            _logger.LogError("[{buildFilePath}, {worker}] File {file} is getting handled by several workers.", file.FullName, worker.GetType().FullName, file);
-                            return -1;
-                        }
-
                         isProcessed = true;
 
                         (FileMapping fileMap, FileMetadata fileMetadata)[] layoutResultArray = layoutResult.LayoutDataEnumerable.ToArray();
@@ -261,6 +253,9 @@ namespace ReleaseTool.Core
                             _logger.LogTrace("[{buildFilePath}, {worker}, {layoutInd}: {srcPath} -> {dstPath}, {fileMetadata}] adding layout to release data.", file.FullName, worker.GetType().FullName, i, srcPath, dstPath, fileMetadata);
                             _filesToRelease.Add(new FileReleaseData(fileMap, fileMetadata));
                         }
+
+                        // Skip remaining layout workers
+                        break;
                     }
                 }
 

--- a/eng/release/DiagnosticsReleaseTool/DarcHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DarcHelpers.cs
@@ -96,5 +96,10 @@ namespace DiagnosticsReleaseTool.Util
                 return new DirectoryInfo(matchingProducts.First().GetProperty("fileshare").GetString());
             }
         }
+
+        internal static bool IsNuGetPackage(FileInfo file)
+        {
+            return file.Extension == ".nupkg" && file.Directory.Name == "packages";
+        }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLine.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLine.cs
@@ -27,11 +27,11 @@ namespace DiagnosticsReleaseTool.CommandLine
                 name: "prepare-release",
                 description: "Given a darc drop, generates validated manifests and layouts to initiate a tool release.")
             {
-                CommandHandler.Create<Config, bool, CancellationToken>(DiagnosticsReleaseRunner.PrepareRelease),
+                CommandHandler.Create<Config, bool, bool, CancellationToken>(DiagnosticsReleaseRunner.PrepareRelease),
                 // Inputs
                 InputDropPathOption(), ToolManifestPathOption(), ReleaseNameOption(),
                 // Toggles
-                ToolManifestVerificationOption(), DiagnosticLoggingOption(),
+                ToolManifestVerificationOption(), DiagnosticLoggingOption(), DryRunOption(),
                 // Outputs
                 StagingPathOption(), AzureStorageAccountNameOption(), AzureStorageAccountKeyOption(), AzureStorageContainerNameOption(), AzureStorageSasExpirationOption()
             };
@@ -40,6 +40,12 @@ namespace DiagnosticsReleaseTool.CommandLine
             new Option<bool>(
                 aliases: new[] { "-v", "--verbose" },
                 description: "Enables diagnostic logging",
+                getDefaultValue: () => false);
+
+        private static Option<bool> DryRunOption() =>
+            new Option<bool>(
+                aliases: new[] { "--dry-run" },
+                description: "Stages files and generates manifest, but does not publish.",
                 getDefaultValue: () => false);
 
         private static Option ToolManifestPathOption() =>

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseRunner.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseRunner.cs
@@ -25,10 +25,11 @@ namespace DiagnosticsReleaseTool.Impl
             var layoutWorkerList = new List<ILayoutWorker>
             {
                 // TODO: We may want to inject a logger.
-                new NugetLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName),
+                new NugetLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName, DarcHelpers.IsNuGetPackage),
                 new SymbolPackageLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName),
                 new ChecksumLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName),
                 new SkipLayoutWorker(shouldHandleFileFunc: DiagnosticsRepoHelpers.IsDockerUtilityFile),
+                // This should always be last since it will accept any file
                 new BlobLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName)
             };
 

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseRunner.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseRunner.cs
@@ -8,7 +8,6 @@ using ReleaseTool.Core;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace DiagnosticsReleaseTool.Impl
 {
@@ -16,7 +15,7 @@ namespace DiagnosticsReleaseTool.Impl
     {
         internal const string ManifestName = "publishManifest.json";
 
-        internal async static Task<int> PrepareRelease(Config releaseConfig, bool verbose, CancellationToken ct)
+        internal async static Task<int> PrepareRelease(Config releaseConfig, bool verbose, bool dryRun, CancellationToken ct)
         {
             // TODO: This will throw if invalid drop path is given.
             var darcLayoutHelper = new DarcHelpers(releaseConfig.DropPath);
@@ -28,9 +27,9 @@ namespace DiagnosticsReleaseTool.Impl
                 // TODO: We may want to inject a logger.
                 new NugetLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName),
                 new SymbolPackageLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName),
-                new SkipLayoutWorker(
-                    shouldHandleFileFunc: DiagnosticsRepoHelpers.IsDockerUtilityFile
-                )
+                new ChecksumLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName),
+                new SkipLayoutWorker(shouldHandleFileFunc: DiagnosticsRepoHelpers.IsDockerUtilityFile),
+                new BlobLayoutWorker(stagingPath: releaseConfig.StagingDirectory.FullName)
             };
 
             var verifierList = new List<IReleaseVerifier> { };
@@ -46,7 +45,9 @@ namespace DiagnosticsReleaseTool.Impl
             DirectoryInfo basePublishDirectory = darcLayoutHelper.GetShippingDirectoryForSingleProjectVariants(DiagnosticsRepoHelpers.ProductNames);
             string publishManifestPath = Path.Combine(releaseConfig.StagingDirectory.FullName, ManifestName);
 
-            IPublisher releasePublisher = new AzureBlobBublisher(releaseConfig.AccountName, releaseConfig.AccountKey, releaseConfig.ContainerName, releaseConfig.ReleaseName, releaseConfig.SasValidDays, logger);
+            IPublisher releasePublisher = dryRun ?
+                new SkipPublisher() :
+                new AzureBlobBublisher(releaseConfig.AccountName, releaseConfig.AccountKey, releaseConfig.ContainerName, releaseConfig.ReleaseName, releaseConfig.SasValidDays, logger);
             IManifestGenerator manifestGenerator = new DiagnosticsManifestGenerator(releaseMetadata, releaseConfig.ToolManifest, logger);
 
             using var diagnosticsRelease = new Release(

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
@@ -7,8 +7,7 @@ namespace DiagnosticsReleaseTool.Util
         public static readonly string[] ProductNames = new []{ "dotnet-monitor", "dotnet-dotnet-monitor" };
         public static readonly string[] RepositoryUrls = new [] { "https://github.com/dotnet/dotnet-monitor", "https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor" };
         internal static bool IsDockerUtilityFile(FileInfo arg) =>
-            arg.FullName.EndsWith(".nupkg.sha512")
-            || arg.FullName.EndsWith(".nupkg.version")
+            arg.FullName.EndsWith(".nupkg.version")
             || arg.FullName.EndsWith(".nupkg.buildversion");
     }
 }


### PR DESCRIPTION
- Change NugetLayoutWorker to only consider files under the packages directory
- Add checksum file to ChecksumAssets in publish manifest
- Add unprocessed files to BlobAssets in publish manifest
- Add --dry-run option to run tool without publishing

The changes will make it easier to publish blob assets to the desired target storage account, checksums to a different storage account, and more easily have NuGet publishing only consider NuGet packages (fixes issue where the nupkg was listed twice under NuGetAssets).

Example dry run publish manifest:
```json
{
  "ReleaseVersion": "20220127.7",
  "RepoUrl": "https://github.com/dotnet/dotnet-monitor",
  "Branch": "refs/heads/release/6.0",
  "Commit": "9774a8ccc1a015d47960ed76de1bc6a5a1227f2c",
  "DateProduced": "2022-01-28T05:44:47+00:00",
  "BuildNumber": "20220127.7",
  "BarBuildId": 124762,
  "BlobAssets": [
    {
      "PublishRelativePath": "BlobAssets/dotnet-monitor.6.0.2.nupkg",
      "PublishedPath": "BlobAssets/dotnet-monitor.6.0.2.nupkg",
      "Sha512": "3203E455FE4FA9E7B251BA957DDF286A3A3FCF1C88663315547D5F4F7DF9EE1C1F164DFCC42EDEEBAF786BF1B893753C5A5339377B259798208D5F07C48F9A10"
    }
  ],
  "NugetAssets": [
    {
      "PublishRelativePath": "NugetAssets/dotnet-monitor.6.0.2.nupkg",
      "PublishedPath": "NugetAssets/dotnet-monitor.6.0.2.nupkg",
      "Sha512": "3203E455FE4FA9E7B251BA957DDF286A3A3FCF1C88663315547D5F4F7DF9EE1C1F164DFCC42EDEEBAF786BF1B893753C5A5339377B259798208D5F07C48F9A10"
    }
  ],
  "SymbolNugetAssets": [
    {
      "PublishRelativePath": "SymbolNugetAssets/dotnet-monitor.6.0.2.symbols.nupkg",
      "PublishedPath": "SymbolNugetAssets/dotnet-monitor.6.0.2.symbols.nupkg",
      "Sha512": "3203E455FE4FA9E7B251BA957DDF286A3A3FCF1C88663315547D5F4F7DF9EE1C1F164DFCC42EDEEBAF786BF1B893753C5A5339377B259798208D5F07C48F9A10"
    }
  ],
  "ChecksumAssets": [
    {
      "PublishRelativePath": "ChecksumAssets/dotnet-monitor.6.0.2.nupkg.sha512",
      "PublishedPath": "ChecksumAssets/dotnet-monitor.6.0.2.nupkg.sha512",
      "Sha512": "9D6045C11F71F380D97D8A3A4CC0B6C07FD866DB21DD19F422F973DB6F00C5F4FC037316443C727DD7E810303B9079EAD50289EE703A50782C306E5059A1F387"
    }
  ],
  "UnknownAssets": []
}
```

closes #1386 