### PR TITLE
Update Docker docs with new Dockerfile links

### DIFF
--- a/documentation/docker.md
+++ b/documentation/docker.md
@@ -17,6 +17,9 @@ In addition to its availability as a .NET CLI tool, the `dotnet monitor` tool is
 | Version | Platform | Architecture | Link |
 |---|---|---|---|
 | 7.0 (Preview, Latest) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile |
+| 7.0 (Preview, Latest) | Linux (Alpine) | arm64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/arm64v8/Dockerfile |
+| 6.2 (Preview) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/amd64/Dockerfile |
+| 6.2 (Preview) | Linux (Alpine) | arm64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/arm64v8/Dockerfile |
 | 6.1 (Current) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile |
 | 6.0 | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile |
 


### PR DESCRIPTION
This excludes the CBL-Mariner links as they are not documented.