### PR TITLE
ARM64 cross build support

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -52,37 +52,68 @@ stages:
       architecture: x86
       publishArtifactsSubPath: bin/Windows_NT.x86.Release
       runTests: ${{ parameters.RunTests }}
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/build.yml
+      parameters:
+        name: Windows_arm64_Release
+        displayName: Windows arm64 Release
+        osGroup: Windows
+        configuration: Release
+        architecture: arm64
+        publishArtifactsSubPath: bin/Windows_NT.arm64.Release
+        runTests: false
   - template: /eng/build.yml
     parameters:
-      name: CentOS_x64_Debug
-      displayName: CentOS x64 Debug
+      name: Linux_x64_Debug
+      displayName: Linux x64 Debug
       osGroup: Linux
       configuration: Debug
       runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
-      name: CentOS_x64_Release
-      displayName: CentOS x64 Release
+      name: Linux_x64_Release
+      displayName: Linux x64 Release
       osGroup: Linux
       configuration: Release
       publishArtifactsSubPath: bin/Linux.x64.Release
       runTests: ${{ parameters.RunTests }}
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/build.yml
+      parameters:
+        name: Linux_arm64_Release
+        displayName: Linux arm64 Release
+        osGroup: Linux
+        configuration: Release
+        architecture: arm64
+        publishArtifactsSubPath: bin/Linux.arm64.Release
+        runTests: false
   - template: /eng/build.yml
     parameters:
-      name: Alpine_x64_Debug
-      displayName: Alpine x64 Debug
+      name: Linux_Musl_x64_Debug
+      displayName: Linux Musl x64 Debug
       osGroup: Linux_Musl
       configuration: Debug
       runTests: ${{ parameters.RunTests }}
   - template: /eng/build.yml
     parameters:
-      name: Alpine_x64_Release
-      displayName: Alpine x64 Release
+      name: Linux_Musl_x64_Release
+      displayName: Linux Musl x64 Release
       osGroup: Linux_Musl
       configuration: Release
       publishArtifactsSubPath: bin/Linux.x64.Release
       publishArtifactsTargetSubPath: bin/Linux-musl.x64.Release
       runTests: ${{ parameters.RunTests }}
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/build.yml
+      parameters:
+        name: Linux_Musl_arm64_Release
+        displayName: Linux Musl arm64 Release
+        osGroup: Linux_Musl
+        configuration: Release
+        architecture: arm64
+        publishArtifactsSubPath: bin/Linux.arm64.Release
+        publishArtifactsTargetSubPath: bin/Linux-musl.arm64.Release
+        runTests: false
   - template: /eng/build.yml
     parameters:
       name: MacOS_x64_Debug
@@ -98,6 +129,16 @@ stages:
       configuration: Release
       publishArtifactsSubPath: bin/OSX.x64.Release
       runTests: ${{ parameters.RunTests }}
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/build.yml
+      parameters:
+        name: MacOS_arm64_Release
+        displayName: MacOS arm64 Release
+        osGroup: MacOS
+        configuration: Release
+        architecture: arm64
+        publishArtifactsSubPath: bin/OSX.arm64.Release
+        runTests: false
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     # Pack, sign, and publish
     - template: /eng/common/templates/job/job.yml
@@ -107,9 +148,13 @@ stages:
         dependsOn:
         - Windows_x64_Release
         - Windows_x86_Release
-        - CentOS_x64_Release
-        - Alpine_x64_Release
+        - Windows_arm64_Release
+        - Linux_x64_Release
+        - Linux_arm64_Release
+        - Linux_Musl_x64_Release
+        - Linux_Musl_arm64_Release
         - MacOS_x64_Release
+        - MacOS_arm64_Release
         pool:
           name: NetCore1ESPool-Internal
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -70,11 +70,17 @@ jobs:
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2
+      ${{ if eq(parameters.architecture, 'arm64') }}:
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20220223205945-8a8d3be
+      ${{ else }}:
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20220107135107-9b5bbc2
 
-    # CMake + Clang is broken on Alpine 3.14 prereqs image
     ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210910135845-c401c85
+      ${{ if eq(parameters.architecture, 'arm64') }}:
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20220223205945-538077f
+      ${{ else }}:
+        # CMake + Clang is broken on Alpine 3.14 prereqs image
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20211214164113-c401c85
 
     ${{ if ne(parameters.dependsOn, '') }}:
       dependsOn: ${{ parameters.dependsOn }}
@@ -87,6 +93,7 @@ jobs:
     - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
+    - _CrossBuildArgs: ''
     - _TestArgs: ''
     - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
@@ -95,6 +102,10 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
       - skipComponentGovernanceDetection: true
     
+    # Cross build for arm64 non-Windows builds
+    - ${{ if and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows')) }}:
+      - _CrossBuildArgs: '-cross'
+
     - ${{ if eq(parameters.runTests, true) }}:
       - _TestArgs: '-test'
 
@@ -141,14 +152,21 @@ jobs:
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
+    - ${{ if and(eq(parameters.architecture, 'arm64'), eq(parameters.osGroup, 'MacOS')) }}:
+      - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.4.app/Contents/Developer"
+
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
+        $(_CrossBuildArgs)
         $(_TestArgs)
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)
       displayName: Build and Test
+      ${{ if and(eq(parameters.architecture, 'arm64'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
+        env:
+          ROOTFS_DIR: '/crossrootfs/arm64'
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(parameters.publishArtifactsSubPath, '')) }}:
       - task: CopyFiles@2

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -71,13 +71,13 @@ jobs:
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       ${{ if eq(parameters.architecture, 'arm64') }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20220223205945-8a8d3be
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-20220312201346-b2c2436
       ${{ else }}:
         container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20220107135107-9b5bbc2
 
     ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
       ${{ if eq(parameters.architecture, 'arm64') }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20220223205945-538077f
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20220312201346-538077f
       ${{ else }}:
         # CMake + Clang is broken on Alpine 3.14 prereqs image
         container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20211214164113-c401c85
@@ -151,9 +151,6 @@ jobs:
             arguments: $(Build.SourcesDirectory)/NuGet.config $Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-    - ${{ if and(eq(parameters.architecture, 'arm64'), eq(parameters.osGroup, 'MacOS')) }}:
-      - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.4.app/Contents/Developer"
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)


### PR DESCRIPTION
Add support for building native libraries for arm64 Windows, Linux, Linux Musl, and MacOS without testing them. Package projects have not been updated to include these binaries because the package projects do not include native libraries yet.

~~Internal build (skipped tests): https://dev.azure.com/dnceng/internal/_build/results?buildId=1660023&view=results~~
Internal build (skipped tests): https://dev.azure.com/dnceng/internal/_build/results?buildId=1663048&view=results