### PR TITLE
[release/6.x] Update release notes with product changes

### DIFF
--- a/documentation/releaseNotes/releaseNotes.md
+++ b/documentation/releaseNotes/releaseNotes.md
@@ -1,3 +1,5 @@
 Today we are releasing the 6.2.0 build of the `dotnet monitor` tool. This release includes:
 
-- Add experience survey link (#1601)
+- Allow for pushing a message to a queue when writing to Azure egress (#163)
+- Allow for simplified process filter configuration (#636)
+- Allow `config show` command to list configuration sources (#277)


### PR DESCRIPTION
I removed the experience link item since that will ship in 6.1.1 before 6.2 ships.