### PR TITLE
Have collect actions throw exceptions on failure

### DIFF
--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectDumpAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectDumpAction.cs
@@ -65,27 +65,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
                 KeyValueLogScope scope = Utils.CreateArtifactScope(Utils.ArtifactType_Dump, EndpointInfo);
 
-                try
-                {
-                    EgressOperation egressOperation = new EgressOperation(
-                        token => {
-                            startCompletionSource.TrySetResult(null);
-                            return _dumpService.DumpAsync(EndpointInfo, dumpType, token);
-                        },
-                        egressProvider,
-                        dumpFileName,
-                        EndpointInfo,
-                        ContentTypes.ApplicationOctetStream,
-                        scope);
+                EgressOperation egressOperation = new EgressOperation(
+                    token => {
+                        startCompletionSource.TrySetResult(null);
+                        return _dumpService.DumpAsync(EndpointInfo, dumpType, token);
+                    },
+                    egressProvider,
+                    dumpFileName,
+                    EndpointInfo,
+                    ContentTypes.ApplicationOctetStream,
+                    scope);
 
-                    ExecutionResult<EgressResult> result = await egressOperation.ExecuteAsync(_serviceProvider, token);
-
-                    dumpFilePath = result.Result.Value;
-                }
-                catch (Exception ex)
+                ExecutionResult<EgressResult> result = await egressOperation.ExecuteAsync(_serviceProvider, token);
+                if (null != result.Exception)
                 {
-                    throw new CollectionRuleActionException(ex);
+                    throw new CollectionRuleActionException(result.Exception);
                 }
+                dumpFilePath = result.Result.Value;
 
                 return new CollectionRuleActionResult()
                 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectGCDumpAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectGCDumpAction.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
 using System;
 using System.Collections.Generic;
@@ -70,7 +71,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                     scope);
 
                 ExecutionResult<EgressResult> result = await egressOperation.ExecuteAsync(_serviceProvider, token);
-
+                if (null != result.Exception)
+                {
+                    throw new CollectionRuleActionException(result.Exception);
+                }
                 string gcdumpFilePath = result.Result.Value;
 
                 return new CollectionRuleActionResult()

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLogsAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLogsAction.cs
@@ -5,6 +5,7 @@
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
 using Microsoft.Extensions.Logging;
 using System;
@@ -83,7 +84,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                     scope);
 
                 ExecutionResult<EgressResult> result = await egressOperation.ExecuteAsync(_serviceProvider, token);
-
+                if (null != result.Exception)
+                {
+                    throw new CollectionRuleActionException(result.Exception);
+                }
                 string logsFilePath = result.Result.Value;
 
                 return new CollectionRuleActionResult()

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -5,6 +5,7 @@
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -97,7 +98,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                     scope);
 
                 ExecutionResult<EgressResult> result = await egressOperation.ExecuteAsync(_serviceProvider, token);
-
+                if (null != result.Exception)
+                {
+                    throw new CollectionRuleActionException(result.Exception);
+                }
                 string traceFilePath = result.Result.Value;
 
                 return new CollectionRuleActionResult()


### PR DESCRIPTION
The collection rule actions do not throw exceptions when they fail to collect their artifacts. The call to `IEgressOperation.ExecuteAsync` will return a failed `ExecutionResult` instead of throwing an exception when the operation fails.

To fix this, I've added an `Exception` property to the `ExecutionResult` class which is populated when creating a failure result and updated the actions to throw a `CollectionRuleActoinException` that wraps the exception from the `ExecutionResult`.