### PR TITLE
[Egress Extensibility] Setup configuration system for extensibility

### DIFF
--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -40,6 +40,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.ExecuteActionApp", "src\Tests\Microsoft.Diagnostics.Monitoring.ExecuteActionApp\Microsoft.Diagnostics.Monitoring.ExecuteActionApp.csproj", "{A5A0CAAB-C200-44D2-BC93-8445C6E748AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.AzureStorage", "src\Extensions\azure-storage\azure-storage\Microsoft.Diagnostics.Monitoring.AzureStorage.csproj", "{82AA3CAD-1604-4C62-9702-5A8E996A9DF7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{0E74EE3F-B88C-4095-89B0-26C1C216FFF0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +102,10 @@ Global
 		{A5A0CAAB-C200-44D2-BC93-8445C6E748AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5A0CAAB-C200-44D2-BC93-8445C6E748AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5A0CAAB-C200-44D2-BC93-8445C6E748AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82AA3CAD-1604-4C62-9702-5A8E996A9DF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82AA3CAD-1604-4C62-9702-5A8E996A9DF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82AA3CAD-1604-4C62-9702-5A8E996A9DF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82AA3CAD-1604-4C62-9702-5A8E996A9DF7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -119,6 +127,8 @@ Global
 		{173F959B-231B-45D1-8328-9460D4C5BC71} = {19FAB78C-3351-4911-8F0C-8C6056401740}
 		{0DBE362D-82F1-4740-AE6A-40C1A82EDCDB} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{A5A0CAAB-C200-44D2-BC93-8445C6E748AD} = {C7568468-1C79-4944-8136-18812A7F9EA7}
+		{82AA3CAD-1604-4C62-9702-5A8E996A9DF7} = {0E74EE3F-B88C-4095-89B0-26C1C216FFF0}
+		{0E74EE3F-B88C-4095-89B0-26C1C216FFF0} = {19FAB78C-3351-4911-8F0C-8C6056401740}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,13 +18,13 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>2a6ebdb7c30b59bee7223666f39df428cb3f316a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22221.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22222.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>daab9b4d3afbde7ed92882f0f0c540ef5e015fd2</Sha>
+      <Sha>5f04b602a86b74f6cdd12f48aca2d1868e6425f3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="7.0.0-beta.22221.2">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="7.0.0-beta.22222.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>daab9b4d3afbde7ed92882f0f0c540ef5e015fd2</Sha>
+      <Sha>5f04b602a86b74f6cdd12f48aca2d1868e6425f3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FileFormats" Version="1.0.321801">
       <Uri>https://github.com/dotnet/symstore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,9 +14,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22222.2">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22224.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2f68ef8d42646046eb36ff2db5f17965a7893545</Sha>
+      <Sha>1ea7f29104772615fb461016a014a32b1f67d83a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22222.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -30,17 +30,17 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>411f4c8bb161205bdc3d9891dd38eb75fb209a68</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22222.1" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22223.6" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a806647da556f19a5e9476f85758c373814d5251</Sha>
+      <Sha>46464bd651568673cbb82717c4d3bbe558595ef3</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22222.2">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22224.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2f68ef8d42646046eb36ff2db5f17965a7893545</Sha>
+      <Sha>1ea7f29104772615fb461016a014a32b1f67d83a</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22222.1" CoherentParentDependency="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22223.6" CoherentParentDependency="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a806647da556f19a5e9476f85758c373814d5251</Sha>
+      <Sha>46464bd651568673cbb82717c4d3bbe558595ef3</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,11 +4,11 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>166610c56ff732093f0145a2911d4f6c40b786da</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.22221.1">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.22222.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>2d9d866853065ad6c23b0e4cb35d4d918db30ac8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.0-preview.22221.1">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.0-preview.22222.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>2d9d866853065ad6c23b0e4cb35d4d918db30ac8</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,9 +14,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22221.6">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22222.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2a6ebdb7c30b59bee7223666f39df428cb3f316a</Sha>
+      <Sha>2f68ef8d42646046eb36ff2db5f17965a7893545</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22222.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -30,17 +30,17 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>411f4c8bb161205bdc3d9891dd38eb75fb209a68</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22220.8" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.5.22222.1" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>c78bf2f522b4ce5a449faf6a38a0752b642a7f79</Sha>
+      <Sha>a806647da556f19a5e9476f85758c373814d5251</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22221.6">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22222.2">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2a6ebdb7c30b59bee7223666f39df428cb3f316a</Sha>
+      <Sha>2f68ef8d42646046eb36ff2db5f17965a7893545</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22220.8" CoherentParentDependency="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.5.22222.1" CoherentParentDependency="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>c78bf2f522b4ce5a449faf6a38a0752b642a7f79</Sha>
+      <Sha>a806647da556f19a5e9476f85758c373814d5251</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- dotnet/arcade references -->
-    <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22221.2</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22222.4</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
     <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.5.22221.6</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22221.6</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,14 +46,14 @@
     <!-- dotnet/arcade references -->
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22222.4</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
-    <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.5.22222.2</MicrosoftAspNetCoreAppRuntimewinx64Version>
-    <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22222.2</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
+    <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.5.22224.2</MicrosoftAspNetCoreAppRuntimewinx64Version>
+    <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22224.2</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.22222.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.22222.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
-    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.5.22222.1</MicrosoftNETCoreAppRuntimewinx64Version>
-    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22222.1</VSRedistCommonNetCoreSharedFrameworkx6470Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.5.22223.6</MicrosoftNETCoreAppRuntimewinx64Version>
+    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22223.6</VSRedistCommonNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.321801</MicrosoftFileFormatsVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,14 +46,14 @@
     <!-- dotnet/arcade references -->
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22222.4</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
-    <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.5.22221.6</MicrosoftAspNetCoreAppRuntimewinx64Version>
-    <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22221.6</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
+    <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.5.22222.2</MicrosoftAspNetCoreAppRuntimewinx64Version>
+    <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22222.2</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.22222.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.22222.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
-    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.5.22220.8</MicrosoftNETCoreAppRuntimewinx64Version>
-    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22220.8</VSRedistCommonNetCoreSharedFrameworkx6470Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.5.22222.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22222.1</VSRedistCommonNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.321801</MicrosoftFileFormatsVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,8 +49,8 @@
     <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.5.22221.6</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22221.6</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.22221.1</MicrosoftDiagnosticsMonitoringVersion>
-    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.22221.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
+    <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.22222.1</MicrosoftDiagnosticsMonitoringVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.22222.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
     <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.5.22220.8</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-preview.5.22220.8</VSRedistCommonNetCoreSharedFrameworkx6470Version>

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -4,12 +4,13 @@ set -e
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [--skipunmount] --rootfsdir <directory>]"
+    echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [llvmx[.y]] [--skipunmount] --rootfsdir <directory>]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "CodeName - optional, Code name for Linux, can be: xenial(default), zesty, bionic, alpine, alpine3.13 or alpine3.14. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
     echo "                              for FreeBSD can be: freebsd12, freebsd13"
     echo "                              for illumos can be: illumos."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.9(default), lldb4.0, lldb5.0, lldb6.0 no-lldb. Ignored for alpine and FreeBSD"
+    echo "llvmx[.y] - optional, LLVM version for LLVM related packages."
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     echo "--use-mirror - optional, use mirror URL to fetch resources, when available."
     exit 1
@@ -48,6 +49,7 @@ __AlpinePackages+=" gettext-dev"
 __AlpinePackages+=" icu-dev"
 __AlpinePackages+=" libunwind-dev"
 __AlpinePackages+=" lttng-ust-dev"
+__AlpinePackages+=" compiler-rt-static"
 
 # CoreFX dependencies
 __UbuntuPackages+=" libcurl4-openssl-dev"
@@ -164,6 +166,15 @@ while :; do
         no-lldb)
             unset __LLDB_Package
             ;;
+        llvm*)
+            version="$(echo "$lowerI" | tr -d '[:alpha:]-=')"
+            parts=(${version//./ })
+            __LLVM_MajorVersion="${parts[0]}"
+            __LLVM_MinorVersion="${parts[1]}"
+            if [[ -z "$__LLVM_MinorVersion" && "$__LLVM_MajorVersion" -le 6 ]]; then
+                __LLVM_MinorVersion=0;
+            fi
+            ;;
         xenial) # Ubuntu 16.04
             if [ "$__CodeName" != "jessie" ]; then
                 __CodeName=xenial
@@ -260,6 +271,10 @@ if [ "$__BuildArch" == "armel" ]; then
     __LLDB_Package="lldb-3.5-dev"
 fi
 __UbuntuPackages+=" ${__LLDB_Package:-}"
+
+if [ ! -z "$__LLVM_MajorVersion" ]; then
+    __UbuntuPackages+=" libclang-common-${__LLVM_MajorVersion}${__LLVM_MinorVersion:+.$__LLVM_MinorVersion}-dev"
+fi
 
 if [ -z "$__RootfsDir" ] && [ ! -z "$ROOTFS_DIR" ]; then
     __RootfsDir=$ROOTFS_DIR

--- a/global.json
+++ b/global.json
@@ -18,6 +18,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22221.2"
+    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22222.4"
   }
 }

--- a/src/Extensions/azure-storage/azure-storage/AzureBlobEgressProvider.AutoFlushStream.cs
+++ b/src/Extensions/azure-storage/azure-storage/AzureBlobEgressProvider.AutoFlushStream.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob
+{
+    partial class AzureBlobEgressProvider
+    {
+        /// <summary>
+        /// Automatically flushes the stream after a certain amount of bytes have been written.
+        /// </summary>
+        private sealed class AutoFlushStream : Stream
+        {
+            private readonly Stream _baseStream;
+            private readonly long _flushSize;
+            private long _written;
+
+            public AutoFlushStream(Stream stream, long flushSize)
+            {
+                _flushSize = flushSize >= 0 ? flushSize : throw new ArgumentOutOfRangeException(nameof(flushSize));
+                _baseStream = stream ?? throw new ArgumentNullException(nameof(stream));
+            }
+
+            public override bool CanRead => _baseStream.CanRead;
+            public override bool CanSeek => _baseStream.CanSeek;
+            public override bool CanWrite => _baseStream.CanWrite;
+            public override long Length => _baseStream.Length;
+            public override bool CanTimeout => _baseStream.CanTimeout;
+            public override int WriteTimeout { get => _baseStream.WriteTimeout; set => _baseStream.WriteTimeout = value; }
+            public override int ReadTimeout { get => _baseStream.ReadTimeout; set => _baseStream.ReadTimeout = value; }
+            public override long Position { get => _baseStream.Position; set => _baseStream.Position = value; }
+            public override int Read(byte[] buffer, int offset, int count) => _baseStream.Read(buffer, offset, count);
+            public override long Seek(long offset, SeekOrigin origin) => _baseStream.Seek(offset, origin);
+            public override void SetLength(long value) => _baseStream.SetLength(value);
+            public override void Close() => _baseStream.Close();
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
+                _baseStream.CopyToAsync(destination, bufferSize, cancellationToken);
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                _baseStream.ReadAsync(buffer, offset, count, cancellationToken);
+            public override int ReadByte() => _baseStream.ReadByte();
+
+            //CONSIDER These are not really used, but should still autoflush.
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+                _baseStream.BeginRead(buffer, offset, count, callback, state);
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
+                _baseStream.BeginWrite(buffer, offset, count, callback, state);
+            public override int EndRead(IAsyncResult asyncResult) => _baseStream.EndRead(asyncResult);
+            public override void EndWrite(IAsyncResult asyncResult) => _baseStream.EndWrite(asyncResult);
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                _baseStream.Write(buffer, offset, count);
+                ProcessWrite(count);
+            }
+
+            public override void WriteByte(byte value)
+            {
+                _baseStream.WriteByte(value);
+                ProcessWrite(1);
+            }
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await _baseStream.WriteAsync(buffer, offset, count, cancellationToken);
+                await ProcessWriteAsync(count, cancellationToken);
+            }
+
+            public override void Flush()
+            {
+                _baseStream.Flush();
+                _written = 0;
+            }
+
+            public override async Task FlushAsync(CancellationToken cancellationToken)
+            {
+                await _baseStream.FlushAsync(cancellationToken);
+                _written = 0;
+            }
+
+            private void ProcessWrite(int count)
+            {
+                _written += count;
+                if (_written >= _flushSize)
+                {
+                    Flush();
+                }
+            }
+
+            private Task ProcessWriteAsync(int count, CancellationToken cancellationToken)
+            {
+                _written += count;
+                if (_written >= _flushSize)
+                {
+                    return FlushAsync(cancellationToken);
+                }
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Extensions/azure-storage/azure-storage/AzureBlobEgressProviderOptions.cs
+++ b/src/Extensions/azure-storage/azure-storage/AzureBlobEgressProviderOptions.cs
@@ -1,0 +1,30 @@
+﻿
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Diagnostics.Monitoring.AzureStorage
+{
+    internal sealed class AzureBlobEgressProviderOptions 
+    {
+        [Required]
+        public Uri AccountUri { get; set; }
+
+        public string AccountKey { get; set; }
+
+        public string AccountKeyName { get; set; }
+
+        public string SharedAccessSignature { get; set; }
+
+        public string SharedAccessSignatureName { get; set; }
+
+        [Required]
+        public string ContainerName { get; set; }
+
+        public string BlobPrefix { get; set; }
+
+        public int? CopyBufferSize { get; set; }
+
+        public string QueueName { get; set; }
+
+        public Uri QueueAccountUri { get; set; }
+    }
+}

--- a/src/Extensions/azure-storage/azure-storage/ContentTypes.cs
+++ b/src/Extensions/azure-storage/azure-storage/ContentTypes.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.AzureStorage
+{
+    internal static class ContentTypes
+    {
+        public const string ApplicationJson = "application/json";
+        public const string ApplicationJsonSequence = "application/json-seq";
+        public const string ApplicationNdJson = "application/x-ndjson";
+        public const string ApplicationOctetStream = "application/octet-stream";
+        public const string ApplicationProblemJson = "application/problem+json";
+        public const string TextPlain = "text/plain";
+        public const string TextPlain_v0_0_4 = TextPlain + "; version=0.0.4";
+    }
+}

--- a/src/Extensions/azure-storage/azure-storage/EgressArtifactSettings.cs
+++ b/src/Extensions/azure-storage/azure-storage/EgressArtifactSettings.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+namespace Microsoft.Diagnostics.Monitoring.AzureStorage
 {
-    public sealed class EgressArtifactSettings
+    internal sealed class EgressArtifactSettings
     {
         /// <summary>
         /// The content encoding of the blob to be created.

--- a/src/Extensions/azure-storage/azure-storage/EgressException.cs
+++ b/src/Extensions/azure-storage/azure-storage/EgressException.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring;
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Exception that egress providers can throw when an operational error occurs (e.g. failed to write the stream data).
+    /// </summary>
+    internal class EgressException : Exception
+    {
+        public EgressException(string message) : base(message) { }
+
+        public EgressException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Extensions/azure-storage/azure-storage/Microsoft.Diagnostics.Monitoring.AzureStorage.csproj
+++ b/src/Extensions/azure-storage/azure-storage/Microsoft.Diagnostics.Monitoring.AzureStorage.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+		<RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
+		<PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<RootNamespace>Microsoft.Diagnostics.Monitoring.AzureStorage</RootNamespace>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>disable</Nullable>
+		<AssemblyName>azure-storage</AssemblyName>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
+		<PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />
+		<PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\..\..\Tools\dotnet-monitor\Egress\ExtensionEgress\ExtensionEgressPayload.cs" Link="References\ExtensionEgressPayload.cs" />
+		<Compile Include="..\..\..\Tools\dotnet-monitor\Egress\EgressArtifactSettings.cs" Link="References\EgressArtifactSettings.cs" />
+	</ItemGroup>
+
+</Project>

--- a/src/Extensions/azure-storage/azure-storage/Program.cs
+++ b/src/Extensions/azure-storage/azure-storage/Program.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob;
+using System.Text.Json;
+
+namespace Microsoft.Diagnostics.Monitoring.AzureStorage
+{
+    internal class Program
+    {
+        private static Stream StdInStream = null;
+        static async Task Main(string[] args)
+        {
+            string jsonConfig = Console.ReadLine();
+
+            Console.WriteLine("ReadJson: " + jsonConfig);
+
+            ExtensionEgressPayload config = JsonSerializer.Deserialize<ExtensionEgressPayload>(jsonConfig);
+
+            AzureBlobEgressProviderOptions options = new AzureBlobEgressProviderOptions()
+            {
+                AccountUri = GetUriConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.AccountUri)),
+                AccountKey = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.AccountKey)),
+                AccountKeyName = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.AccountKeyName)),
+                SharedAccessSignature = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.SharedAccessSignature)),
+                SharedAccessSignatureName = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.SharedAccessSignatureName)),
+                ContainerName = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.ContainerName)),
+                BlobPrefix = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.BlobPrefix)),
+                QueueName = GetConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.QueueName)),
+                QueueAccountUri = GetUriConfig(config.Configuration, nameof(AzureBlobEgressProviderOptions.QueueAccountUri)),
+            };
+
+            if (options.AccountKey == null && options.AccountKeyName != null && config.Properties.ContainsKey(options.AccountKeyName))
+            {
+                options.AccountKey = config.Properties[options.AccountKeyName];
+            }
+
+            if (options.SharedAccessSignature == null && options.SharedAccessSignatureName != null && config.Properties.ContainsKey(options.SharedAccessSignatureName))
+            {
+                options.SharedAccessSignature = config.Properties[options.SharedAccessSignatureName];
+            }
+
+            Func<CancellationToken, Task<Stream>> action = new Func<CancellationToken, Task<Stream>>(
+                (CancellationToken token) =>
+                {
+                    StdInStream = Console.OpenStandardInput();
+                    return Task.FromResult(StdInStream);
+                });
+
+            EgressArtifactSettings artifactSettings = new EgressArtifactSettings()
+            {
+                ContentType = ContentTypes.ApplicationOctetStream,
+                Name = $"{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}",                
+            };
+
+            AzureBlobEgressProvider provider = new AzureBlobEgressProvider();
+
+            //Console.TreatControlCAsInput = true;
+            Console.CancelKeyPress += Console_CancelKeyPress;
+
+            string blobUri = await provider.EgressAsync(options, action, config.Settings, CancellationToken.None);
+            Console.Write(blobUri);
+        }
+
+        private static void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            StdInStream.Close();
+        }
+
+        private static string GetConfig(Dictionary<string, string> configDict, string propKey)
+        {
+            if (configDict.ContainsKey(propKey))
+            {
+                return configDict[propKey];
+            }
+            return null;
+        }
+        private static Uri GetUriConfig(Dictionary<string, string> configDict, string propKey)
+        {
+            string uriStr = GetConfig(configDict, propKey);
+            if (uriStr == null)
+            {
+                return null;
+            }
+            return new Uri(uriStr);
+        }
+    }
+
+}

--- a/src/Microsoft.Diagnostics.Monitoring.Options/EgressCategoryOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/EgressCategoryOptions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Egress provider options for external egress providers.
+    /// </summary>
+    internal sealed partial class EgressCategoryOptions
+    {
+        public object ConfigurationSection { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ExtensionEgressProviderOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ExtensionEgressProviderOptions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Egress provider options for external egress providers.
+    /// </summary>
+    internal sealed partial class ExtensionEgressProviderOptions : 
+        Dictionary<string, string>,
+        IEgressProviderCommonOptions
+    {
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CommonEgressProviderOptions_CopyBufferSize))]
+        public int? CopyBufferSize { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         void ValidateProvider(string providerName);
 
+        string GetProviderCategory(string providerName);
+
         Task<EgressResult> EgressAsync(
             string providerName,
             Func<CancellationToken, Task<Stream>> action,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     services.ConfigureCollectionRuleDefaults(context.Configuration);
                     services.AddSingleton<OperationTrackerService>();
                     services.ConfigureCollectionRules();
-                    services.ConfigureEgress();
+                    services.ConfigureEgress(context.Configuration);
 
                     services.ConfigureDiagnosticPort(context.Configuration);
 

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 services.AddSingleton<IEndpointInfoSourceCallbacks, OperationTrackerServiceEndpointInfoSourceCallback>();
                 services.AddSingleton<RequestLimitTracker>();
                 services.ConfigureOperationStore();
-                services.ConfigureEgress();
+                services.ConfigureEgress(context.Configuration);
                 services.ConfigureMetrics(context.Configuration);
                 services.ConfigureStorage(context.Configuration);
                 services.ConfigureDefaultProcess(context.Configuration);

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesProvider.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
 {
@@ -17,6 +19,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
         public EgressPropertiesProvider(IEgressPropertiesConfigurationProvider provider)
         {
             _provider = provider;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> GetKeys()
+        {
+            return _provider.Configuration.GetChildren().Select(s => s.Key);
         }
 
         /// <inheritdoc/>

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationChangeTokenSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
@@ -13,8 +14,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
     internal sealed class EgressProviderConfigurationChangeTokenSource<TOptions> :
         ConfigurationChangeTokenSource<TOptions>
     {
-        public EgressProviderConfigurationChangeTokenSource(IEgressProviderConfigurationProvider<TOptions> provider)
-            : base(provider.Configuration)
+        public EgressProviderConfigurationChangeTokenSource(IConfiguration configuration, string providerCategoryName)
+            : base (configuration.GetEgressSection().GetSection(providerCategoryName))
         {
         }
     }

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationProvider.cs
@@ -14,17 +14,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
     internal sealed class EgressProviderConfigurationProvider<TOptions> :
         IEgressProviderConfigurationProvider<TOptions>
     {
-        public EgressProviderConfigurationProvider(IConfiguration configuration, string providerType)
+        public EgressProviderConfigurationProvider(IConfiguration configuration, string providerCategoryName)
         {
-            ProviderType = providerType;
-            Configuration = configuration.GetEgressSection().GetSection(providerType);
+            ProviderCategory = providerCategoryName;
+            Configuration = configuration.GetEgressSection().GetSection(providerCategoryName);
         }
 
         /// <inheritdoc/>
         public IConfiguration Configuration { get; }
 
         /// <inheritdoc/>
-        public string ProviderType { get; }
+        public string ProviderCategory { get; }
 
         /// <inheritdoc/>
         public Type OptionsType => typeof(TOptions);

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressPropertiesProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressPropertiesProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
 {
     /// <summary>
@@ -9,6 +11,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
     /// </summary>
     internal interface IEgressPropertiesProvider
     {
+        /// <summary>
+        /// Gets the set of keys defined.
+        /// </summary>
+        /// <returns><see cref="IEnumerable{string}"/> that has the set of keys that can be retreived.</returns>
+        IEnumerable<string> GetKeys();
+
         /// <summary>
         /// Attempts to get the value associated with the specified key from the Egress:Properties section.
         /// </summary>

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressProviderConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressProviderConfigurationProvider.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
         IConfiguration Configuration { get; }
 
         /// <summary>
-        /// The type of the egress provider.
+        /// The name of the category defined in configuration of this provider.
         /// </summary>
-        string ProviderType { get; }
+        string ProviderCategory { get; }
 
         /// <summary>
         /// The type of the options class associated with the egress provider.

--- a/src/Tools/dotnet-monitor/Egress/EgressCategoryProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressCategoryProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Configure an <see cref="ExtensionEgressPayload"/> by binding to
+    /// its associated Egress:{ProviderType}:{Name} section in the configuration.
+    /// </summary>
+    /// <remarks>
+    /// Only named options are support for egress providers. This also binds the object specially by binding to the internal data structure.
+    /// </remarks>
+    internal sealed class EgressCategoryProvider : IEgressCategoryProvider
+    {
+        public EgressCategoryProvider(IConfiguration configuration)
+        {
+            Configuration = configuration.GetEgressSection();
+        }
+
+        /// <inheritdoc/>
+        public IConfiguration Configuration { get; }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/EgressConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressConfigureNamedOptions.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Configure an <see cref="ExtensionEgressPayload"/> by binding to
+    /// its associated Egress:{ProviderType}:{Name} section in the configuration.
+    /// </summary>
+    /// <remarks>
+    /// Only named options are support for egress providers. This also binds the object specially by binding to the internal data structure.
+    /// </remarks>
+    internal sealed class EgressConfigureNamedOptions :
+        IConfigureNamedOptions<EgressCategoryOptions>
+    {
+        private readonly IEgressCategoryProvider _provider;
+
+        public EgressConfigureNamedOptions(IEgressCategoryProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public void Configure(string name, EgressCategoryOptions options)
+        {
+            IConfigurationSection section = _provider.Configuration.GetSection(name);
+            Debug.Assert(section.Exists());
+            if (section.Exists())
+            {
+                options.ConfigurationSection = section;
+            }
+        }
+
+        public void Configure(EgressCategoryOptions options)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/EgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProvider.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         /// this is a path to access the stream without any information indicating whether any particular
         /// user has access to it (e.g. no file system permissions or SAS tokens).</returns>
         public virtual Task<string> EgressAsync(
+            string providerCategory,
+            string providerName,
             TOptions options,
             Func<CancellationToken, Task<Stream>> action,
             EgressArtifactSettings artifactSettings,
@@ -77,6 +79,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
             };
 
             return EgressAsync(
+                providerCategory,
+                providerName,
                 options,
                 wrappingAction,
                 artifactSettings,
@@ -94,6 +98,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         /// this is a path to access the stream without any information indicating whether any particular
         /// user has access to it (e.g. no file system permissions or SAS tokens).</returns>
         public abstract Task<string> EgressAsync(
+            string providerCategory,
+            string providerName,
             TOptions options,
             Func<Stream, CancellationToken, Task> action,
             EgressArtifactSettings artifactSettings,

--- a/src/Tools/dotnet-monitor/Egress/EgressProviderFactory.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProviderFactory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    internal class EgressProviderFactory<TOptions> 
+        where TOptions : class
+    {
+        public readonly string _name;
+        private EgressProviderConfigurationProvider<TOptions> _configurationProvider;
+
+        public EgressProviderFactory(string name)
+        {
+            this._name = name;
+        }
+
+        public EgressProviderConfigurationProvider<TOptions> Manufacture(IServiceProvider serviceProvider)
+        {
+            if (this._configurationProvider == null)
+            {
+                this._configurationProvider = new EgressProviderConfigurationProvider<TOptions>(serviceProvider.GetRequiredService<IConfiguration>(), this._name);
+            }
+            return this._configurationProvider;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/EgressProviderInternal.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProviderInternal.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -20,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
     /// </summary>
     internal class EgressProviderInternal<TOptions> :
         IEgressProviderInternal<TOptions>
-        where TOptions : class
+        where TOptions : new()
     {
         private readonly ILogger<EgressProviderInternal<TOptions>> _logger;
         private readonly IEgressProvider<TOptions> _provider;
@@ -38,13 +40,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         /// <inheritdoc/>
         public Task<string> EgressAsync(
+            string providerCategory,
             string providerName,
             Func<CancellationToken, Task<Stream>> action,
             EgressArtifactSettings artifactSettings,
             CancellationToken token)
         {
             return _provider.EgressAsync(
-                GetOptions(providerName),
+                providerCategory,
+                providerName,
+                GetOptions(providerCategory, providerName),
                 action,
                 artifactSettings,
                 token);
@@ -52,23 +57,31 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         /// <inheritdoc/>
         public Task<string> EgressAsync(
+            string providerCategory,
             string providerName,
             Func<Stream, CancellationToken, Task> action,
             EgressArtifactSettings artifactSettings,
             CancellationToken token)
         {
             return _provider.EgressAsync(
-                GetOptions(providerName),
+                providerCategory,
+                providerName,
+                GetOptions(providerCategory, providerName),
                 action,
                 artifactSettings,
                 token);
         }
 
-        private TOptions GetOptions(string providerName)
+        private TOptions GetOptions(string providerCategory, string providerName)
         {
             try
             {
-                return _monitor.Get(providerName);
+                TOptions opts = _monitor.Get(providerName);
+                return opts;
+                //IConfigurationSection configSection = (IConfigurationSection)catOptions.ConfigurationSection;
+                //TOptions result = new();
+                //configSection.GetSection(providerName).Bind(result);
+                //return result;
             }
             catch (OptionsValidationException ex)
             {

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
             // GetProvider should never return null so no need to check; it will throw
             // if the egress provider could not be located or instantiated.
             IEgressProviderConfigurationProvider configProvider = GetConfigProvider(providerName);
-            IEgressProviderInternal _ = GetProvider(configProvider);
+            //IEgressProviderInternal _ = GetProvider(configProvider);
         }
 
         public string GetProviderCategory(string providerName)

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         private readonly IDisposable _changeRegistration;
         private readonly ILogger<EgressService> _logger;
         private readonly IEnumerable<IEgressProviderConfigurationProvider> _providers;
-        private readonly IDictionary<string, string> _providerTypeMap;
-        private readonly IDictionary<string, Type> _optionsTypeMap;
+        private readonly IDictionary<string, IEgressProviderConfigurationProvider> _egressProviderMap;
+        private readonly IDictionary<string, string> _providerNameToTypeMap;
         private readonly IServiceProvider _serviceProvider;
 
         public EgressService(
@@ -39,8 +39,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         {
             _logger = logger;
             _providers = providers;
-            _providerTypeMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            _optionsTypeMap = new ConcurrentDictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+            _egressProviderMap = new ConcurrentDictionary<string, IEgressProviderConfigurationProvider>(StringComparer.OrdinalIgnoreCase);
+            _providerNameToTypeMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _serviceProvider = serviceProvider;
 
             _changeRegistration = ChangeToken.OnChange(
@@ -59,12 +59,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         {
             // GetProvider should never return null so no need to check; it will throw
             // if the egress provider could not be located or instantiated.
-            GetProvider(providerName);
+            IEgressProviderConfigurationProvider configProvider = GetConfigProvider(providerName);
+            IEgressProviderInternal _ = GetProvider(configProvider);
+        }
+
+        public string GetProviderCategory(string providerName)
+        {
+            IEgressProviderConfigurationProvider configProvider = GetConfigProvider(providerName);
+            return configProvider.ProviderCategory;
         }
 
         public async Task<EgressResult> EgressAsync(string providerName, Func<CancellationToken, Task<Stream>> action, string fileName, string contentType, IEndpointInfo source, CancellationToken token)
         {
-            string value = await GetProvider(providerName).EgressAsync(
+            IEgressProviderConfigurationProvider configProvider = GetConfigProvider(providerName);
+            IEgressProviderInternal provider = GetProvider(configProvider);
+
+            string value = await provider.EgressAsync(
+                configProvider.ProviderCategory,
                 providerName,
                 action,
                 CreateSettings(source, fileName, contentType),
@@ -75,7 +86,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         public async Task<EgressResult> EgressAsync(string providerName, Func<Stream, CancellationToken, Task> action, string fileName, string contentType, IEndpointInfo source, CancellationToken token)
         {
-            string value = await GetProvider(providerName).EgressAsync(
+            IEgressProviderConfigurationProvider configProvider = GetConfigProvider(providerName);
+            IEgressProviderInternal provider = GetProvider(configProvider);
+
+            string value = await provider.EgressAsync(
+                configProvider.ProviderCategory,
                 providerName,
                 action,
                 CreateSettings(source, fileName, contentType),
@@ -84,23 +99,30 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
             return new EgressResult(value);
         }
 
-        private IEgressProviderInternal GetProvider(string providerName)
+        private IEgressProviderConfigurationProvider GetConfigProvider(string providerName)
         {
-            if (!_providerTypeMap.TryGetValue(providerName, out string providerType))
+            if (!_providerNameToTypeMap.TryGetValue(providerName, out string providerCategoryName))
             {
                 throw new EgressException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressProviderDoesNotExist, providerName));
             }
 
-            if (!_optionsTypeMap.TryGetValue(providerType, out Type optionsType))
+            if (!_egressProviderMap.TryGetValue(providerCategoryName, out IEgressProviderConfigurationProvider configProvider) || configProvider.ProviderCategory != providerCategoryName)
             {
-                throw new EgressException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressProviderTypeNotRegistered, providerName));
+                throw new EgressException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressProviderTypeNotRegistered, providerCategoryName));
             }
 
+            return configProvider;
+        }
+
+        private IEgressProviderInternal GetProvider(IEgressProviderConfigurationProvider configProvider)
+        {
             // Get the egress provider that matches the options type and return the weaker-typed
             // interface in order to allow egressing from the service without having to use reflection
             // to invoke it.
-            return (IEgressProviderInternal)_serviceProvider.GetRequiredService(
-                typeof(IEgressProviderInternal<>).MakeGenericType(optionsType));
+            Type serviceType = typeof(IEgressProviderInternal<>).MakeGenericType(configProvider.OptionsType);
+            object serviceReference = _serviceProvider.GetRequiredService(serviceType);
+            IEgressProviderInternal typedServiceReference = (IEgressProviderInternal)serviceReference;
+            return typedServiceReference;
         }
 
         private static EgressArtifactSettings CreateSettings(IEndpointInfo source, string fileName, string contentType)
@@ -137,26 +159,26 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         private void Reload()
         {
-            _providerTypeMap.Clear();
-            _optionsTypeMap.Clear();
+            _egressProviderMap.Clear();
 
             // Deliberately fill the maps in the reverse order of how they are accessed
             // by the GetProvider method to avoid indeterminate accessing of the option
             // information.
             foreach (IEgressProviderConfigurationProvider provider in _providers)
             {
-                _optionsTypeMap.Add(provider.ProviderType, provider.OptionsType);
+                _egressProviderMap.Add(provider.ProviderCategory, provider);
 
                 foreach (IConfigurationSection optionsSection in provider.Configuration.GetChildren())
                 {
                     string providerName = optionsSection.Key;
-                    if (_providerTypeMap.TryGetValue(providerName, out string existingProviderType))
+
+                    if (_providerNameToTypeMap.TryGetValue(providerName, out string existingProviderCategory))
                     {
-                        _logger.DuplicateEgressProviderIgnored(providerName, provider.ProviderType, existingProviderType);
+                        _logger.DuplicateEgressProviderIgnored(providerName, provider.ProviderCategory, existingProviderCategory);
                     }
                     else
                     {
-                        _providerTypeMap.Add(providerName, provider.ProviderType);
+                        _providerNameToTypeMap.Add(providerName, provider.ProviderCategory);
                     }
                 }
             }

--- a/src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressDiscoverer.cs
+++ b/src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressDiscoverer.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Queues;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Egress provider for egressing stream data to an Azure blob storage account.
+    /// </summary>
+    /// <remarks>
+    /// Blobs created through this provider will overwrite existing blobs if they have the same blob name.
+    /// </remarks>
+    internal partial class ExtensionEgressDiscoverer
+        : IExternalEgressDiscovererConfigurationProvider
+    {
+        private readonly IConfiguration EgressSection;
+        //private readonly ILogger<ExternalEgressDiscoverer> Logger;
+
+        public ExtensionEgressDiscoverer(IConfiguration configuration)//, ILogger<ExternalEgressDiscoverer> logger)
+        {
+            EgressSection = configuration.GetEgressSection();
+            //Logger = logger;
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return EgressSection.GetChildren().Where(s => !IsBuiltInSection(s)).Select(s => s.Key).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private bool IsBuiltInSection(IConfigurationSection s)
+        {
+            Type egressType = typeof(EgressOptions);
+            return egressType.GetProperty(s.Key) != null || egressType.GetField(s.Key) != null;
+        }
+    }
+
+    public interface IExternalEgressDiscovererConfigurationProvider : IEnumerable<string>
+    {
+
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressPayload.cs
+++ b/src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressPayload.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    public class ExtensionEgressPayload
+    {
+        public EgressArtifactSettings Settings { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
+        public Dictionary<string, string> Configuration { get; set; }
+        public string ProfileName { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressProvider.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Queues;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    /// <summary>
+    /// Egress provider for egressing stream data to an Azure blob storage account.
+    /// </summary>
+    /// <remarks>
+    /// Blobs created through this provider will overwrite existing blobs if they have the same blob name.
+    /// </remarks>
+    internal partial class ExtensionEgressProvider :
+        EgressProvider<ExtensionEgressProviderOptions>
+    {
+        private readonly IEgressPropertiesProvider _propertyProvider;
+
+        public ExtensionEgressProvider(IEgressPropertiesProvider propertyProvider, ILogger<ExtensionEgressProvider> logger)
+            : base(logger)
+        {
+            _propertyProvider = propertyProvider;
+        }
+
+        public override async Task<string> EgressAsync(
+            string providerCategory,
+            string providerName,
+            ExtensionEgressProviderOptions options,
+            Func<Stream, CancellationToken, Task> action,
+            EgressArtifactSettings artifactSettings,
+            CancellationToken token)
+        {
+            Dictionary<string, string> props = new Dictionary<string, string>();
+            foreach (string key in _propertyProvider.GetKeys())
+            {
+                if (_propertyProvider.TryGetPropertyValue(key, out string val))
+                {
+                    props.Add(key, val);
+                }
+            }
+
+            ExtensionEgressPayload payload = new ExtensionEgressPayload()
+            {
+                Settings = artifactSettings,
+                Configuration = options,
+                Properties = props,
+                ProfileName = providerName,
+            };
+
+            string startingPayload = JsonSerializer.Serialize<ExtensionEgressPayload>(payload);
+
+            // [TODO] add a new service to dynamically find these extensions
+            ProcessStartInfo pStart = new ProcessStartInfo()
+            {
+                FileName = "D:\\repos\\github\\dotnet-monitor-kelltrick\\artifacts\\bin\\Microsoft.Diagnostics.Monitoring.AzureStorage\\Debug\\net6.0\\azure-storage.exe",
+                RedirectStandardInput = true,
+            };
+            Process p = new Process()
+            {
+                StartInfo = pStart,
+            };
+
+            Logger?.LogInformation("Starting process...");
+            p.Start();
+            Logger?.LogInformation("starting stream...");
+
+            p.StandardInput.WriteLine(startingPayload);
+
+            await action(p.StandardInput.BaseStream, token);
+            p.StandardInput.BaseStream.Flush();
+
+            Logger?.LogInformation("Stream done, sending close...");
+
+            p.StandardInput.Close();
+
+            string procContent = await p.StandardOutput.ReadToEndAsync();
+
+            Logger?.LogInformation("Waiting for exit...");
+            p.WaitForExit();
+            Logger?.LogInformation($"Exited with code: {p.ExitCode}");
+
+            return procContent;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
         }
 
         public override async Task<string> EgressAsync(
+            string providerCategory,
+            string providerName,
             FileSystemEgressProviderOptions options,
             Func<Stream, CancellationToken, Task> action,
             EgressArtifactSettings artifactSettings,

--- a/src/Tools/dotnet-monitor/Egress/IEgressCategoryProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/IEgressCategoryProvider.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Configuration;
+
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 {
-    internal static class EgressProviderTypes
+    internal interface IEgressCategoryProvider
     {
-        public const string AzureBlobStorage = nameof(AzureBlobStorage);
-
-        public const string External = nameof(External);
-
-        public const string FileSystem = nameof(FileSystem);
+        /// <summary>
+        /// The configuration section for egress provider.
+        /// </summary>
+        IConfiguration Configuration { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/Egress/IEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/IEgressProvider.cs
@@ -12,12 +12,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
     internal interface IEgressProvider<TOptions>
     {
         Task<string> EgressAsync(
+            string providerCategory,
+            string providerName,
             TOptions options,
             Func<CancellationToken, Task<Stream>> action,
             EgressArtifactSettings artifactSettings,
             CancellationToken token);
 
         Task<string> EgressAsync(
+            string providerCategory,
+            string providerName,
             TOptions options,
             Func<Stream, CancellationToken, Task> action,
             EgressArtifactSettings artifactSettings,

--- a/src/Tools/dotnet-monitor/Egress/IEgressProviderInternal.cs
+++ b/src/Tools/dotnet-monitor/Egress/IEgressProviderInternal.cs
@@ -12,12 +12,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
     internal interface IEgressProviderInternal
     {
         Task<string> EgressAsync(
+            string providerCategory,
             string providerName,
             Func<CancellationToken, Task<Stream>> action,
             EgressArtifactSettings artifactSettings,
             CancellationToken token);
 
         Task<string> EgressAsync(
+            string providerCategory,
             string providerName,
             Func<Stream, CancellationToken, Task> action,
             EgressArtifactSettings artifactSettings,


### PR DESCRIPTION
This is the first PR for egress extensibility, this is a work in progress and should not go into `main` yet. The PR includes other changes that are required to test the configuration system but aren't ready for `main`.
- [Should be reviewed] Adds configuration system, the main workaround and change is that `TOptions` was previously relied on as a unique key in the configuration system. This makes `TOptions` not need to be unique.
- [Not intended to be reviewed yet, files under `src/Extensions/azure-storage/*`] Adds a `AzureStorage` assembly to test upload.
- [Not intended to be reviewed yet, one file `src/Tools/dotnet-monitor/Egress/ExtensionEgress/ExtensionEgressProvider.cs`] Adds an `ExtensionEgressProvider` class to call external extensions, this is a work in progress and not complete.