### PR TITLE
Splits symbols from native libraries

### DIFF
--- a/src/Tests/TestProfiler/CMakeLists.txt
+++ b/src/Tests/TestProfiler/CMakeLists.txt
@@ -17,10 +17,11 @@ set(SOURCES
     ProfilerBase.cpp
     )
 
-add_library(TestProfiler SHARED ${SOURCES})
+# Build library and split symbols
+add_library_clr(TestProfiler SHARED ${SOURCES})
 
-install(TARGETS TestProfiler)
-
-if(CLR_CMAKE_HOST_WIN32)
-    install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)
-endif(CLR_CMAKE_HOST_WIN32)
+# Install library
+install(TARGETS TestProfiler DESTINATION .)
+# Install symbols
+get_symbol_file_name(TestProfiler SymbolFileName)
+install(FILES ${SymbolFileName} DESTINATION . OPTIONAL)


### PR DESCRIPTION
This change bifurcates the symbols from the native libraries so that the libraries are smaller. The symbol files are *.dbg on Linux and *.dwarf on MacOS. These files will be uploaded to the pipeline artifacts to be for debugging and symbol resolution later.