### PR TITLE
Exclude profiler from nupkg until productized

### DIFF
--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -61,7 +61,8 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherNativeFilesForTfm</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="GatherNativeFilesForTfm">
+  <!-- Don't include profiler files in official builds until productized. -->
+  <Target Name="GatherNativeFilesForTfm" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
     <ItemGroup>
       <!-- Create profiler library items for all of the native platforms. -->
       <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">


### PR DESCRIPTION
The profiler is not ready to be used in the product; exclude it until a scenario is enabled. Non-official builds will still include the profiler files for easier testing.