### PR TITLE
Retry logs and dumps tests on failure

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -107,6 +107,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
         private async Task Retry(DumpType type, Func<Task> func, int attemptCount = 3)
         {
+            bool isMacOSFullDump =
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                type == DumpType.Full;
+
             int attemptIteration = 0;
             while (true)
             {
@@ -118,16 +122,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                     break;
                 }
-                catch (TaskCanceledException) when (attemptIteration < attemptCount && IsMacOSFullDump())
+                catch (TaskCanceledException) when (attemptIteration < attemptCount && isMacOSFullDump)
                 {
                     // Full dumps on MacOS sometimes take a very long time (longer than 100 seconds, the default
                     // HttpClient timeout). Retry the test when this condition is detected.
                 }
             }
-
-            bool IsMacOSFullDump() =>
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                type == DumpType.Full;
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -45,6 +46,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [InlineData(DiagnosticPortConnectionMode.Listen, DumpType.WithHeap)]
 #endif
         public Task DumpTest(DiagnosticPortConnectionMode mode, DumpType type)
+        {
+            return Retry(type, () => DumpTestCore(mode, type));
+        }
+
+        private Task DumpTestCore(DiagnosticPortConnectionMode mode, DumpType type)
         {
 #if !NET6_0_OR_GREATER
             // Capturing non-full dumps via diagnostic command works inconsistently
@@ -97,6 +103,31 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                     runner.ConfigurationFromEnvironment.SetDumpTempFolder(dumpTempFolder);
                 });
+        }
+
+        private async Task Retry(DumpType type, Func<Task> func, int attemptCount = 3)
+        {
+            int attemptIteration = 0;
+            while (true)
+            {
+                attemptIteration++;
+                _outputHelper.WriteLine("===== Attempt #{0} =====", attemptIteration);
+                try
+                {
+                    await func();
+
+                    break;
+                }
+                catch (TaskCanceledException) when (attemptIteration < attemptCount && IsMacOSFullDump())
+                {
+                    // Full dumps on MacOS sometimes take a very long time (longer than 100 seconds, the default
+                    // HttpClient timeout). Retry the test when this condition is detected.
+                }
+            }
+
+            bool IsMacOSFullDump() =>
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                type == DumpType.Full;
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectDumpActionTests.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
         private async Task Retry(DumpType type, Func<Task> func, int attemptCount = 3)
         {
+            bool isMacOSFullDump =
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                type == DumpType.Full;
+
             int attemptIteration = 0;
             while (true)
             {
@@ -104,16 +108,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                     break;
                 }
-                catch (TaskCanceledException) when (attemptIteration < attemptCount && IsMacOSFullDump())
+                catch (TaskCanceledException) when (attemptIteration < attemptCount && isMacOSFullDump)
                 {
                     // Full dumps on MacOS sometimes take a very long time (longer than 100 seconds, the default
                     // HttpClient timeout). Retry the test when this condition is detected.
                 }
             }
-
-            bool IsMacOSFullDump() =>
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                type == DumpType.Full;
         }
     }
 }


### PR DESCRIPTION
Add retry logic to the logs and dumps tests in an effort to allow builds to complete with a higher success rate.