### PR TITLE
Update OSS Versions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -13,6 +13,7 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <!-- Standard feeds -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -49,7 +49,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -58,7 +60,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -66,7 +70,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           }
         ],
@@ -104,7 +110,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -113,7 +121,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -121,7 +131,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           }
         ],
@@ -162,7 +174,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -171,7 +185,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -179,7 +195,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -195,7 +213,9 @@
             "in": "query",
             "description": "The egress provider to which the dump is saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the dump is saved.",
+              "nullable": true
             }
           }
         ],
@@ -240,7 +260,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -249,7 +271,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -257,7 +281,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -265,7 +291,9 @@
             "in": "query",
             "description": "The egress provider to which the GC dump is saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the GC dump is saved.",
+              "nullable": true
             }
           }
         ],
@@ -310,7 +338,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -319,7 +349,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -327,7 +359,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -346,6 +380,7 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
+              "description": "The duration of the trace session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -355,7 +390,9 @@
             "in": "query",
             "description": "The egress provider to which the trace is saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the trace is saved.",
+              "nullable": true
             }
           }
         ],
@@ -398,7 +435,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -407,7 +446,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -415,7 +456,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -426,6 +469,7 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
+              "description": "The duration of the trace session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -435,7 +479,9 @@
             "in": "query",
             "description": "The egress provider to which the trace is saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the trace is saved.",
+              "nullable": true
             }
           }
         ],
@@ -501,7 +547,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -510,7 +558,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -518,7 +568,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -529,6 +581,7 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
+              "description": "The duration of the logs session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -546,7 +599,9 @@
             "in": "query",
             "description": "The egress provider to which the logs are saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the logs are saved.",
+              "nullable": true
             }
           }
         ],
@@ -598,7 +653,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -607,7 +664,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -615,7 +674,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -626,6 +687,7 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
+              "description": "The duration of the logs session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -635,7 +697,9 @@
             "in": "query",
             "description": "The egress provider to which the logs are saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the logs are saved.",
+              "nullable": true
             }
           }
         ],
@@ -736,7 +800,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -745,7 +811,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -753,7 +821,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -764,6 +834,7 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
+              "description": "The duration of the metrics session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -773,7 +844,9 @@
             "in": "query",
             "description": "The egress provider to which the metrics are saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the metrics are saved.",
+              "nullable": true
             }
           }
         ],
@@ -805,7 +878,9 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "format": "int32"
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
             }
           },
           {
@@ -814,7 +889,9 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
             }
           },
           {
@@ -822,7 +899,9 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
             }
           },
           {
@@ -833,6 +912,7 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
+              "description": "The duration of the metrics session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -842,7 +922,9 @@
             "in": "query",
             "description": "The egress provider to which the metrics are saved.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "The egress provider to which the metrics are saved.",
+              "nullable": true
             }
           }
         ],
@@ -1002,246 +1084,7 @@
   },
   "components": {
     "schemas": {
-      "DiagnosticPortConnectionMode": {
-        "enum": [
-          "Connect",
-          "Listen"
-        ],
-        "type": "string"
-      },
-      "DotnetMonitorInfo": {
-        "type": "object",
-        "properties": {
-          "version": {
-            "type": "string",
-            "description": "The dotnet monitor version.",
-            "nullable": true
-          },
-          "runtimeVersion": {
-            "type": "string",
-            "description": "The dotnet runtime version.",
-            "nullable": true
-          },
-          "diagnosticPortMode": {
-            "$ref": "#/components/schemas/DiagnosticPortConnectionMode"
-          },
-          "diagnosticPortName": {
-            "type": "string",
-            "description": "The name of the named pipe or unix domain socket to use for connecting to the diagnostic server.",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "DumpType": {
-        "enum": [
-          "Full",
-          "Mini",
-          "WithHeap",
-          "Triage"
-        ],
-        "type": "string"
-      },
-      "EventLevel": {
-        "enum": [
-          "LogAlways",
-          "Critical",
-          "Error",
-          "Warning",
-          "Informational",
-          "Verbose"
-        ],
-        "type": "string"
-      },
-      "EventMetricsConfiguration": {
-        "type": "object",
-        "properties": {
-          "includeDefaultProviders": {
-            "type": "boolean"
-          },
-          "providers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EventMetricsProvider"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "EventMetricsProvider": {
-        "required": [
-          "providerName"
-        ],
-        "type": "object",
-        "properties": {
-          "providerName": {
-            "type": "string"
-          },
-          "counterNames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "EventPipeConfiguration": {
-        "required": [
-          "providers"
-        ],
-        "type": "object",
-        "properties": {
-          "providers": {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EventPipeProvider"
-            }
-          },
-          "requestRundown": {
-            "type": "boolean"
-          },
-          "bufferSizeInMB": {
-            "maximum": 1024,
-            "minimum": 1,
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "EventPipeProvider": {
-        "required": [
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "keywords": {
-            "type": "string",
-            "nullable": true
-          },
-          "eventLevel": {
-            "$ref": "#/components/schemas/EventLevel"
-          },
-          "arguments": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "LogLevel": {
-        "enum": [
-          "Trace",
-          "Debug",
-          "Information",
-          "Warning",
-          "Error",
-          "Critical",
-          "None"
-        ],
-        "type": "string"
-      },
-      "LogsConfiguration": {
-        "required": [
-          "logLevel"
-        ],
-        "type": "object",
-        "properties": {
-          "logLevel": {
-            "$ref": "#/components/schemas/LogLevel"
-          },
-          "filterSpecs": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/LogLevel"
-            },
-            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.",
-            "nullable": true
-          },
-          "useAppFilters": {
-            "type": "boolean",
-            "description": "Set to true to collect logs at the application-defined categories and levels."
-          }
-        },
-        "additionalProperties": false
-      },
-      "OperationError": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "nullable": true
-          },
-          "message": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "OperationState": {
-        "enum": [
-          "Running",
-          "Succeeded",
-          "Failed",
-          "Cancelled"
-        ],
-        "type": "string"
-      },
-      "OperationStatus": {
-        "type": "object",
-        "properties": {
-          "operationId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "createdDateTime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/OperationState"
-          },
-          "resourceLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "error": {
-            "$ref": "#/components/schemas/OperationError"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Represents the state of a long running operation. Used for all types of results, including successes and failures."
-      },
-      "OperationSummary": {
-        "type": "object",
-        "properties": {
-          "operationId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "createdDateTime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/OperationState"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Represents a partial model when enumerating all operations."
-      },
-      "ProblemDetails": {
+      "ValidationProblemDetails": {
         "type": "object",
         "properties": {
           "type": {
@@ -1264,6 +1107,17 @@
           "instance": {
             "type": "string",
             "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "nullable": true,
+            "readOnly": true
           }
         },
         "additionalProperties": { }
@@ -1319,16 +1173,16 @@
         },
         "additionalProperties": false
       },
-      "TraceProfile": {
+      "DumpType": {
         "enum": [
-          "Cpu",
-          "Http",
-          "Logs",
-          "Metrics"
+          "Full",
+          "Mini",
+          "WithHeap",
+          "Triage"
         ],
         "type": "string"
       },
-      "ValidationProblemDetails": {
+      "ProblemDetails": {
         "type": "object",
         "properties": {
           "type": {
@@ -1351,19 +1205,248 @@
           "instance": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "TraceProfile": {
+        "enum": [
+          "Cpu",
+          "Http",
+          "Logs",
+          "Metrics"
+        ],
+        "type": "string"
+      },
+      "EventLevel": {
+        "enum": [
+          "LogAlways",
+          "Critical",
+          "Error",
+          "Warning",
+          "Informational",
+          "Verbose"
+        ],
+        "type": "string"
+      },
+      "EventPipeProvider": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "errors": {
+          "keywords": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventLevel": {
+            "$ref": "#/components/schemas/EventLevel"
+          },
+          "arguments": {
             "type": "object",
             "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "string"
             },
             "nullable": true
           }
         },
-        "additionalProperties": { }
+        "additionalProperties": false
+      },
+      "EventPipeConfiguration": {
+        "required": [
+          "providers"
+        ],
+        "type": "object",
+        "properties": {
+          "providers": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventPipeProvider"
+            }
+          },
+          "requestRundown": {
+            "type": "boolean"
+          },
+          "bufferSizeInMB": {
+            "maximum": 1024,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogLevel": {
+        "enum": [
+          "Trace",
+          "Debug",
+          "Information",
+          "Warning",
+          "Error",
+          "Critical",
+          "None"
+        ],
+        "type": "string"
+      },
+      "LogsConfiguration": {
+        "required": [
+          "logLevel"
+        ],
+        "type": "object",
+        "properties": {
+          "logLevel": {
+            "$ref": "#/components/schemas/LogLevel"
+          },
+          "filterSpecs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/LogLevel"
+            },
+            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.",
+            "nullable": true
+          },
+          "useAppFilters": {
+            "type": "boolean",
+            "description": "Set to true to collect logs at the application-defined categories and levels."
+          }
+        },
+        "additionalProperties": false
+      },
+      "DiagnosticPortConnectionMode": {
+        "enum": [
+          "Connect",
+          "Listen"
+        ],
+        "type": "string"
+      },
+      "DotnetMonitorInfo": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "The dotnet monitor version.",
+            "nullable": true
+          },
+          "runtimeVersion": {
+            "type": "string",
+            "description": "The dotnet runtime version.",
+            "nullable": true
+          },
+          "diagnosticPortMode": {
+            "$ref": "#/components/schemas/DiagnosticPortConnectionMode"
+          },
+          "diagnosticPortName": {
+            "type": "string",
+            "description": "The name of the named pipe or unix domain socket to use for connecting to the diagnostic server.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventMetricsProvider": {
+        "required": [
+          "providerName"
+        ],
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "counterNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventMetricsConfiguration": {
+        "type": "object",
+        "properties": {
+          "includeDefaultProviders": {
+            "type": "boolean"
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventMetricsProvider"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OperationState": {
+        "enum": [
+          "Running",
+          "Succeeded",
+          "Failed",
+          "Cancelled"
+        ],
+        "type": "string"
+      },
+      "OperationSummary": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationState"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a partial model when enumerating all operations."
+      },
+      "OperationError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OperationStatus": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationState"
+          },
+          "resourceLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/OperationError"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents the state of a long running operation. Used for all types of results, including successes and failures."
       }
     },
     "responses": {

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -49,9 +49,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -60,9 +58,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -70,9 +66,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -110,9 +104,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -121,9 +113,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -131,9 +121,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -174,9 +162,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -185,9 +171,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -195,9 +179,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -213,9 +195,7 @@
             "in": "query",
             "description": "The egress provider to which the dump is saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the dump is saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -260,9 +240,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -271,9 +249,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -281,9 +257,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -291,9 +265,7 @@
             "in": "query",
             "description": "The egress provider to which the GC dump is saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the GC dump is saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -338,9 +310,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -349,9 +319,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -359,9 +327,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -380,7 +346,6 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the trace session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -390,9 +355,7 @@
             "in": "query",
             "description": "The egress provider to which the trace is saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the trace is saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -435,9 +398,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -446,9 +407,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -456,9 +415,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -469,7 +426,6 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the trace session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -479,9 +435,7 @@
             "in": "query",
             "description": "The egress provider to which the trace is saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the trace is saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -547,9 +501,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -558,9 +510,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -568,9 +518,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -581,7 +529,6 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the logs session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -599,9 +546,7 @@
             "in": "query",
             "description": "The egress provider to which the logs are saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the logs are saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -653,9 +598,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -664,9 +607,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -674,9 +615,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -687,7 +626,6 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the logs session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -697,9 +635,7 @@
             "in": "query",
             "description": "The egress provider to which the logs are saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the logs are saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -800,9 +736,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -811,9 +745,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -821,9 +753,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -834,7 +764,6 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the metrics session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -844,9 +773,7 @@
             "in": "query",
             "description": "The egress provider to which the metrics are saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the metrics are saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -878,9 +805,7 @@
             "description": "Process ID used to identify the target process.",
             "schema": {
               "type": "integer",
-              "description": "Process ID used to identify the target process.",
-              "format": "int32",
-              "nullable": true
+              "format": "int32"
             }
           },
           {
@@ -889,9 +814,7 @@
             "description": "The Runtime instance cookie used to identify the target process.",
             "schema": {
               "type": "string",
-              "description": "The Runtime instance cookie used to identify the target process.",
-              "format": "uuid",
-              "nullable": true
+              "format": "uuid"
             }
           },
           {
@@ -899,9 +822,7 @@
             "in": "query",
             "description": "Process name used to identify the target process.",
             "schema": {
-              "type": "string",
-              "description": "Process name used to identify the target process.",
-              "nullable": true
+              "type": "string"
             }
           },
           {
@@ -912,7 +833,6 @@
               "maximum": 2147483647,
               "minimum": -1,
               "type": "integer",
-              "description": "The duration of the metrics session (in seconds).",
               "format": "int32",
               "default": 30
             }
@@ -922,9 +842,7 @@
             "in": "query",
             "description": "The egress provider to which the metrics are saved.",
             "schema": {
-              "type": "string",
-              "description": "The egress provider to which the metrics are saved.",
-              "nullable": true
+              "type": "string"
             }
           }
         ],
@@ -1084,7 +1002,246 @@
   },
   "components": {
     "schemas": {
-      "ValidationProblemDetails": {
+      "DiagnosticPortConnectionMode": {
+        "enum": [
+          "Connect",
+          "Listen"
+        ],
+        "type": "string"
+      },
+      "DotnetMonitorInfo": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "The dotnet monitor version.",
+            "nullable": true
+          },
+          "runtimeVersion": {
+            "type": "string",
+            "description": "The dotnet runtime version.",
+            "nullable": true
+          },
+          "diagnosticPortMode": {
+            "$ref": "#/components/schemas/DiagnosticPortConnectionMode"
+          },
+          "diagnosticPortName": {
+            "type": "string",
+            "description": "The name of the named pipe or unix domain socket to use for connecting to the diagnostic server.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DumpType": {
+        "enum": [
+          "Full",
+          "Mini",
+          "WithHeap",
+          "Triage"
+        ],
+        "type": "string"
+      },
+      "EventLevel": {
+        "enum": [
+          "LogAlways",
+          "Critical",
+          "Error",
+          "Warning",
+          "Informational",
+          "Verbose"
+        ],
+        "type": "string"
+      },
+      "EventMetricsConfiguration": {
+        "type": "object",
+        "properties": {
+          "includeDefaultProviders": {
+            "type": "boolean"
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventMetricsProvider"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventMetricsProvider": {
+        "required": [
+          "providerName"
+        ],
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "counterNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventPipeConfiguration": {
+        "required": [
+          "providers"
+        ],
+        "type": "object",
+        "properties": {
+          "providers": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventPipeProvider"
+            }
+          },
+          "requestRundown": {
+            "type": "boolean"
+          },
+          "bufferSizeInMB": {
+            "maximum": 1024,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventPipeProvider": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventLevel": {
+            "$ref": "#/components/schemas/EventLevel"
+          },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogLevel": {
+        "enum": [
+          "Trace",
+          "Debug",
+          "Information",
+          "Warning",
+          "Error",
+          "Critical",
+          "None"
+        ],
+        "type": "string"
+      },
+      "LogsConfiguration": {
+        "required": [
+          "logLevel"
+        ],
+        "type": "object",
+        "properties": {
+          "logLevel": {
+            "$ref": "#/components/schemas/LogLevel"
+          },
+          "filterSpecs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/LogLevel"
+            },
+            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.",
+            "nullable": true
+          },
+          "useAppFilters": {
+            "type": "boolean",
+            "description": "Set to true to collect logs at the application-defined categories and levels."
+          }
+        },
+        "additionalProperties": false
+      },
+      "OperationError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OperationState": {
+        "enum": [
+          "Running",
+          "Succeeded",
+          "Failed",
+          "Cancelled"
+        ],
+        "type": "string"
+      },
+      "OperationStatus": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationState"
+          },
+          "resourceLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/OperationError"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents the state of a long running operation. Used for all types of results, including successes and failures."
+      },
+      "OperationSummary": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationState"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a partial model when enumerating all operations."
+      },
+      "ProblemDetails": {
         "type": "object",
         "properties": {
           "type": {
@@ -1107,17 +1264,6 @@
           "instance": {
             "type": "string",
             "nullable": true
-          },
-          "errors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "nullable": true,
-            "readOnly": true
           }
         },
         "additionalProperties": { }
@@ -1173,16 +1319,16 @@
         },
         "additionalProperties": false
       },
-      "DumpType": {
+      "TraceProfile": {
         "enum": [
-          "Full",
-          "Mini",
-          "WithHeap",
-          "Triage"
+          "Cpu",
+          "Http",
+          "Logs",
+          "Metrics"
         ],
         "type": "string"
       },
-      "ProblemDetails": {
+      "ValidationProblemDetails": {
         "type": "object",
         "properties": {
           "type": {
@@ -1205,248 +1351,19 @@
           "instance": {
             "type": "string",
             "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "nullable": true
           }
         },
         "additionalProperties": { }
-      },
-      "TraceProfile": {
-        "enum": [
-          "Cpu",
-          "Http",
-          "Logs",
-          "Metrics"
-        ],
-        "type": "string"
-      },
-      "EventLevel": {
-        "enum": [
-          "LogAlways",
-          "Critical",
-          "Error",
-          "Warning",
-          "Informational",
-          "Verbose"
-        ],
-        "type": "string"
-      },
-      "EventPipeProvider": {
-        "required": [
-          "name"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "keywords": {
-            "type": "string",
-            "nullable": true
-          },
-          "eventLevel": {
-            "$ref": "#/components/schemas/EventLevel"
-          },
-          "arguments": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "EventPipeConfiguration": {
-        "required": [
-          "providers"
-        ],
-        "type": "object",
-        "properties": {
-          "providers": {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EventPipeProvider"
-            }
-          },
-          "requestRundown": {
-            "type": "boolean"
-          },
-          "bufferSizeInMB": {
-            "maximum": 1024,
-            "minimum": 1,
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "LogLevel": {
-        "enum": [
-          "Trace",
-          "Debug",
-          "Information",
-          "Warning",
-          "Error",
-          "Critical",
-          "None"
-        ],
-        "type": "string"
-      },
-      "LogsConfiguration": {
-        "required": [
-          "logLevel"
-        ],
-        "type": "object",
-        "properties": {
-          "logLevel": {
-            "$ref": "#/components/schemas/LogLevel"
-          },
-          "filterSpecs": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/LogLevel"
-            },
-            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.",
-            "nullable": true
-          },
-          "useAppFilters": {
-            "type": "boolean",
-            "description": "Set to true to collect logs at the application-defined categories and levels."
-          }
-        },
-        "additionalProperties": false
-      },
-      "DiagnosticPortConnectionMode": {
-        "enum": [
-          "Connect",
-          "Listen"
-        ],
-        "type": "string"
-      },
-      "DotnetMonitorInfo": {
-        "type": "object",
-        "properties": {
-          "version": {
-            "type": "string",
-            "description": "The dotnet monitor version.",
-            "nullable": true
-          },
-          "runtimeVersion": {
-            "type": "string",
-            "description": "The dotnet runtime version.",
-            "nullable": true
-          },
-          "diagnosticPortMode": {
-            "$ref": "#/components/schemas/DiagnosticPortConnectionMode"
-          },
-          "diagnosticPortName": {
-            "type": "string",
-            "description": "The name of the named pipe or unix domain socket to use for connecting to the diagnostic server.",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "EventMetricsProvider": {
-        "required": [
-          "providerName"
-        ],
-        "type": "object",
-        "properties": {
-          "providerName": {
-            "type": "string"
-          },
-          "counterNames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "EventMetricsConfiguration": {
-        "type": "object",
-        "properties": {
-          "includeDefaultProviders": {
-            "type": "boolean"
-          },
-          "providers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EventMetricsProvider"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "OperationState": {
-        "enum": [
-          "Running",
-          "Succeeded",
-          "Failed",
-          "Cancelled"
-        ],
-        "type": "string"
-      },
-      "OperationSummary": {
-        "type": "object",
-        "properties": {
-          "operationId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "createdDateTime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/OperationState"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Represents a partial model when enumerating all operations."
-      },
-      "OperationError": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "nullable": true
-          },
-          "message": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "OperationStatus": {
-        "type": "object",
-        "properties": {
-          "operationId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "createdDateTime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/OperationState"
-          },
-          "resourceLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "error": {
-            "$ref": "#/components/schemas/OperationError"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Represents the state of a long running operation. Used for all types of results, including successes and failures."
       }
     },
     "responses": {

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,7 +78,7 @@
     <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftIdentityModelTokensVersion>6.17.0</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
-    <SystemCommandLineVersion>2.0.0-beta1.21308.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta3.22173.1</SystemCommandLineVersion>
     <SystemIdentityModelTokensJwtVersion>6.17.0</SystemIdentityModelTokensJwtVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,25 +67,25 @@
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp70Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
-    <AzureStorageBlobsVersion>12.10.0</AzureStorageBlobsVersion>
-    <AzureStorageQueuesVersion>12.8.0</AzureStorageQueuesVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>6.0.0</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>6.0.0</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <AzureStorageBlobsVersion>12.12.0</AzureStorageBlobsVersion>
+    <AzureStorageQueuesVersion>12.10.0</AzureStorageQueuesVersion>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>6.0.4</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>6.0.4</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.0</MicrosoftExtensionsConfigurationKeyPerFileVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.4</MicrosoftExtensionsConfigurationKeyPerFileVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
-    <MicrosoftIdentityModelTokensVersion>6.11.1</MicrosoftIdentityModelTokensVersion>
+    <MicrosoftIdentityModelTokensVersion>6.17.0</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
-    <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
-    <SystemIdentityModelTokensJwtVersion>6.11.1</SystemIdentityModelTokensJwtVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.21308.1</SystemCommandLineVersion>
+    <SystemIdentityModelTokensJwtVersion>6.17.0</SystemIdentityModelTokensJwtVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
+    <SystemTextJsonVersion>6.0.3</SystemTextJsonVersion>
     <!-- Third-party references -->
-    <NJsonSchemaVersion>10.3.11</NJsonSchemaVersion>
-    <SwashbuckleAspNetCoreSwaggerGenVersion>5.6.3</SwashbuckleAspNetCoreSwaggerGenVersion>
+    <NJsonSchemaVersion>10.5.2</NJsonSchemaVersion>
+    <SwashbuckleAspNetCoreSwaggerGenVersion>6.2.3</SwashbuckleAspNetCoreSwaggerGenVersion>
     <XunitAssertVersion>2.4.1</XunitAssertVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dev Workflow">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,7 +84,7 @@
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <!-- Third-party references -->
     <NJsonSchemaVersion>10.5.2</NJsonSchemaVersion>
-    <SwashbuckleAspNetCoreSwaggerGenVersion>6.2.3</SwashbuckleAspNetCoreSwaggerGenVersion>
+    <SwashbuckleAspNetCoreSwaggerGenVersion>5.6.3</SwashbuckleAspNetCoreSwaggerGenVersion>
     <XunitAssertVersion>2.4.1</XunitAssertVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dev Workflow">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,10 +69,10 @@
   <PropertyGroup Label="Manual">
     <AzureStorageBlobsVersion>12.12.0</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.10.0</AzureStorageQueuesVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>6.0.4</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>6.0.4</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>6.0.5</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>6.0.5</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.4</MicrosoftExtensionsConfigurationKeyPerFileVersion>
+    <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.5</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
@@ -82,7 +82,6 @@
     <SystemIdentityModelTokensJwtVersion>6.17.0</SystemIdentityModelTokensJwtVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextJsonVersion>6.0.3</SystemTextJsonVersion>
     <!-- Third-party references -->
     <NJsonSchemaVersion>10.5.2</NJsonSchemaVersion>
     <SwashbuckleAspNetCoreSwaggerGenVersion>6.2.3</SwashbuckleAspNetCoreSwaggerGenVersion>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios;
+using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
@@ -13,14 +14,16 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
     {
         public static Task<int> Main(string[] args)
         {
-            return new CommandLineBuilder()
-                .AddCommand(AsyncWaitScenario.Command())
-                .AddCommand(LoggerScenario.Command())
-                .AddCommand(SpinWaitScenario.Command())
-                .AddCommand(EnvironmentVariablesScenario.Command())
-                .UseDefaults()
-                .Build()
-                .InvokeAsync(args);
+            return new CommandLineBuilder(new RootCommand()
+            {
+                AsyncWaitScenario.Command(),
+                LoggerScenario.Command(),
+                SpinWaitScenario.Command(),
+                EnvironmentVariablesScenario.Command()
+            })
+            .UseDefaults()
+            .Build()
+            .InvokeAsync(args);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AsyncWaitScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AsyncWaitScenario.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         public static Command Command()
         {
             Command command = new(TestAppScenarios.AsyncWait.Name);
-            command.Handler = CommandHandler.Create((Func<CancellationToken, Task<int>>)ExecuteAsync);
+            command.SetHandler((Func<CancellationToken, Task<int>>)ExecuteAsync);
             return command;
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/EnvironmentVariablesScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/EnvironmentVariablesScenario.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         public static Command Command()
         {
             Command command = new(TestAppScenarios.EnvironmentVariables.Name);
-            command.Handler = CommandHandler.Create((Func<CancellationToken, Task<int>>)ExecuteAsync);
+            command.SetHandler((Func<CancellationToken, Task<int>>)ExecuteAsync);
             return command;
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/LoggerScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/LoggerScenario.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         public static Command Command()
         {
             Command command = new(TestAppScenarios.Logger.Name);
-            command.Handler = CommandHandler.Create((Func<CancellationToken, Task<int>>)ExecuteAsync);
+            command.SetHandler((Func<CancellationToken, Task<int>>)ExecuteAsync);
             return command;
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/SpinWaitScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/SpinWaitScenario.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         public static Command Command()
         {
             Command command = new(TestAppScenarios.SpinWait.Name);
-            command.Handler = CommandHandler.Create((Func<CancellationToken, Task<int>>)ExecuteAsync);
+            command.SetHandler((Func<CancellationToken, Task<int>>)ExecuteAsync);
             return command;
         }
 

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 description: Strings.HelpDescription_OptionNoHttpEgress,
                 getDefaultValue: () => false)
             {
-                ArgumentHelpName =  "noHttpEgress"
+                ArgumentHelpName = "noHttpEgress"
             };
 
         private static Option TempApiKey() =>

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -60,25 +60,28 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private static Option Urls() =>
             new Option(
                 aliases: new[] { "-u", "--urls" },
-                description: Strings.HelpDescription_OptionUrls)
+                description: Strings.HelpDescription_OptionUrls,
+                getDefaultValue: () => new[] { "https://localhost:52323" })
             {
-                Argument = new Argument<string[]>(name: "urls", getDefaultValue: () => new[] { "https://localhost:52323" })
+                ArgumentHelpName = "urls"
             };
 
         private static Option MetricUrls() =>
-            new Option(
+            new Option<string[]>(
                 aliases: new[] { "--metricUrls" },
-                description: Strings.HelpDescription_OptionMetricsUrls)
+                description: Strings.HelpDescription_OptionMetricsUrls,
+                getDefaultValue: () => new[] { "http://localhost:52325" })
             {
-                Argument = new Argument<string[]>(name: "metricUrls", getDefaultValue: () => new[] { "http://localhost:52325" })
+                ArgumentHelpName = "metricUrls"
             };
 
         private static Option ProvideMetrics() =>
             new Option(
                 aliases: new[] { "-m", "--metrics" },
-                description: Strings.HelpDescription_OptionMetrics)
+                description: Strings.HelpDescription_OptionMetrics,
+                getDefaultValue: () => true)
             {
-                Argument = new Argument<bool>(name: "metrics", getDefaultValue: () => true)
+                ArgumentHelpName = "metrics"
             };
 
         private static Option DiagnosticPort() =>
@@ -86,58 +89,61 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 alias: "--diagnostic-port",
                 description: Strings.HelpDescription_OptionDiagnosticPort)
             {
-                Argument = new Argument<string>(name: "diagnosticPort")
+                ArgumentHelpName = "diagnosticPort"
             };
 
         private static Option NoAuth() =>
             new Option(
                 alias: "--no-auth",
-                description: Strings.HelpDescription_OptionNoAuth
-                )
+                description: Strings.HelpDescription_OptionNoAuth,
+                getDefaultValue: () => false)
             {
-                Argument = new Argument<bool>(name: "noAuth", getDefaultValue: () => false)
+                ArgumentHelpName = "noAuth"
             };
 
         private static Option NoHttpEgress() =>
             new Option(
                 alias: "--no-http-egress",
-                description: Strings.HelpDescription_OptionNoHttpEgress
-                )
+                description: Strings.HelpDescription_OptionNoHttpEgress,
+                getDefaultValue: () => false)
             {
-                Argument = new Argument<bool>(name: "noHttpEgress", getDefaultValue: () => false)
+                ArgumentHelpName =  "noHttpEgress"
             };
 
         private static Option TempApiKey() =>
             new Option(
                 alias: "--temp-apikey",
-                description: Strings.HelpDescription_OptionTempApiKey
-                )
+                description: Strings.HelpDescription_OptionTempApiKey,
+                getDefaultValue: () => false)
             {
-                Argument = new Argument<bool>(name: "tempApiKey", getDefaultValue: () => false)
+                ArgumentHelpName = "tempApiKey"
             };
 
         private static Option Output() =>
             new Option(
                 aliases: new[] { "-o", "--output" },
-                description: Strings.HelpDescription_OutputFormat)
+                description: Strings.HelpDescription_OutputFormat,
+                getDefaultValue: () => OutputFormat.Json)
             {
-                Argument = new Argument<OutputFormat>(name: "output", getDefaultValue: () => OutputFormat.Json)
+                ArgumentHelpName = "output"
             };
 
         private static Option ConfigLevel() =>
             new Option(
                 alias: "--level",
-                description: Strings.HelpDescription_OptionLevel)
+                description: Strings.HelpDescription_OptionLevel,
+                getDefaultValue: () => ConfigDisplayLevel.Redacted)
             {
-                Argument = new Argument<ConfigDisplayLevel>(name: "level", getDefaultValue: () => ConfigDisplayLevel.Redacted)
+                ArgumentHelpName = "level"
             };
 
         private static Option ShowSources() =>
             new Option(
                 alias: "--show-sources",
-                description: Strings.HelpDescription_OptionShowSources)
+                description: Strings.HelpDescription_OptionShowSources,
+                getDefaultValue: () => false)
             {
-                Argument = new Argument<bool>(name: "showSources", getDefaultValue: () => false)
+                ArgumentHelpName = "showSources"
             };
 
         public static Task<int> Main(string[] args)

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         };
         
         private static Option Urls() =>
-            new Option(
+            new Option<string[]>(
                 aliases: new[] { "-u", "--urls" },
                 description: Strings.HelpDescription_OptionUrls,
                 getDefaultValue: () => new[] { "https://localhost:52323" })
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option ProvideMetrics() =>
-            new Option(
+            new Option<bool>(
                 aliases: new[] { "-m", "--metrics" },
                 description: Strings.HelpDescription_OptionMetrics,
                 getDefaultValue: () => true)
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option DiagnosticPort() =>
-            new Option(
+            new Option<string>(
                 alias: "--diagnostic-port",
                 description: Strings.HelpDescription_OptionDiagnosticPort)
             {
@@ -93,7 +93,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option NoAuth() =>
-            new Option(
+            new Option<bool>(
                 alias: "--no-auth",
                 description: Strings.HelpDescription_OptionNoAuth,
                 getDefaultValue: () => false)
@@ -102,7 +102,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option NoHttpEgress() =>
-            new Option(
+            new Option<bool>(
                 alias: "--no-http-egress",
                 description: Strings.HelpDescription_OptionNoHttpEgress,
                 getDefaultValue: () => false)
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option TempApiKey() =>
-            new Option(
+            new Option<bool>(
                 alias: "--temp-apikey",
                 description: Strings.HelpDescription_OptionTempApiKey,
                 getDefaultValue: () => false)
@@ -120,7 +120,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option Output() =>
-            new Option(
+            new Option<OutputFormat>(
                 aliases: new[] { "-o", "--output" },
                 description: Strings.HelpDescription_OutputFormat,
                 getDefaultValue: () => OutputFormat.Json)
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option ConfigLevel() =>
-            new Option(
+            new Option<ConfigDisplayLevel>(
                 alias: "--level",
                 description: Strings.HelpDescription_OptionLevel,
                 getDefaultValue: () => ConfigDisplayLevel.Redacted)
@@ -138,7 +138,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
 
         private static Option ShowSources() =>
-            new Option(
+            new Option<bool>(
                 alias: "--show-sources",
                 description: Strings.HelpDescription_OptionShowSources,
                 getDefaultValue: () => false)

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -10,47 +10,81 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
     class Program
     {
-        private static Command GenerateApiKeyCommand() =>
-            new Command(
+        private static Command GenerateApiKeyCommand()
+        {
+            Command command = new Command(
                 name: "generatekey",
-                description: Strings.HelpDescription_CommandGenerateKey)
+                description: Strings.HelpDescription_CommandGenerateKey);
+
+            var output = Output();
+
+            command.Add(output);
+
+            command.SetHandler((CancellationToken token, OutputFormat output, IConsole console) => GenerateApiKeyCommandHandler.Invoke(token, output, console), output);
+
+            return command;
+        }
+
+        private static Command CollectCommand()
+        {
+            var urls = Urls();
+            var metricUrls = MetricUrls();
+            var provideMetrics = ProvideMetrics();
+            var diagnosticPort = DiagnosticPort();
+            var noAuth = NoAuth();
+            var tempApiKey = TempApiKey();
+            var noHttpEgress = NoHttpEgress();
+
+            Command command = new Command(
+                name: "collect",
+                description: Strings.HelpDescription_CommandCollect)
             {
-                CommandHandler.Create(GenerateApiKeyCommandHandler.Invoke),
-                Output()
+                urls, metricUrls, provideMetrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress
             };
 
+            //command.Add(SharedOptions());
+
+            //             Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth(), TempApiKey(), NoHttpEgress()
+
+            command.SetHandler((CancellationToken token, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress) => CollectCommandHandler.Invoke(token, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress), urls, metricUrls, provideMetrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress);
+
+            return command;
+        }
+
+        /*
         private static Command CollectCommand() =>
             new Command(
                 name: "collect",
                 description: Strings.HelpDescription_CommandCollect)
             {
                 // Handler
-                CommandHandler.Create(CollectCommandHandler.Invoke),
+                CommandHandler.Create(CollectCommandHandler.Dummy),
                 SharedOptions()
             };
+        */
 
-        private static Command ConfigCommand() =>
-            new Command(
+        private static Command ConfigCommand()
+        {
+            // Doesn't have show
+            Command command = new Command(
                 name: "config",
-                description: Strings.HelpDescription_CommandConfig)
-            {
-                new Command(
-                    name: "show",
-                    description: Strings.HelpDescription_CommandShow)
-                {
-                    // Handler
-                    CommandHandler.Create(ConfigShowCommandHandler.Invoke),
-                    SharedOptions(),
-                    ConfigLevel(),
-                    ShowSources()
-                }
-            };
+                description: Strings.HelpDescription_CommandConfig);
+
+            command.Add(SharedOptions());
+            command.Add(ConfigLevel());
+            command.Add(ShowSources());
+
+            command.SetHandler((string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, ConfigDisplayLevel level, bool showSources) => ConfigShowCommandHandler.Invoke(urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, noHttpEgress, level, showSources));
+
+            return command;
+        }
 
         private static IEnumerable<Option> SharedOptions() => new Option[]
         {
@@ -86,7 +120,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option DiagnosticPort() =>
             new Option<string>(
-                alias: "--diagnostic-port",
+                name: "--diagnostic-port",
                 description: Strings.HelpDescription_OptionDiagnosticPort)
             {
                 ArgumentHelpName = "diagnosticPort"
@@ -94,7 +128,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option NoAuth() =>
             new Option<bool>(
-                alias: "--no-auth",
+                name: "--no-auth",
                 description: Strings.HelpDescription_OptionNoAuth,
                 getDefaultValue: () => false)
             {
@@ -103,7 +137,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option NoHttpEgress() =>
             new Option<bool>(
-                alias: "--no-http-egress",
+                name: "--no-http-egress",
                 description: Strings.HelpDescription_OptionNoHttpEgress,
                 getDefaultValue: () => false)
             {
@@ -112,7 +146,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option TempApiKey() =>
             new Option<bool>(
-                alias: "--temp-apikey",
+                name: "--temp-apikey",
                 description: Strings.HelpDescription_OptionTempApiKey,
                 getDefaultValue: () => false)
             {
@@ -130,7 +164,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option ConfigLevel() =>
             new Option<ConfigDisplayLevel>(
-                alias: "--level",
+                name: "--level",
                 description: Strings.HelpDescription_OptionLevel,
                 getDefaultValue: () => ConfigDisplayLevel.Redacted)
             {
@@ -139,7 +173,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static Option ShowSources() =>
             new Option<bool>(
-                alias: "--show-sources",
+                name: "--show-sources",
                 description: Strings.HelpDescription_OptionShowSources,
                 getDefaultValue: () => false)
             {
@@ -148,12 +182,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static Task<int> Main(string[] args)
         {
-            var parser = new CommandLineBuilder()
-                .AddCommand(CollectCommand())
-                .AddCommand(ConfigCommand())
-                .AddCommand(GenerateApiKeyCommand())
-                .UseDefaults()
-                .Build();
+            var parser = new CommandLineBuilder(new RootCommand()
+            {
+                CollectCommand(),
+                ConfigCommand(),
+                GenerateApiKeyCommand()
+            })
+            .UseDefaults()
+            .Build();
+
             return parser.InvokeAsync(args);
         }
     }


### PR DESCRIPTION
As part of the Security Review, we need to keep our OSS up-to-date. This is an initial pass - @jander-msft will be taking a look and making recommendations for what versions we should use. Some versions were updated (but not to the latest version), since the latest version (or its dependencies) hadn't been picked up yet. `System CommandLine` also had breaking changes, which led to changes in how we set Arguments.