### PR TITLE
Do not warn about unconfigured auth when --no-auth is used

### DIFF
--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -33,10 +33,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public void Initialize()
         {
-            _changeRegistration = _options.OnChange(OnMonitorApiKeyOptionsChanged);
-
             if (_authConfigurationOptions.KeyAuthenticationMode != KeyAuthenticationMode.NoAuth)
             {
+                _changeRegistration = _options.OnChange(OnMonitorApiKeyOptionsChanged);
+
                 // Write out current validation state of options when starting the tool.
                 CheckMonitorApiKeyOptions(_options.CurrentValue);
             }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     _logger.ApiKeyAuthenticationOptionsValidated();
                 }
             }
-            else if (!options.Configured && !noAuthEnabled)
+            else
             {
                 _logger.MonitorApiKeyNotConfigured();
             }

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -35,8 +35,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             _changeRegistration = _options.OnChange(OnMonitorApiKeyOptionsChanged);
 
-            // Write out current validation state of options when starting the tool.
-            CheckMonitorApiKeyOptions(_options.CurrentValue);
+            if (_authConfigurationOptions.KeyAuthenticationMode != KeyAuthenticationMode.NoAuth)
+            {
+                // Write out current validation state of options when starting the tool.
+                CheckMonitorApiKeyOptions(_options.CurrentValue);
+            }
         }
 
         public void Dispose()
@@ -51,11 +54,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void CheckMonitorApiKeyOptions(MonitorApiKeyConfiguration options)
         {
-            if (_authConfigurationOptions.KeyAuthenticationMode == KeyAuthenticationMode.NoAuth)
-            {
-                return;
-            }
-
             if (options.Configured)
             {
                 if (null != options.ValidationErrors && options.ValidationErrors.Any())

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -51,9 +51,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void CheckMonitorApiKeyOptions(MonitorApiKeyConfiguration options)
         {
-            bool noAuthEnabled = _authConfigurationOptions.KeyAuthenticationMode == KeyAuthenticationMode.NoAuth;
+            if (_authConfigurationOptions.KeyAuthenticationMode == KeyAuthenticationMode.NoAuth)
+            {
+                return;
+            }
 
-            if (options.Configured || noAuthEnabled)
+            if (options.Configured)
             {
                 if (null != options.ValidationErrors && options.ValidationErrors.Any())
                 {

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -17,16 +17,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         private readonly ILogger<MonitorApiKeyConfigurationObserver> _logger;
         private readonly IOptionsMonitor<MonitorApiKeyConfiguration> _options;
+        private readonly IAuthConfiguration _authConfigurationOptions;
 
         private IDisposable _changeRegistration;
 
         public MonitorApiKeyConfigurationObserver(
             ILogger<MonitorApiKeyConfigurationObserver> logger,
-            IOptionsMonitor<MonitorApiKeyConfiguration> options
-            )
+            IOptionsMonitor<MonitorApiKeyConfiguration> options,
+            IAuthConfiguration authConfigurationOptions)
         {
             _logger = logger;
             _options = options;
+            _authConfigurationOptions = authConfigurationOptions;
         }
 
         public void Initialize()
@@ -49,7 +51,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private void CheckMonitorApiKeyOptions(MonitorApiKeyConfiguration options)
         {
-            if (options.Configured)
+            bool noAuthEnabled = _authConfigurationOptions.KeyAuthenticationMode == KeyAuthenticationMode.NoAuth;
+
+            if (options.Configured || noAuthEnabled)
             {
                 if (null != options.ValidationErrors && options.ValidationErrors.Any())
                 {
@@ -60,7 +64,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     _logger.ApiKeyAuthenticationOptionsValidated();
                 }
             }
-            else
+            else if (!options.Configured && !noAuthEnabled)
             {
                 _logger.MonitorApiKeyNotConfigured();
             }


### PR DESCRIPTION
Introduces a no-auth check to prevent the warning from appearing when `--no-auth` is present. ~~**NOTE:** I kept this in-line with the pre-regression behavior where "MonitorApiKey settings have changed. The new settings have passed validation." is printed when the no-auth flag is present. If we don't want this, I can modify the check to only show that message when the user omits the flag.~~

Closes #1624
Closes #1625