### PR TITLE
Add warning when collection rules are configured but not running in Listen mode

### DIFF
--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                 _logger.CollectionRuleConfigurationChanged();
 
-                if (!(_portOptions.ConnectionMode == DiagnosticPortConnectionMode.Listen && !string.IsNullOrEmpty(_portOptions.EndpointName)))
+                if (_portOptions.ConnectionMode != DiagnosticPortConnectionMode.Listen || string.IsNullOrEmpty(_portOptions.EndpointName))
                 {
                     _logger.LogWarning(Strings.ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules);
                 }

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -159,9 +159,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                 _logger.CollectionRuleConfigurationChanged();
 
-                if (_portOptions.ConnectionMode != DiagnosticPortConnectionMode.Listen || string.IsNullOrEmpty(_portOptions.EndpointName))
+                if (DiagnosticPortOptionsExtensions.GetConnectionMode(_portOptions) != DiagnosticPortConnectionMode.Listen)
                 {
-                    _logger.LogWarning(Strings.ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules);
+                    _logger.DiagnosticPortNotInListenModeForCollectionRules();
                 }
 
                 // Get a copy of the container list to avoid having to

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                 Channel.CreateBounded<CollectionRuleContainer>(containersToRemoveChannelOptions);
             _containersToRemoveReader = containersToRemoveChannel.Reader;
             _containersToRemoveWriter = containersToRemoveChannel.Writer;
+
+            CheckForListenDiagnosticMode();
         }
 
         public async ValueTask DisposeAsync()
@@ -159,10 +161,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                 _logger.CollectionRuleConfigurationChanged();
 
-                if (DiagnosticPortOptionsExtensions.GetConnectionMode(_portOptions) != DiagnosticPortConnectionMode.Listen)
-                {
-                    _logger.DiagnosticPortNotInListenModeForCollectionRules();
-                }
+                CheckForListenDiagnosticMode();
 
                 // Get a copy of the container list to avoid having to
                 // lock the entire list during stop and restart of all containers.
@@ -227,6 +226,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                     tasks.Clear();
                 }
+            }
+        }
+
+        private void CheckForListenDiagnosticMode()
+        {
+            if (DiagnosticPortOptionsExtensions.GetConnectionMode(_portOptions) != DiagnosticPortConnectionMode.Listen 
+                && _provider.GetCollectionRuleNames().Any())
+            {
+                _logger.DiagnosticPortNotInListenModeForCollectionRules();
             }
         }
 

--- a/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
@@ -25,17 +25,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public ValidateOptionsResult Validate(string name, DiagnosticPortOptions options)
         {
-            var collectionRuleNames = _provider.GetCollectionRuleNames();
-
-            if (collectionRuleNames != null && collectionRuleNames.Count > 0)
-            {
-                if (options.ConnectionMode != DiagnosticPortConnectionMode.Listen
-                    || string.IsNullOrEmpty(options.EndpointName))
-                {
-                    _logger.LogWarning(Strings.ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules);
-                }
-            }
-
             var failures = new List<string>();
 
             if (options.ConnectionMode == DiagnosticPortConnectionMode.Listen

--- a/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             if (collectionRuleNames != null && collectionRuleNames.Count > 0)
             {
-                if (!(options.ConnectionMode == DiagnosticPortConnectionMode.Listen
-                    && !string.IsNullOrEmpty(options.EndpointName)))
+                if (options.ConnectionMode != DiagnosticPortConnectionMode.Listen
+                    || string.IsNullOrEmpty(options.EndpointName))
                 {
                     _logger.LogWarning(Strings.ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules);
                 }

--- a/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPortValidateOptions.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
-using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -14,15 +12,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal class DiagnosticPortValidateOptions :
         IValidateOptions<DiagnosticPortOptions>
     {
-        private readonly CollectionRulesConfigurationProvider _provider;
-        private readonly ILogger<DiagnosticPortValidateOptions> _logger;
-
-        public DiagnosticPortValidateOptions(CollectionRulesConfigurationProvider provider, ILogger<DiagnosticPortValidateOptions> logger)
-        {
-            _provider = provider;
-            _logger = logger;
-        }
-
         public ValidateOptionsResult Validate(string name, DiagnosticPortOptions options)
         {
             var failures = new List<string>();

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         QueueDoesNotExist = 57,
         QueueOptionsPartiallySet = 58,
         WritingMessageToQueueFailed = 59,
-        ExperienceSurvey = 60
+        ExperienceSurvey = 60,
+        DiagnosticPortNotInListenModeForCollectionRules = 61
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -333,6 +333,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ExperienceSurvey);
 
+        private static readonly Action<ILogger, Exception> _diagnosticPortNotInListenModeForCollectionRules =
+            LoggerMessage.Define(
+                eventId: LoggingEventIds.DiagnosticPortNotInListenModeForCollectionRules.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_DiagnosticPortNotInListenModeForCollectionRules);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -611,6 +617,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void ExperienceSurvey(this ILogger logger)
         {
             _experienceSurvey(logger, Monitor.ExperienceSurvey.ExperienceSurveyLink, null);
+        }
+
+        public static void DiagnosticPortNotInListenModeForCollectionRules(this ILogger logger)
+        {
+            _diagnosticPortNotInListenModeForCollectionRules(logger, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When using collection rules, the diagnostic port must be in &apos;Listen&apos; mode and the diagnostic port endpoint name must be specified. To use collection rules, please restart dotnet monitor with the updated configuration..
+        /// </summary>
+        internal static string ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules {
+            get {
+                return ResourceManager.GetString("ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duplicate action name &apos;{0}&apos;..
         /// </summary>
         internal static string ErrorMessage_DuplicateActionName {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -97,15 +97,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When using collection rules, the diagnostic port must be in &apos;Listen&apos; mode and the diagnostic port endpoint name must be specified. To use collection rules, please restart dotnet monitor with the updated configuration..
-        /// </summary>
-        internal static string ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules {
-            get {
-                return ResourceManager.GetString("ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Duplicate action name &apos;{0}&apos;..
         /// </summary>
         internal static string ErrorMessage_DuplicateActionName {
@@ -759,6 +750,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string LogFormatString_CollectionRuleUnmatchedFilters {
             get {
                 return ResourceManager.GetString("LogFormatString_CollectionRuleUnmatchedFilters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When using collection rules, the diagnostic port must be in &apos;Listen&apos; mode. Please correct the configuration and restart dotnet monitor..
+        /// </summary>
+        internal static string LogFormatString_DiagnosticPortNotInListenModeForCollectionRules {
+            get {
+                return ResourceManager.GetString("LogFormatString_DiagnosticPortNotInListenModeForCollectionRules", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -133,6 +133,10 @@
     <value>In 'Listen' mode, the diagnostic port endpoint name must be specified.</value>
     <comment>Gets a string similar to "In 'Listen' mode, the diagnostic port endpoint name must be specified.".</comment>
   </data>
+  <data name="ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules" xml:space="preserve">
+    <value>When using collection rules, the diagnostic port must be in 'Listen' mode and the diagnostic port endpoint name must be specified. To use collection rules, please restart dotnet monitor with the updated configuration.</value>
+    <comment>Gets a string similar to "When using collection rules, the diagnostic port must be in 'Listen' mode and the diagnostic port endpoint name must be specified. To use collection rules, please restart dotnet monitor with the updated configuration.".</comment>
+  </data>
   <data name="ErrorMessage_DuplicateActionName" xml:space="preserve">
     <value>Duplicate action name '{0}'.</value>
   </data>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -133,10 +133,6 @@
     <value>In 'Listen' mode, the diagnostic port endpoint name must be specified.</value>
     <comment>Gets a string similar to "In 'Listen' mode, the diagnostic port endpoint name must be specified.".</comment>
   </data>
-  <data name="ErrorMessage_DiagnosticPortNotInListenModeForCollectionRules" xml:space="preserve">
-    <value>When using collection rules, the diagnostic port must be in 'Listen' mode and the diagnostic port endpoint name must be specified. To use collection rules, please restart dotnet monitor with the updated configuration.</value>
-    <comment>Gets a string similar to "When using collection rules, the diagnostic port must be in 'Listen' mode and the diagnostic port endpoint name must be specified. To use collection rules, please restart dotnet monitor with the updated configuration.".</comment>
-  </data>
   <data name="ErrorMessage_DuplicateActionName" xml:space="preserve">
     <value>Duplicate action name '{0}'.</value>
   </data>
@@ -471,6 +467,9 @@
   </data>
   <data name="LogFormatString_CollectionRuleUnmatchedFilters" xml:space="preserve">
     <value>Collection rule '{ruleName}' filters do not match the process.</value>
+  </data>
+  <data name="LogFormatString_DiagnosticPortNotInListenModeForCollectionRules" xml:space="preserve">
+    <value>When using collection rules, the diagnostic port must be in 'Listen' mode. Please correct the configuration and restart dotnet monitor.</value>
   </data>
   <data name="LogFormatString_DiagnosticRequestCancelled" xml:space="preserve">
     <value>Cancelled waiting for diagnostic response from runtime in process {processId}.</value>


### PR DESCRIPTION
Currently, if a user is running in `Connect` mode and has collection rules configured, we don't give a warning indicating the issue. Now, a Warning logger message gives a brief description of what to do to resolve the issue. The check also occurs in two separate places since changes to the diagnostic port aren't respected once dotnet monitor is running - the first check will occur during validation for the diagnostic port, and then a check will occur every time the collection rule configuration changes. This will **not** fail validation, as that would be a breaking change.

Closes #1774 