### PR TITLE
Prevent rebuild while packing in official builds

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -55,7 +55,9 @@ stages:
       displayName: Windows x64 Release
       osGroup: Windows
       configuration: Release
-      publishArtifactsSubPath: bin
+      publishArtifactsSubPaths:
+      - source: 'bin'
+      - source: 'obj'
       testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:
@@ -64,7 +66,8 @@ stages:
       osGroup: Windows
       configuration: Release
       architecture: x86
-      publishArtifactsSubPath: bin/Windows_NT.x86.Release
+      publishArtifactsSubPaths:
+      - source: 'bin/Windows_NT.x86.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
@@ -74,7 +77,8 @@ stages:
         osGroup: Windows
         configuration: Release
         architecture: arm64
-        publishArtifactsSubPath: bin/Windows_NT.arm64.Release
+        publishArtifactsSubPaths:
+        - source: 'bin/Windows_NT.arm64.Release'
         testGroup: None
   - template: /eng/build.yml
     parameters:
@@ -89,7 +93,8 @@ stages:
       displayName: Linux x64 Release
       osGroup: Linux
       configuration: Release
-      publishArtifactsSubPath: bin/Linux.x64.Release
+      publishArtifactsSubPaths:
+      - source: 'bin/Linux.x64.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
@@ -99,7 +104,8 @@ stages:
         osGroup: Linux
         configuration: Release
         architecture: arm64
-        publishArtifactsSubPath: bin/Linux.arm64.Release
+        publishArtifactsSubPaths:
+        - source: 'bin/Linux.arm64.Release'
         testGroup: None
   - template: /eng/build.yml
     parameters:
@@ -114,8 +120,9 @@ stages:
       displayName: Linux Musl x64 Release
       osGroup: Linux_Musl
       configuration: Release
-      publishArtifactsSubPath: bin/Linux.x64.Release
-      publishArtifactsTargetSubPath: bin/Linux-musl.x64.Release
+      publishArtifactsSubPaths:
+      - source: 'bin/Linux.x64.Release'
+        target: 'bin/Linux-musl.x64.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
@@ -125,8 +132,9 @@ stages:
         osGroup: Linux_Musl
         configuration: Release
         architecture: arm64
-        publishArtifactsSubPath: bin/Linux.arm64.Release
-        publishArtifactsTargetSubPath: bin/Linux-musl.arm64.Release
+        publishArtifactsSubPaths:
+        - source: 'bin/Linux.arm64.Release'
+          target: 'bin/Linux-musl.arm64.Release'
         testGroup: None
   - template: /eng/build.yml
     parameters:
@@ -141,7 +149,8 @@ stages:
       displayName: MacOS x64 Release
       osGroup: MacOS
       configuration: Release
-      publishArtifactsSubPath: bin/OSX.x64.Release
+      publishArtifactsSubPaths:
+      - source: 'bin/OSX.x64.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - template: /eng/build.yml
@@ -151,7 +160,8 @@ stages:
         osGroup: MacOS
         configuration: Release
         architecture: arm64
-        publishArtifactsSubPath: bin/OSX.arm64.Release
+        publishArtifactsSubPaths:
+        - source: 'bin/OSX.arm64.Release'
         testGroup: None
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     # Pack, sign, and publish

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -11,10 +11,8 @@ parameters:
   timeoutInMinutes: 180
   # Depends on 
   dependsOn: ''
-  # Sub path under 'artifacts' folder from which files are published to artifacts location
-  publishArtifactsSubPath: ''
-  # Sub path under artifacts location to which artifact files are publish
-  publishArtifactsTargetSubPath: ''
+  # Sub paths under 'artifacts' folder from which files are published to artifacts location
+  publishArtifactsSubPaths: []
   # Group of tests to be run
   testGroup: Default
   # TFMs for which test results are uploaded
@@ -174,13 +172,14 @@ jobs:
         env:
           ROOTFS_DIR: '/crossrootfs/arm64'
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(parameters.publishArtifactsSubPath, '')) }}:
-      - task: CopyFiles@2
-        displayName: Gather Artifacts
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts/${{ parameters.publishArtifactsSubPath }}'
-          Contents: '**'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/${{ coalesce(parameters.publishArtifactsTargetSubPath, parameters.publishArtifactsSubPath) }}'
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), gt(length(parameters.publishArtifactsSubPaths), 0)) }}:
+      - ${{ each subPath in parameters.publishArtifactsSubPaths }}:
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (${{ subPath.source }})
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/${{ subPath.source }}'
+            Contents: '**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/${{ coalesce(subPath.target, subPath.source) }}'
 
       - task: PublishBuildArtifacts@1
         displayName: Publish Artifacts

--- a/eng/cipacksignpublish.cmd
+++ b/eng/cipacksignpublish.cmd
@@ -4,5 +4,5 @@ setlocal
 set "_commonArgs=-restore -ci -prepareMachine -verbosity minimal -configuration Release"
 set "_logDir=%~dp0..\artifacts\log\Release\"
 
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" %_commonArgs% -pack -sign -publish -noBl /bl:'%_logDir%PackSignPublish.binlog' %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" %_commonArgs% -pack -sign -publish /p:NoBuild=true -noBl /bl:'%_logDir%PackSignPublish.binlog' %*"
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
These changes allow the packing phase, which occurs on a different job than the platform build jobs, to not rebuild the product. This required capturing the `obj` folder of the same build job that provided the managed assemblies, namely the Windows x64 Release job, in the `Build_Release` artifact such that it can be reused in the packing job. This allows the assemblies and pdbs that are packged into the nupkg file to be exactly the same as those that were produced by the build job.

[Example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=1702307&view=logs&j=8302af6e-291f-54bf-6d61-b832e4017e5a&t=31c4598f-342a-52ea-54df-47052f2aafdf) shows that the packing phase does not rebuild any assemblies.