### PR TITLE
[Backport] Add command ipc to profiler 

### DIFF
--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CLR_CMAKE_HOST_WIN32)
         Logging/DebugLogger.cpp
         MonitorProfiler.def
         )
+    add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif(CLR_CMAKE_HOST_WIN32)
 
 set(SOURCES
@@ -20,10 +21,23 @@ set(SOURCES
     ClassFactory.cpp
     DllMain.cpp
     ProfilerBase.cpp
+    Communication/IpcCommServer.cpp
+    Communication/IpcCommClient.cpp
+    Communication/CommandServer.cpp
     )
 
 # Build library and split symbols
 add_library_clr(MonitorProfiler SHARED ${SOURCES})
+
+if(CLR_CMAKE_HOST_WIN32)
+    target_link_libraries(MonitorProfiler ws2_32)
+endif(CLR_CMAKE_HOST_WIN32)
+
+if (CLR_CMAKE_HOST_UNIX)
+    target_link_libraries(MonitorProfiler
+    stdc++
+    pthread)
+endif(CLR_CMAKE_HOST_UNIX)
 
 # Install library
 install(TARGETS MonitorProfiler DESTINATION .)

--- a/src/MonitorProfiler/Communication/CommandServer.cpp
+++ b/src/MonitorProfiler/Communication/CommandServer.cpp
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "CommandServer.h"
+#include <thread>
+#include "../Logging/Logger.h"
+
+CommandServer::CommandServer(const std::shared_ptr<ILogger>& logger) : _shutdown(false), _logger(logger)
+{
+}
+
+HRESULT CommandServer::Start(const std::string& path, std::function<HRESULT(const IpcMessage& message)> callback)
+{
+    if (_shutdown.load())
+    {
+        return E_UNEXPECTED;
+    }
+
+    HRESULT hr;
+#if TARGET_WINDOWS
+    WSADATA wsaData;
+    int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
+    if (result != 0)
+    {
+        return HRESULT_FROM_WIN32(result);
+    }
+#endif
+
+    _callback = callback;
+
+    IfFailLogRet_(_logger, _server.Bind(path));
+    _listeningThread = std::thread(&CommandServer::ListeningThread, this);
+    _clientThread = std::thread(&CommandServer::ClientProcessingThread, this);
+    return S_OK;
+}
+
+void CommandServer::Shutdown()
+{
+    bool shutdown = false;
+    if (_shutdown.compare_exchange_strong(shutdown, true))
+    {
+        _clientQueue.Complete();
+        _server.Shutdown();
+
+        _listeningThread.join();
+        _clientThread.join();
+    }
+}
+
+void CommandServer::ListeningThread()
+{
+    while (true)
+    {
+        std::shared_ptr<IpcCommClient> client;
+        HRESULT hr = _server.Accept(client);
+        if (FAILED(hr))
+        {
+            break;
+        }
+
+        IpcMessage message;
+
+        //Note this can timeout if the client doesn't send anything
+        hr = client->Receive(message);
+        if (FAILED(hr))
+        {
+            _logger->Log(LogLevel::Error, _T("Unexpected error when receiving data: 0x%08x"), hr);
+            continue;
+        }
+
+        IpcMessage response;
+        response.MessageType = SUCCEEDED(hr) ? MessageType::OK : MessageType::Error;
+        response.Parameters = hr;
+
+        hr = client->Send(response);
+        if (FAILED(hr))
+        {
+            _logger->Log(LogLevel::Error, _T("Unexpected error when sending data: 0x%08x"), hr);
+            continue;
+        }
+        hr = client->Shutdown();
+        if (FAILED(hr))
+        {
+            _logger->Log(LogLevel::Warning, _T("Unexpected error during shutdown: 0x%08x"), hr);
+        }
+
+        _clientQueue.Enqueue(message);
+    }
+}
+
+void CommandServer::ClientProcessingThread()
+{
+    while (true)
+    {
+        IpcMessage message;
+        HRESULT hr = _clientQueue.BlockingDequeue(message);
+        if (hr != S_OK)
+        {
+            //We are complete, discard all messages
+            break;
+        }
+        hr = _callback(message);
+        if (hr != S_OK)
+        {
+            _logger->Log(LogLevel::Warning, _T("IpcMessage callback failed: 0x%08x"), hr);
+        }
+    }
+}

--- a/src/MonitorProfiler/Communication/CommandServer.h
+++ b/src/MonitorProfiler/Communication/CommandServer.h
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "IpcCommServer.h"
+#include "Messages.h"
+#include <functional>
+#include <string>
+#include <atomic>
+#include <thread>
+#include "../Logging/Logger.h"
+#include "../Utilities/BlockingQueue.h"
+
+class CommandServer final
+{
+public:
+    CommandServer(const std::shared_ptr<ILogger>& logger);
+    HRESULT Start(const std::string& path, std::function<HRESULT (const IpcMessage& message)> callback);
+    void Shutdown();
+
+private:
+    void ListeningThread();
+    void ClientProcessingThread();
+
+    std::atomic_bool _shutdown;
+
+    std::function<HRESULT(const IpcMessage& message)> _callback;
+    IpcCommServer _server;
+
+    BlockingQueue<IpcMessage> _clientQueue;
+    std::shared_ptr<ILogger> _logger;
+
+    std::thread _listeningThread;
+    std::thread _clientThread;
+};

--- a/src/MonitorProfiler/Communication/IpcCommClient.cpp
+++ b/src/MonitorProfiler/Communication/IpcCommClient.cpp
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "IpcCommClient.h"
+#include <memory>
+
+HRESULT IpcCommClient::Receive(IpcMessage& message)
+{
+    if (_shutdown.load())
+    {
+        return E_UNEXPECTED;
+    }
+    if (!_socket.Valid())
+    {
+        return E_UNEXPECTED;
+    }
+
+    //CONSIDER It is generally more performant to read and buffer larger chunks, in this case we are not expecting very frequent communication.
+    char buffer[sizeof(MessageType) + sizeof(int)];
+    int read = 0;
+    int offset = 0;
+
+    do
+    {
+        int read = recv(_socket, &buffer[offset], sizeof(buffer) - offset, 0);
+        if (read == 0)
+        {
+            return E_ABORT;
+        }
+        if (read < 0)
+        {
+#if TARGET_UNIX
+            if (errno == EINTR)
+            {
+                //Signal can interrupt operations. Try again.
+                continue;
+            }
+#endif
+            return SocketWrapper::GetSocketError();
+        }
+        offset += read;
+
+    } while (offset < sizeof(buffer));
+
+    message.MessageType = *reinterpret_cast<MessageType*>(buffer);
+    message.Parameters = *reinterpret_cast<int*>(&buffer[sizeof(MessageType)]);
+
+    return S_OK;
+}
+
+HRESULT IpcCommClient::Send(const IpcMessage& message)
+{
+    if (_shutdown.load())
+    {
+        return E_UNEXPECTED;
+    }
+    if (!_socket.Valid())
+    {
+        return E_UNEXPECTED;
+    }
+
+    char buffer[sizeof(MessageType) + sizeof(int)];
+    *reinterpret_cast<MessageType*>(buffer) = message.MessageType;
+    *reinterpret_cast<int*>(&buffer[sizeof(MessageType)]) = message.Parameters;
+
+    int sent = 0;
+    int offset = 0;
+    do
+    {
+        sent = send(_socket, &buffer[offset], sizeof(buffer) - offset, 0);
+
+        if (sent == 0)
+        {
+            return E_ABORT;
+        }
+        if (sent < 0)
+        {
+#if TARGET_UNIX
+            if (errno == EINTR)
+            {
+                //Signal can interrupt operations. Try again.
+                continue;
+            }
+#endif
+            return SocketWrapper::GetSocketError();
+        }
+        offset += sent;
+    } while (offset < sizeof(buffer));
+
+    return S_OK;
+}
+
+HRESULT IpcCommClient::Shutdown()
+{
+    _shutdown.store(true);
+    int result = shutdown(_socket,
+#if TARGET_WINDOWS
+        SD_BOTH
+#else
+        SHUT_RDWR
+#endif
+    );
+
+    if (result != 0)
+    {
+        return SocketWrapper::GetSocketError();
+    }
+    return S_OK;
+}
+
+IpcCommClient::IpcCommClient(SOCKET socket) : _socket(socket), _shutdown(false)
+{
+}

--- a/src/MonitorProfiler/Communication/IpcCommClient.h
+++ b/src/MonitorProfiler/Communication/IpcCommClient.h
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "SocketWrapper.h"
+#include "Messages.h"
+#include <atomic>
+
+class IpcCommClient
+{
+    friend class IpcCommServer;
+public:
+    HRESULT Receive(IpcMessage& message);
+    HRESULT Send(const IpcMessage& message);
+    HRESULT Shutdown();
+    IpcCommClient(SOCKET socket);
+
+private:
+    SocketWrapper _socket;
+    std::atomic_bool _shutdown;
+};

--- a/src/MonitorProfiler/Communication/IpcCommServer.cpp
+++ b/src/MonitorProfiler/Communication/IpcCommServer.cpp
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "IpcCommClient.h"
+#include "IpcCommServer.h"
+#include "../Logging/Logger.h"
+
+IpcCommServer::IpcCommServer() : _shutdown(false)
+{
+}
+
+IpcCommServer::~IpcCommServer()
+{
+    //We explicitly run the destructor first so that it can call closesocket prior to deletion of the path.
+    _domainSocket.~SocketWrapper();
+    std::remove(_rootAddress.c_str());
+}
+
+HRESULT IpcCommServer::Bind(const std::string& rootAddress)
+{
+    if (_shutdown.load())
+    {
+        return E_UNEXPECTED;
+    }
+
+    if (_domainSocket.Valid())
+    {
+        return E_UNEXPECTED;
+    }
+
+    _rootAddress = rootAddress;
+
+    sockaddr_un address;
+    memset(&address, 0, sizeof(address));
+
+    if ((rootAddress.length() == 0) || (rootAddress.length() >= sizeof(address.sun_path)))
+    {
+        return E_INVALIDARG;
+    }
+
+    //We don't error check this on purpose
+    std::remove(rootAddress.c_str());
+
+    address.sun_family = AF_UNIX;
+#if TARGET_WINDOWS
+    strncpy_s(address.sun_path, rootAddress.c_str(), sizeof(address.sun_path));
+#else
+    strncpy(address.sun_path, rootAddress.c_str(), sizeof(address.sun_path));
+#endif
+    _domainSocket = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (!_domainSocket.Valid())
+    {
+        return SocketWrapper::GetSocketError();
+    }
+    
+    HRESULT hr;
+    IfFailRet(_domainSocket.SetBlocking(false));
+
+    if (bind(_domainSocket, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0)
+    {
+        return SocketWrapper::GetSocketError();
+    }
+    if (listen(_domainSocket, Backlog) != 0)
+    {
+        return SocketWrapper::GetSocketError();
+    }
+
+    return S_OK;
+}
+
+HRESULT IpcCommServer::Accept(std::shared_ptr<IpcCommClient>& client)
+{
+    if (_shutdown.load())
+    {
+        return E_UNEXPECTED;
+    }
+    if (!_domainSocket.Valid())
+    {
+        return E_UNEXPECTED;
+    }
+
+    int result = 0;
+
+    do
+    {
+        fd_set set;
+        FD_ZERO(&set);
+        FD_SET(_domainSocket, &set);
+
+        TIMEVAL timeout;
+        timeout.tv_sec = AcceptTimeoutSeconds;
+        timeout.tv_usec = 0;
+        result = select(2, &set, nullptr, nullptr, &timeout);
+
+        if (_shutdown.load())
+        {
+            return E_ABORT;
+        }
+
+        //0 indicates timeout
+        if (result < 0)
+        {
+#if TARGET_UNIX
+            if (errno == EINTR)
+            {
+                continue;
+            }
+#endif
+            return SocketWrapper::GetSocketError();
+        }
+    } while (result <= 0);
+
+    SocketWrapper clientSocket = SocketWrapper(accept(_domainSocket, nullptr, nullptr));
+    if (!clientSocket.Valid())
+    {
+        return SocketWrapper::GetSocketError();
+    }
+#if TARGET_WINDOWS
+    DWORD receiveTimeout = ReceiveTimeoutMilliseconds;
+
+    HRESULT hr;
+
+    //Windows sockets inherit non-blocking
+    IfFailRet(clientSocket.SetBlocking(true));
+
+#else
+    TIMEVAL receiveTimeout;
+    receiveTimeout.tv_sec = ReceiveTimeoutMilliseconds / 1000;
+    receiveTimeout.tv_usec = 0;
+#endif
+
+    if (setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&receiveTimeout), sizeof(receiveTimeout)) != 0)
+    {
+        return SocketWrapper::GetSocketError();
+    }
+
+    client = std::make_shared<IpcCommClient>(clientSocket.Release());
+
+    return S_OK;
+}
+
+void IpcCommServer::Shutdown()
+{
+    _shutdown.store(true);
+}

--- a/src/MonitorProfiler/Communication/IpcCommServer.h
+++ b/src/MonitorProfiler/Communication/IpcCommServer.h
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <string>
+#include <memory>
+#include <atomic>
+
+#include "SocketWrapper.h"
+#include "IpcCommClient.h"
+
+class IpcCommServer
+{
+public:
+    IpcCommServer();
+    ~IpcCommServer();
+    HRESULT Bind(const std::string& rootAddress);
+    HRESULT Accept(std::shared_ptr<IpcCommClient>& client);
+    void Shutdown();
+private:
+    const int ReceiveTimeoutMilliseconds = 10000;
+    const int AcceptTimeoutSeconds = 3;
+    const int Backlog = 20;
+    std::string _rootAddress;
+    SocketWrapper _domainSocket = 0;
+    std::atomic_bool _shutdown;
+};

--- a/src/MonitorProfiler/Communication/Messages.h
+++ b/src/MonitorProfiler/Communication/Messages.h
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+enum class MessageType : short
+{
+    OK,
+    Error,
+    Callstack
+};
+
+struct IpcMessage
+{
+    MessageType MessageType = MessageType::OK;
+    int Parameters = 0;
+};

--- a/src/MonitorProfiler/Communication/SocketWrapper.h
+++ b/src/MonitorProfiler/Communication/SocketWrapper.h
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#if TARGET_WINDOWS
+#include <WinSock2.h>
+#include <afunix.h>
+#else
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <sys/un.h>
+#include <unistd.h> 
+#include <fcntl.h> 
+typedef int SOCKET;
+typedef struct timeval TIMEVAL;
+#endif
+
+//Includes pal on Linux
+#include <windows.h>
+
+class SocketWrapper
+{
+private:
+    SOCKET _socket;
+
+public:
+    SocketWrapper(SOCKET socket) : _socket(socket)
+    {
+    }
+
+    SocketWrapper(SocketWrapper&& other)
+    {
+        _socket = other._socket;
+        other._socket = 0;
+    }
+
+    operator SOCKET const ()
+    {
+        return _socket;
+    }
+
+    SOCKET Release()
+    {
+        SOCKET s = _socket;
+        _socket = 0;
+        return s;
+    }
+
+    HRESULT SetBlocking(bool blocking)
+    {
+#if TARGET_WINDOWS
+        u_long blockParameter = blocking ? 0 : 1; //0 == blocking
+        if (ioctlsocket(_socket, FIONBIO, &blockParameter) != 0)
+        {
+            return SocketWrapper::GetSocketError();
+        }
+#else
+        int flags = fcntl(_socket, F_GETFD);
+        if (flags < 0)
+        {
+            return SocketWrapper::GetSocketError();
+        }
+        if (blocking)
+        {
+            flags &= ~O_NONBLOCK;
+        }
+        else
+        {
+            flags |= O_NONBLOCK;
+        }
+
+        if (fcntl(_socket, F_SETFD, flags) != 0)
+        {
+            return SocketWrapper::GetSocketError();
+        }
+#endif
+
+        return S_OK;
+    }
+
+    static HRESULT GetSocketError()
+    {
+#if TARGET_UNIX
+        return HRESULT_FROM_WIN32(errno);
+#else
+        return HRESULT_FROM_WIN32(WSAGetLastError());
+#endif
+    }
+
+    const SocketWrapper& operator = (SocketWrapper&& other)
+    {
+        if (&other == this)
+        {
+            return *this;
+        }
+
+        Close();
+        _socket = other._socket;
+        other._socket = 0;
+
+        return *this;
+    }
+
+    const SocketWrapper& operator = (const SocketWrapper&) = delete;
+    SocketWrapper(const SocketWrapper&) = delete;
+
+    ~SocketWrapper()
+    {
+        Close();
+    }
+
+    bool Valid()
+    {
+#if TARGET_UNIX
+        return _socket > 0;
+#else
+        return _socket != 0 && _socket != INVALID_SOCKET;
+#endif
+    }
+
+private:
+    void Close()
+    {
+        //Note this should be idempotent. The destructor may be called twice.
+        if (Valid())
+        {
+#if TARGET_WINDOWS
+            closesocket(_socket);
+#else
+            close(_socket);
+#endif
+            _socket = 0;
+        }
+    }
+};

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
@@ -40,3 +40,33 @@ HRESULT EnvironmentHelper::SetProductVersion(
 
     return S_OK;
 }
+
+HRESULT EnvironmentHelper::GetRuntimeInstanceId(const std::shared_ptr<IEnvironment>& pEnvironment, const std::shared_ptr<ILogger>& pLogger, tstring& instanceId)
+{
+    HRESULT hr = S_OK;
+
+    IfFailLogRet(pEnvironment->GetEnvironmentVariable(s_wszRuntimeInstanceEnvVar, instanceId));
+
+    return S_OK;
+}
+
+HRESULT EnvironmentHelper::GetTempFolder(const std::shared_ptr<IEnvironment>& pEnvironment, const std::shared_ptr<ILogger>& pLogger, tstring& tempFolder)
+{
+    HRESULT hr = S_OK;
+
+    tstring tmpDir;
+#if TARGET_WINDOWS
+    IfFailLogRet(pEnvironment->GetEnvironmentVariable(s_wszTempEnvVar, tmpDir));
+#else
+    hr = pEnvironment->GetEnvironmentVariable(s_wszTempEnvVar, tmpDir);
+#endif
+
+    if (FAILED(hr))
+    {
+        tmpDir = s_wszDefaultTempFolder;
+    }
+
+    tempFolder = std::move(tmpDir);
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.h
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.h
@@ -16,6 +16,15 @@ class EnvironmentHelper final
 private:
     static constexpr LPCWSTR s_wszDebugLoggerLevelEnvVar = _T("DotnetMonitorProfiler_DebugLogger_Level");
     static constexpr LPCWSTR s_wszProfilerVersionEnvVar = _T("DotnetMonitorProfiler_ProductVersion");
+    static constexpr LPCWSTR s_wszRuntimeInstanceEnvVar = _T("DotnetMonitorProfiler_InstanceId");
+    static constexpr LPCWSTR s_wszDefaultTempFolder = _T("/tmp");
+
+    static constexpr LPCWSTR s_wszTempEnvVar =
+#if TARGET_WINDOWS
+    _T("TEMP");
+#else
+    _T("TMPDIR");
+#endif
 
 public:
     /// <summary>
@@ -31,4 +40,14 @@ public:
     static HRESULT SetProductVersion(
         const std::shared_ptr<IEnvironment>& pEnvironment,
         const std::shared_ptr<ILogger>& pLogger);
+
+    static HRESULT GetRuntimeInstanceId(
+        const std::shared_ptr<IEnvironment>& pEnvironment,
+        const std::shared_ptr<ILogger>& pLogger,
+        tstring& instanceId);
+
+    static HRESULT GetTempFolder(
+        const std::shared_ptr<IEnvironment>& pEnvironment,
+        const std::shared_ptr<ILogger>& pLogger,
+        tstring& tempFolder);
 };

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -9,6 +9,7 @@
 #include "../Logging/DebugLogger.h"
 #include "corhlpr.h"
 #include "macros.h"
+#include <memory>
 
 using namespace std;
 
@@ -28,9 +29,12 @@ STDMETHODIMP MainProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
 
     HRESULT hr = S_OK;
 
+    //These should always be initialized first
     IfFailRet(ProfilerBase::Initialize(pICorProfilerInfoUnk));
     IfFailRet(InitializeEnvironment());
     IfFailRet(InitializeLogging());
+
+    IfFailLogRet(InitializeCommandServer());
 
     // Logging is initialized and can now be used
 
@@ -51,6 +55,8 @@ STDMETHODIMP MainProfiler::Shutdown()
 {
     m_pLogger.reset();
     m_pEnvironment.reset();
+    _commandServer->Shutdown();
+    _commandServer.reset();
 
     return ProfilerBase::Shutdown();
 }
@@ -91,5 +97,44 @@ HRESULT MainProfiler::InitializeLogging()
 
     m_pLogger.reset(pAggregateLogger.release());
 
+    return S_OK;
+}
+
+HRESULT MainProfiler::InitializeCommandServer()
+{
+    HRESULT hr = S_OK;
+
+    //TODO For now we are using the process id to generate the unique server name. We should use the environment
+    //value with the runtime instance id once it's available.
+    unsigned long pid =
+#if TARGET_WINDOWS
+        GetCurrentProcessId();
+#else
+        getpid();
+#endif
+
+    tstring instanceId = to_tstring(to_string(pid));
+    //IfFailRet(EnvironmentHelper::GetRuntimeInstanceId(m_pEnvironment, m_pLogger, instanceId));
+
+#if TARGET_UNIX
+    tstring separator = _T("/");
+#else
+    tstring separator = _T("\\");
+#endif
+
+    tstring tmpDir;
+    IfFailRet(EnvironmentHelper::GetTempFolder(m_pEnvironment, m_pLogger, tmpDir));
+
+    _commandServer = std::unique_ptr<CommandServer>(new CommandServer(m_pLogger));
+    tstring socketPath = tmpDir + separator + instanceId + _T(".sock");
+
+    IfFailRet(_commandServer->Start(to_string(socketPath), [this](const IpcMessage& message)-> HRESULT { return this->MessageCallback(message); }));
+
+    return S_OK;
+}
+
+HRESULT MainProfiler::MessageCallback(const IpcMessage& message)
+{
+    m_pLogger->Log(LogLevel::Information, _T("Message received from client: %d %d"), message.MessageType, message.Parameters);
     return S_OK;
 }

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -7,6 +7,7 @@
 #include "../ProfilerBase.h"
 #include "../Environment/Environment.h"
 #include "../Logging/Logger.h"
+#include "../Communication/CommandServer.h"
 #include <memory>
 
 class MainProfiler final :
@@ -26,4 +27,8 @@ public:
 private:
     HRESULT InitializeEnvironment();
     HRESULT InitializeLogging();
+    HRESULT InitializeCommandServer();
+    HRESULT MessageCallback(const IpcMessage& message);
+private:
+    std::unique_ptr<CommandServer> _commandServer;
 };

--- a/src/MonitorProfiler/Utilities/BlockingQueue.h
+++ b/src/MonitorProfiler/Utilities/BlockingQueue.h
@@ -1,0 +1,58 @@
+#// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template<typename T>
+class BlockingQueue final
+{
+public:
+    HRESULT Enqueue(const T& item)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_complete)
+            {
+                return E_UNEXPECTED;
+            }
+            _queue.push(item);
+        }
+        _condition.notify_all();
+
+        return S_OK;
+    }
+
+    HRESULT BlockingDequeue(T& item)
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        _condition.wait(lock, [this]() { return !_queue.empty() || _complete; });
+
+        //We can't really tell if the caller wants to drain the remaining entries or simply abandon the queue
+        if (!_queue.empty())
+        {
+            item = _queue.front();
+            _queue.pop();
+            return _complete ? S_FALSE : S_OK;
+        }
+
+        return E_FAIL;
+    }
+
+    void Complete()
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _complete = true;
+        }
+        _condition.notify_all();
+    }
+
+private:
+    std::queue<T> _queue;
+    std::mutex _mutex;
+    std::condition_variable _condition;
+    bool _complete = false;
+};


### PR DESCRIPTION
Backport from #1790

Add a communication mechanism between the profiler and dotnet-monitor.
- Currently using Unix Domain Socket on both Windows and Linux
- Current model is to receive small control messages from dotnet-monitor.
- Requests are handled serially, long/con-current sessions are not really supported with the current model.