### PR TITLE
Reduce log messages for APIKey changes when no API key is configured

### DIFF
--- a/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public void PostConfigure(string name, JwtBearerOptions options)
         {
             MonitorApiKeyConfiguration configSnapshot = _apiKeyConfig.CurrentValue;
-            if (configSnapshot.ValidationErrors.Any())
+            if (!configSnapshot.Configured || configSnapshot.ValidationErrors.Any())
             {
                 options.SecurityTokenValidators.Add(new RejectAllSecurityValidator());
                 return;

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     /// </summary>
     internal class MonitorApiKeyConfiguration : AuthenticationSchemeOptions
     {
+        public bool Configured { get; set; }
         public string Subject { get; set; }
         public SecurityKey PublicKey { get; set; }
         public IEnumerable<ValidationResult> ValidationErrors { get; set; }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -49,14 +49,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void CheckMonitorApiKeyOptions(MonitorApiKeyConfiguration options)
         {
-            // ValidationErrors will be null if API key authentication is not enabled.
-            if (null != options.ValidationErrors && options.ValidationErrors.Any())
+            // lets only print out messages if the user passed something into the API Key configuration
+            if (options.Configured)
             {
-                _logger.ApiKeyValidationFailures(options.ValidationErrors);
-            }
-            else
-            {
-                _logger.ApiKeyAuthenticationOptionsValidated();
+                if (null != options.ValidationErrors && options.ValidationErrors.Any())
+                {
+                    _logger.ApiKeyValidationFailures(options.ValidationErrors);
+                }
+                else
+                {
+                    _logger.ApiKeyAuthenticationOptionsValidated();
+                }
             }
         }
     }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void CheckMonitorApiKeyOptions(MonitorApiKeyConfiguration options)
         {
-            // lets only print out messages if the user passed something into the API Key configuration
             if (options.Configured)
             {
                 if (null != options.ValidationErrors && options.ValidationErrors.Any())
@@ -60,6 +59,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     _logger.ApiKeyAuthenticationOptionsValidated();
                 }
+            }
+            else
+            {
+                _logger.MonitorApiKeyNotConfigured();
             }
         }
     }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyPostConfigure.cs
@@ -36,6 +36,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             IList<ValidationResult> errors = new List<ValidationResult>();
 
+            // If nothing is set, lets not attach an error and instead pass along the blank config
+            if (sourceOptions.Subject == null && sourceOptions.PublicKey == null)
+            {
+                options.Configured = false;
+                options.Subject = null;
+                options.PublicKey = null;
+                return;
+            }
+
+            // Some options are configured (but may not be valid)
+            options.Configured = true;
+
             Validator.TryValidateObject(
                 sourceOptions,
                 new ValidationContext(sourceOptions, null, null),

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         LoadingProfiler = 53,
         SetEnvironmentVariable = 54,
         GetEnvironmentVariable = 55,
+        MonitorApiKeyNotConfigured = 56,
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static void MonitorApiKeyNotConfigured(this ILogger logger)
         {
-            _monitorApiKeyNotConfigured(logger, CultureInfo.CurrentCulture.LCID, null);
+            _monitorApiKeyNotConfigured(logger, CultureInfo.CurrentUICulture.LCID, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -302,8 +302,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_GetEnvironmentVariable);
 
-        private static readonly Action<ILogger, int, Exception> _monitorApiKeyNotConfigured =
-            LoggerMessage.Define<int>(
+        private static readonly Action<ILogger, string, Exception> _monitorApiKeyNotConfigured =
+            LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.MonitorApiKeyNotConfigured.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ApiKeyNotConfigured);
@@ -554,7 +554,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static void MonitorApiKeyNotConfigured(this ILogger logger)
         {
-            _monitorApiKeyNotConfigured(logger, CultureInfo.CurrentUICulture.LCID, null);
+            const long myFwLinkId = 2187444;
+            string fwLink = GetFwLinkWithCurrentLcidUri(myFwLinkId);
+            _monitorApiKeyNotConfigured(logger, fwLink, null);
+        }
+
+        private static string GetFwLinkWithCurrentLcidUri(long fwlinkId)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                @"https://go.microsoft.com/fwlink/?linkid={0}&clcid=0x{1:x}",
+                fwlinkId,
+                CultureInfo.CurrentUICulture.LCID);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -301,6 +301,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_GetEnvironmentVariable);
 
+        private static readonly Action<ILogger, Exception> _monitorApiKeyNotConfigured =
+            LoggerMessage.Define(
+                eventId: LoggingEventIds.MonitorApiKeyNotConfigured.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_ApiKeyNotConfigured);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -543,6 +549,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void GettingEnvironmentVariable(this ILogger logger, string variableName, int processId)
         {
             _getEnvironmentVariable(logger, variableName, processId, null);
+        }
+
+        public static void MonitorApiKeyNotConfigured(this ILogger logger)
+        {
+            _monitorApiKeyNotConfigured(logger, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -301,8 +302,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_GetEnvironmentVariable);
 
-        private static readonly Action<ILogger, Exception> _monitorApiKeyNotConfigured =
-            LoggerMessage.Define(
+        private static readonly Action<ILogger, int, Exception> _monitorApiKeyNotConfigured =
+            LoggerMessage.Define<int>(
                 eventId: LoggingEventIds.MonitorApiKeyNotConfigured.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ApiKeyNotConfigured);
@@ -553,7 +554,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static void MonitorApiKeyNotConfigured(this ILogger logger)
         {
-            _monitorApiKeyNotConfigured(logger, null);
+            _monitorApiKeyNotConfigured(logger, CultureInfo.CurrentCulture.LCID, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API key authentication not configured. See https://go.microsoft.com/fwlink/?linkid=2187444&amp;clcid=0x{0:X3}.
+        ///   Looks up a localized string similar to API key authentication is not configured. See {0}.
         /// </summary>
         internal static string LogFormatString_ApiKeyNotConfigured {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -547,6 +547,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to API key authentication not configured. See https://aka.ms/dotnet-monitor-apikeydoc.
+        /// </summary>
+        internal static string LogFormatString_ApiKeyNotConfigured {
+            get {
+                return ResourceManager.GetString("LogFormatString_ApiKeyNotConfigured", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {configName} have changed, new values: Subject={subject}, PublicKey={publicKey}.
         /// </summary>
         internal static string LogFormatString_ApiKeyOptionsChanged {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API key authentication is not configured. See {0}.
+        ///   Looks up a localized string similar to API key authentication is not configured. See {0} for more details..
         /// </summary>
         internal static string LogFormatString_ApiKeyNotConfigured {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API key authentication not configured. See https://aka.ms/dotnet-monitor-apikeydoc.
+        ///   Looks up a localized string similar to API key authentication not configured. See https://go.microsoft.com/fwlink/?linkid=2187444&amp;clcid=0x{0:X3}.
         /// </summary>
         internal static string LogFormatString_ApiKeyNotConfigured {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -381,10 +381,11 @@
 1. apiAuthenticationConfigKey: The string key of ApiAuthentication object in configuration.</comment>
   </data>
   <data name="LogFormatString_ApiKeyNotConfigured" xml:space="preserve">
-    <value>API key authentication not configured. See https://aka.ms/dotnet-monitor-apikeydoc</value>
+    <value>API key authentication not configured. See https://go.microsoft.com/fwlink/?linkid=2187444&amp;clcid=0x{0:X3}</value>
     <comment>Gets the format string that is printed in the 56:MonitorApiKeyNotConfigured event.
 
-0 formattable parameters</comment>
+1 formattable parameter
+0. Culture LCID of the documentation link</comment>
   </data>
   <data name="LogFormatString_ApiKeyOptionsChanged" xml:space="preserve">
     <value>The {configName} have changed, new values: Subject={subject}, PublicKey={publicKey}</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -380,6 +380,12 @@
 1 Format Parameter:
 1. apiAuthenticationConfigKey: The string key of ApiAuthentication object in configuration.</comment>
   </data>
+  <data name="LogFormatString_ApiKeyNotConfigured" xml:space="preserve">
+    <value>API key authentication not configured. See https://aka.ms/dotnet-monitor-apikeydoc</value>
+    <comment>Gets the format string that is printed in the 56:MonitorApiKeyNotConfigured event.
+
+0 formattable parameters</comment>
+  </data>
   <data name="LogFormatString_ApiKeyOptionsChanged" xml:space="preserve">
     <value>The {configName} have changed, new values: Subject={subject}, PublicKey={publicKey}</value>
     <comment>Gets the format string that is printed in the 21:ApiKeyValidationFailure event.

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -381,7 +381,7 @@
 1. apiAuthenticationConfigKey: The string key of ApiAuthentication object in configuration.</comment>
   </data>
   <data name="LogFormatString_ApiKeyNotConfigured" xml:space="preserve">
-    <value>API key authentication not configured. See https://go.microsoft.com/fwlink/?linkid=2187444&amp;clcid=0x{0:X3}</value>
+    <value>API key authentication is not configured. See {0}</value>
     <comment>Gets the format string that is printed in the 56:MonitorApiKeyNotConfigured event.
 
 1 formattable parameter

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -381,7 +381,7 @@
 1. apiAuthenticationConfigKey: The string key of ApiAuthentication object in configuration.</comment>
   </data>
   <data name="LogFormatString_ApiKeyNotConfigured" xml:space="preserve">
-    <value>API key authentication is not configured. See {0}</value>
+    <value>API key authentication is not configured. See {0} for more details.</value>
     <comment>Gets the format string that is printed in the 56:MonitorApiKeyNotConfigured event.
 
 1 formattable parameter


### PR DESCRIPTION
Removes unnecessary api config warning messages when no Api key is configured.
- Adds a bool to the internal `MonitorApiKeyConfiguration` object that tracks if any value was provided for the 2 settings. If null was passed, the log messages are omitted.
Resolves #1509 