### PR TITLE
Pack and sign from combined build artifacts

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -9,6 +9,12 @@ pr:
     - internal/release/*
     - feature/*
 
+parameters:
+- name: RunTests
+  displayName: 'Run Tests'
+  type: boolean
+  default: true
+
 variables:
 - name: _TeamName
   value: DotNetCore
@@ -19,20 +25,24 @@ variables:
 
 stages:
 - stage: Build
+  displayName: Build and Test
   jobs:
+  # Build and test binaries
   - template: /eng/build.yml
     parameters:
       name: Windows_x64_Debug
       displayName: Windows x64 Debug
       osGroup: Windows
       configuration: Debug
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: Windows_x64_Release
       displayName: Windows x64 Release
       osGroup: Windows
       configuration: Release
-      signAndPublishArtifacts: true
+      publishArtifactsSubPath: bin
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: Windows_x86_Release
@@ -40,61 +50,101 @@ stages:
       osGroup: Windows
       configuration: Release
       architecture: x86
+      publishArtifactsSubPath: bin/Windows_NT.x86.Release
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: CentOS_x64_Debug
       displayName: CentOS x64 Debug
       osGroup: Linux
       configuration: Debug
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: CentOS_x64_Release
       displayName: CentOS x64 Release
       osGroup: Linux
       configuration: Release
+      publishArtifactsSubPath: bin/Linux.x64.Release
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: Alpine_x64_Debug
       displayName: Alpine x64 Debug
       osGroup: Linux_Musl
       configuration: Debug
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: Alpine_x64_Release
       displayName: Alpine x64 Release
       osGroup: Linux_Musl
       configuration: Release
+      publishArtifactsSubPath: bin/Linux.x64.Release
+      publishArtifactsTargetSubPath: bin/Linux-musl.x64.Release
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: MacOS_x64_Debug
       displayName: MacOS x64 Debug
       osGroup: MacOS
       configuration: Debug
+      runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
       name: MacOS_x64_Release
       displayName: MacOS x64 Release
       osGroup: MacOS
       configuration: Release
-  # This registers the build with BAR.
+      publishArtifactsSubPath: bin/OSX.x64.Release
+      runTests: ${{ parameters.RunTests }}
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    # Pack, sign, and publish
+    - template: /eng/common/templates/job/job.yml
+      parameters:
+        name: Pack_Sign
+        displayName: Pack and Sign
+        dependsOn:
+        - Windows_x64_Release
+        - Windows_x86_Release
+        - CentOS_x64_Release
+        - Alpine_x64_Release
+        - MacOS_x64_Release
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+        enablePublishUsingPipelines: true
+        enableMicrobuild: true
+        artifacts:
+          download:
+            name: Build_Release
+          publish:
+            artifacts:
+              name: Artifacts_Pack_Sign
+            logs:
+              name: Logs_Pack_Sign
+            manifests: true
+        variables:
+        - _BuildConfig: Release
+        - _SignType: real
+        steps:
+        - script: >-
+            $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
+            /p:TeamName=$(_TeamName)
+            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            /p:DotNetSignType=real
+            /p:DotNetPublishUsingPipelines=true
+          displayName: Pack, Sign, and Publish
+    # Register with BAR
     - template: /eng/common/templates/job/publish-build-assets.yml
       parameters:
         configuration: Release
         dependsOn:
-        - Windows_x64_Debug
-        - Windows_x64_Release
-        - Windows_x86_Release
-        - CentOS_x64_Debug
-        - CentOS_x64_Release
-        - Alpine_x64_Debug
-        - Alpine_x64_Release
-        - MacOS_x64_Debug
-        - MacOS_x64_Release
+        - Pack_Sign
         publishUsingPipelines: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.windows.10.amd64.vs2017
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -11,8 +11,12 @@ parameters:
   timeoutInMinutes: 180
   # Depends on 
   dependsOn: ''
-  # Flag to determine if files should be signed and published
-  signAndPublishArtifacts: false
+  # Sub path under 'artifacts' folder from which files are published to artifacts location
+  publishArtifactsSubPath: ''
+  # Sub path under artifacts location to which artifact files are publish
+  publishArtifactsTargetSubPath: ''
+  # Allow disabling test runs
+  runTests: true
   # TFMs for which test results are uploaded
   testResultTfms:
   - key: netcoreapp3.1
@@ -38,9 +42,6 @@ jobs:
       publish:
         logs:
           name: Logs_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(parameters.signAndPublishArtifacts, 'true')) }}:
-          artifacts:
-            name: Artifacts_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
 
     pool:
       # Public Linux Build Pool
@@ -86,15 +87,16 @@ jobs:
     - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
-    - _SignType: test
+    - _TestArgs: ''
     - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
-    - _InternalSignArgs: ''
-    - _InternalPublishArgs: ''
 
     # Component Governance does not work on Musl
     - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
       - skipComponentGovernanceDetection: true
+    
+    - ${{ if eq(parameters.runTests, true) }}:
+      - _TestArgs: '-test'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-MSRC-Storage
@@ -141,49 +143,50 @@ jobs:
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
-        -test
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
+        $(_TestArgs)
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)
       displayName: Build and Test
-      condition: succeeded()
-    
-    # Native build does not support signing. Move pack, sign, and publish
-    # to non-build step after build and tests have completed. This will not
-    # restore prerequisites nor rebuild the binaries.
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.signAndPublishArtifacts, 'true')) }}:
-      - script: >-
-          $(Build.SourcesDirectory)/eng/cipacksignpublish$(scriptExt)
-          $(_InternalInstallArgs)
-          $(_InternalBuildArgs)
-          /p:DotNetSignType=real
-          /p:DotNetPublishUsingPipelines=true
-        displayName: Pack, Sign, and Publish
-        condition: succeeded()
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(parameters.publishArtifactsSubPath, '')) }}:
+      - task: CopyFiles@2
+        displayName: Gather Artifacts
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/${{ parameters.publishArtifactsSubPath }}'
+          Contents: '**'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/${{ coalesce(parameters.publishArtifactsTargetSubPath, parameters.publishArtifactsSubPath) }}'
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+          artifactName: Build_${{ parameters.configuration }}
 
     # Publish test results to Azure Pipelines
-    - ${{ each testResultTfm in parameters.testResultTfms }}:
-      - task: PublishTestResults@2
-        displayName: Publish Test Results (${{ testResultTfm.value }})
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-          failTaskOnFailedTests: true
-          testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} ${{ testResultTfm.value }}'
-          publishRunAttachments: true
-          mergeTestResults: true
-          buildConfiguration: ${{ parameters.name }}
-        continueOnError: true
-        condition: succeededOrFailed()
+    - ${{ if eq(parameters.runTests, true) }}:
+      - ${{ each testResultTfm in parameters.testResultTfms }}:
+        - task: PublishTestResults@2
+          displayName: Publish Test Results (${{ testResultTfm.value }})
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+            failTaskOnFailedTests: true
+            testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} ${{ testResultTfm.value }}'
+            publishRunAttachments: true
+            mergeTestResults: true
+            buildConfiguration: ${{ parameters.name }}
+          continueOnError: true
+          condition: succeededOrFailed()
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Test Result Files
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-          PublishLocation: Container
-          ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
-        continueOnError: true
-        condition: succeededOrFailed()
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Test Result Files
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            PublishLocation: Container
+            ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
+          continueOnError: true
+          condition: succeededOrFailed()

--- a/eng/cipacksignpublish.cmd
+++ b/eng/cipacksignpublish.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-set "_commonArgs=-ci -prepareMachine -verbosity minimal -configuration Release"
+set "_commonArgs=-restore -ci -prepareMachine -verbosity minimal -configuration Release"
 set "_logDir=%~dp0..\artifacts\log\Release\"
 
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" %_commonArgs% -pack -sign -publish -noBl /bl:'%_logDir%PackSignPublish.binlog' %*"


### PR DESCRIPTION
These changes allow individual build jobs to contribute their native assemblies to a single pipeline artifact so that all platform variations of each native assembly can be incorporated into the same package. Note that the dotnet-monitor package does not pack any native assemblies at this time, but these changes allow that to happen more easily in a subsequent change.

Summary of Changes:
- Remove pack, sign, and publish from the individual build jobs
- Build jobs publish only the binaries the contribute to the NuGet packages
  - Windows x64 Release contributes managed and native assemblies
  - All other release builds contribute native assemblies only
- Add single job for pack, sign, and publish
- Add pipeline parameter to allow skipping test runs; by default, tests are run