### PR TITLE
Refactor blob group and package version file writing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -16,10 +16,72 @@
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
   </ItemGroup>
 
-  <Target Name="GenerateChecksumsForBlobgroups">
+  <Target Name="CalculateBlobGroupAndBuildVersion">
+    <PropertyGroup>
+      <!--
+        These properties take a package version and transform it into a blob group name so that
+        all builds from the same product and release version are grouped together. This code has
+        to consider when the version is a release version (e.g. 7.0.0) or has a prerelease label
+        (e.g. 7.0.0-preview.1). The former is transformed into '7.0/release' whereas
+        the latter is transformed into '7.0/preview.1'. It also accounts for the
+        BlobGroupBuildQuality defined in Version.props, which determines if the prerelease information
+        should be used in the final blob group name.
+        -->
+      <_PreReleaseSeperatorIndex>$(Version.IndexOf('-'))</_PreReleaseSeperatorIndex>
+      
+      <!-- Prerelease: '7.0.0-preview.8' -> '7.0.0' and 'preview.8' -->
+      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(Version.Substring(0, $(_PreReleaseSeperatorIndex)))</_BlobGroupVersion>
+      
+      <!-- Release: take the package version as-is. -->
+      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' == '-1'">$(Version)</_BlobGroupVersion>
+    </PropertyGroup>
+    <!-- These are the valid BlobGroupBuildQuality values. -->
     <ItemGroup>
-      <GenerateChecksumItems Include="%(PackageFile.Identity)"
-                             Condition="$([System.IO.File]::Exists('%(PackageFile.Identity).blobgroup'))" >
+      <_BlobGroupBuildQualityName Include="daily" ReleaseName="daily" />
+      <_BlobGroupBuildQualityName Include="release" ReleaseName="release" />
+    </ItemGroup>
+    <!-- Select the blob group build quality based on the specified property. -->
+    <ItemGroup>
+      <_SelectedBlobGroupQualityName Include="@(_BlobGroupBuildQualityName)" Condition="'%(Identity)' == '$(BlobGroupBuildQuality)'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <!-- Extract major and minor version fields from version number. -->
+      <_BlobGroupVersionMajor>$(_BlobGroupVersion.Split('.')[0])</_BlobGroupVersionMajor>
+      <_BlobGroupVersionMinor>$(_BlobGroupVersion.Split('.')[1])</_BlobGroupVersionMinor>
+      <!-- Get release name from blob group build quality. -->
+      <_BlobGroupReleaseName>@(_SelectedBlobGroupQualityName->'%(ReleaseName)')</_BlobGroupReleaseName>
+    </PropertyGroup>
+    <!-- Validate the selected and calculated values. -->
+    <Error Text="BlobGroupBuildQuality must be set to a valid value: @(_BlobGroupBuildQualityName, ', ')" Condition="'@(_SelectedBlobGroupQualityName)' == ''" />
+    <Error Text="Unable to calculate _BlobGroupVersionMajor" Condition="'$(_BlobGroupVersionMajor)' == ''" />
+    <Error Text="Unable to calculate _BlobGroupVersionMinor" Condition="'$(_BlobGroupVersionMinor)' == ''" />
+    <Error Text="Unable to calculate _BlobGroupReleaseName" Condition="'$(_BlobGroupReleaseName)' == ''" />
+    <PropertyGroup>
+      <!--
+        Combine all parts to create blob group name.
+        Daily: '7.0.0-preview.1.12345' -> '7.0/daily'
+        Release: '7.0.0' -> '7.0/release'
+        -->
+      <_BlobGroupName>$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>
+      <!--
+        This computes the original version without considering the effect of DotNetFinalVersionKind.
+        This can be used to uniquely identify a version of a specific build even if the build produces
+        stable package versions.
+        -->
+      <_BuildVersion>$(_OriginalVersionPrefix)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_BuildVersion>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="CalculatePackagesToPublish">
+    <ItemGroup>
+      <PackageToPublish Include="%(PackageFile.Identity)"
+                        Condition="$([System.IO.File]::Exists('%(PackageFile.Identity).projectpath'))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateChecksumsForPackages">
+    <ItemGroup>
+      <GenerateChecksumItems Include="@(PackageToPublish)">
         <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>
     </ItemGroup>
@@ -27,51 +89,52 @@
     <GenerateChecksums Items="@(GenerateChecksumItems)" />
   </Target>
 
-  <!-- Run the CollectPackageArtifactFiles target on each PackageFile by target batching on a non-existing file.
+  <!-- Run the CollectPackageArtifactFiles target on each PackageToPublish by target batching on a non-existing file.
        This allows using the ReadLinesFromFile task to read the blob group file, which was written with WriteLinesToFile,
        thus avoiding erroneously reading in the newline at the end of the blob group file. -->
   <Target Name="CollectPackageArtifactFiles"
-          DependsOnTargets="GenerateChecksumsForBlobgroups"
-          Inputs="@(PackageFile)"
-          Outputs="%(PackageFile.Identity).notexist">
+          DependsOnTargets="CalculateBlobGroupAndBuildVersion;CalculatePackagesToPublish;GenerateChecksumsForPackages"
+          Inputs="@(PackageToPublish)"
+          Outputs="%(PackageToPublish.Identity).notexist">
 
     <!-- Find the artifact files next to the package file. -->
     <PropertyGroup>
-      <_BlobGroupFilePath>%(PackageFile.FullPath).blobgroup</_BlobGroupFilePath>
-      <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
-      <_BuildVersionFileFilePath>%(PackageFile.FullPath).buildversionfile</_BuildVersionFileFilePath>
-      <_PackageVersionFileFilePath>%(PackageFile.FullPath).versionfile</_PackageVersionFileFilePath>
+      <_ChecksumFilePath>%(PackageToPublish.FullPath).sha512</_ChecksumFilePath>
+      <_BuildVersionFilePath>%(PackageToPublish.FullPath).buildversion</_BuildVersionFilePath>
+      <_PackageVersionFilePath>%(PackageToPublish.FullPath).version</_PackageVersionFilePath>
     </PropertyGroup>
 
-    <Error Condition="Exists('$(_BlobGroupFilePath)') and !Exists('$(_ChecksumFilePath)')"
-        Text="Expected SHA512 hash for %(PackageFile.FullPath) not found at $(_ChecksumFilePath)"/>
-
-    <!-- Read in blob group name, if it exists -->
-    <ReadLinesFromFile File="$(_BlobGroupFilePath)" Condition="Exists('$(_BlobGroupFilePath)')">
-      <Output TaskParameter="Lines" PropertyName="_BlobGroupName"/>
-    </ReadLinesFromFile>
-    <!-- Read in build version file name, if it exists -->
-    <ReadLinesFromFile File="$(_BuildVersionFileFilePath)" Condition="Exists('$(_BuildVersionFileFilePath)')">
-      <Output TaskParameter="Lines" PropertyName="_BuildVersionFileName"/>
-    </ReadLinesFromFile>
-    <!-- Read in package version file name, if it exists -->
-    <ReadLinesFromFile File="$(_PackageVersionFileFilePath)" Condition="Exists('$(_PackageVersionFileFilePath)')">
-      <Output TaskParameter="Lines" PropertyName="_PackageVersionFileName"/>
+    <!-- Read in project file name -->
+    <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectpath">
+      <Output TaskParameter="Lines" PropertyName="_ProjectPath"/>
     </ReadLinesFromFile>
 
-    <PropertyGroup>
-      <_BuildVersionFilePath>%(PackageFile.RootDir)%(PackageFile.Directory)$(_BuildVersionFileName)</_BuildVersionFilePath>
-      <_PackageVersionFilePath>%(PackageFile.RootDir)%(PackageFile.Directory)$(_PackageVersionFileName)</_PackageVersionFilePath>
-    </PropertyGroup>
+    <!-- Get package version from project -->
+    <MSBuild Projects="$(_ProjectPath)"
+             Targets="GetPackageVersion">
+      <Output ItemName="_PackageVersion" TaskParameter="TargetOutputs" />
+    </MSBuild>
 
-    <!-- Read in build version, if it exists -->
-    <ReadLinesFromFile File="$(_BuildVersionFilePath)" Condition="Exists('$(_BuildVersionFilePath)')">
-      <Output TaskParameter="Lines" PropertyName="_BuildVersion"/>
-    </ReadLinesFromFile>
+    <!--
+      A file that contains the version of the package.
+      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
+      -->
+    <WriteLinesToFile File="$(_PackageVersionFilePath)"
+                      Lines="@(_PackageVersion)"
+                      Overwrite="true" />
+
+    <!--
+      A file that contains the build version of the package. The name of this file contains the build
+      version in order to avoid collisions when uploaded to blob storage.
+      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
+      -->
+    <WriteLinesToFile File="$(_BuildVersionFilePath)"
+                      Lines="$(_BuildVersion)"
+                      Overwrite="true" />
 
     <!-- Calculate manifest artifact data for each file type. -->
     <ItemGroup>
-      <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageFile.IsShipping)' != 'true'" />
+      <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageToPublish.IsShipping)' != 'true'" />
     </ItemGroup>
     <ItemGroup>
       <_PackageArtifactData Include="@(_CommonArtifactData)" />
@@ -96,7 +159,7 @@
       </_VersionContainerBlobItem>
       <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism
            so that they can be retrieved from a stable location. -->
-      <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
+      <_VersionContainerBlobItem Include="%(PackageToPublish.FullPath)" Condition="Exists('%(PackageToPublish.FullPath)')" >
         <ManifestArtifactData Condition="'@(_PackageArtifactData)' != ''">@(_PackageArtifactData)</ManifestArtifactData>
       </_VersionContainerBlobItem>
     </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -12,108 +12,15 @@
   </ItemGroup>
 
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
-  <Target Name="GeneratePackageArtifactFiles"
+  <Target Name="GeneratePackageProjectPathFile"
           AfterTargets="Pack"
-          Condition="'$(IsPackable)' == 'true' and '$(PublishToBlob)' == 'true'">
-    <PropertyGroup>
-      <!--
-        These properties take a package version and transform it into a blob group name so that
-        all builds from the same product and release version are grouped together. This code has
-        to consider when the version is a release version (e.g. 7.0.0) or has a prerelease label
-        (e.g. 7.0.0-preview.1). The former is transformed into '7.0/release' whereas
-        the latter is transformed into '7.0/preview.1'. It also accounts for the
-        BlobGroupBuildQuality defined in Version.props, which determines if the prerelease information
-        should be used in the final blob group name.
-        -->
-      <_PreReleaseSeperatorIndex>$(PackageVersion.IndexOf('-'))</_PreReleaseSeperatorIndex>
-      
-      <!-- Prerelease: '7.0.0-preview.8' -> '7.0.0' and 'preview.8' -->
-      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring(0, $(_PreReleaseSeperatorIndex)))</_BlobGroupVersion>
-      
-      <!-- Release: take the package version as-is. -->
-      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' == '-1'">$(PackageVersion)</_BlobGroupVersion>
-    </PropertyGroup>
-    <!-- These are the valid BlobGroupBuildQuality values. -->
-    <ItemGroup>
-      <_BlobGroupBuildQualityName Include="daily" ReleaseName="daily" />
-      <_BlobGroupBuildQualityName Include="release" ReleaseName="release" />
-    </ItemGroup>
-    <!-- Select the blob group build quality based on the specified property. -->
-    <ItemGroup>
-      <_SelectedBlobGroupQualityName Include="@(_BlobGroupBuildQualityName)" Condition="'%(Identity)' == '$(BlobGroupBuildQuality)'" />
-    </ItemGroup>
-    <PropertyGroup>
-      <!-- Extract major and minor version fields from version number. -->
-      <_BlobGroupVersionMajor>$(_BlobGroupVersion.Split('.')[0])</_BlobGroupVersionMajor>
-      <_BlobGroupVersionMinor>$(_BlobGroupVersion.Split('.')[1])</_BlobGroupVersionMinor>
-      <!-- Get release name from blob group build quality. -->
-      <_BlobGroupReleaseName>@(_SelectedBlobGroupQualityName->'%(ReleaseName)')</_BlobGroupReleaseName>
-    </PropertyGroup>
-    <!-- Validate the selected and calculated values. -->
-    <Error Text="BlobGroupBuildQuality must be set to a valid value: @(_BlobGroupBuildQualityName, ', ')" Condition="'@(_SelectedBlobGroupQualityName)' == ''" />
-    <Error Text="Unable to calculate _BlobGroupVersionMajor" Condition="'$(_BlobGroupVersionMajor)' == ''" />
-    <Error Text="Unable to calculate _BlobGroupVersionMinor" Condition="'$(_BlobGroupVersionMinor)' == ''" />
-    <Error Text="Unable to calculate _BlobGroupReleaseName" Condition="'$(_BlobGroupReleaseName)' == ''" />
-    <PropertyGroup>
-      <!--
-        Combine all parts to create blob group name.
-        Daily: '7.0.0-preview.1.12345' -> '7.0/daily'
-        Release: '7.0.0' -> '7.0/release'
-        -->
-      <_BlobGroupName>$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>
-      <!--
-        This computes the original version without considering the effect of DotNetFinalVersionKind.
-        This can be used to uniquely identify a version of a specific build even if the build produces
-        stable package versions.
-        -->
-      <_BuildVersion>$(_OriginalVersionPrefix)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_BuildVersion>
-      <!-- Name of the package file. Used as a prefix for the following files. -->
-      <_PackageFileName>$(PackageId).$(PackageVersion).nupkg</_PackageFileName>
-      <_PackageWithBuildVersionFileName>$(PackageId).$(_BuildVersion).nupkg</_PackageWithBuildVersionFileName>
-    </PropertyGroup>
-    <!-- A file that contains the blob group so that publishing can use it in the blob path calculation. -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).blobgroup"
-                      Lines="$(_BlobGroupName)"
-                      Overwrite="true" />
-
-    <!--
-      A file that contains the name of another file that contains the package version. It effectively
-      states that "for a given package and version, the named file contains the package version". This
-      file is used by publishing to determine which package version file to upload to blob storage. The
-      file itself is not uploaded to blob storage.
-      Example name: dotnet-monitor.7.0.0.nupkg.versionfile
-      -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).versionfile"
-                      Lines="$(_PackageWithBuildVersionFileName).version"
-                      Overwrite="true" />
-
-    <!--
-      A file that contains the version of the nuget package.
-      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
-      -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageWithBuildVersionFileName).version"
-                      Lines="$(PackageVersion)"
-                      Overwrite="true" />
-
-    <!--
-      A file that contains the name of another file that contains the build version. It effectively
-      states that "for a given package and version, the named file contains the build version". This
-      file is used by publishing to determine which build version file to upload to blob storage. The
-      file itself is not uploaded to blob storage.
-      Example name: dotnet-monitor.7.0.0.nupkg.buildversionfile
-      -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageFileName).buildversionfile"
-                      Lines="$(_PackageWithBuildVersionFileName).buildversion"
-                      Overwrite="true" />
-
-    <!--
-      A file that contains the build version of the package. The name of this file contains the build
-      version in order to avoid collisions when uploaded to blob storage.
-      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
-      -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(_PackageWithBuildVersionFileName).buildversion"
-                      Lines="$(_BuildVersion)"
+          Condition="'$(IsPackable)' == 'true' and '$(IsShipping)' == 'true'">
+    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.projectpath"
+                      Lines="$(MSBuildProjectFullPath)"
                       Overwrite="true" />
   </Target>
+
+  <Target Name="GetPackageVersion"
+          Returns="$(PackageVersion)" />
 
 </Project>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -10,7 +10,6 @@
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <RollForward>Major</RollForward>
-    <PublishToBlob>true</PublishToBlob>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change refactors the blob group calculation and package version file writing such that these are done during the publish phase instead of the pack phase. The blob group and build version calculation are only done once (as opposed to for each project file). The package version is looked up using a custom MSBuild target invoked on the project file that corresponds to the package file.

The two motivations for this change are:
1. Minimize the number of files written to support blob subpath calculations. Note that the *.buildversionfile and *.versionfile files are no longer generated.
1. Allows for future changes to add more package types (e.g. *.zip and *.tar.gz) to make use of the same changes in the publish phase.