### PR TITLE
Update releases and docker documentation

### DIFF
--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -97,7 +97,7 @@ spec:
       secretName: apikey
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/monitor:6.0
+    image: mcr.microsoft.com/dotnet/monitor:6
     volumeMounts:
       - name: apikey
         mountPath: /etc/dotnet-monitor

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -70,7 +70,7 @@ spec:
       secretName: apikey
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/monitor:6.0
+    image: mcr.microsoft.com/dotnet/monitor:6
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor
@@ -97,7 +97,7 @@ spec:
       name: my-configmap
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/monitor:6.0
+    image: mcr.microsoft.com/dotnet/monitor:6
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor
@@ -117,7 +117,7 @@ spec:
             name: my-configmap
   containers:
   - name: dotnetmonitoragent
-    image: mcr.microsoft.com/dotnet/monitor:6.0
+    image: mcr.microsoft.com/dotnet/monitor:6
     volumeMounts:
       - name: config
         mountPath: /etc/dotnet-monitor

--- a/documentation/docker.md
+++ b/documentation/docker.md
@@ -8,14 +8,17 @@ In addition to its availability as a .NET CLI tool, the `dotnet monitor` tool is
 
 | Version | Platform | Architecture | Link |
 |---|---|---|---|
-| 6.0 (Current) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/6.0/alpine/amd64/Dockerfile |
+| 7.0 (Preview) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/7.0/alpine/amd64/Dockerfile |
+| 6.1 (Current, Latest) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/6.1/alpine/amd64/Dockerfile |
+| 6.0 | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/6.0/alpine/amd64/Dockerfile |
 
 ### Nightly Dockerfiles
 
 | Version | Platform | Architecture | Link |
 |---|---|---|---|
-| 7.0 (Preview) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile |
-| 6.0 (Current) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile |
+| 7.0 (Preview, Latest) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile |
+| 6.1 (Current) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile |
+| 6.0 | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile |
 
 ## Image Repositories
 

--- a/documentation/releases.md
+++ b/documentation/releases.md
@@ -1,5 +1,14 @@
 # Releases
 
-| Version | Release Date | Latest Patch Version | Runtime Frameworks |
+## Supported Versions
+
+| Version | Original Release Date | Latest Patch Version | Patch Release Date | End of Support | Runtime Frameworks |
+|---|---|---|---|---|---|
+| 6.1 | February 17, 2022 | [6.1.0](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v6.1.0.md) | February 17, 2022 |  | .NET Core 3.1 (with major roll forward)<br/>.NET 6 |
+| 6.0 | November 8, 2021 | [6.0.2](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v6.0.2.md) | February 8, 2022 | May 17, 2022 | .NET Core 3.1 (with major roll forward)<br/>.NET 6 |
+
+## Preview Versions
+
+| Version  | Latest Version | Release Date | Runtime Frameworks |
 |---|---|---|---|
-| 6.0 | February 8, 2022 | [6.0.2](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v6.0.2.md) | .NET Core 3.1 (with major roll forward)<br/>.NET 6 |
+| 7.0 | [7.0.0 Preview 1](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v7.0.0-preview.1.22109.7.md) | February 17, 2022 | .NET 6 (with major roll forward)<br/>.NET 7 |


### PR DESCRIPTION
Update the release information with the new releases and expected end of support time frames. Made similar updates to the docker information. Also changed the docker image tags to use major only versions to promote automatic acquisition of minor releases.