### PR TITLE
Profiler logging infrastructure

### DIFF
--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -5,6 +5,7 @@ project(MonitorProfiler)
 if(CLR_CMAKE_HOST_WIN32)
     set(SOURCES
         ${SOURCES}
+        Logging/DebugLogger.cpp
         MonitorProfiler.def
         )
 endif(CLR_CMAKE_HOST_WIN32)
@@ -12,6 +13,9 @@ endif(CLR_CMAKE_HOST_WIN32)
 set(SOURCES
     ${SOURCES}
     ${PROFILER_SOURCES}
+    Environment/EnvironmentHelper.cpp
+    Environment/ProfilerEnvironment.cpp
+    Logging/AggregateLogger.cpp
     MainProfiler/MainProfiler.cpp
     ClassFactory.cpp
     DllMain.cpp

--- a/src/MonitorProfiler/ClassFactory.h
+++ b/src/MonitorProfiler/ClassFactory.h
@@ -8,7 +8,7 @@
 #include "com.h"
 #include "refcount.h"
 
-class ClassFactory :
+class ClassFactory final :
     public RefCount,
     public IClassFactory
 {

--- a/src/MonitorProfiler/Environment/Environment.h
+++ b/src/MonitorProfiler/Environment/Environment.h
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "corhlpr.h"
+#include "tstring.h"
+
+/// <summary>
+/// Interface allowing getting and setting of environment variables.
+/// </summary>
+DECLARE_INTERFACE(IEnvironment)
+{
+    /// <summary>
+    /// Gets the value of the specified environment variable.
+    /// </summary>
+    STDMETHOD(GetEnvironmentVariable)(const tstring name, tstring& value) PURE;
+
+    /// <summary>
+    /// Sets the value of the specified environment variable.
+    /// </summary>
+    STDMETHOD(SetEnvironmentVariable)(const tstring name, const tstring value) PURE;
+};

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "EnvironmentHelper.h"
+#include "productversion.h"
+
+using namespace std;
+
+#define IfFailLogRet(EXPR) IfFailLogRet_(pLogger, EXPR)
+
+HRESULT EnvironmentHelper::SetProductVersion(
+    const shared_ptr<IEnvironment>& pEnvironment,
+    const shared_ptr<ILogger>& pLogger)
+{
+    HRESULT hr = S_OK;
+
+    IfFailLogRet(pEnvironment->SetEnvironmentVariable(
+        s_wszProfilerVersionEnvVar,
+        MonitorProductVersion_TSTR
+        ));
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.h
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+#include "Environment.h"
+#include "../Logging/Logger.h"
+
+/// <summary>
+/// Helper class for getting and setting known environment variables.
+/// </summary>
+class EnvironmentHelper final
+{
+private:
+    static constexpr LPCWSTR s_wszProfilerVersionEnvVar = _T("DotnetMonitorProfiler_ProductVersion");
+
+public:
+    /// <summary>
+    /// Sets the product version environment variable in the specified environment.
+    /// </summary>
+    static HRESULT SetProductVersion(
+        const std::shared_ptr<IEnvironment>& pEnvironment,
+        const std::shared_ptr<ILogger>& pLogger);
+};

--- a/src/MonitorProfiler/Environment/ProfilerEnvironment.cpp
+++ b/src/MonitorProfiler/Environment/ProfilerEnvironment.cpp
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "ProfilerEnvironment.h"
+
+using namespace std;
+
+ProfilerEnvironment::ProfilerEnvironment(ICorProfilerInfo11* pCorProfilerInfo) :
+    m_pCorProfilerInfo(pCorProfilerInfo)
+{
+}
+
+STDMETHODIMP ProfilerEnvironment::GetEnvironmentVariable(const tstring name, tstring& value)
+{
+    HRESULT hr = S_OK;
+
+    ULONG cchValue;
+    IfFailRet(m_pCorProfilerInfo->GetEnvironmentVariable(
+        name.c_str(),
+        0,
+        &cchValue,
+        nullptr));
+
+    unique_ptr<WCHAR[]> pwszValue(new (nothrow) WCHAR[cchValue + 1]);
+    IfNullRet(pwszValue);
+
+    IfFailRet(m_pCorProfilerInfo->GetEnvironmentVariable(
+        name.c_str(),
+        cchValue + 1,
+        nullptr,
+        pwszValue.get()
+        ));
+
+    value.assign(pwszValue.get());
+
+    return S_OK;
+}
+
+STDMETHODIMP ProfilerEnvironment::SetEnvironmentVariable(const tstring name, const tstring value)
+{
+    HRESULT hr = S_OK;
+
+    IfFailRet(m_pCorProfilerInfo->SetEnvironmentVariable(
+        name.c_str(),
+        value.c_str()
+        ));
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/Environment/ProfilerEnvironment.h
+++ b/src/MonitorProfiler/Environment/ProfilerEnvironment.h
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+#include "Environment.h"
+#include "../Logging/Logger.h"
+#include "corprof.h"
+#include "com.h"
+
+/// <summary>
+/// Abstraction for getting and setting environment variables from an ICorProfilerInfo instance.
+/// </summary>
+class ProfilerEnvironment final :
+    public IEnvironment
+{
+private:
+    ComPtr<ICorProfilerInfo11> m_pCorProfilerInfo;
+
+public:
+    ProfilerEnvironment(ICorProfilerInfo11* pCorProfilerInfo);
+
+public:
+    // IEnvironment
+
+    /// <inheritdoc />
+    STDMETHOD(GetEnvironmentVariable)(tstring name, tstring& value) override;
+
+    /// <inheritdoc />
+    STDMETHOD(SetEnvironmentVariable)(tstring name, tstring value) override;
+};

--- a/src/MonitorProfiler/Environment/ProfilerEnvironment.h
+++ b/src/MonitorProfiler/Environment/ProfilerEnvironment.h
@@ -13,6 +13,18 @@
 /// <summary>
 /// Abstraction for getting and setting environment variables from an ICorProfilerInfo instance.
 /// </summary>
+/// <remarks>
+/// On non-Windows platforms, the runtime will cache the initial environment variable block. Managed
+/// caled to Environment::[Get|Set]EnvironmentVariable will only mutate the cache, not the real
+/// environment block. Additionally, diagnostic commands for accessing the environment variables
+/// only mutate and get from the cache, not the real environment block.
+/// 
+/// This cache is accessible by profilers via the ICorProfilerInfo11 methods instead of using the
+/// native platform environment variable methods.
+/// 
+/// This class provides an abstraction over the profiler methods to allow getting access to the current
+/// environment variables as seen by managed code and by diagnostic services.
+/// </remarks>
 class ProfilerEnvironment final :
     public IEnvironment
 {

--- a/src/MonitorProfiler/Logging/AggregateLogger.cpp
+++ b/src/MonitorProfiler/Logging/AggregateLogger.cpp
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "AggregateLogger.h"
+
+using namespace std;
+
+STDMETHODIMP AggregateLogger::Add(const shared_ptr<ILogger> pLogger)
+{
+    m_loggers.push_back(pLogger);
+
+    return S_OK;
+}
+
+STDMETHODIMP AggregateLogger::Log(LogLevel level, const string format, va_list args)
+{
+    HRESULT hr = S_OK;
+
+    for (shared_ptr<ILogger>& pLogger : m_loggers)
+    {
+        IfFailRet(pLogger->Log(level, format, args));
+    }
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/Logging/AggregateLogger.h
+++ b/src/MonitorProfiler/Logging/AggregateLogger.h
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "Logger.h"
+
+/// <summary>
+/// Aggregates multiple ILogger implementations together in order to dispatch
+/// ILogger method invocations to each ILogger implementation.
+/// </summary>
+class AggregateLogger final :
+    public ILogger
+{
+private:
+    std::vector<std::shared_ptr<ILogger>> m_loggers;
+
+public:
+    /// <summary>
+    /// Adds an ILogger implemetation to the aggregation.
+    /// </summary>
+    STDMETHOD(Add)(const std::shared_ptr<ILogger> pLogger);
+
+public:
+    // ILogger Members
+
+    /// <summary>
+    /// Invokes the Log method on each registered ILogger implementation.
+    /// </summary>
+    STDMETHOD(Log)(LogLevel level, const std::string format, va_list args) override;
+};

--- a/src/MonitorProfiler/Logging/DebugLogger.cpp
+++ b/src/MonitorProfiler/Logging/DebugLogger.cpp
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "DebugLogger.h"
+#include "LogLevelHelper.h"
+
+using namespace std;
+
+STDMETHODIMP DebugLogger::Log(LogLevel level, const string format, va_list args)
+{
+    HRESULT hr = S_OK;
+
+    CHAR szMessage[s_nMaxEntrySize];
+    _vsnprintf_s(szMessage, s_nMaxEntrySize, _TRUNCATE, format.c_str(), args);
+
+    string strLevel;
+    if (FAILED(LogLevelHelper::GetShortName(level, strLevel)))
+    {
+        strLevel.assign("ukwn");
+    }
+
+    CHAR szString[s_nMaxEntrySize];
+    _snprintf_s(szString, s_nMaxEntrySize, _TRUNCATE, "[profiler]%s: %s\r\n", strLevel.c_str(), szMessage);
+
+    OutputDebugStringA(szString);
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/Logging/DebugLogger.h
+++ b/src/MonitorProfiler/Logging/DebugLogger.h
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "Logger.h"
+
+/// <summary>
+/// Logs messages to the debug output window when running under a debugger.
+/// </summary>
+class DebugLogger final :
+    public ILogger
+{
+private:
+    const static int s_nMaxEntrySize = 1000;
+
+public:
+    // ILogger Members
+
+    /// <inheritdoc />
+    STDMETHOD(Log)(LogLevel level, const std::string format, va_list args) override;
+};

--- a/src/MonitorProfiler/Logging/LogLevelHelper.h
+++ b/src/MonitorProfiler/Logging/LogLevelHelper.h
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <string>
+#include "Logger.h"
+
+/// <summary>
+/// Utility methods for log level.
+/// </summary>
+class LogLevelHelper final
+{
+public:
+    /// <summary>
+    /// Gets the short name of the log level.
+    /// </summary>
+    static HRESULT GetShortName(LogLevel level, std::string& strName)
+    {
+        // The log levels are intentionally four characters long
+        // to allow for easy horizontal alignment.
+        switch (level)
+        {
+        case LogLevel::Critical:
+            strName.assign("crit");
+            return S_OK;
+        case LogLevel::Debug:
+            strName.assign("dbug");
+            return S_OK;
+        case LogLevel::Error:
+            strName.assign("fail");
+            return S_OK;
+        case LogLevel::Information:
+            strName.assign("info");
+            return S_OK;
+        case LogLevel::None:
+            strName.assign("none");
+            return S_OK;
+        case LogLevel::Trace:
+            strName.assign("trce");
+            return S_OK;
+        case LogLevel::Warning:
+            strName.assign("warn");
+            return S_OK;
+        default:
+            return E_FAIL;
+        }
+    }
+};

--- a/src/MonitorProfiler/Logging/Logger.h
+++ b/src/MonitorProfiler/Logging/Logger.h
@@ -48,11 +48,11 @@ DECLARE_INTERFACE(ILogger)
         hr = (EXPR); \
         if(FAILED(hr)) { \
             if (nullptr != pLogger) { \
-                IfFailRet(pLogger->Log( \
+                pLogger->Log( \
                     LogLevel::Error, \
                     "IfFailLogRet(" #EXPR ") failed in function %s: 0x%08x", \
                     __func__, \
-                    hr)); \
+                    hr); \
             } \
             return (hr); \
         } \
@@ -64,10 +64,10 @@ DECLARE_INTERFACE(ILogger)
     do { \
         if(nullptr == (EXPR)) { \
             if (nullptr != pLogger) { \
-                IfFailRet(pLogger->Log( \
+                pLogger->Log( \
                     LogLevel::Error, \
                     "IfNullLogRetPtr(" #EXPR ") failed in function %s", \
-                    __func__)); \
+                    __func__); \
             } \
             return E_POINTER; \
         } \

--- a/src/MonitorProfiler/Logging/Logger.h
+++ b/src/MonitorProfiler/Logging/Logger.h
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <string>
+#include "corhlpr.h"
+
+/// <summary>
+/// Logging severity levels.
+/// </summary>
+enum class LogLevel
+{
+    Trace,
+    Debug,
+    Information,
+    Warning,
+    Error,
+    Critical,
+    None
+};
+
+/// <summary>
+/// Interface for logging messages.
+/// </summary>
+DECLARE_INTERFACE(ILogger)
+{
+    /// <summary>
+    /// Writes a log message.
+    /// </summary>
+    STDMETHOD(Log)(LogLevel level, const std::string format, va_list args) PURE;
+
+    inline STDMETHODIMP Log(LogLevel level, const std::string format, ...)
+    {
+        va_list args;
+        va_start(args, format);
+        HRESULT hr = Log(level, format, args);
+        va_end(args);
+        return hr;
+    }
+};
+
+// Checks if EXPR is a failed HRESULT
+// If failed, logs the failure and returns the HRESULT
+#define IfFailLogRet_(pLogger, EXPR) \
+    do { \
+        hr = (EXPR); \
+        if(FAILED(hr)) { \
+            if (nullptr != pLogger) { \
+                IfFailRet(pLogger->Log( \
+                    LogLevel::Error, \
+                    "IfFailLogRet(" #EXPR ") failed in function %s: 0x%08x", \
+                    __func__, \
+                    hr)); \
+            } \
+            return (hr); \
+        } \
+    } while (0)
+
+// Checks if EXPR is nullptr
+// If nullptr, logs the failure and returns E_POINTER
+#define IfNullLogRetPtr_(pLogger, EXPR) \
+    do { \
+        if(nullptr == (EXPR)) { \
+            if (nullptr != pLogger) { \
+                IfFailRet(pLogger->Log( \
+                    LogLevel::Error, \
+                    "IfNullLogRetPtr(" #EXPR ") failed in function %s", \
+                    __func__)); \
+            } \
+            return E_POINTER; \
+        } \
+    } while (0)
+
+// Logs a message with arguments at the specified level
+// Checks if logging failed, returns the HRESULT if failed
+#define LogV_(pLogger, level, format, args) \
+    IfFailRet(pLogger->Log(level, format, args))
+
+// Logs a message at the Trace level
+#define LogTraceV_(pLogger, format, args) \
+    LogV_(pLogger, LogLevel::Trace, format, args)
+
+// Logs a message at the Debug level
+#define LogDebugV_(pLogger, format, args) \
+    LogV_(pLogger, LogLevel::Debug, format, args)
+
+// Logs a message at the Information level
+#define LogInformationV_(pLogger, format, args) \
+    LogV_(pLogger, LogLevel::Information, format, args)
+
+// Logs a message at the Warning level
+#define LogWarningV_(pLogger, format, args) \
+    LogV_(pLogger, LogLevel::Warning, format, args)
+
+// Logs a message at the Error level
+#define LogErrorV_(pLogger, format, args) \
+    LogV_(pLogger, LogLevel::Error, format, args)
+
+// Logs a message at the Critical level
+#define LogCriticalV_(pLogger, format, args) \
+    LogV_(pLogger, LogLevel::Critical, format, args)

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -39,7 +39,7 @@ STDMETHODIMP MainProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
     // communication channel's GetProcessEnvironment command to get this value.
     IfFailLogRet(EnvironmentHelper::SetProductVersion(m_pEnvironment, m_pLogger));
 
-#ifdef WIN32
+#ifdef TARGET_WINDOWS
     DWORD processId = GetCurrentProcessId();
     LogInformationV("Process Id: %d", processId);
 #endif
@@ -66,7 +66,7 @@ STDMETHODIMP MainProfiler::LoadAsNotficationOnly(BOOL *pbNotificationOnly)
 
 HRESULT MainProfiler::InitializeEnvironment()
 {
-    m_pEnvironment.reset(new (nothrow) ProfilerEnvironment(m_pCorProfilerInfo));
+    m_pEnvironment = make_shared<ProfilerEnvironment>(m_pCorProfilerInfo);
     IfNullRet(m_pEnvironment);
 
     return S_OK;
@@ -79,9 +79,9 @@ HRESULT MainProfiler::InitializeLogging()
     IfNullRet(pAggregateLogger);
 
 #ifdef _DEBUG
-#ifdef WIN32
+#ifdef TARGET_WINDOWS
     // Add the debug output logger for when debugging on Windows
-    shared_ptr<DebugLogger> pDebugLogger(new (nothrow) DebugLogger());
+    shared_ptr<DebugLogger> pDebugLogger = make_shared<DebugLogger>();
     IfNullRet(pDebugLogger);
     pAggregateLogger->Add(pDebugLogger);
 #endif

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -2,17 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include "corhlpr.h"
 #include "MainProfiler.h"
+#include "../Environment/EnvironmentHelper.h"
+#include "../Environment/ProfilerEnvironment.h"
+#include "../Logging/AggregateLogger.h"
+#include "../Logging/DebugLogger.h"
+#include "corhlpr.h"
 #include "macros.h"
-#include "productversion.h"
-#include "tstring.h"
-#include "tostream.h"
-#include <iostream>
-#include <iomanip>
 
-#define HRESULTHEX(x) \
-   "0x" << std::setw(8) << std::setfill('0') << std::hex << x
+using namespace std;
+
+#define IfFailLogRet(EXPR) IfFailLogRet_(m_pLogger, EXPR)
+
+#define LogInformationV(format, args) LogInformationV_(m_pLogger, format, args)
 
 GUID MainProfiler::GetClsid()
 {
@@ -22,19 +24,35 @@ GUID MainProfiler::GetClsid()
 
 STDMETHODIMP MainProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
 {
+    ExpectedPtr(pICorProfilerInfoUnk);
+
     HRESULT hr = S_OK;
 
-    if (FAILED(hr = ProfilerBase::Initialize(pICorProfilerInfoUnk)))
-    {
-        std::cerr << "Failed to initialize profiler." << std::endl;
-    }
+    IfFailRet(ProfilerBase::Initialize(pICorProfilerInfoUnk));
+    IfFailRet(InitializeEnvironment());
+    IfFailRet(InitializeLogging());
 
-    IfFailRet(m_pCorProfilerInfo->SetEnvironmentVariable(
-        _T("DOTNETMONITOR_ProductVersion"),
-        MonitorProductVersion_TSTR
-        ));
+    // Logging is initialized and can now be used
+
+    // Set product version environment variable to allow discovery of if the profiler
+    // as been applied to a target process. Diagnostic tools must use the diagnostic
+    // communication channel's GetProcessEnvironment command to get this value.
+    IfFailLogRet(EnvironmentHelper::SetProductVersion(m_pEnvironment, m_pLogger));
+
+#ifdef WIN32
+    DWORD processId = GetCurrentProcessId();
+    LogInformationV("Process Id: %d", processId);
+#endif
 
     return S_OK;
+}
+
+STDMETHODIMP MainProfiler::Shutdown()
+{
+    m_pLogger.reset();
+    m_pEnvironment.reset();
+
+    return ProfilerBase::Shutdown();
 }
 
 STDMETHODIMP MainProfiler::LoadAsNotficationOnly(BOOL *pbNotificationOnly)
@@ -42,6 +60,34 @@ STDMETHODIMP MainProfiler::LoadAsNotficationOnly(BOOL *pbNotificationOnly)
     ExpectedPtr(pbNotificationOnly);
 
     *pbNotificationOnly = TRUE;
+
+    return S_OK;
+}
+
+HRESULT MainProfiler::InitializeEnvironment()
+{
+    m_pEnvironment.reset(new (nothrow) ProfilerEnvironment(m_pCorProfilerInfo));
+    IfNullRet(m_pEnvironment);
+
+    return S_OK;
+}
+
+HRESULT MainProfiler::InitializeLogging()
+{
+    // Create an aggregate logger to allow for multiple logging implementations
+    unique_ptr<AggregateLogger> pAggregateLogger(new (nothrow) AggregateLogger());
+    IfNullRet(pAggregateLogger);
+
+#ifdef _DEBUG
+#ifdef WIN32
+    // Add the debug output logger for when debugging on Windows
+    shared_ptr<DebugLogger> pDebugLogger(new (nothrow) DebugLogger());
+    IfNullRet(pDebugLogger);
+    pAggregateLogger->Add(pDebugLogger);
+#endif
+#endif
+
+    m_pLogger.reset(pAggregateLogger.release());
 
     return S_OK;
 }

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -5,14 +5,25 @@
 #pragma once
 
 #include "../ProfilerBase.h"
+#include "../Environment/Environment.h"
+#include "../Logging/Logger.h"
+#include <memory>
 
-class MainProfiler :
+class MainProfiler final :
     public ProfilerBase
 {
+private:
+    std::shared_ptr<IEnvironment> m_pEnvironment;
+    std::shared_ptr<ILogger> m_pLogger;
+
 public:
     static GUID GetClsid();
 
     STDMETHOD(Initialize)(IUnknown* pICorProfilerInfoUnk) override;
+    STDMETHOD(Shutdown)() override;
     STDMETHOD(LoadAsNotficationOnly)(BOOL *pbNotificationOnly) override;
-};
 
+private:
+    HRESULT InitializeEnvironment();
+    HRESULT InitializeLogging();
+};

--- a/src/MonitorProfiler/ProfilerBase.cpp
+++ b/src/MonitorProfiler/ProfilerBase.cpp
@@ -4,6 +4,7 @@
 
 #include "ProfilerBase.h"
 #include "corhlpr.h"
+#include "macros.h"
 
 ProfilerBase::ProfilerBase() :
     m_pCorProfilerInfo(nullptr)
@@ -12,6 +13,8 @@ ProfilerBase::ProfilerBase() :
 
 STDMETHODIMP ProfilerBase::Initialize(IUnknown *pICorProfilerInfoUnk)
 {
+    ExpectedPtr(pICorProfilerInfoUnk);
+
     HRESULT hr = S_OK;
 
     IfFailRet(pICorProfilerInfoUnk->QueryInterface(
@@ -23,6 +26,8 @@ STDMETHODIMP ProfilerBase::Initialize(IUnknown *pICorProfilerInfoUnk)
 
 STDMETHODIMP ProfilerBase::Shutdown()
 {
+    m_pCorProfilerInfo.Release();
+
     return S_OK;
 }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         // This environment variable name is embedded into the profiler and set at profiler initialization.
         // The value is determined BEFORE native build by the generation of the product version into the
         // _productversion.h header file.
-        private const string ProductVersionEnvVarName = "DOTNETMONITOR_ProductVersion";
+        private const string ProductVersionEnvVarName = "DotnetMonitorProfiler_ProductVersion";
 
         private readonly ITestOutputHelper _outputHelper;
         private readonly EndpointUtilities _endpointUtilities;

--- a/src/inc/com.h
+++ b/src/inc/com.h
@@ -47,11 +47,7 @@ public:
 
     ~ComPtr()
     {
-        if (nullptr != m_p)
-        {
-            m_p->Release();
-            m_p = nullptr;
-        }
+        Release();
     }
 
     void Attach(T* p)
@@ -68,6 +64,15 @@ public:
         T* p = m_p;
         m_p = nullptr;
         return p;
+    }
+
+    void Release()
+    {
+        if (nullptr != m_p)
+        {
+            m_p->Release();
+            m_p = nullptr;
+        }
     }
 
     T* operator=(T* p) throw()

--- a/src/inc/tostream.h
+++ b/src/inc/tostream.h
@@ -11,11 +11,11 @@
 
 std::ostream& operator<<(std::ostream& os, const tstring& str)
 {
-#ifdef HOST_UNIX
+#ifdef TARGET_UNIX
     std::wstring_convert<std::codecvt_utf8_utf16<WCHAR>, WCHAR> conv;
-#else // HOST_UNIX
+#else // TARGET_UNIX
     std::wstring_convert<std::codecvt_utf8<WCHAR>, WCHAR> conv;
-#endif // HOST_UNIX
+#endif // TARGET_UNIX
     os << conv.to_bytes(str);
     return os;
 }

--- a/src/inc/tstring.h
+++ b/src/inc/tstring.h
@@ -6,14 +6,14 @@
 
 #include <string>
 
-#if HOST_UNIX
+#if TARGET_UNIX
 
 typedef std::u16string tstring;
 #define _T(str) u##str
 
-#else // HOST_UNIX
+#else // TARGET_UNIX
 
 typedef std::wstring tstring;
 #define _T(str) L##str
 
-#endif // HOST_UNIX
+#endif // TARGET_UNIX


### PR DESCRIPTION
## Logging
These changes add a logging infrastructure that has a similar shape as [ILogger](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger?view=dotnet-plat-ext-6.0) in managed code. There currently only two logger implementations: a debug output logger (logs to the output window when debugging on Windows) and an aggregate logger (dispatches log calls to a list of loggers). Choosing a similar abstraction with the same log levels allows easier integration with managed code if we decide to serialize log entries back to the dotnet-monitor process. Finally, common macros and implementation specific macros were added to aid in logging HRESULT failures and log entries in general.

## Environment
These changes also refactor the notion of getting and setting environment variables information into separate abstraction (the `IEnvironment` interface) that allows for sourcing the environment information from different sources. The only source available in this change is from the `ICorProfilerInfo*` instance (provided as the `ProfilerEnvironment` class). This will allow testing more easily independent of having a profiler if we choose to add those tests in the future. An additional helper class, named `EnvironmentHelper`, is added to aid in consolidating the logic for getting and setting specifically known environment variables.