### PR TITLE
Add experience survey link

### DIFF
--- a/documentation/releaseNotes/releaseNotes.md
+++ b/documentation/releaseNotes/releaseNotes.md
@@ -1,6 +1,3 @@
 Today we are releasing the 6.1.1 build of the `dotnet monitor` tool. This release includes:
 
-- ⚠️ [Here is a breaking change we did and its work item] (#737)
-- [Here is a new feature we added and its work item] (#737)
-
-\*⚠️ **_indicates a breaking change_**
+- Add experience survey link (#1601)

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.IO;
+using System.Text;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 {
@@ -17,7 +19,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         // to get the same configuration without telling them to drop specific command line arguments.
         public static void Invoke(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, ConfigDisplayLevel level)
         {
-            Write(Console.OpenStandardOutput(), urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, level);
+            Stream stream = Console.OpenStandardOutput();
+
+            using StreamWriter writer = new(stream, EncodingCache.UTF8NoBOMNoThrow, 1024, leaveOpen: true);
+            writer.WriteLine(ExperienceSurvey.ExperienceSurveyMessage);
+            writer.WriteLine();
+            writer.Flush();
+
+            Write(stream, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, level);
         }
 
         public static void Write(Stream stream, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, ConfigDisplayLevel level)

--- a/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             }
             else
             {
+                outputBldr.AppendLine(ExperienceSurvey.ExperienceSurveyMessage);
+                outputBldr.AppendLine();
                 outputBldr.AppendLine(Strings.Message_GenerateApiKey);
                 outputBldr.AppendLine();
                 outputBldr.AppendLine(string.Format(Strings.Message_GeneratedAuthorizationHeader, HeaderNames.Authorization, AuthConstants.ApiKeySchema, newJwt.Token));

--- a/src/Tools/dotnet-monitor/ExperienceSurvey.cs
+++ b/src/Tools/dotnet-monitor/ExperienceSurvey.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static class ExperienceSurvey
+    {
+        public const string ExperienceSurveyLink = "https://aka.ms/dotnet-monitor-survey";
+
+        public static string ExperienceSurveyMessage = string.Format(
+            CultureInfo.InvariantCulture,
+            Strings.Message_ExperienceSurvey,
+            ExperienceSurveyLink);
+    }
+}

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         LoadingProfiler = 53,
         SetEnvironmentVariable = 54,
         GetEnvironmentVariable = 55,
+        MonitorApiKeyNotConfigured = 56,
+        QueueDoesNotExist = 57,
+        QueueOptionsPartiallySet = 58,
+        WritingMessageToQueueFailed = 59,
+        ExperienceSurvey = 60
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -301,6 +301,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_GetEnvironmentVariable);
 
+        private static readonly Action<ILogger, string, Exception> _experienceSurvey =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.ExperienceSurvey.EventId(),
+                logLevel: LogLevel.Information,
+                formatString: Strings.LogFormatString_ExperienceSurvey);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -543,6 +549,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void GettingEnvironmentVariable(this ILogger logger, string variableName, int processId)
         {
             _getEnvironmentVariable(logger, variableName, processId, null);
+        }
+
+        public static void ExperienceSurvey(this ILogger logger)
+        {
+            _experienceSurvey(logger, Monitor.ExperienceSurvey.ExperienceSurveyLink, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             MonitorApiKeyConfigurationObserver optionsObserver,
             ILogger<Startup> logger)
         {
+            logger.ExperienceSurvey();
+
             // These errors are populated before Startup.Configure is called because
             // the KestrelServer class is configured as a prerequisite of
             // GenericWebHostServer being instantiated. The GenericWebHostServer invokes

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -844,6 +844,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Tell us about your experience with dotnet monitor: {link}.
+        /// </summary>
+        internal static string LogFormatString_ExperienceSurvey {
+            get {
+                return ResourceManager.GetString("LogFormatString_ExperienceSurvey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Getting the environment variable {variableName} from process {processId}..
         /// </summary>
         internal static string LogFormatString_GetEnvironmentVariable {
@@ -957,6 +966,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string LogFormatString_UnableToListenToAddress {
             get {
                 return ResourceManager.GetString("LogFormatString_UnableToListenToAddress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tell us about your experience with dotnet monitor: {0}.
+        /// </summary>
+        internal static string Message_ExperienceSurvey {
+            get {
+                return ResourceManager.GetString("Message_ExperienceSurvey", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -527,6 +527,9 @@
   <data name="LogFormatString_EndpointTimeout" xml:space="preserve">
     <value>Unexpected timeout from process {processId}. Process will no longer be monitored.</value>
   </data>
+  <data name="LogFormatString_ExperienceSurvey" xml:space="preserve">
+    <value>Tell us about your experience with dotnet monitor: {link}</value>
+  </data>
   <data name="LogFormatString_GetEnvironmentVariable" xml:space="preserve">
     <value>Getting the environment variable {variableName} from process {processId}.</value>
     <comment>Gets the format string that is printed in the 55:GetEnvironmentVariable event.
@@ -596,6 +599,9 @@
     <comment>Gets the format string that is printed in the 15:UnableToListenToAddress event.
 1 Format Parameter:
 1. url: The URL that could not have a listener attached to it</comment>
+  </data>
+  <data name="Message_ExperienceSurvey" xml:space="preserve">
+    <value>Tell us about your experience with dotnet monitor: {0}</value>
   </data>
   <data name="Message_GenerateApiKey" xml:space="preserve">
     <value>Generated ApiKey for dotnet-monitor; use the following header for authorization:</value>


### PR DESCRIPTION
Example outputs:
```
> dotnet dotnet-monitor.dll collect
10:17:12 info: Microsoft.Diagnostics.Tools.Monitor.Startup[60]
      Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey
10:17:12 warn: Microsoft.Diagnostics.Tools.Monitor.MonitorApiKeyConfigurationObserver[21]
      MonitorApiKey settings are invalid: The Subject field is required.
10:17:12 warn: Microsoft.Diagnostics.Tools.Monitor.MonitorApiKeyConfigurationObserver[21]
      MonitorApiKey settings are invalid: The PublicKey field is required.
10:17:12 warn: Microsoft.Diagnostics.Tools.Monitor.MonitorApiKeyConfigurationObserver[21]
      MonitorApiKey settings are invalid: The configuration parameter PublicKey must be base64Url encoded, the value '' could not be parsed as a base64Url-encoded string.
10:17:13 warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://localhost:52323'. Binding to endpoints defined in UseKestrel() instead.
...
```
```
> dotnet dotnet-monitor.dll collect
{"Timestamp":"10:41:08 ","EventId":60,"LogLevel":"Information","Category":"Microsoft.Diagnostics.Tools.Monitor.Startup","Message":"Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey","State":{"Message":"Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey","link":"https://aka.ms/dotnet-monitor-survey","{OriginalFormat}":"Tell us about your experience with dotnet monitor: {link}"},"Scopes":[]}
{"Timestamp":"10:41:08 ","EventId":21,"LogLevel":"Warning","Category":"Microsoft.Diagnostics.Tools.Monitor.MonitorApiKeyConfigurationObserver","Message":"MonitorApiKey settings are invalid: The Subject field is required.","State":{"Message":"MonitorApiKey settings are invalid: The Subject field is required.","apiAuthenticationConfigKey":"MonitorApiKey","validationFailure":"The Subject field is required.","{OriginalFormat}":"{apiAuthenticationConfigKey} settings are invalid: {validationFailure}"},"Scopes":[]}
{"Timestamp":"10:41:08 ","EventId":21,"LogLevel":"Warning","Category":"Microsoft.Diagnostics.Tools.Monitor.MonitorApiKeyConfigurationObserver","Message":"MonitorApiKey settings are invalid: The PublicKey field is required.","State":{"Message":"MonitorApiKey settings are invalid: The PublicKey field is required.","apiAuthenticationConfigKey":"MonitorApiKey","validationFailure":"The PublicKey field is required.","{OriginalFormat}":"{apiAuthenticationConfigKey} settings are invalid: {validationFailure}"},"Scopes":[]}
{"Timestamp":"10:41:08 ","EventId":21,"LogLevel":"Warning","Category":"Microsoft.Diagnostics.Tools.Monitor.MonitorApiKeyConfigurationObserver","Message":"MonitorApiKey settings are invalid: The configuration parameter PublicKey must be base64Url encoded, the value \u0027\u0027 could not be parsed as a base64Url-encoded string.","State":{"Message":"MonitorApiKey settings are invalid: The configuration parameter PublicKey must be base64Url encoded, the value \u0027\u0027 could not be parsed as a base64Url-encoded string.","apiAuthenticationConfigKey":"MonitorApiKey","validationFailure":"The configuration parameter PublicKey must be base64Url encoded, the value \u0027\u0027 could not be parsed as a base64Url-encoded string.","{OriginalFormat}":"{apiAuthenticationConfigKey} settings are invalid: {validationFailure}"},"Scopes":[]}
{"Timestamp":"10:41:08 ","EventId":0,"LogLevel":"Warning","Category":"Microsoft.AspNetCore.Server.Kestrel","Message":"Overriding address(es) \u0027https://localhost:52323\u0027. Binding to endpoints defined in UseKestrel() instead.","State":{"Message":"Overriding address(es) \u0027https://localhost:52323\u0027. Binding to endpoints defined in UseKestrel() instead.","addresses":"https://localhost:52323","methodName":"UseKestrel()","{OriginalFormat}":"Overriding address(es) \u0027{addresses}\u0027. Binding to endpoints defined in {methodName} instead."},"Scopes":[]}
```
```
> dotnet dotnet-monitor.dll generatekey
Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey

Generated ApiKey for dotnet-monitor; use the following header for authorization:

Authorization: Bearer ...
```
```
> dotnet dotnet-monitor.dll config show
Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey

{
  "urls": "https://localhost:52323",
  "Kestrel": ":NOT PRESENT:",
  "GlobalCounter": {
    "IntervalSeconds": "5"
  },
  ...
}
```

cc @poppastring 

closes #1601