### PR TITLE
[release/6.1] Remove prerelease blob group

### DIFF
--- a/documentation/release-process.md
+++ b/documentation/release-process.md
@@ -4,7 +4,7 @@
 
 1. Merge from the `main` branch to the appropriate release branch (e.g. `release/5.0`).
 1. In `/eng/Versions.props`, update `dotnet/diagnostics` dependencies to versions from the corresponding release of the `dotnet/diagnostics` repo.
-1. In `/eng/Version.props`, ensure that `<BlobGroupBuildQuality>` is set appropriately. See the documentation next to this setting for the appropriate values. In release branches, its value should either be `prerelease` or `release`. This setting, in combination with the version settings, determine for which 'channel' the aks.ms links are created.
+1. In `/eng/Version.props`, ensure that `<BlobGroupBuildQuality>` is set appropriately. See the documentation next to this setting for the appropriate values. In release branches, its value should be `release`. This setting, in combination with the version settings, determine for which 'channel' the aks.ms links are created.
 1. Complete at least one successful build.
 1. Bump the version number in the `main` branch. [Example Pull Request](https://github.com/dotnet/dotnet-monitor/pull/1560). 
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,7 @@
     <!--
       Build quality notion for blob group naming, similar to aka.ms channel build quality in Arcade:
       - 'daily': sets the blob group release name to 'daily' so a release type does not have to be assigned.
-      - 'prerelease': allows the blob group release name to use prerelease version information.
-      - 'release': sets the blob group release name to 'release'.
+      - 'release': sets the blob group release name to 'release'. Can be used for prereleases and full releases.
     -->
     <BlobGroupBuildQuality>release</BlobGroupBuildQuality>
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -29,22 +29,13 @@
       
       <!-- Prerelease: '6.0.0-preview.8' -> '6.0.0' and 'preview.8' -->
       <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring(0, $(_PreReleaseSeperatorIndex)))</_BlobGroupVersion>
-      <_BlobGroupPreRelease Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(PackageVersion.Substring($([MSBuild]::Add($(_PreReleaseSeperatorIndex), 1))))</_BlobGroupPreRelease>
       
       <!-- Release: take the package version as-is. -->
       <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' == '-1'">$(PackageVersion)</_BlobGroupVersion>
-
-      <!--
-        Prerelease may contain additional fields; only want the label and first number
-        (e.g. 'preview.1.12345' -> 'preview' and '1').
-        -->
-      <_BlobGroupPreReleaseLabel Condition="'$(_BlobGroupPreRelease)' != ''">$(_BlobGroupPreRelease.Split('.')[0])</_BlobGroupPreReleaseLabel>
-      <_BlobGroupPreReleaseIteration Condition="'$(_BlobGroupPreRelease)' != ''">$(_BlobGroupPreRelease.Split('.')[1])</_BlobGroupPreReleaseIteration>
     </PropertyGroup>
     <!-- These are the valid BlobGroupBuildQuality values. -->
     <ItemGroup>
       <_BlobGroupBuildQualityName Include="daily" ReleaseName="daily" />
-      <_BlobGroupBuildQualityName Include="prerelease" ReleaseName="$(_BlobGroupPreReleaseLabel).$(_BlobGroupPreReleaseIteration)" />
       <_BlobGroupBuildQualityName Include="release" ReleaseName="release" />
     </ItemGroup>
     <!-- Select the blob group build quality based on the specified property. -->
@@ -67,7 +58,6 @@
       <!--
         Combine all parts to create blob group name.
         Daily: '6.0.0-preview.1.12345' -> '6.0/daily'
-        Prerelease: '6.0.0-preview.1.12345' -> '6.0/preview.1'
         Release: '6.0.0' -> '6.0/release'
         -->
       <_BlobGroupName>$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet-monitor/pull/1813 to release/6.1

/cc @jander-msft