### PR TITLE
[release/6.x] Reduce log messages for APIKey changes when no API key is configured

### DIFF
--- a/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public void PostConfigure(string name, JwtBearerOptions options)
         {
             MonitorApiKeyConfiguration configSnapshot = _apiKeyConfig.CurrentValue;
-            if (configSnapshot.ValidationErrors.Any())
+            if (!configSnapshot.Configured || configSnapshot.ValidationErrors.Any())
             {
                 options.SecurityTokenValidators.Add(new RejectAllSecurityValidator());
                 return;

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     /// </summary>
     internal class MonitorApiKeyConfiguration : AuthenticationSchemeOptions
     {
+        public bool Configured { get; set; }
         public string Subject { get; set; }
         public SecurityKey PublicKey { get; set; }
         public IEnumerable<ValidationResult> ValidationErrors { get; set; }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -49,14 +49,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void CheckMonitorApiKeyOptions(MonitorApiKeyConfiguration options)
         {
-            // ValidationErrors will be null if API key authentication is not enabled.
-            if (null != options.ValidationErrors && options.ValidationErrors.Any())
+            if (options.Configured)
             {
-                _logger.ApiKeyValidationFailures(options.ValidationErrors);
+                if (null != options.ValidationErrors && options.ValidationErrors.Any())
+                {
+                    _logger.ApiKeyValidationFailures(options.ValidationErrors);
+                }
+                else
+                {
+                    _logger.ApiKeyAuthenticationOptionsValidated();
+                }
             }
             else
             {
-                _logger.ApiKeyAuthenticationOptionsValidated();
+                _logger.MonitorApiKeyNotConfigured();
             }
         }
     }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyPostConfigure.cs
@@ -36,6 +36,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             IList<ValidationResult> errors = new List<ValidationResult>();
 
+            // If nothing is set, lets not attach an error and instead pass along the blank config
+            if (sourceOptions.Subject == null && sourceOptions.PublicKey == null)
+            {
+                options.Configured = false;
+                options.Subject = null;
+                options.PublicKey = null;
+                return;
+            }
+
+            // Some options are configured (but may not be valid)
+            options.Configured = true;
+
             Validator.TryValidateObject(
                 sourceOptions,
                 new ValidationContext(sourceOptions, null, null),

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -301,6 +302,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_GetEnvironmentVariable);
 
+        private static readonly Action<ILogger, string, Exception> _monitorApiKeyNotConfigured =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.MonitorApiKeyNotConfigured.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_ApiKeyNotConfigured);
+
         private static readonly Action<ILogger, string, Exception> _experienceSurvey =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExperienceSurvey.EventId(),
@@ -551,9 +558,25 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _getEnvironmentVariable(logger, variableName, processId, null);
         }
 
+        public static void MonitorApiKeyNotConfigured(this ILogger logger)
+        {
+            const long myFwLinkId = 2187444;
+            string fwLink = GetFwLinkWithCurrentLcidUri(myFwLinkId);
+            _monitorApiKeyNotConfigured(logger, fwLink, null);
+        }
+
         public static void ExperienceSurvey(this ILogger logger)
         {
             _experienceSurvey(logger, Monitor.ExperienceSurvey.ExperienceSurveyLink, null);
+        }
+
+        private static string GetFwLinkWithCurrentLcidUri(long fwlinkId)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                @"https://go.microsoft.com/fwlink/?linkid={0}&clcid=0x{1:x}",
+                fwlinkId,
+                CultureInfo.CurrentUICulture.LCID);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -547,6 +547,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to API key authentication is not configured. See {0} for more details..
+        /// </summary>
+        internal static string LogFormatString_ApiKeyNotConfigured {
+            get {
+                return ResourceManager.GetString("LogFormatString_ApiKeyNotConfigured", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {configName} have changed, new values: Subject={subject}, PublicKey={publicKey}.
         /// </summary>
         internal static string LogFormatString_ApiKeyOptionsChanged {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -380,6 +380,13 @@
 1 Format Parameter:
 1. apiAuthenticationConfigKey: The string key of ApiAuthentication object in configuration.</comment>
   </data>
+  <data name="LogFormatString_ApiKeyNotConfigured" xml:space="preserve">
+    <value>API key authentication is not configured. See {0} for more details.</value>
+    <comment>Gets the format string that is printed in the 56:MonitorApiKeyNotConfigured event.
+
+1 formattable parameter
+0. Culture LCID of the documentation link</comment>
+  </data>
   <data name="LogFormatString_ApiKeyOptionsChanged" xml:space="preserve">
     <value>The {configName} have changed, new values: Subject={subject}, PublicKey={publicKey}</value>
     <comment>Gets the format string that is printed in the 21:ApiKeyValidationFailure event.


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet-monitor/pull/1510 to release/6.x

/cc @jander-msft @kelltrick 