### PR TITLE
Set OpenApiGen runner to use ASP.NET framework

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
             string path = Path.GetTempFileName();
 
             DotNetRunner runner = new();
+            runner.FrameworkReference = DotNetFrameworkReference.Microsoft_AspNetCore_App;
             runner.EntrypointAssemblyPath = OpenApiGenPath;
             runner.Arguments = path;
 


### PR DESCRIPTION
In the release/6.* branches, when attempting to update the SDK version to beyond 6.0.100, the OpenApiGen unit test fails with a message such as `The specified framework 'Microsoft.NETCore.App', version '6.0.0', apply_patches=0, version_compatibility_range=exact cannot roll-forward to the previously referenced version '6.0.1'.`

What's happening is that the test runner incorrectly assumes that the OpenApiGen tool is a .NET application whereas it is really an ASP.NET application. We've made changes to not attempt to roll forward ASP.NET applications starting with .NET 6 since the `--fx-version` parameter seems to break the ability to run them due to the *.runtimeconfig.json file having multiple frameworks.

The fix is to specify that the OpenApiGen tool is an ASP.NET framework-based tool, which will then prevent the forced roll forward. With this fix, the Arcade updates will be unblocked once it is back ported.