### PR TITLE
Skip netcoreapp3.1 and net5.0 tests in PR and CI builds

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -9,11 +9,25 @@ pr:
     - internal/release/*
     - feature/*
 
+schedules:
+- cron: 0 12 * * 6
+  displayName: Weekly Full Test Run
+  branches:
+    include:
+    - main
+  always: true
+
 parameters:
-- name: RunTests
-  displayName: 'Run Tests'
-  type: boolean
-  default: true
+- name: TestGroup
+  displayName: 'Test Group'
+  type: string
+  default: Default
+  values:
+  - Default
+  - All
+  - None
+  - CI
+  - PR
 
 variables:
 - name: _TeamName
@@ -34,7 +48,7 @@ stages:
       displayName: Windows x64 Debug
       osGroup: Windows
       configuration: Debug
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:
       name: Windows_x64_Release
@@ -42,7 +56,7 @@ stages:
       osGroup: Windows
       configuration: Release
       publishArtifactsSubPath: bin
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:
       name: Windows_x86_Release
@@ -51,7 +65,7 @@ stages:
       configuration: Release
       architecture: x86
       publishArtifactsSubPath: bin/Windows_NT.x86.Release
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
       parameters:
@@ -68,7 +82,7 @@ stages:
       displayName: Linux x64 Debug
       osGroup: Linux
       configuration: Debug
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:
       name: Linux_x64_Release
@@ -76,7 +90,7 @@ stages:
       osGroup: Linux
       configuration: Release
       publishArtifactsSubPath: bin/Linux.x64.Release
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
       parameters:
@@ -93,7 +107,7 @@ stages:
       displayName: Linux Musl x64 Debug
       osGroup: Linux_Musl
       configuration: Debug
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:
       name: Linux_Musl_x64_Release
@@ -102,7 +116,7 @@ stages:
       configuration: Release
       publishArtifactsSubPath: bin/Linux.x64.Release
       publishArtifactsTargetSubPath: bin/Linux-musl.x64.Release
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
       parameters:
@@ -120,7 +134,7 @@ stages:
       displayName: MacOS x64 Debug
       osGroup: MacOS
       configuration: Debug
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:
       name: MacOS_x64_Release
@@ -128,7 +142,7 @@ stages:
       osGroup: MacOS
       configuration: Release
       publishArtifactsSubPath: bin/OSX.x64.Release
-      runTests: ${{ parameters.RunTests }}
+      testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
       parameters:

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -4,6 +4,7 @@ Param(
     [ValidateSet("Debug","Release")][string][Alias('c')] $configuration = "Debug",
     [string][Alias('v')] $verbosity = "minimal",
     [switch][Alias('t')] $test,
+    [string] $testgroup = 'All',
     [switch] $ci,
     [switch] $skipmanaged,
     [switch] $skipnative,
@@ -71,7 +72,8 @@ if ($test) {
           -verbosity $verbosity `
           -ci:$ci `
           /bl:$logdir\Test.binlog `
-          /p:BuildArch=$architecture
+          /p:BuildArch=$architecture `
+          /p:TestGroup=$testgroup
 
         if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -29,6 +29,7 @@ __SkipConfigure=0
 __SkipGenerateVersion=0
 __TargetOS=Linux
 __Test=0
+__TestGroup=All
 __UnprocessedBuildArgs=
 
 usage_list+=("-skipmanaged: do not build managed components.")
@@ -83,6 +84,11 @@ handle_arguments() {
 
         test|-test)
             __Test=1
+            ;;
+
+        testgroup|-testgroup)
+            __TestGroup=$2
+            __ShiftArgs=1
             ;;
 
         -warnaserror|-nodereuse)
@@ -243,6 +249,7 @@ if [[ "$__Test" == 1 ]]; then
         --configuration "$__BuildType" \
         /bl:"$__LogsDir"/Test.binlog \
         /p:BuildArch="$__BuildArch" \
+        /p:TestGroup="$__TestGroup" \
         $__CommonMSBuildArgs
 
       if [ $? != 0 ]; then

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -15,8 +15,8 @@ parameters:
   publishArtifactsSubPath: ''
   # Sub path under artifacts location to which artifact files are publish
   publishArtifactsTargetSubPath: ''
-  # Allow disabling test runs
-  runTests: true
+  # Group of tests to be run
+  testGroup: Default
   # TFMs for which test results are uploaded
   testResultTfms:
   - key: netcoreapp3.1
@@ -106,8 +106,17 @@ jobs:
     - ${{ if and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows')) }}:
       - _CrossBuildArgs: '-cross'
 
-    - ${{ if eq(parameters.runTests, true) }}:
-      - _TestArgs: '-test'
+    - ${{ if ne(parameters.testGroup, 'None') }}:
+      # If TestGroup == 'Default', choose the test group based on the type of pipeline run
+      - ${{ if eq(parameters.testGroup, 'Default') }}:
+        - ${{ if in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI') }}:
+          - _TestArgs: '-test -testgroup CI'
+        - ${{ elseif eq(variables['Build.Reason'], 'PullRequest') }}:
+          - _TestArgs: '-test -testgroup PR'
+        - ${{ else }}:
+          - _TestArgs: '-test -testgroup All'
+      - ${{ else }}:
+          - _TestArgs: '-test -testgroup ${{ parameters.testGroup }}'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-MSRC-Storage
@@ -180,7 +189,7 @@ jobs:
           artifactName: Build_${{ parameters.configuration }}
 
     # Publish test results to Azure Pipelines
-    - ${{ if eq(parameters.runTests, true) }}:
+    - ${{ if ne(parameters.testGroup, 'None') }}:
       - ${{ each testResultTfm in parameters.testResultTfms }}:
         - task: PublishTestResults@2
           displayName: Publish Test Results (${{ testResultTfm.value }})

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,16 @@
     <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=3m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
+  <!-- Filter tests based on specified TestGroup -->
+  <PropertyGroup Condition="'$(TestGroup)' == 'CI'">
+    <!-- Exclude netcoreapp3.1 and net5.0 tests from CI builds -->
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker!=NetCoreApp31&amp;TargetFrameworkMoniker!=Net50"</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TestGroup)' == 'PR'">
+    <!-- Exclude netcoreapp3.1 and net5.0 tests from PR builds -->
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker!=NetCoreApp31&amp;TargetFrameworkMoniker!=Net50"</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             return Version.Parse(versionString);
         }
 
-        private static readonly TargetFrameworkMoniker CurrentTargetFrameworkMoniker =
+        public const TargetFrameworkMoniker CurrentTargetFrameworkMoniker =
 #if NET7_0
             TargetFrameworkMoniker.Net70;
 #elif NET6_0

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitAttribute.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit.Sdk;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    [TraitDiscoverer("Microsoft.Diagnostics.Monitoring.TestCommon.TargetFrameworkMonikerTraitDiscoverer", "Microsoft.Diagnostics.Monitoring.TestCommon")]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
+    public class TargetFrameworkMonikerTraitAttribute :
+        Attribute,
+        ITraitAttribute
+    {
+        public TargetFrameworkMonikerTraitAttribute(TargetFrameworkMoniker targetFrameworkMoniker)
+        {
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitDiscoverer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitDiscoverer.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    internal class TargetFrameworkMonikerTraitDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            TargetFrameworkMoniker tfm = traitAttribute.GetConstructorArguments().OfType<TargetFrameworkMoniker>().Single();
+            yield return new KeyValuePair<string, string>("TargetFrameworkMoniker", tfm.ToString());
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -28,6 +28,7 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class AuthenticationTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class CollectionRuleTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class DumpTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
@@ -28,6 +28,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class EgressTests : IDisposable
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class GenerateKeyTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class InfoTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -29,6 +29,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class LiveMetricsTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
@@ -25,6 +25,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class LogsTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
@@ -20,6 +21,7 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class MetricsTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class ProcessTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/RootTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/RootTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
@@ -15,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
     public class RootTests
     {


### PR DESCRIPTION
Allow selecting subset of tests to run.
Schedule once-a-week build that runs all tests.
Test selection uses xUnit trait filtering.