### PR TITLE
Unhandled exception detection

### DIFF
--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -17,7 +17,10 @@ set(SOURCES
     Environment/EnvironmentHelper.cpp
     Environment/ProfilerEnvironment.cpp
     Logging/AggregateLogger.cpp
+    MainProfiler/ExceptionTracker.cpp
     MainProfiler/MainProfiler.cpp
+    MainProfiler/ThreadData.cpp
+    MainProfiler/ThreadDataManager.cpp
     ClassFactory.cpp
     DllMain.cpp
     ProfilerBase.cpp

--- a/src/MonitorProfiler/Logging/Logger.h
+++ b/src/MonitorProfiler/Logging/Logger.h
@@ -67,6 +67,25 @@ DECLARE_INTERFACE(ILogger)
         } \
     } while (0)
 
+// Checks if EXPR is false
+// If false, logs the failure and returns the provided HRESULT
+#define IfFalseLogRet_(pLogger, EXPR, hr) \
+    do { \
+        if(!(EXPR)) { \
+            if (nullptr != pLogger) { \
+                if (pLogger->IsEnabled(LogLevel::Error)) \
+                { \
+                    pLogger->Log(\
+                        LogLevel::Error, \
+                        _T("IfFalseLogRet(" #EXPR ") is false in function %s: 0x%08x"), \
+                        to_tstring(__func__).c_str(), \
+                        hr); \
+                } \
+            } \
+            return hr; \
+        } \
+    } while (0)
+
 // Checks if EXPR is nullptr
 // If nullptr, logs the failure and returns E_POINTER
 #define IfNullLogRetPtr_(pLogger, EXPR) \

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -41,13 +41,11 @@ using namespace std;
     Unhandled Exception Detection Algorithm
 
     A subset of the aboved described callbacks is used to determine if an unhandled exception has occurred:
-    - ExceptionThrown: Record the originating FunctionID and ObjectID of the exception that is thrown.
+    - ExceptionThrown: Record the originating FunctionID and the existance of the exception.
     - ExceptionSearchCatcherFound: Record that the exception will be handled in a catching FunctionID.
     - ExceptionUnwindFunctionEnter: If the exception was not handled (ExceptionSearchCatcherFound was not invoked),
       then the exception is unhandled at this point. Do some extra bookkeeping in the case when the exception is
-      handled so that the exception is cleared once frame with the corresponding catching FunctionID is encountered.
-
-    Additionally, use GC callbacks, such as MovedReferences#, to update the exception ObjectID when compacting occurs.
+      handled so that the exception is cleared once the frame with the corresponding catching FunctionID is encountered.
 
     Current pitfalls:
     - Algorithm doesn't account for exceptions thrown within exception filters. These will be seen as a new set of

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -69,7 +69,10 @@ ExceptionTracker::ExceptionTracker(
 
 void ExceptionTracker::AddProfilerEventMask(DWORD& eventsLow)
 {
-    eventsLow |= COR_PRF_MONITOR::COR_PRF_ENABLE_STACK_SNAPSHOT;
+    if (_logger->IsEnabled(LogLevel::Debug))
+    {
+        eventsLow |= COR_PRF_MONITOR::COR_PRF_ENABLE_STACK_SNAPSHOT;
+    }
 }
 
 HRESULT ExceptionTracker::ExceptionThrown(ThreadID threadId, ObjectID objectId)

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -1,0 +1,301 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "ExceptionTracker.h"
+
+using namespace std;
+
+#define IfFailLogRet(EXPR) IfFailLogRet_(m_pLogger, EXPR)
+
+#define LogDebugV(format, ...) LogDebugV_(m_pLogger, format, __VA_ARGS__)
+#define LogInformationV(format, ...) LogInformationV_(m_pLogger, format, __VA_ARGS__)
+#define LogErrorV(format, ...) LogErrorV_(m_pLogger, format, __VA_ARGS__)
+
+/*
+    Exception Callbacks
+
+    When a managed exception is thrown, the runtime will invoke the profiler with several
+    callback methods during the exception processing phases. For a thrown exception, the
+    following callbacks are invoked in the following order:
+    - Phase 1: Throwing
+      - ExceptionThrown: Invoked when the exception object has been thrown.
+    - Phase 2: Finding Exception Catcher. Each frame on the callstack is inspected for a matching handler.
+      The following are invoked for each frame starting at the leaf frame (the frame from which the exception is thrown):
+      - ExceptionSearchFunctionEnter: Invoked when beginning to inspect a function for a matching handler.
+      - If the function has handlers with filters (e.g. C#'s when clause), the following are invoked for each filter:
+        - ExceptionSearchFilterEnter: Invoked when beginning to evaluate the filter.
+        - ExceptionSearchFilterLeave: Invoked when finishing the evaluation of the filter.
+      - ExceptionSearchCatcherFound: Invoked only if a matching filter is found.
+      - ExceptionSearchFunctionLeave: Invoked when finishing the inspection of the function for a matching handler.
+      If a matching handler was found, the exception catcher finding phase ends after the ExceptionSearchFunctionLeave callback.
+    - Phase 3: Unwinding.
+      The following are invoked for each frame starting at the leaf frame (the frame from which the exception is thrown):
+      - ExceptionUnwindFunctionEnter: Invoked when beginning to unwind a frame.
+      If a matching handler was found, the unwind phase ends after the invocation of
+      the ExceptionUnwindFunctionEnter callback for the frame that contains the matching handler.
+      - ExceptionUnwindFunctionLeave: Invoked when finishing the unwind of a frame.
+      If all of the frames are unwound to completion, the process is terminated.
+
+    Unhandled Exception Detection Algorithm
+
+    A subset of the aboved described callbacks is used to determine if an unhandled exception has occurred:
+    - ExceptionThrown: Record the originating FunctionID and ObjectID of the exception that is thrown.
+    - ExceptionSearchCatcherFound: Record that the exception will be handled in a catching FunctionID.
+    - ExceptionUnwindFunctionEnter: If the exception was not handled (ExceptionSearchCatcherFound was not invoked),
+      then the exception is unhandled at this point. Do some extra bookkeeping in the case when the exception is
+      handled so that the exception is cleared once frame with the corresponding catching FunctionID is encountered.
+
+    Additionally, use GC callbacks, such as MovedReferences#, to update the exception ObjectID when compacting occurs.
+
+    Current pitfalls:
+    - Algorithm doesn't account for exceptions thrown within exception filters. These will be seen as a new set of
+      callback invocations starting with throwing, searching, and unwinding, however, the callstack does not unwind
+      out of the exception filter and the original exception processing is resumed.
+    - Algorithm doesn't account for exceptions thrown within finally blocks. Presumably, these will be seen as new set
+      of callback invocations starting with throwing, searching, and unwinding. The original exception processing is
+      superceded by the new set of callbacks for the new exception.
+*/
+
+
+ExceptionTracker::ExceptionTracker(
+    const shared_ptr<ILogger>& pLogger,
+    const shared_ptr<ThreadDataManager> pThreadDataManager,
+    ICorProfilerInfo2* pCorProfilerInfo)
+{
+    m_pCorProfilerInfo = pCorProfilerInfo;
+    m_pLogger = pLogger;
+    m_pThreadDataManager = pThreadDataManager;
+}
+
+void ExceptionTracker::AddProfilerEventMask(DWORD& eventsLow)
+{
+    eventsLow |= COR_PRF_MONITOR::COR_PRF_ENABLE_STACK_SNAPSHOT;
+    eventsLow |= COR_PRF_MONITOR::COR_PRF_MONITOR_GC;
+}
+
+HRESULT ExceptionTracker::ExceptionThrown(ThreadID threadId, ObjectID objectId)
+{
+    HRESULT hr = S_OK;
+
+    IfFailLogRet(m_pThreadDataManager->SetExceptionObject(threadId, objectId));
+
+    // Exception throwing is common; don't pay to calculate method name if it won't be logged.
+    if (m_pLogger->IsEnabled(LogLevel::Debug))
+    {
+        FunctionID functionId = 0;
+        hr = m_pCorProfilerInfo->DoStackSnapshot(
+            threadId,
+            ExceptionThrownStackSnapshotCallback,
+            COR_PRF_SNAPSHOT_INFO::COR_PRF_SNAPSHOT_DEFAULT,
+            &functionId,
+            nullptr,
+            0);
+
+        if (FAILED(hr) && hr != CORPROF_E_STACKSNAPSHOT_ABORTED)
+        {
+            LogErrorV(_T("DoStackSnapshot failed in function %s: 0x%08x"), to_tstring(__func__).c_str(), hr);
+            return hr;
+        }
+
+        tstring methodName;
+        IfFailLogRet(GetFullyQualifiedMethodName(functionId, methodName));
+        LogDebugV(_T("Exception thrown: %s"), methodName.c_str());
+    }
+
+    return S_OK;
+}
+
+HRESULT ExceptionTracker::ExceptionSearchCatcherFound(ThreadID threadId, FunctionID functionId)
+{
+    HRESULT hr = S_OK;
+
+    IfFailLogRet(m_pThreadDataManager->SetExceptionCatcherFunction(threadId, functionId));
+
+    return S_OK;
+}
+
+HRESULT ExceptionTracker::ExceptionUnwindFunctionEnter(ThreadID threadId, FunctionID functionId)
+{
+    HRESULT hr = S_OK;
+
+    ObjectID thrownObjectId;
+    FunctionID catcherFunctionId;
+    IfFailLogRet(m_pThreadDataManager->GetException(threadId, &thrownObjectId, &catcherFunctionId));
+
+    if (ThreadData::NoFunctionId == catcherFunctionId)
+    {
+        tstring methodName;
+        IfFailLogRet(GetFullyQualifiedMethodName(functionId, methodName));
+        LogInformationV(_T("Exception unhandled: %s"), methodName.c_str());
+
+        // Future: Block thread until collection is initiated of the desired artifact.
+        // Possible serialization of some context of the exception and surrounding method
+        // information such as locals and parameters.
+    }
+    else if (functionId == catcherFunctionId)
+    {
+        IfFailLogRet(m_pThreadDataManager->ClearException(threadId));
+
+        // Exception handling is common; don't pay to calculate method name if it won't be logged.
+        if (m_pLogger->IsEnabled(LogLevel::Debug))
+        {
+            tstring methodName;
+            IfFailLogRet(GetFullyQualifiedMethodName(functionId, methodName));
+            LogDebugV(_T("Exception handled: %s"), methodName.c_str());
+        }
+    }
+
+    return S_OK;
+}
+
+HRESULT ExceptionTracker::MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[])
+{
+    HRESULT hr = S_OK;
+
+    IfFailLogRet(m_pThreadDataManager->MovedReferences(cMovedObjectIDRanges, oldObjectIDRangeStart, newObjectIDRangeStart, cObjectIDRangeLength));
+
+    return S_OK;
+}
+
+HRESULT ExceptionTracker::ExceptionThrownStackSnapshotCallback(
+    FunctionID funcId,
+    UINT_PTR ip,
+    COR_PRF_FRAME_INFO frameInfo,
+    ULONG32 contextSize,
+    BYTE context[],
+    void* clientData)
+{
+    // Callback is only used to get the function ID of the top frame.
+    *static_cast<FunctionID*>(clientData) = funcId;
+
+    // Cancel stack snapshot callbacks after the top frame.
+    return S_FALSE;
+}
+
+HRESULT ExceptionTracker::GetFullyQualifiedMethodName(FunctionID functionId, tstring& fullMethodName)
+{
+    HRESULT hr = S_OK;
+
+    ClassID classId;
+    ModuleID moduleId;
+    mdToken token;
+    IfFailLogRet(m_pCorProfilerInfo->GetFunctionInfo(
+        functionId,
+        &classId,
+        &moduleId,
+        &token
+    ));
+
+    if (0 == (token & mdtMethodDef))
+    {
+        return E_FAIL;
+    }
+    mdMethodDef methodDef = token;
+
+    ComPtr<IMetaDataImport2> pMetadataImport;
+    IfFailLogRet(m_pCorProfilerInfo->GetModuleMetaData(
+        moduleId,
+        CorOpenFlags::ofRead,
+        IID_IMetaDataImport2,
+        (IUnknown**)&pMetadataImport
+    ));
+
+    // Get Module Name
+    ULONG count = 0;
+    IfFailLogRet(m_pCorProfilerInfo->GetModuleInfo(
+        moduleId,
+        nullptr,
+        0,
+        &count,
+        nullptr,
+        nullptr
+    ));
+
+    unique_ptr<WCHAR[]> pModulePath(new (nothrow) WCHAR[count + 1]);
+    IfFailLogRet(m_pCorProfilerInfo->GetModuleInfo(
+        moduleId,
+        nullptr,
+        count + 1,
+        nullptr,
+        pModulePath.get(),
+        nullptr
+    ));
+
+    // Get Class Name
+    tstring className;
+    if (0 == classId)
+    {
+        // Probably a value type e.g. struct
+        className.assign(_T("[Unknown]"));
+    }
+    else
+    {
+        mdTypeDef typeDef = mdTokenNil;
+        IfFailLogRet(m_pCorProfilerInfo->GetClassIDInfo(
+            classId,
+            nullptr,
+            &typeDef
+        ));
+
+        IfFailLogRet(pMetadataImport->GetTypeDefProps(
+            typeDef,
+            nullptr,
+            0,
+            &count,
+            nullptr,
+            nullptr
+        ));
+
+        unique_ptr<WCHAR[]> pClassName(new (nothrow) WCHAR[count + 1]);
+        IfFailLogRet(pMetadataImport->GetTypeDefProps(
+            typeDef,
+            pClassName.get(),
+            count + 1,
+            nullptr,
+            nullptr,
+            nullptr
+        ));
+
+        className.assign(pClassName.get());
+    }
+
+    // Get Method Name
+    IfFailLogRet(pMetadataImport->GetMethodProps(
+        methodDef,
+        nullptr,
+        nullptr,
+        0,
+        &count,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr
+    ));
+
+    unique_ptr<WCHAR[]> pMethodName(new (nothrow) WCHAR[count + 1]);
+    IfFailLogRet(pMetadataImport->GetMethodProps(
+        methodDef,
+        nullptr,
+        pMethodName.get(),
+        count + 1,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr
+    ));
+
+    tstring modulePath(pModulePath.get());
+
+    fullMethodName.clear();
+    fullMethodName.append(modulePath.substr(modulePath.find_last_of(_T("/\\")) + 1));
+    fullMethodName.append(_T("!"));
+    fullMethodName.append(className);
+    fullMethodName.append(_T("."));
+    fullMethodName.append(pMethodName.get());
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -87,7 +87,6 @@ HRESULT ExceptionTracker::ExceptionThrown(ThreadID threadId, ObjectID objectId)
     // Exception throwing is common; don't pay to calculate method name if it won't be logged.
     if (_logger->IsEnabled(LogLevel::Debug))
     {
-        FunctionID functionId = 0;
         hr = _corProfilerInfo->DoStackSnapshot(
             threadId,
             LogExceptionThrownFrameCallback,
@@ -372,7 +371,7 @@ HRESULT ExceptionTracker::LogExceptionThrownFrame(FunctionID functionId, COR_PRF
 }
 
 HRESULT ExceptionTracker::LogExceptionThrownFrameCallback(
-    FunctionID funcId,
+    FunctionID functionId,
     UINT_PTR ip,
     COR_PRF_FRAME_INFO frameInfo,
     ULONG32 contextSize,
@@ -388,7 +387,7 @@ HRESULT ExceptionTracker::LogExceptionThrownFrameCallback(
 
     HRESULT hr = S_OK;
 
-    IfFailRet(exceptionTracker->LogExceptionThrownFrame(funcId, frameInfo));
+    IfFailRet(exceptionTracker->LogExceptionThrownFrame(functionId, frameInfo));
 
     // Cancel stack snapshot callbacks after the top frame.
     return S_FALSE;

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -28,7 +28,7 @@ public:
     /// <summary>
     /// Adds profiler event masks needed by class.
     /// </summary>
-    static void AddProfilerEventMask(DWORD& eventsLow);
+    void AddProfilerEventMask(DWORD& eventsLow);
 
     // Exceptions
     HRESULT ExceptionThrown(ThreadID threadId, ObjectID objectId);

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -15,15 +15,15 @@
 class ExceptionTracker
 {
 private:
-    ComPtr<ICorProfilerInfo2> m_pCorProfilerInfo;
-    std::shared_ptr<ILogger> m_pLogger;
-    std::shared_ptr<ThreadDataManager> m_pThreadDataManager;
+    ComPtr<ICorProfilerInfo2> _corProfilerInfo;
+    std::shared_ptr<ILogger> _logger;
+    std::shared_ptr<ThreadDataManager> _threadDataManager;
 
 public:
     ExceptionTracker(
-        const std::shared_ptr<ILogger>& pLogger,
-        const std::shared_ptr<ThreadDataManager> pThreadDataManager,
-        ICorProfilerInfo2* pCorProfilerInfo);
+        const std::shared_ptr<ILogger>& logger,
+        const std::shared_ptr<ThreadDataManager> threadDataManager,
+        ICorProfilerInfo2* corProfilerInfo);
 
     /// <summary>
     /// Adds profiler event masks needed by class.
@@ -39,7 +39,7 @@ public:
     HRESULT MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]);
 
 private:
-    HRESULT GetFullyQualifiedMethodName(FunctionID functionId, tstring& tstrName);
+    HRESULT GetFullyQualifiedMethodName(FunctionID functionId, tstring& name);
     static HRESULT STDMETHODCALLTYPE ExceptionThrownStackSnapshotCallback(
         FunctionID funcId,
         UINT_PTR ip,

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -47,7 +47,7 @@ private:
     // ExceptionThrown frame logging utilities
     HRESULT LogExceptionThrownFrame(FunctionID functionId, COR_PRF_FRAME_INFO frameInfo);
     static HRESULT STDMETHODCALLTYPE LogExceptionThrownFrameCallback(
-        FunctionID funcId,
+        FunctionID functionId,
         UINT_PTR ip,
         COR_PRF_FRAME_INFO frameInfo,
         ULONG32 contextSize,

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+#include "../Logging/Logger.h"
+#include "ThreadDataManager.h"
+#include "com.h"
+
+/// <summary>
+/// Class for tracking exceptions for a runtime instance.
+/// </summary>
+class ExceptionTracker
+{
+private:
+    ComPtr<ICorProfilerInfo2> m_pCorProfilerInfo;
+    std::shared_ptr<ILogger> m_pLogger;
+    std::shared_ptr<ThreadDataManager> m_pThreadDataManager;
+
+public:
+    ExceptionTracker(
+        const std::shared_ptr<ILogger>& pLogger,
+        const std::shared_ptr<ThreadDataManager> pThreadDataManager,
+        ICorProfilerInfo2* pCorProfilerInfo);
+
+    /// <summary>
+    /// Adds profiler event masks need by class.
+    /// </summary>
+    static void AddProfilerEventMask(DWORD& eventsLow);
+
+    // Exceptions
+    HRESULT ExceptionThrown(ThreadID threadId, ObjectID objectId);
+    HRESULT ExceptionSearchCatcherFound(ThreadID threadId, FunctionID functionId);
+    HRESULT ExceptionUnwindFunctionEnter(ThreadID threadId, FunctionID functionId);
+
+    // Garbage Collection
+    HRESULT MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]);
+
+private:
+    HRESULT GetFullyQualifiedMethodName(FunctionID functionId, tstring& tstrName);
+    static HRESULT STDMETHODCALLTYPE ExceptionThrownStackSnapshotCallback(
+        FunctionID funcId,
+        UINT_PTR ip,
+        COR_PRF_FRAME_INFO frameInfo,
+        ULONG32 contextSize,
+        BYTE context[],
+        void* clientData);
+};

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -35,12 +35,18 @@ public:
     HRESULT ExceptionSearchCatcherFound(ThreadID threadId, FunctionID functionId);
     HRESULT ExceptionUnwindFunctionEnter(ThreadID threadId, FunctionID functionId);
 
-    // Garbage Collection
-    HRESULT MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]);
-
 private:
-    HRESULT GetFullyQualifiedMethodName(FunctionID functionId, tstring& name);
-    static HRESULT STDMETHODCALLTYPE ExceptionThrownStackSnapshotCallback(
+    // Method and type name utilities
+    HRESULT GetFullyQualifiedMethodName(FunctionID functionId, tstring& fullMethodName);
+    HRESULT GetFullyQualifiedMethodName(FunctionID functionId, COR_PRF_FRAME_INFO frameInfo, tstring& fullMethodName);
+    HRESULT GetFullyQualifiedMethodName(ModuleID moduleId, ClassID classId, mdMethodDef token, tstring& fullMethodName);
+    HRESULT GetFullClassName(ClassID classId, tstring& fullClassName);
+    HRESULT GetFullTypeName(IMetaDataImport2* metadataImport, mdTypeDef typeDefToken, tstring& fullTypeName);
+    static bool IsNestedType(CorTypeAttr attributes);
+
+    // ExceptionThrown frame logging utilities
+    HRESULT LogExceptionThrownFrame(FunctionID functionId, COR_PRF_FRAME_INFO frameInfo);
+    static HRESULT STDMETHODCALLTYPE LogExceptionThrownFrameCallback(
         FunctionID funcId,
         UINT_PTR ip,
         COR_PRF_FRAME_INFO frameInfo,

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -26,7 +26,7 @@ public:
         ICorProfilerInfo2* pCorProfilerInfo);
 
     /// <summary>
-    /// Adds profiler event masks need by class.
+    /// Adds profiler event masks needed by class.
     /// </summary>
     static void AddProfilerEventMask(DWORD& eventsLow);
 

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -48,7 +48,7 @@ STDMETHODIMP MainProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
 
     DWORD eventsLow = COR_PRF_MONITOR::COR_PRF_MONITOR_NONE;
     ThreadDataManager::AddProfilerEventMask(eventsLow);
-    ExceptionTracker::AddProfilerEventMask(eventsLow);
+    _exceptionTracker->AddProfilerEventMask(eventsLow);
 
     IfFailRet(m_pCorProfilerInfo->SetEventMask2(
         eventsLow,

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -32,14 +32,14 @@ STDMETHODIMP MainProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
     IfFailRet(InitializeEnvironment());
     IfFailRet(InitializeLogging());
 
-    m_pThreadDataManager = make_shared<ThreadDataManager>(m_pLogger);
-    IfNullRet(m_pThreadDataManager);
-    m_pExceptionTracker.reset(new (nothrow) ExceptionTracker(m_pLogger, m_pThreadDataManager, m_pCorProfilerInfo));
-    IfNullRet(m_pExceptionTracker);
+    // Logging is initialized and can now be used
+
+    _threadDataManager = make_shared<ThreadDataManager>(m_pLogger);
+    IfNullRet(_threadDataManager);
+    _exceptionTracker.reset(new (nothrow) ExceptionTracker(m_pLogger, _threadDataManager, m_pCorProfilerInfo));
+    IfNullRet(_exceptionTracker);
 
     IfFailLogRet(InitializeCommandServer());
-
-    // Logging is initialized and can now be used
 
     // Set product version environment variable to allow discovery of if the profiler
     // as been applied to a target process. Diagnostic tools must use the diagnostic
@@ -71,7 +71,7 @@ STDMETHODIMP MainProfiler::ThreadCreated(ThreadID threadId)
 {
     HRESULT hr = S_OK;
 
-    IfFailLogRet(m_pThreadDataManager->ThreadCreated(threadId));
+    IfFailLogRet(_threadDataManager->ThreadCreated(threadId));
 
     return S_OK;
 }
@@ -80,7 +80,7 @@ STDMETHODIMP MainProfiler::ThreadDestroyed(ThreadID threadId)
 {
     HRESULT hr = S_OK;
 
-    IfFailLogRet(m_pThreadDataManager->ThreadDestroyed(threadId));
+    IfFailLogRet(_threadDataManager->ThreadDestroyed(threadId));
 
     return S_OK;
 }
@@ -92,7 +92,7 @@ STDMETHODIMP MainProfiler::ExceptionThrown(ObjectID thrownObjectId)
     ThreadID threadId;
     IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    IfFailLogRet(m_pExceptionTracker->ExceptionThrown(threadId, thrownObjectId));
+    IfFailLogRet(_exceptionTracker->ExceptionThrown(threadId, thrownObjectId));
 
     return S_OK;
 }
@@ -104,7 +104,7 @@ STDMETHODIMP MainProfiler::ExceptionSearchCatcherFound(FunctionID functionId)
     ThreadID threadId;
     IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    IfFailLogRet(m_pExceptionTracker->ExceptionSearchCatcherFound(threadId, functionId));
+    IfFailLogRet(_exceptionTracker->ExceptionSearchCatcherFound(threadId, functionId));
 
     return S_OK;
 }
@@ -116,7 +116,7 @@ STDMETHODIMP MainProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
     ThreadID threadId;
     IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    IfFailLogRet(m_pExceptionTracker->ExceptionUnwindFunctionEnter(threadId, functionId));
+    IfFailLogRet(_exceptionTracker->ExceptionUnwindFunctionEnter(threadId, functionId));
 
     return S_OK;
 }
@@ -125,7 +125,7 @@ STDMETHODIMP MainProfiler::MovedReferences2(ULONG cMovedObjectIDRanges, ObjectID
 {
     HRESULT hr = S_OK;
 
-    IfFailLogRet(m_pExceptionTracker->MovedReferences(cMovedObjectIDRanges, oldObjectIDRangeStart, newObjectIDRangeStart, cObjectIDRangeLength));
+    IfFailLogRet(_exceptionTracker->MovedReferences(cMovedObjectIDRanges, oldObjectIDRangeStart, newObjectIDRangeStart, cObjectIDRangeLength));
 
     return S_OK;
 }

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -121,21 +121,11 @@ STDMETHODIMP MainProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
     return S_OK;
 }
 
-STDMETHODIMP MainProfiler::MovedReferences2(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[])
-{
-    HRESULT hr = S_OK;
-
-    IfFailLogRet(_exceptionTracker->MovedReferences(cMovedObjectIDRanges, oldObjectIDRangeStart, newObjectIDRangeStart, cObjectIDRangeLength));
-
-    return S_OK;
-}
-
 STDMETHODIMP MainProfiler::LoadAsNotficationOnly(BOOL *pbNotificationOnly)
 {
     ExpectedPtr(pbNotificationOnly);
 
-    // GC callbacks are not supported by notification only profilers
-    //*pbNotificationOnly = TRUE;
+    *pbNotificationOnly = TRUE;
 
     return S_OK;
 }

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -31,7 +31,6 @@ public:
     STDMETHOD(ExceptionThrown)(ObjectID thrownObjectId) override;
     STDMETHOD(ExceptionSearchCatcherFound)(FunctionID functionId) override;
     STDMETHOD(ExceptionUnwindFunctionEnter)(FunctionID functionId) override;
-    STDMETHOD(MovedReferences2)(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override;
     STDMETHOD(LoadAsNotficationOnly)(BOOL *pbNotificationOnly) override;
 
 private:

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -9,6 +9,8 @@
 #include "../Logging/Logger.h"
 #include "../Communication/CommandServer.h"
 #include <memory>
+#include "ThreadDataManager.h"
+#include "ExceptionTracker.h"
 
 class MainProfiler final :
     public ProfilerBase
@@ -16,12 +18,20 @@ class MainProfiler final :
 private:
     std::shared_ptr<IEnvironment> m_pEnvironment;
     std::shared_ptr<ILogger> m_pLogger;
+    std::shared_ptr<ThreadDataManager> m_pThreadDataManager;
+    std::unique_ptr<ExceptionTracker> m_pExceptionTracker;
 
 public:
     static GUID GetClsid();
 
     STDMETHOD(Initialize)(IUnknown* pICorProfilerInfoUnk) override;
     STDMETHOD(Shutdown)() override;
+    STDMETHOD(ThreadCreated)(ThreadID threadId) override;
+    STDMETHOD(ThreadDestroyed)(ThreadID threadId) override;
+    STDMETHOD(ExceptionThrown)(ObjectID thrownObjectId) override;
+    STDMETHOD(ExceptionSearchCatcherFound)(FunctionID functionId) override;
+    STDMETHOD(ExceptionUnwindFunctionEnter)(FunctionID functionId) override;
+    STDMETHOD(MovedReferences2)(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]) override;
     STDMETHOD(LoadAsNotficationOnly)(BOOL *pbNotificationOnly) override;
 
 private:
@@ -32,3 +42,4 @@ private:
 private:
     std::unique_ptr<CommandServer> _commandServer;
 };
+

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -18,8 +18,8 @@ class MainProfiler final :
 private:
     std::shared_ptr<IEnvironment> m_pEnvironment;
     std::shared_ptr<ILogger> m_pLogger;
-    std::shared_ptr<ThreadDataManager> m_pThreadDataManager;
-    std::unique_ptr<ExceptionTracker> m_pExceptionTracker;
+    std::shared_ptr<ThreadDataManager> _threadDataManager;
+    std::unique_ptr<ExceptionTracker> _exceptionTracker;
 
 public:
     static GUID GetClsid();

--- a/src/MonitorProfiler/MainProfiler/ThreadData.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.cpp
@@ -16,11 +16,6 @@ ThreadData::ThreadData(const shared_ptr<ILogger>& logger) :
 {
 }
 
-mutex& ThreadData::GetMutex()
-{
-    return _mutex;
-}
-
 void ThreadData::ClearException()
 {
     _exceptionCatcherFunctionId = NoFunctionId;

--- a/src/MonitorProfiler/MainProfiler/ThreadData.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.cpp
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "ThreadData.h"
+#include "macros.h"
+
+using namespace std;
+
+#define IfFalseLogRet(EXPR, hr) IfFalseLogRet_(m_pLogger, EXPR, hr)
+
+ThreadData::ThreadData(const shared_ptr<ILogger>& pLogger) :
+    m_exceptionCatcherFunctionId(NoFunctionId),
+    m_exceptionObjectId(NoExceptionId),
+    m_pLogger(pLogger)
+{
+}
+
+mutex& ThreadData::GetMutex()
+{
+    return m_mutex;
+}
+
+void ThreadData::ClearException()
+{
+    m_exceptionCatcherFunctionId = NoFunctionId;
+    m_exceptionObjectId = NoExceptionId;
+}
+
+HRESULT ThreadData::ExceptionObjectMoved(ObjectID newObjectId)
+{
+    IfFalseLogRet(NoExceptionId != newObjectId, E_INVALIDARG);
+    IfFalseLogRet(NoExceptionId != m_exceptionObjectId, E_UNEXPECTED);
+
+    m_exceptionObjectId = newObjectId;
+
+    return S_OK;
+}
+
+HRESULT ThreadData::GetException(ObjectID* pObjectId, FunctionID* pCatcherFunctionId)
+{
+    ExpectedPtr(pObjectId);
+    ExpectedPtr(pCatcherFunctionId);
+
+    *pObjectId = m_exceptionObjectId;
+    *pCatcherFunctionId = m_exceptionCatcherFunctionId;
+
+    return S_OK;
+}
+
+HRESULT ThreadData::SetExceptionObject(ObjectID objectId)
+{
+    IfFalseLogRet(NoExceptionId != objectId, E_INVALIDARG);
+    IfFalseLogRet(NoExceptionId == m_exceptionObjectId, E_UNEXPECTED);
+    IfFalseLogRet(NoFunctionId == m_exceptionCatcherFunctionId, E_UNEXPECTED);
+
+    m_exceptionObjectId = objectId;
+
+    return S_OK;
+}
+
+HRESULT ThreadData::SetExceptionCatcherFunction(FunctionID functionId)
+{
+    IfFalseLogRet(NoFunctionId != functionId, E_INVALIDARG);
+    IfFalseLogRet(NoExceptionId != m_exceptionObjectId, E_UNEXPECTED);
+
+    m_exceptionCatcherFunctionId = functionId;
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/MainProfiler/ThreadData.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.cpp
@@ -7,43 +7,43 @@
 
 using namespace std;
 
-#define IfFalseLogRet(EXPR, hr) IfFalseLogRet_(m_pLogger, EXPR, hr)
+#define IfFalseLogRet(EXPR, hr) IfFalseLogRet_(_logger, EXPR, hr)
 
-ThreadData::ThreadData(const shared_ptr<ILogger>& pLogger) :
-    m_exceptionCatcherFunctionId(NoFunctionId),
-    m_exceptionObjectId(NoExceptionId),
-    m_pLogger(pLogger)
+ThreadData::ThreadData(const shared_ptr<ILogger>& logger) :
+    _exceptionCatcherFunctionId(NoFunctionId),
+    _exceptionObjectId(NoExceptionId),
+    _logger(logger)
 {
 }
 
 mutex& ThreadData::GetMutex()
 {
-    return m_mutex;
+    return _mutex;
 }
 
 void ThreadData::ClearException()
 {
-    m_exceptionCatcherFunctionId = NoFunctionId;
-    m_exceptionObjectId = NoExceptionId;
+    _exceptionCatcherFunctionId = NoFunctionId;
+    _exceptionObjectId = NoExceptionId;
 }
 
 HRESULT ThreadData::ExceptionObjectMoved(ObjectID newObjectId)
 {
     IfFalseLogRet(NoExceptionId != newObjectId, E_INVALIDARG);
-    IfFalseLogRet(NoExceptionId != m_exceptionObjectId, E_UNEXPECTED);
+    IfFalseLogRet(NoExceptionId != _exceptionObjectId, E_UNEXPECTED);
 
-    m_exceptionObjectId = newObjectId;
+    _exceptionObjectId = newObjectId;
 
     return S_OK;
 }
 
-HRESULT ThreadData::GetException(ObjectID* pObjectId, FunctionID* pCatcherFunctionId)
+HRESULT ThreadData::GetException(ObjectID* objectId, FunctionID* catcherFunctionId)
 {
-    ExpectedPtr(pObjectId);
-    ExpectedPtr(pCatcherFunctionId);
+    ExpectedPtr(objectId);
+    ExpectedPtr(catcherFunctionId);
 
-    *pObjectId = m_exceptionObjectId;
-    *pCatcherFunctionId = m_exceptionCatcherFunctionId;
+    *objectId = _exceptionObjectId;
+    *catcherFunctionId = _exceptionCatcherFunctionId;
 
     return S_OK;
 }
@@ -51,10 +51,10 @@ HRESULT ThreadData::GetException(ObjectID* pObjectId, FunctionID* pCatcherFuncti
 HRESULT ThreadData::SetExceptionObject(ObjectID objectId)
 {
     IfFalseLogRet(NoExceptionId != objectId, E_INVALIDARG);
-    IfFalseLogRet(NoExceptionId == m_exceptionObjectId, E_UNEXPECTED);
-    IfFalseLogRet(NoFunctionId == m_exceptionCatcherFunctionId, E_UNEXPECTED);
+    IfFalseLogRet(NoExceptionId == _exceptionObjectId, E_UNEXPECTED);
+    IfFalseLogRet(NoFunctionId == _exceptionCatcherFunctionId, E_UNEXPECTED);
 
-    m_exceptionObjectId = objectId;
+    _exceptionObjectId = objectId;
 
     return S_OK;
 }
@@ -62,9 +62,9 @@ HRESULT ThreadData::SetExceptionObject(ObjectID objectId)
 HRESULT ThreadData::SetExceptionCatcherFunction(FunctionID functionId)
 {
     IfFalseLogRet(NoFunctionId != functionId, E_INVALIDARG);
-    IfFalseLogRet(NoExceptionId != m_exceptionObjectId, E_UNEXPECTED);
+    IfFalseLogRet(NoExceptionId != _exceptionObjectId, E_UNEXPECTED);
 
-    m_exceptionCatcherFunctionId = functionId;
+    _exceptionCatcherFunctionId = functionId;
 
     return S_OK;
 }

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include "corhlpr.h"
 #include "corprof.h"

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -20,7 +20,7 @@ public:
 
 private:
     FunctionID _exceptionCatcherFunctionId;
-    ObjectID _hasException;
+    bool _hasException;
     std::mutex _mutex;
     std::shared_ptr<ILogger> _logger;
 

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 #include "corhlpr.h"
 #include "corprof.h"
 #include "../Logging/Logger.h"
@@ -21,13 +20,10 @@ public:
 private:
     FunctionID _exceptionCatcherFunctionId;
     bool _hasException;
-    std::mutex _mutex;
     std::shared_ptr<ILogger> _logger;
 
 public:
     ThreadData(const std::shared_ptr<ILogger>& logger);
-
-    std::mutex& GetMutex();
 
     // Exceptions
     void ClearException();

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -16,12 +16,11 @@
 class ThreadData
 {
 public:
-    static const ObjectID NoExceptionId = 0;
     static const FunctionID NoFunctionId = 0;
 
 private:
     FunctionID _exceptionCatcherFunctionId;
-    ObjectID _exceptionObjectId;
+    ObjectID _hasException;
     std::mutex _mutex;
     std::shared_ptr<ILogger> _logger;
 
@@ -32,8 +31,7 @@ public:
 
     // Exceptions
     void ClearException();
-    HRESULT ExceptionObjectMoved(ObjectID newObjectId);
-    HRESULT GetException(ObjectID* objectId, FunctionID* catcherFunctionId);
-    HRESULT SetExceptionObject(ObjectID objectId);
+    HRESULT GetException(bool* hasException, FunctionID* catcherFunctionId);
+    HRESULT SetHasException();
     HRESULT SetExceptionCatcherFunction(FunctionID functionId);
 };

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -20,20 +20,20 @@ public:
     static const FunctionID NoFunctionId = 0;
 
 private:
-    FunctionID m_exceptionCatcherFunctionId;
-    ObjectID m_exceptionObjectId;
-    std::mutex m_mutex;
-    std::shared_ptr<ILogger> m_pLogger;
+    FunctionID _exceptionCatcherFunctionId;
+    ObjectID _exceptionObjectId;
+    std::mutex _mutex;
+    std::shared_ptr<ILogger> _logger;
 
 public:
-    ThreadData(const std::shared_ptr<ILogger>& pLogger);
+    ThreadData(const std::shared_ptr<ILogger>& logger);
 
     std::mutex& GetMutex();
 
     // Exceptions
     void ClearException();
     HRESULT ExceptionObjectMoved(ObjectID newObjectId);
-    HRESULT GetException(ObjectID* pObjectId, FunctionID* pHandlingFunctionId);
+    HRESULT GetException(ObjectID* objectId, FunctionID* catcherFunctionId);
     HRESULT SetExceptionObject(ObjectID objectId);
     HRESULT SetExceptionCatcherFunction(FunctionID functionId);
 };

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <mutex>
+#include "corhlpr.h"
+#include "corprof.h"
+#include "../Logging/Logger.h"
+
+/// <summary>
+/// Class representing common data for a single thread.
+/// </summary>
+class ThreadData
+{
+public:
+    static const ObjectID NoExceptionId = 0;
+    static const FunctionID NoFunctionId = 0;
+
+private:
+    FunctionID m_exceptionCatcherFunctionId;
+    ObjectID m_exceptionObjectId;
+    std::mutex m_mutex;
+    std::shared_ptr<ILogger> m_pLogger;
+
+public:
+    ThreadData(const std::shared_ptr<ILogger>& pLogger);
+
+    std::mutex& GetMutex();
+
+    // Exceptions
+    void ClearException();
+    HRESULT ExceptionObjectMoved(ObjectID newObjectId);
+    HRESULT GetException(ObjectID* pObjectId, FunctionID* pHandlingFunctionId);
+    HRESULT SetExceptionObject(ObjectID objectId);
+    HRESULT SetExceptionCatcherFunction(FunctionID functionId);
+};

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
@@ -49,8 +49,6 @@ HRESULT ThreadDataManager::ClearException(ThreadID threadId)
     shared_ptr<ThreadData> threadData;
     IfFailLogRet(GetThreadData(threadId, threadData));
 
-    lock_guard<mutex> lock(threadData->GetMutex());
-
     threadData->ClearException();
 
     return S_OK;
@@ -66,8 +64,6 @@ HRESULT ThreadDataManager::GetException(ThreadID threadId, bool* hasException, F
     shared_ptr<ThreadData> threadData;
     IfFailLogRet(GetThreadData(threadId, threadData));
 
-    lock_guard<mutex> lock(threadData->GetMutex());
-
     IfFailLogRet(threadData->GetException(hasException, catcherFunctionId));
 
     return *hasException ? S_FALSE : S_OK;
@@ -80,8 +76,6 @@ HRESULT ThreadDataManager::SetHasException(ThreadID threadId)
     shared_ptr<ThreadData> threadData;
     IfFailLogRet(GetThreadData(threadId, threadData));
 
-    lock_guard<mutex> lock(threadData->GetMutex());
-
     IfFailLogRet(threadData->SetHasException());
 
     return S_OK;
@@ -93,8 +87,6 @@ HRESULT ThreadDataManager::SetExceptionCatcherFunction(ThreadID threadId, Functi
 
     shared_ptr<ThreadData> threadData;
     IfFailLogRet(GetThreadData(threadId, threadData));
-
-    lock_guard<mutex> lock(threadData->GetMutex());
 
     IfFailLogRet(threadData->SetExceptionCatcherFunction(catcherFunctionId));
 

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "ThreadDataManager.h"
+#include "macros.h"
+#include <utility>
+
+using namespace std;
+
+#define IfFailLogRet(EXPR) IfFailLogRet_(m_pLogger, EXPR)
+
+typedef unordered_map<ThreadID, shared_ptr<ThreadData>>::iterator DataMapIterator;
+
+ThreadDataManager::ThreadDataManager(const shared_ptr<ILogger>& pLogger)
+{
+    m_pLogger = pLogger;
+}
+
+void ThreadDataManager::AddProfilerEventMask(DWORD& eventsLow)
+{
+    eventsLow |= COR_PRF_MONITOR::COR_PRF_MONITOR_THREADS;
+    eventsLow |= COR_PRF_MONITOR::COR_PRF_MONITOR_EXCEPTIONS;
+    eventsLow |= COR_PRF_MONITOR::COR_PRF_MONITOR_GC;
+}
+
+HRESULT ThreadDataManager::ThreadCreated(ThreadID threadId)
+{
+    lock_guard<mutex> lock(m_dataMapMutex);
+
+    m_dataMap.insert(make_pair(threadId, make_shared<ThreadData>(m_pLogger)));
+
+    return S_OK;
+}
+
+HRESULT ThreadDataManager::ThreadDestroyed(ThreadID threadId)
+{
+    lock_guard<mutex> lock(m_dataMapMutex);
+
+    m_dataMap.erase(threadId);
+
+    return S_OK;
+}
+
+HRESULT ThreadDataManager::ClearException(ThreadID threadId)
+{
+    HRESULT hr = S_OK;
+
+    shared_ptr<ThreadData> pThreadData;
+    IfFailLogRet(GetThreadData(threadId, pThreadData));
+
+    lock_guard<mutex> lock(pThreadData->GetMutex());
+
+    pThreadData->ClearException();
+
+    return S_OK;
+}
+
+HRESULT ThreadDataManager::GetException(ThreadID threadId, ObjectID* pObjectId, FunctionID* pCatcherFunctionId)
+{
+    ExpectedPtr(pObjectId);
+    ExpectedPtr(pCatcherFunctionId);
+
+    HRESULT hr = S_OK;
+
+    shared_ptr<ThreadData> pThreadData;
+    IfFailLogRet(GetThreadData(threadId, pThreadData));
+
+    lock_guard<mutex> lock(pThreadData->GetMutex());
+
+    IfFailLogRet(pThreadData->GetException(pObjectId, pCatcherFunctionId));
+
+    return ThreadData::NoExceptionId == *pObjectId ? S_FALSE : S_OK;
+}
+
+HRESULT ThreadDataManager::SetExceptionObject(ThreadID threadId, ObjectID objectId)
+{
+    HRESULT hr = S_OK;
+
+    shared_ptr<ThreadData> pThreadData;
+    IfFailLogRet(GetThreadData(threadId, pThreadData));
+
+    lock_guard<mutex> lock(pThreadData->GetMutex());
+
+    IfFailLogRet(pThreadData->SetExceptionObject(objectId));
+
+    return S_OK;
+}
+
+HRESULT ThreadDataManager::SetExceptionCatcherFunction(ThreadID threadId, FunctionID handlingFunctionId)
+{
+    HRESULT hr = S_OK;
+
+    shared_ptr<ThreadData> pThreadData;
+    IfFailLogRet(GetThreadData(threadId, pThreadData));
+
+    lock_guard<mutex> lock(pThreadData->GetMutex());
+
+    IfFailLogRet(pThreadData->SetExceptionCatcherFunction(handlingFunctionId));
+
+    return S_OK;
+}
+
+HRESULT ThreadDataManager::MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[])
+{
+    HRESULT hr = S_OK;
+
+    lock_guard<mutex> mapLock(m_dataMapMutex);
+
+    // Update all of the exception ObjectIDs for each thread
+    for (pair<const ThreadID, shared_ptr<ThreadData>>& pair : m_dataMap)
+    {
+        shared_ptr<ThreadData> pThreadData = pair.second;
+        lock_guard<mutex> lock(pThreadData->GetMutex());
+
+        ObjectID exceptionObjectId;
+        FunctionID exceptionCatcherFunctionId;
+        IfFailLogRet(pThreadData->GetException(&exceptionObjectId, &exceptionCatcherFunctionId));
+
+        // If the thread has an exception associated with it, check if it is one of the compacted
+        // ranges. If it is in a range, recalculate the new ObjectID and store it.
+        if (ThreadData::NoExceptionId != exceptionObjectId)
+        {
+            for (ULONG i = 0; i < cMovedObjectIDRanges; i++)
+            {
+                if (oldObjectIDRangeStart[i] <= exceptionObjectId && exceptionObjectId < (oldObjectIDRangeStart[i] + cObjectIDRangeLength[i]))
+                {
+                    ObjectID newExceptionObjectId = newObjectIDRangeStart[i] + (exceptionObjectId - oldObjectIDRangeStart[i]);
+                    IfFailLogRet(pThreadData->ExceptionObjectMoved(newExceptionObjectId));
+                }
+            }
+        }
+    }
+
+    return S_OK;
+}
+
+HRESULT ThreadDataManager::GetThreadData(ThreadID threadId, shared_ptr<ThreadData>& pThreadData)
+{
+    lock_guard<mutex> mapLock(m_dataMapMutex);
+
+    DataMapIterator iterator = m_dataMap.find(threadId);
+    if (iterator == m_dataMap.end())
+    {
+        return E_FAIL;
+    }
+
+    pThreadData = iterator->second;
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
@@ -9,6 +9,7 @@
 using namespace std;
 
 #define IfFailLogRet(EXPR) IfFailLogRet_(_logger, EXPR)
+#define IfFalseLogRet(EXPR, hr) IfFalseLogRet_(_logger, EXPR, hr)
 
 typedef unordered_map<ThreadID, shared_ptr<ThreadData>>::iterator DataMapIterator;
 
@@ -105,10 +106,7 @@ HRESULT ThreadDataManager::GetThreadData(ThreadID threadId, shared_ptr<ThreadDat
     lock_guard<mutex> mapLock(_dataMapMutex);
 
     DataMapIterator iterator = _dataMap.find(threadId);
-    if (iterator == _dataMap.end())
-    {
-        return E_FAIL;
-    }
+    IfFalseLogRet(iterator != _dataMap.end(), E_UNEXPECTED);
 
     threadData = iterator->second;
 

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include "corhlpr.h"
+#include "corprof.h"
+#include "ThreadData.h"
+#include "../Logging/Logger.h"
+
+/// <summary>
+/// Class for managing common thread information.
+/// </summary>
+class ThreadDataManager
+{
+private:
+    std::unordered_map<ThreadID, std::shared_ptr<ThreadData>> m_dataMap;
+    std::mutex m_dataMapMutex;
+    std::shared_ptr<ILogger> m_pLogger;
+
+public:
+    ThreadDataManager(const std::shared_ptr<ILogger>& pLogger);
+
+    /// <summary>
+    /// Adds profiler event masks need by class.
+    /// </summary>
+    static void AddProfilerEventMask(DWORD& eventsLow);
+
+    // Threads
+    HRESULT ThreadCreated(ThreadID threadId);
+    HRESULT ThreadDestroyed(ThreadID threadId);
+
+    // Exceptions
+    HRESULT ClearException(ThreadID threadId);
+    HRESULT GetException(ThreadID threadId, ObjectID* pObjectId, FunctionID* pHandlingFunctionId);
+    HRESULT SetExceptionObject(ThreadID threadId, ObjectID objectId);
+    HRESULT SetExceptionCatcherFunction(ThreadID threadId, FunctionID handlingFunctionId);
+
+    // Garbage Collection
+    HRESULT MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]);
+
+private:
+    HRESULT GetThreadData(ThreadID threadId, std::shared_ptr<ThreadData>& pThreadData);
+};

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
@@ -36,12 +36,9 @@ public:
 
     // Exceptions
     HRESULT ClearException(ThreadID threadId);
-    HRESULT GetException(ThreadID threadId, ObjectID* objectId, FunctionID* catcherFunctionId);
-    HRESULT SetExceptionObject(ThreadID threadId, ObjectID objectId);
+    HRESULT GetException(ThreadID threadId, bool* hasException, FunctionID* catcherFunctionId);
+    HRESULT SetHasException(ThreadID threadId);
     HRESULT SetExceptionCatcherFunction(ThreadID threadId, FunctionID catcherFunctionId);
-
-    // Garbage Collection
-    HRESULT MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]);
 
 private:
     HRESULT GetThreadData(ThreadID threadId, std::shared_ptr<ThreadData>& threadData);

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
@@ -18,12 +18,12 @@
 class ThreadDataManager
 {
 private:
-    std::unordered_map<ThreadID, std::shared_ptr<ThreadData>> m_dataMap;
-    std::mutex m_dataMapMutex;
-    std::shared_ptr<ILogger> m_pLogger;
+    std::unordered_map<ThreadID, std::shared_ptr<ThreadData>> _dataMap;
+    std::mutex _dataMapMutex;
+    std::shared_ptr<ILogger> _logger;
 
 public:
-    ThreadDataManager(const std::shared_ptr<ILogger>& pLogger);
+    ThreadDataManager(const std::shared_ptr<ILogger>& logger);
 
     /// <summary>
     /// Adds profiler event masks needed by class.
@@ -36,13 +36,13 @@ public:
 
     // Exceptions
     HRESULT ClearException(ThreadID threadId);
-    HRESULT GetException(ThreadID threadId, ObjectID* pObjectId, FunctionID* pHandlingFunctionId);
+    HRESULT GetException(ThreadID threadId, ObjectID* objectId, FunctionID* catcherFunctionId);
     HRESULT SetExceptionObject(ThreadID threadId, ObjectID objectId);
-    HRESULT SetExceptionCatcherFunction(ThreadID threadId, FunctionID handlingFunctionId);
+    HRESULT SetExceptionCatcherFunction(ThreadID threadId, FunctionID catcherFunctionId);
 
     // Garbage Collection
     HRESULT MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], SIZE_T cObjectIDRangeLength[]);
 
 private:
-    HRESULT GetThreadData(ThreadID threadId, std::shared_ptr<ThreadData>& pThreadData);
+    HRESULT GetThreadData(ThreadID threadId, std::shared_ptr<ThreadData>& threadData);
 };

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
@@ -26,7 +26,7 @@ public:
     ThreadDataManager(const std::shared_ptr<ILogger>& pLogger);
 
     /// <summary>
-    /// Adds profiler event masks need by class.
+    /// Adds profiler event masks needed by class.
     /// </summary>
     static void AddProfilerEventMask(DWORD& eventsLow);
 


### PR DESCRIPTION
These changes add the ability to detect unhandled exceptions in the most commons cases. The algorithm is described (along with its known caveats) and coded into the [ExceptionTracker class](https://github.com/dotnet/dotnet-monitor/compare/release/6.x...jander-msft:dev/jander/exceptions?expand=1#diff-5eb9c3b5e67efbf830637957e3fa121a43d4ebdb4cde8b9d23ad566a7cccf518). No action is taken in these changes when an unhandled exception does occur; these changes are purely about detection.