### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository contains the source code for dotnet-monitor, a diagnostic tool f
 
 See [Releases](documentation/releases.md) for the release history.
 
+## Docs
+
+[Docs](documentation/README.md) - Learn how to install, configure, and use dotnet-monitor.
+
 ## Building the Repository
 
 See [building instructions](documentation/building.md) in our documentation directory.


### PR DESCRIPTION
People wanting to use dotnet-monitor are likely to come here, but the README didn't forward them to the docs.
They might guess that the documentation folder is a good place to go on their own, but I am trying to make it a pit of
success.