### PR TITLE
Update version to 6.1.1

### DIFF
--- a/documentation/releaseNotes/releaseNotes.md
+++ b/documentation/releaseNotes/releaseNotes.md
@@ -1,9 +1,6 @@
-Today we are releasing the 6.1.0 build of the `dotnet monitor` tool. This release includes:
+Today we are releasing the 6.1.1 build of the `dotnet monitor` tool. This release includes:
 
-- Load a profiler via a collection rule action (#781)
-- Get or Set an environment variable via a collection rule action (#1176)
-- Add `MachineJson` option to `--output` parameter for `generatekey` command. This is useful for automating credential provisioning. (#1428)
-- Allow for simplified diagnostic port configuration (#1292)
-- Ensure `config show` command displays arrays without indices (#1054)
+- ⚠️ [Here is a breaking change we did and it's work item] (#737)
+- [Here is a new feature we added and it's work item] (#737)
 
 \*⚠️ **_indicates a breaking change_**

--- a/documentation/releaseNotes/releaseNotes.md
+++ b/documentation/releaseNotes/releaseNotes.md
@@ -1,6 +1,6 @@
 Today we are releasing the 6.1.1 build of the `dotnet monitor` tool. This release includes:
 
-- ⚠️ [Here is a breaking change we did and it's work item] (#737)
-- [Here is a new feature we added and it's work item] (#737)
+- ⚠️ [Here is a breaking change we did and its work item] (#737)
+- [Here is a new feature we added and its work item] (#737)
 
 \*⚠️ **_indicates a breaking change_**

--- a/documentation/releaseNotes/releaseNotes.template.md
+++ b/documentation/releaseNotes/releaseNotes.template.md
@@ -1,6 +1,6 @@
-Today we are releasing the 6.1.0 build of the `dotnet-monitor` tool. This release includes:
+Today we are releasing the 6.1.0 build of the `dotnet monitor` tool. This release includes:
 
-- ⚠️ [Here is a breaking change we did and it's work item] (#737)
-- [Here is a new feature we added and it's work item] (#737)
+- ⚠️ [Here is a breaking change we did and its work item] (#737)
+- [Here is a new feature we added and its work item] (#737)
 
 \*⚠️ **_indicates a breaking change_**

--- a/documentation/releaseNotes/releaseNotes.template.md
+++ b/documentation/releaseNotes/releaseNotes.template.md
@@ -1,4 +1,4 @@
-Today we are releasing the 6.0.3 build of the `dotnet-monitor` tool. This release includes:
+Today we are releasing the 6.1.0 build of the `dotnet-monitor` tool. This release includes:
 
 - ⚠️ [Here is a breaking change we did and it's work item] (#737)
 - [Here is a new feature we added and it's work item] (#737)

--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -85,7 +85,7 @@ stages:
           - MacOSRelease
           publishUsingPipelines: true
           pool:
-            name: NetCore1ESPool-Internal
+            name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals build.windows.10.amd64.vs2017
   # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/PrepareRelease.yml
+++ b/eng/PrepareRelease.yml
@@ -9,10 +9,10 @@ stages:
     displayName: Prepare release with Darc
     pool: 
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore1ESPool-Svc-Public
         demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Internal
+        name: NetCore1ESPool-Svc-Internal
         demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
     variables:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
-    <VersionPrefix>6.1.0</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <VersionPrefix>6.1.1</VersionPrefix>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!--

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -35,12 +35,12 @@ jobs:
       # Public Linux Build Pool
       ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Public
+          name: NetCore1ESPool-Svc-Public
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
       # Build OSX Pool
@@ -50,11 +50,11 @@ jobs:
       # Public Windows Build Pool
       ${{ if eq(parameters.osGroup, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Public
+          name: NetCore1ESPool-Svc-Public
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:


### PR DESCRIPTION
Update build pools to servicing
Reset release notes

> **NOTE:** this is targeting a new release branch (`release/6.1`) which was forked from `release/6.x`