### PR TITLE
Scripts and pipeline for release to blob storage

### DIFF
--- a/eng/release.yml
+++ b/eng/release.yml
@@ -1,0 +1,183 @@
+trigger: none
+pr: none
+
+parameters:
+- name: IsTest
+  type: boolean
+  default: true
+- name: IsDryRun
+  type: boolean
+  default: true
+
+variables:
+- name: _TeamName
+  value: DotNetCore
+- group: Release-Pipeline
+
+resources:
+  pipelines:
+  - pipeline: Build
+    source: dotnet-dotnet-monitor
+
+stages:
+- stage: Validation
+
+  pool:
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+
+  jobs:
+  - job: Validate
+
+    variables:
+    # Allow for differentiation of runs of this pipeline
+    # when running it with the same build repeatedly.
+    - name: RunRevision
+      value: $[counter(variables['resources.pipeline.Build.runID'],1)]
+
+    workspace:
+      clean: all
+
+    steps:
+    - download: none
+
+    - task: PowerShell@2
+      displayName: Get BAR ID
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBarId.ps1
+        arguments: >-
+          -BuildId $(resources.pipeline.Build.runID)
+          -TaskVariableName 'BarId'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+    - task: PowerShell@2
+      displayName: Get Release Version
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
+        arguments: >-
+          -BarId $(BarId)
+          -MaestroToken $(MaestroAccessToken)
+          -TaskVariableName 'ReleaseVersion'
+    
+    - task: PowerShell@2
+      displayName: Get Build Version
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+        arguments: >-
+          -BarId $(BarId)
+          -MaestroToken $(MaestroAccessToken)
+          -TaskVariableName 'BuildVersion'
+
+    - powershell: Write-Host "##vso[build.updatebuildnumber]$(ReleaseVersion) ($(BuildVersion)) (R$(RunRevision))"
+      displayName: Set Name
+
+- stage: Publish
+  dependsOn:
+  - Validation
+
+  pool:
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+
+  jobs:
+  - deployment: PublishToStorageAccounts
+    displayName: Publish to Storage Accounts
+
+    ${{ if eq(parameters.IsTest, 'true') }}:
+      environment: Diagnostics-Monitor-Storage-Test
+    ${{ else }}:
+      environment: Diagnostics-Monitor-Storage-DotNetCli
+
+    variables:
+    - ${{ if eq(parameters.IsTest, 'true') }}:
+      - group: DotNet-Diagnostics-Storage-Test
+    - group: DotNet-DotNetStage-Storage
+
+    workspace:
+      clean: all
+
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - checkout: self
+          - download: none
+
+          - task: PowerShell@2
+            displayName: Install AzCopy
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/release/Scripts/InstallAzCopy.ps1
+              arguments: >-
+                -ToolsDirectory $(Agent.ToolsDirectory)
+                -TaskVariableName 'AzCopyPath'
+
+          - task: PowerShell@2
+            displayName: Get BAR ID
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBarId.ps1
+              arguments: >-
+                -BuildId $(resources.pipeline.Build.runID)
+                -TaskVariableName 'BarId'
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+          - task: PowerShell@2
+            displayName: Get Release Version
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
+              arguments: >-
+                -BarId $(BarId)
+                -MaestroToken $(MaestroAccessToken)
+                -TaskVariableName 'ReleaseVersion'
+
+          - powershell: Install-PackageProvider -Name NuGet -Force -Scope CurrentUser
+            displayName: Install NuGet PowerShell Package Provider
+
+          - powershell: Install-Module Az.Storage -Force -Scope CurrentUser -AllowClobber -Verbose
+            displayName: Install Az.Storage Module
+
+          - powershell: |
+              Write-Host "##vso[task.setvariable variable=DestinationAccountName]$env:DESTINATION_ACCOUNT_NAME"
+              Write-Host "##vso[task.setvariable variable=DestinationAccountKey;issecret=true]$env:DESTINATION_ACCOUNT_KEY"
+              Write-Host "##vso[task.setvariable variable=ChecksumsAccountName]$env:CHECKSUMS_ACCOUNT_NAME"
+              Write-Host "##vso[task.setvariable variable=ChecksumsAccountKey;issecret=true]$env:CHECKSUMS_ACCOUNT_KEY"
+            displayName: Set Storage Accounts
+            ${{ if eq(parameters.IsTest, 'true') }}:
+              env:
+                # Variables provided by DotNet-Diagnostics-Storage-Test group
+                DESTINATION_ACCOUNT_NAME: $(dotnet-monitor-test-storage-accountname)
+                DESTINATION_ACCOUNT_KEY: $(dotnet-monitor-test-storage-accountkey)
+                CHECKSUMS_ACCOUNT_NAME: $(dotnet-monitor-checksums-test-storage-accountname)
+                CHECKSUMS_ACCOUNT_KEY: $(dotnet-monitor-checksums-test-storage-accountkey)
+            ${{ else }}:
+              env:
+                # Variables provided by Release-Pipeline group
+                DESTINATION_ACCOUNT_NAME: dotnetcli
+                DESTINATION_ACCOUNT_KEY: $(dotnetcli-storage-key)
+                CHECKSUMS_ACCOUNT_NAME: dotnetclichecksums
+                CHECKSUMS_ACCOUNT_KEY: $(dotnetclichecksums-storage-key)
+
+          - task: PowerShell@2
+            displayName: Publish Assets
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/release/Scripts/PublishToBlobAccounts.ps1
+              arguments: >-
+                -AzCopyPath $(AzCopyPath)
+                -BuildNumber $(resources.pipeline.Build.runName)
+                -ReleaseVersion $(ReleaseVersion)
+                -DotnetStageAccountKey $(dotnetstage-storage-key)
+                -DestinationAccountName $(DestinationAccountName)
+                -DestinationAccountKey $(DestinationAccountKey)
+                -ChecksumsAccountName $(ChecksumsAccountName)
+                -ChecksumsAccountKey $(ChecksumsAccountKey)
+                -WhatIf:${{ format('${0}', parameters.IsDryRun) }}
+          
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Logs
+            inputs:
+              PathtoPublish: '$(USERPROFILE)\.azcopy'
+              PublishLocation: Container
+              ArtifactName: AzCopyLogs
+            continueOnError: true
+            condition: succeededOrFailed()

--- a/eng/release.yml
+++ b/eng/release.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 parameters:
-- name: IsTest
+- name: IsTestRun
   type: boolean
   default: true
 - name: IsDryRun
@@ -12,7 +12,14 @@ parameters:
 variables:
 - name: _TeamName
   value: DotNetCore
+  readonly: true
 - group: Release-Pipeline
+- name: IsDryRun
+  value: ${{ parameters.IsDryRun }}
+  readonly: true
+- name: IsTestRun
+  value: ${{ parameters.IsTestRun }}
+  readonly: true
 
 resources:
   pipelines:
@@ -33,7 +40,8 @@ stages:
     # Allow for differentiation of runs of this pipeline
     # when running it with the same build repeatedly.
     - name: RunRevision
-      value: $[counter(variables['resources.pipeline.Build.runID'],1)]
+      value: $[counter(format('{0}|{1}|{2}', variables['resources.pipeline.Build.runID'], variables['IsDryRun'], variables['IsTestRun']), 1)]
+      readonly: true
 
     workspace:
       clean: all
@@ -69,7 +77,16 @@ stages:
           -MaestroToken $(MaestroAccessToken)
           -TaskVariableName 'BuildVersion'
 
-    - powershell: Write-Host "##vso[build.updatebuildnumber]$(ReleaseVersion) ($(BuildVersion)) (R$(RunRevision))"
+    - powershell: |
+        $buildName = "${env:ReleaseVersion} [${env:BuildVersion}]"
+        if ($env:IsDryRun -eq 'true') {
+          $buildName += "[Dry]"
+        }
+        if ($env:IsTestRun -eq 'true') {
+          $buildName += "[Test]"
+        }
+        $buildName += "[Run ${env:RunRevision}]"
+        Write-Host "##vso[build.updatebuildnumber]$buildName"
       displayName: Set Name
 
 - stage: Publish
@@ -84,13 +101,13 @@ stages:
   - deployment: PublishToStorageAccounts
     displayName: Publish to Storage Accounts
 
-    ${{ if eq(parameters.IsTest, 'true') }}:
+    ${{ if eq(parameters.IsTestRun, 'true') }}:
       environment: Diagnostics-Monitor-Storage-Test
     ${{ else }}:
       environment: Diagnostics-Monitor-Storage-DotNetCli
 
     variables:
-    - ${{ if eq(parameters.IsTest, 'true') }}:
+    - ${{ if eq(parameters.IsTestRun, 'true') }}:
       - group: DotNet-Diagnostics-Storage-Test
     - group: DotNet-DotNetStage-Storage
 
@@ -143,7 +160,7 @@ stages:
               Write-Host "##vso[task.setvariable variable=ChecksumsAccountName]$env:CHECKSUMS_ACCOUNT_NAME"
               Write-Host "##vso[task.setvariable variable=ChecksumsAccountKey;issecret=true]$env:CHECKSUMS_ACCOUNT_KEY"
             displayName: Set Storage Accounts
-            ${{ if eq(parameters.IsTest, 'true') }}:
+            ${{ if eq(parameters.IsTestRun, 'true') }}:
               env:
                 # Variables provided by DotNet-Diagnostics-Storage-Test group
                 DESTINATION_ACCOUNT_NAME: $(dotnet-monitor-test-storage-accountname)

--- a/eng/release/Scripts/InstallAzCopy.ps1
+++ b/eng/release/Scripts/InstallAzCopy.ps1
@@ -1,0 +1,48 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][string] $ToolsDirectory,
+    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$url = 'https://aka.ms/downloadazcopy-v10-windows'
+$basePath = Join-Path $ToolsDirectory 'azcopy'
+
+$zipPath = Join-Path $basePath 'azcopy.zip'
+$toolDirPath = Join-Path $basePath 'azcopy'
+$azCopyPath = Join-Path $toolDirPath 'azcopy.exe'
+
+if (Test-Path $azCopyPath) {
+    Write-Verbose 'Already installed'
+} else {
+    if (!(Test-Path $basePath)) {
+        New-Item -ItemType 'Directory' -Path $basePath | Out-Null
+    }
+
+    Write-Verbose 'Fetching...'
+    Invoke-WebRequest -Uri $url -OutFile $zipPath
+
+    Write-Verbose 'Unzipping...'
+    Expand-Archive -LiteralPath $zipPath -Force -DestinationPath $basePath
+
+    # There should only be one directory that is named like 'azcopy_windows_amd64_<version>'
+    Write-Verbose 'Renaming...'
+    $unpackDirName = Get-ChildItem -Path $basePath -Directory -Name
+    $unpackDirPath = Join-Path $basePath $unpackDirName
+    Rename-Item -Path $unpackDirPath -NewName 'azcopy'
+
+    # Delete zip
+    Remove-Item -Path $zipPath
+
+    Write-Verbose 'Finished'
+}
+
+if ($TaskVariableName) {
+    & $PSScriptRoot\SetTaskVariable.ps1 `
+        -Name $TaskVariableName `
+        -Value $azCopyPath
+}
+
+Write-Output $azCopyPath

--- a/eng/release/Scripts/PublishToBlobAccounts.ps1
+++ b/eng/release/Scripts/PublishToBlobAccounts.ps1
@@ -1,0 +1,121 @@
+[CmdletBinding(SupportsShouldProcess)]
+Param(
+    [Parameter(Mandatory=$true)][string]$AzCopyPath,
+    [Parameter(Mandatory=$true)][string]$BuildNumber,
+    [Parameter(Mandatory=$true)][string]$ReleaseVersion,
+    [Parameter(Mandatory=$true)][string]$DotnetStageAccountKey,
+    [Parameter(Mandatory=$true)][string]$DestinationAccountName,
+    [Parameter(Mandatory=$true)][string]$DestinationAccountKey,
+    [Parameter(Mandatory=$true)][string]$ChecksumsAccountName,
+    [Parameter(Mandatory=$true)][string]$ChecksumsAccountKey
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$sourceAccountName = 'dotnetstage'
+$sourceContainerName = 'dotnet-monitor'
+$destinationContainerName = 'dotnet'
+
+function Generate-Source-Uri{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)][string]$AssetType
+    )
+
+    return "https://$sourceAccountName.blob.core.windows.net/$sourceContainerName/$BuildNumber/${AssetType}Assets/*"
+}
+
+function Generate-Destination-Uri{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)][string]$AccountName
+    )
+
+    return "https://$AccountName.blob.core.windows.net/$destinationContainerName/diagnostics/monitor/$ReleaseVersion"
+}
+
+function Generate-Sas-Token{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)][string]$StorageAccountName,
+        [Parameter(Mandatory=$true)][string]$ContainerName,
+        [Parameter(Mandatory=$true)][string]$AccountKey,
+        [Parameter(Mandatory=$true)][string]$Permissions
+    )
+
+    $context = New-AzStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $AccountKey;
+    return New-AzStorageContainerSASToken -Container $ContainerName -Context $context -Permission $Permissions -ExpiryTime (Get-Date).AddHours(1.0);
+}
+
+function Transfer-File{
+    [CmdletBinding(SupportsShouldProcess)]
+    Param(
+        [Parameter(Mandatory=$true)][string]$From,
+        [Parameter(Mandatory=$true)][string]$To,
+        [Parameter(Mandatory=$true)][string]$FromToken,
+        [Parameter(Mandatory=$true)][string]$ToToken
+    )
+
+    Write-Verbose "Copy $From -> $To"
+
+    if ($From -eq $to) {
+        Write-Verbose 'Skipping copy because source and destination are the same.'
+    } else {
+        [array]$azCopyArgs = "$from$fromToken"
+        $azCopyArgs += "$to$toToken"
+        $azCopyArgs += "--s2s-preserve-properties"
+        $azCopyArgs += "--s2s-preserve-access-tier=false"
+        if ($WhatIfPreference) {
+            $azCopyArgs += "--dry-run"
+        }
+        & $AzCopyPath cp @azCopyArgs
+    }
+}
+
+# Create source URI and SAS token
+$sourceUri = Generate-Source-Uri `
+    -AssetType 'Blob'
+$soureSasToken = Generate-Sas-Token `
+    -StorageAccountName $sourceAccountName `
+    -ContainerName $sourceContainerName `
+    -AccountKey $DotnetStageAccountKey `
+    -Permissions 'rl'
+
+# Create destination URI and SAS token
+$destinationUri = Generate-Destination-Uri `
+    -AccountName $DestinationAccountName
+$destinationSasToken = Generate-Sas-Token `
+    -StorageAccountName $DestinationAccountName `
+    -ContainerName $destinationContainerName `
+    -AccountKey $DestinationAccountKey `
+    -Permissions 'rlw'
+
+# Copy files to destination account
+Transfer-File `
+    -From $sourceUri `
+    -FromToken $soureSasToken `
+    -To $destinationUri `
+    -ToToken $destinationSasToken `
+    -WhatIf:$WhatIfPreference
+
+# Create source checksums URI
+$checksumsSourceUri = Generate-Source-Uri `
+    -AssetType 'Checksum'
+
+# Create checksums destination URI and SAS token
+$checksumsDestinationUri = Generate-Destination-Uri `
+    -AccountName $ChecksumsAccountName
+$checksumsDestinationSasToken = Generate-Sas-Token `
+    -StorageAccountName $ChecksumsAccountName `
+    -ContainerName $destinationContainerName `
+    -AccountKey $ChecksumsAccountKey `
+    -Permissions 'rlw'
+
+# Copy checksums to checksum account
+Transfer-File `
+    -From $checksumsSourceUri `
+    -FromToken $soureSasToken `
+    -To $checksumsDestinationUri `
+    -ToToken $checksumsDestinationSasToken `
+    -WhatIf:$WhatIfPreference

--- a/eng/release/Scripts/PublishToBlobAccounts.ps1
+++ b/eng/release/Scripts/PublishToBlobAccounts.ps1
@@ -44,8 +44,16 @@ function Generate-Sas-Token{
         [Parameter(Mandatory=$true)][string]$Permissions
     )
 
-    $context = New-AzStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $AccountKey;
-    return New-AzStorageContainerSASToken -Container $ContainerName -Context $context -Permission $Permissions -ExpiryTime (Get-Date).AddHours(1.0);
+    $context = New-AzStorageContext `
+        -StorageAccountName $StorageAccountName
+        -StorageAccountKey $AccountKey
+
+    return New-AzStorageContainerSASToken `
+        -Container $ContainerName
+        -Context $context
+        -Permission $Permissions
+        -StartTime (Get-Date).AddMinutes(-15.0)
+        -ExpiryTime (Get-Date).AddHours(1.0)
 }
 
 function Transfer-File{

--- a/eng/release/Scripts/PublishToBlobAccounts.ps1
+++ b/eng/release/Scripts/PublishToBlobAccounts.ps1
@@ -45,14 +45,14 @@ function Generate-Sas-Token{
     )
 
     $context = New-AzStorageContext `
-        -StorageAccountName $StorageAccountName
+        -StorageAccountName $StorageAccountName `
         -StorageAccountKey $AccountKey
 
     return New-AzStorageContainerSASToken `
-        -Container $ContainerName
-        -Context $context
-        -Permission $Permissions
-        -StartTime (Get-Date).AddMinutes(-15.0)
+        -Container $ContainerName `
+        -Context $context `
+        -Permission $Permissions `
+        -StartTime (Get-Date).AddMinutes(-15.0) `
         -ExpiryTime (Get-Date).AddHours(1.0)
 }
 


### PR DESCRIPTION
These changes add scripts and a pipeline for publishing the `dotnet monitor` files from the staging location to the expected production location. They have options for performing a dry-run (exercises all of the publish steps but not actually push the files to the destination accounts) and for testing with test accounts (exercises all of the publish steps but publishes to test accounts rather than `dotnetcli` and `dotnetclichecksums`). The test and dry-run modes are the default to prevent accidental promotion. When not running a test run, the promotion will use an environment that requires an explicit approval, whereas the test run uses an environment that has automatic approval.

Example runs:
- [6.1.0 candidate test (dry-run)](https://dev.azure.com/dnceng/internal/_build/results?buildId=1605372&view=results)
- [6.1.0 candidate test](https://dev.azure.com/dnceng/internal/_build/results?buildId=1605407&view=results)
- [7.0.0 P1 candidate test](https://dev.azure.com/dnceng/internal/_build/results?buildId=1605409&view=results)

Over time, I think the other existing release process (push to NuGet.org, create GitHub release) can be folded into this pipeline.