### PR TITLE
Consolidate dumps folder into diag folder in k8s sample

### DIFF
--- a/documentation/kubernetes.md
+++ b/documentation/kubernetes.md
@@ -33,12 +33,10 @@ spec:
         - name: ASPNETCORE_URLS
           value: http://+:80
         - name: DOTNET_DiagnosticPorts
-          value: /diag/port
+          value: /diag/port.sock
         volumeMounts:
         - mountPath: /diag
           name: diagvol
-        - mountPath: /dumps
-          name: dumpsvol
         resources:
           limits:
             cpu: 250m
@@ -50,12 +48,10 @@ spec:
         - name: ASPNETCORE_URLS
           value: http://+:81
         - name: DOTNET_DiagnosticPorts
-          value: /diag/port
+          value: /diag/port.sock
         volumeMounts:
         - mountPath: /diag
           name: diagvol
-        - mountPath: /dumps
-          name: dumpsvol
         resources:
           limits:
             cpu: 250m
@@ -70,9 +66,9 @@ spec:
         - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
           value: Listen
         - name: DOTNETMONITOR_DiagnosticPort__EndpointName
-          value: /diag/port
+          value: /diag/port.sock
         - name: DOTNETMONITOR_Storage__DumpTempFolder
-          value: /dumps
+          value: /diag/dumps
         # ALWAYS use the HTTPS form of the URL for deployments in production; the removal of HTTPS is done for
         # demonstration purposes only in this example. Please continue reading after this example for further details.
         - name: DOTNETMONITOR_Urls
@@ -80,8 +76,6 @@ spec:
         volumeMounts:
         - mountPath: /diag
           name: diagvol
-        - mountPath: /dumps
-          name: dumpsvol
         resources:
           requests:
             cpu: 50m
@@ -91,8 +85,6 @@ spec:
             memory: 256Mi
       volumes:
       - name: diagvol
-        emptyDir: {}
-      - name: dumpsvol
         emptyDir: {}
 ```
 


### PR DESCRIPTION
As of the 6.0.2 release from February, the dumps folder does not need a separate, already created folder. It can be combined with the `/diag` directory so that only one shared volume is necessary for all scenarios. This should work since the runtime should not be creating a `dumps` file in the `/diag` directory and dotnet monitor is explicitly told to create a `port.sock` file in the `/diag` directory.