### PR TITLE
Simplified Process Filter Schema

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -249,13 +249,22 @@ Unlike the other diagnostic artifacts (for example, traces), memory dumps aren't
 
 ## Default Process Configuration
 
-Default process configuration is used to determine which process is used for metrics and in situations where the process is not specified in the query to retrieve an artifact. A process must match all the specified filters.
+Default process configuration is used to determine which process is used for metrics and in situations where the process is not specified in the query to retrieve an artifact. A process must match all the specified filters. If a `Key` is not specified, the default is `ProcessId`.
 
 | Name | Type | Description |
 |---|---|---|
 | Key | string | Specifies which criteria to match on the process. Can be `ProcessId`, `ProcessName`, `CommandLine`. |
 | Value | string | The value to match against the process. |
 | MatchType | string | The type of match to perform. Can be `Exact` or `Contains` for sub-string matching. Both are case-insensitive.|
+
+
+Optionally, a shorthand format allows you to omit the `Key` and `Value` terms and specify your Key/Value pair as a single line.
+
+| Name | Type | Description |
+|---|---|---|
+| ProcessId | string | Specifies that the corresponding value is the expected `ProcessId`. |
+| ProcessName | string | Specifies that the corresponding value is the expected `ProcessName`. |
+| CommandLine | string | Specifies that the corresponding value is the expected `CommandLine`.|
 
 ### Examples
 
@@ -272,6 +281,18 @@ Match the iisexpress process by name
 }
 ```
 
+Match the iisexpress process by name (Shorthand)
+
+```json
+{
+  "DefaultProcess": {
+    "Filters": [{
+      "ProcessName": "iisexpress"
+    }]
+  },
+}
+```
+
 Match pid 1
 ```json
 {
@@ -279,6 +300,17 @@ Match pid 1
     "Filters": [{
       "Key": "ProcessId",
       "Value": "1"
+    }]
+  },
+}
+```
+
+Match pid 1 (Shorthand)
+```json
+{
+  "DefaultProcess": {
+    "Filters": [{
+      "ProcessId": "1"
     }]
   },
 }
@@ -490,8 +522,7 @@ The following example shows the `Filters` portion of a collection rule that has 
         "Value": "dotnet",
         "MatchType": "Exact"
     },{
-        "Key": "CommandLine",
-        "Value": "myapp.dll",
+        "CommandLine": "myapp.dll",
         "MatchType": "Contains"
     }]
 }

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -449,10 +449,6 @@
     "ProcessFilterDescriptor": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "Key",
-        "Value"
-      ],
       "properties": {
         "Key": {
           "description": "The criteria used to compare against the target process.",
@@ -463,9 +459,11 @@
           ]
         },
         "Value": {
-          "type": "string",
-          "description": "The value of the criteria used to compare against the target process.",
-          "minLength": 1
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The value of the criteria used to compare against the target process."
         },
         "MatchType": {
           "description": "Type of match to use against the process criteria.",
@@ -475,6 +473,27 @@
               "$ref": "#/definitions/ProcessFilterType"
             }
           ]
+        },
+        "ProcessName": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Performs a match based on the name of a process on the system."
+        },
+        "ProcessId": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Performs a match based on the numerical ID of a process on the system."
+        },
+        "CommandLine": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Performs a match based on the contents of the command passed to launch the process on the system; this typically includes the executable path and arguments to the process."
         }
       }
     },

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -946,6 +946,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Performs a match based on the contents of the command passed to launch the process on the system; this typically includes the executable path and arguments to the process..
+        /// </summary>
+        public static string DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The criteria used to compare against the target process..
         /// </summary>
         public static string DisplayAttributeDescription_ProcessFilterDescriptor_Key {
@@ -960,6 +969,24 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         public static string DisplayAttributeDescription_ProcessFilterDescriptor_MatchType {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_ProcessFilterDescriptor_MatchType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Performs a match based on the numerical ID of a process on the system..
+        /// </summary>
+        public static string DisplayAttributeDescription_ProcessFilterDescriptor_ProcessId {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_ProcessFilterDescriptor_ProcessId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Performs a match based on the name of a process on the system..
+        /// </summary>
+        public static string DisplayAttributeDescription_ProcessFilterDescriptor_ProcessName {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_ProcessFilterDescriptor_ProcessName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -1099,6 +1099,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A value is required for the process filter..
+        /// </summary>
+        public static string ErrorMessage_FilterValueMissing {
+            get {
+                return ResourceManager.GetString("ErrorMessage_FilterValueMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} field or the {1} field is required..
         /// </summary>
         public static string ErrorMessage_TwoFieldsMissing {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -571,4 +571,16 @@
     <value>The name of the environment variable to get.</value>
     <comment>The description provided for the Name parameter on GetEnvironmentVariableOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine" xml:space="preserve">
+    <value>Performs a match based on the contents of the command passed to launch the process on the system; this typically includes the executable path and arguments to the process.</value>
+    <comment>The description provided for the CommandLine parameter on ProcessFilterDescriptor.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_ProcessFilterDescriptor_ProcessId" xml:space="preserve">
+    <value>Performs a match based on the numerical ID of a process on the system.</value>
+    <comment>The description provided for the ProcessId parameter on ProcessFilterDescriptor.</comment>
+  </data>
+  <data name="DisplayAttributeDescription_ProcessFilterDescriptor_ProcessName" xml:space="preserve">
+    <value>Performs a match based on the name of a process on the system.</value>
+    <comment>The description provided for the ProcessName parameter on ProcessFilterDescriptor.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -583,4 +583,8 @@
     <value>Performs a match based on the name of a process on the system.</value>
     <comment>The description provided for the ProcessName parameter on ProcessFilterDescriptor.</comment>
   </data>
+  <data name="ErrorMessage_FilterValueMissing" xml:space="preserve">
+    <value>A value is required for the process filter.</value>
+    <comment>Gets the format string for rejecting validation due to no value being provided for a process filter.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -45,18 +45,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public List<ProcessFilterDescriptor> Filters { get; set; } = new List<ProcessFilterDescriptor>(0);
     }
 
-    public sealed class ProcessFilterDescriptor
+    public sealed partial class ProcessFilterDescriptor
     {
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_Key))]
-        [Required]
-        public ProcessFilterKey Key { get;set; }
+        public ProcessFilterKey Key { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_Value))]
-        [Required]
         public string Value { get; set; }
 
         [Display(
@@ -80,5 +78,25 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine))]
         public string CommandLine { get; set; }
 
+    }
+
+    partial class ProcessFilterDescriptor : IValidatableObject
+    {
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            List<ValidationResult> results = new();
+
+            if (string.IsNullOrEmpty(CommandLine) && string.IsNullOrEmpty(ProcessId) && string.IsNullOrEmpty(ProcessName))
+            {
+                if (string.IsNullOrEmpty(Value))
+                {
+                    results.Add(new ValidationResult(
+                        string.Format(
+                            "RANDOM TESTING MESSAGE (FOR NOW)")));
+                }
+            }
+
+            return results;
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine))]
         public string CommandLine { get; set; }
-
     }
 
     partial class ProcessFilterDescriptor : IValidatableObject
@@ -86,10 +85,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             List<ValidationResult> results = new();
 
-            // TODO: Make sure this behavior is what we want (i.e. do we want to enforce that a value is there, or is an empty string accepted?)
-            if (string.IsNullOrEmpty(CommandLine) && string.IsNullOrEmpty(ProcessId) && string.IsNullOrEmpty(ProcessName))
+            if (string.IsNullOrWhiteSpace(CommandLine) && string.IsNullOrWhiteSpace(ProcessId) && string.IsNullOrWhiteSpace(ProcessName))
             {
-                if (string.IsNullOrEmpty(Value))
+                if (string.IsNullOrWhiteSpace(Value))
                 {
                     results.Add(new ValidationResult(
                         string.Format(OptionsDisplayStrings.ErrorMessage_FilterValueMissing)));

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -86,13 +86,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             List<ValidationResult> results = new();
 
+            // TODO: Make sure this behavior is what we want (i.e. do we want to enforce that a value is there, or is an empty string accepted?)
             if (string.IsNullOrEmpty(CommandLine) && string.IsNullOrEmpty(ProcessId) && string.IsNullOrEmpty(ProcessName))
             {
                 if (string.IsNullOrEmpty(Value))
                 {
                     results.Add(new ValidationResult(
-                        string.Format(
-                            "RANDOM TESTING MESSAGE (FOR NOW)")));
+                        string.Format(OptionsDisplayStrings.ErrorMessage_FilterValueMissing)));
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -64,5 +64,21 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_MatchType))]
         [DefaultValue(ProcessFilterType.Exact)]
         public ProcessFilterType MatchType { get; set; } = ProcessFilterType.Exact;
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_ProcessName))]
+        public string ProcessName { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_ProcessId))]
+        public string ProcessId { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine))]
+        public string CommandLine { get; set; }
+
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -74,6 +74,29 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private static DiagProcessFilterEntry TransformDescriptor(ProcessFilterDescriptor processFilterDescriptor)
         {
+            if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessId))
+            {
+                return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.ProcessId };
+            }
+            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
+            {
+                return new DiagProcessFilterEntry
+                {
+                    Criteria = DiagProcessFilterCriteria.ProcessName,
+                    MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
+                    Value = processFilterDescriptor.ProcessName
+                };
+            }
+            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
+            {
+                return new DiagProcessFilterEntry
+                {
+                    Criteria = DiagProcessFilterCriteria.CommandLine,
+                    MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
+                    Value = processFilterDescriptor.CommandLine
+                };
+            }
+
             switch (processFilterDescriptor.Key)
             {
                 case ProcessFilterKey.ProcessId:

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private static DiagProcessFilterEntry TransformDescriptor(ProcessFilterDescriptor processFilterDescriptor)
         {
-            if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessId))
+            if (!string.IsNullOrWhiteSpace(processFilterDescriptor.ProcessId))
             {
                 return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.ProcessId };
             }
-            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
+            else if (!string.IsNullOrWhiteSpace(processFilterDescriptor.ProcessName))
             {
                 return new DiagProcessFilterEntry
                 {
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Value = processFilterDescriptor.ProcessName
                 };
             }
-            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
+            else if (!string.IsNullOrWhiteSpace(processFilterDescriptor.CommandLine))
             {
                 return new DiagProcessFilterEntry
                 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private static DiagProcessFilterEntry TransformDescriptor(ProcessFilterDescriptor processFilterDescriptor)
         {
-            if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessId))
+            if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessId) || processFilterDescriptor.Key == ProcessFilterKey.ProcessId)
             {
                 return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.ProcessId };
             }
-            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
+            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName) || processFilterDescriptor.Key == ProcessFilterKey.ProcessName)
             {
                 return new DiagProcessFilterEntry
                 {
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Value = processFilterDescriptor.ProcessName
                 };
             }
-            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
+            else if (!string.IsNullOrEmpty(processFilterDescriptor.CommandLine) || processFilterDescriptor.Key == ProcessFilterKey.CommandLine)
             {
                 return new DiagProcessFilterEntry
                 {
@@ -96,33 +96,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Value = processFilterDescriptor.CommandLine
                 };
             }
-
-            switch (processFilterDescriptor.Key)
+            else
             {
-                case ProcessFilterKey.ProcessId:
-                    return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.Value };
-                case ProcessFilterKey.ProcessName:
-                    return new DiagProcessFilterEntry
-                    {
-                        Criteria = DiagProcessFilterCriteria.ProcessName,
-                        MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
-                        Value = processFilterDescriptor.Value
-                    };
-                case ProcessFilterKey.CommandLine:
-                    return new DiagProcessFilterEntry
-                    {
-                        Criteria = DiagProcessFilterCriteria.CommandLine,
-                        MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
-                        Value = processFilterDescriptor.Value
-                    };
-                default:
-                    throw new ArgumentException(
-                        string.Format(
-                            CultureInfo.InvariantCulture,
-                            Strings.ErrorMessage_UnexpectedType,
-                            nameof(ProcessFilterDescriptor),
-                            processFilterDescriptor.Key),
-                        nameof(processFilterDescriptor));
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Strings.ErrorMessage_UnexpectedType,
+                        nameof(ProcessFilterDescriptor),
+                        processFilterDescriptor.Key),
+                    nameof(processFilterDescriptor));
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private static DiagProcessFilterEntry TransformDescriptor(ProcessFilterDescriptor processFilterDescriptor)
         {
-            if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessId) || processFilterDescriptor.Key == ProcessFilterKey.ProcessId)
+            if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessId))
             {
                 return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.ProcessId };
             }
-            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName) || processFilterDescriptor.Key == ProcessFilterKey.ProcessName)
+            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
             {
                 return new DiagProcessFilterEntry
                 {
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Value = processFilterDescriptor.ProcessName
                 };
             }
-            else if (!string.IsNullOrEmpty(processFilterDescriptor.CommandLine) || processFilterDescriptor.Key == ProcessFilterKey.CommandLine)
+            else if (!string.IsNullOrEmpty(processFilterDescriptor.ProcessName))
             {
                 return new DiagProcessFilterEntry
                 {
@@ -96,15 +96,33 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Value = processFilterDescriptor.CommandLine
                 };
             }
-            else
+
+            switch (processFilterDescriptor.Key)
             {
-                throw new ArgumentException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        Strings.ErrorMessage_UnexpectedType,
-                        nameof(ProcessFilterDescriptor),
-                        processFilterDescriptor.Key),
-                    nameof(processFilterDescriptor));
+                case ProcessFilterKey.ProcessId:
+                    return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.Value };
+                case ProcessFilterKey.ProcessName:
+                    return new DiagProcessFilterEntry
+                    {
+                        Criteria = DiagProcessFilterCriteria.ProcessName,
+                        MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
+                        Value = processFilterDescriptor.Value
+                    };
+                case ProcessFilterKey.CommandLine:
+                    return new DiagProcessFilterEntry
+                    {
+                        Criteria = DiagProcessFilterCriteria.CommandLine,
+                        MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
+                        Value = processFilterDescriptor.Value
+                    };
+                default:
+                    throw new ArgumentException(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            Strings.ErrorMessage_UnexpectedType,
+                            nameof(ProcessFilterDescriptor),
+                            processFilterDescriptor.Key),
+                        nameof(processFilterDescriptor));
             }
         }
     }


### PR DESCRIPTION
Allows users to use a shorthand means of specifying the process filter instead of listing the key and value separately. This is not a breaking change and should not interfere with the existing functionality. Note: In the testing, I also noticed that the `Key` field could be omitted for a value, and it defaults to checking for a `ProcessId`; since altering this behavior would be a breaking change, it's now listed explicitly in documentation.

Closes #636 