### PR TITLE
Fix shipping metadata for blob files

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -74,7 +74,7 @@
 
   <Target Name="CalculatePackagesToPublish">
     <ItemGroup>
-      <PackageToPublish Include="%(PackageFile.Identity)"
+      <PackageToPublish Include="@(PackageFile)"
                         Condition="$([System.IO.File]::Exists('%(PackageFile.Identity).projectpath'))" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
The metadata on the PackageFile items was accidentally dropped in #1834, which causes all of the files uploaded to the dotnetbuilds storage account to be marked as non-shipping. This fix includes the metadata from the PackageFile items in the PackageToPublish items to allow shipping vs non-shipping to be tracked correctly.