### PR TITLE
[release/6.x] Make aspnetcore a coherent parent of runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -50,7 +50,7 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>cb24099215a83975c360792edf35102ff0d10702</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>
@@ -58,7 +58,7 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>ae1a6cbe225b99c0bf38b7e31bf60cb653b73a52</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rtm.21522.10">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rtm.21522.10" CoherentParentDependency="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>


### PR DESCRIPTION
Same change in #1660 and #1663 but targeting the release/6.x branch

The aspnetcore and runtime versions are already coherent, so only the attributes need to be applied to the version entries.