### PR TITLE
Fix RuntimeId token

### DIFF
--- a/src/MonitorProfiler/Environment/EnvironmentHelper.h
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.h
@@ -20,7 +20,7 @@ class EnvironmentHelper final
 private:
     static constexpr LPCWSTR DebugLoggerLevelEnvVar = _T("DotnetMonitorProfiler_DebugLogger_Level");
     static constexpr LPCWSTR ProfilerVersionEnvVar = _T("DotnetMonitorProfiler_ProductVersion");
-    static constexpr LPCWSTR RuntimeInstanceEnvVar = _T("DotnetMonitorProfiler_InstanceId");
+    static constexpr LPCWSTR RuntimeInstanceEnvVar = _T("DotnetMonitorProfiler_RuntimeId");
 
     std::shared_ptr<IEnvironment> _environment;
     std::shared_ptr<ILogger> _logger;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
     public sealed class ActionDependencyAnalyzerTests
     {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
         private sealed class TestEndpointInfo : WebApi.EndpointInfoBase
         {
             public TestEndpointInfo(Guid runtimeInstanceCookie, int processId = 0, string commandLine = null, string operatingSystem = null, string processArchitecture = null)
@@ -49,6 +51,66 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public ActionDependencyAnalyzerTests(ITestOutputHelper outputHelper)
         {
             _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public async Task DependenciesTest()
+        {
+            const string Output1 = nameof(Output1);
+            const string Output2 = nameof(Output2);
+            const string Output3 = nameof(Output3);
+
+            string a2input1 = FormattableString.Invariant($"$(Actions.a1.{Output1}) with $(Actions.a1.{Output2})T");
+            string a2input2 = FormattableString.Invariant($"$(Actions.a1.{Output2})");
+            string a2input3 = FormattableString.Invariant($"Output $(Actions.a1.{Output3}) trail");
+
+            PassThroughOptions a2Settings = null;
+
+            await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
+            {
+                CollectionRuleOptions options = rootOptions.CreateCollectionRule(DefaultRuleName)
+                    .AddPassThroughAction("a1", "a1input1", "a1input2", "a1input3")
+                    .AddPassThroughAction("a2", a2input1, a2input2, a2input3)
+                    .SetStartupTrigger();
+
+                a2Settings = (PassThroughOptions)options.Actions.Last().Settings;
+            }, async host =>
+            {
+                ActionListExecutor executor = host.Services.GetService<ActionListExecutor>();
+
+                using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(DefaultTimeout);
+
+                CollectionRuleOptions ruleOptions = host.Services.GetRequiredService<IOptionsMonitor<CollectionRuleOptions>>().Get(DefaultRuleName);
+                ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
+                ISystemClock clock = host.Services.GetRequiredService<ISystemClock>();
+
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, clock);
+
+                int callbackCount = 0;
+                Action startCallback = () => callbackCount++;
+
+                IDictionary<string, CollectionRuleActionResult> results = await executor.ExecuteActions(context, startCallback, cancellationTokenSource.Token);
+
+                //Verify that the original settings were not altered during execution.
+                Assert.Equal(a2input1, a2Settings.Input1);
+                Assert.Equal(a2input2, a2Settings.Input2);
+                Assert.Equal(a2input3, a2Settings.Input3);
+
+                Assert.Equal(1, callbackCount);
+                Assert.Equal(2, results.Count);
+                Assert.True(results.TryGetValue("a2", out CollectionRuleActionResult a2result));
+                Assert.Equal(3, a2result.OutputValues.Count);
+
+                Assert.True(a2result.OutputValues.TryGetValue(Output1, out string a2output1));
+                Assert.Equal("a1input1 with a1input2T", a2output1);
+                Assert.True(a2result.OutputValues.TryGetValue(Output2, out string a2output2));
+                Assert.Equal("a1input2", a2output2);
+                Assert.True(a2result.OutputValues.TryGetValue(Output3, out string a2output3));
+                Assert.Equal("Output a1input3 trail", a2output3);
+            }, serviceCollection =>
+            {
+                serviceCollection.RegisterCollectionRuleAction<PassThroughActionFactory, PassThroughOptions>(nameof(PassThroughAction));
+            });
         }
 
         [Fact]
@@ -103,7 +165,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
             {
                 CollectionRuleOptions options = rootOptions.CreateCollectionRule(DefaultRuleName)
-                    .AddPassThroughAction("a1", ActionOptionsDependencyAnalyzer.RuntimeIdReference, "test", "test")
+                    .AddPassThroughAction("a1", ConfigurationTokenParser.RuntimeIdReference, "test", "test")
                     .SetStartupTrigger();
 
                 settings = (PassThroughOptions)options.Actions.Last().Settings;
@@ -123,6 +185,68 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 Assert.Equal(instanceId.ToString("D"), newSettings.Input1);
 
+            }, serviceCollection =>
+            {
+                serviceCollection.RegisterCollectionRuleAction<PassThroughActionFactory, PassThroughOptions>(nameof(PassThroughAction));
+            });
+        }
+
+        [Fact]
+        public async Task ReplacementsAndDependencies()
+        {
+            const string Output1 = nameof(Output1);
+            const string Output2 = nameof(Output2);
+            const string Output3 = nameof(Output3);
+
+            string a2input1 = FormattableString.Invariant($"$(Actions.a1.{Output1}) with rid: $(Process.RuntimeId) and $(Actions.a1.{Output2})");
+            string a2input2 = FormattableString.Invariant($"$(Actions.a1.{Output2})");
+            string a2input3 = FormattableString.Invariant($"Output $(Actions.a1.{Output3}) trail");
+
+            PassThroughOptions a2Settings = null;
+
+            await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
+            {
+                CollectionRuleOptions options = rootOptions.CreateCollectionRule(DefaultRuleName)
+                    .AddPassThroughAction("a1", "a1input1", "a1input2", "a1input3")
+                    .AddPassThroughAction("a2", a2input1, a2input2, a2input3)
+                    .SetStartupTrigger();
+
+                a2Settings = (PassThroughOptions)options.Actions.Last().Settings;
+            }, async host =>
+            {
+                ActionListExecutor executor = host.Services.GetService<ActionListExecutor>();
+
+                using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(DefaultTimeout);
+
+                CollectionRuleOptions ruleOptions = host.Services.GetRequiredService<IOptionsMonitor<CollectionRuleOptions>>().Get(DefaultRuleName);
+                ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
+                ISystemClock clock = host.Services.GetRequiredService<ISystemClock>();
+
+                Guid instanceId = Guid.NewGuid();
+
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, new TestEndpointInfo(instanceId), logger, clock);
+
+                int callbackCount = 0;
+                Action startCallback = () => callbackCount++;
+
+                IDictionary<string, CollectionRuleActionResult> results = await executor.ExecuteActions(context, startCallback, cancellationTokenSource.Token);
+
+                //Verify that the original settings were not altered during execution.
+                Assert.Equal(a2input1, a2Settings.Input1);
+                Assert.Equal(a2input2, a2Settings.Input2);
+                Assert.Equal(a2input3, a2Settings.Input3);
+
+                Assert.Equal(1, callbackCount);
+                Assert.Equal(2, results.Count);
+                Assert.True(results.TryGetValue("a2", out CollectionRuleActionResult a2result));
+                Assert.Equal(3, a2result.OutputValues.Count);
+
+                Assert.True(a2result.OutputValues.TryGetValue(Output1, out string a2output1));
+                Assert.Equal(FormattableString.Invariant($"a1input1 with rid: {instanceId.ToString("D")} and a1input2"), a2output1);
+                Assert.True(a2result.OutputValues.TryGetValue(Output2, out string a2output2));
+                Assert.Equal("a1input2", a2output2);
+                Assert.True(a2result.OutputValues.TryGetValue(Output3, out string a2output3));
+                Assert.Equal("Output a1input3 trail", a2output3);
             }, serviceCollection =>
             {
                 serviceCollection.RegisterCollectionRuleAction<PassThroughActionFactory, PassThroughOptions>(nameof(PassThroughAction));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionListExecutorTests.cs
@@ -158,65 +158,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             });
         }
 
-        [Fact]
-        public async Task ActionListExecutor_Dependencies()
-        {
-            const string Output1 = nameof(Output1);
-            const string Output2 = nameof(Output2);
-            const string Output3 = nameof(Output3);
 
-            string a2input1 = FormattableString.Invariant($"$(Actions.a1.{Output1}) with $(Actions.a1.{Output2})T");
-            string a2input2 = FormattableString.Invariant($"$(Actions.a1.{Output2})");
-            string a2input3 = FormattableString.Invariant($"Output $(Actions.a1.{Output3}) trail");
-
-            PassThroughOptions a2Settings = null;
-
-            await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
-            {
-                CollectionRuleOptions options = rootOptions.CreateCollectionRule(DefaultRuleName)
-                    .AddPassThroughAction("a1", "a1input1", "a1input2", "a1input3")
-                    .AddPassThroughAction("a2", a2input1, a2input2, a2input3)
-                    .SetStartupTrigger();
-
-                a2Settings = (PassThroughOptions)options.Actions.Last().Settings;
-            }, async host =>
-            {
-                ActionListExecutor executor = host.Services.GetService<ActionListExecutor>();
-
-                using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(DefaultTimeout);
-
-                CollectionRuleOptions ruleOptions = host.Services.GetRequiredService<IOptionsMonitor<CollectionRuleOptions>>().Get(DefaultRuleName);
-                ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
-                ISystemClock clock = host.Services.GetRequiredService<ISystemClock>();
-
-                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, clock);
-
-                int callbackCount = 0;
-                Action startCallback = () => callbackCount++;
-
-                IDictionary<string, CollectionRuleActionResult> results = await executor.ExecuteActions(context, startCallback, cancellationTokenSource.Token);
-
-                //Verify that the original settings were not altered during execution.
-                Assert.Equal(a2input1, a2Settings.Input1);
-                Assert.Equal(a2input2, a2Settings.Input2);
-                Assert.Equal(a2input3, a2Settings.Input3);
-
-                Assert.Equal(1, callbackCount);
-                Assert.Equal(2, results.Count);
-                Assert.True(results.TryGetValue("a2", out CollectionRuleActionResult a2result));
-                Assert.Equal(3, a2result.OutputValues.Count);
-
-                Assert.True(a2result.OutputValues.TryGetValue(Output1, out string a2output1));
-                Assert.Equal("a1input1 with a1input2T", a2output1);
-                Assert.True(a2result.OutputValues.TryGetValue(Output2, out string a2output2));
-                Assert.Equal("a1input2", a2output2);
-                Assert.True(a2result.OutputValues.TryGetValue(Output3, out string a2output3));
-                Assert.Equal("Output a1input3 trail", a2output3);
-            }, serviceCollection =>
-            {
-                serviceCollection.RegisterCollectionRuleAction<PassThroughActionFactory, PassThroughOptions>(nameof(PassThroughAction));
-            });
-        }
 
         [Fact]
         public async Task DuplicateActionNamesTest()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
@@ -29,7 +30,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         // The value is determined BEFORE native build by the generation of the product version into the
         // _productversion.h header file.
         private const string ProductVersionEnvVarName = "DotnetMonitorProfiler_ProductVersion";
-        private const string MonitorProfilerInstanceIdEnvVarName = "DotnetMonitorProfiler_InstanceId";
+        private const string MonitorProfilerInstanceIdEnvVarName = "DotnetMonitorProfiler_RuntimeId";
 
         private readonly ITestOutputHelper _outputHelper;
         private readonly EndpointUtilities _endpointUtilities;
@@ -58,7 +59,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             await TestHostHelper.CreateCollectionRulesHost(_outputHelper, rootOptions =>
             {
                 rootOptions.CreateCollectionRule(DefaultRuleName)
-                    .AddSetEnvironmentVariableAction(MonitorProfilerInstanceIdEnvVarName, ActionOptionsDependencyAnalyzer.RuntimeIdReference)
+                    .AddSetEnvironmentVariableAction(MonitorProfilerInstanceIdEnvVarName, ConfigurationTokenParser.RuntimeIdReference)
                     .AddLoadProfilerAction(options =>
                     {
                         options.Path = profilerPath;

--- a/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class TokenContext
+    {
+        public bool CloneOnSubstitution { get; set; } = true;
+
+        public Guid RuntimeId { get; set; } = Guid.Empty;
+
+        public int ProcessId { get; set; } = -1;
+
+        public IDictionary<string, string> EnvironmentBlock { get; set; } = new Dictionary<string, string>();
+    }
+
+    internal sealed class ConfigurationTokenParser
+    {
+        private readonly ILogger _logger;
+
+        public const string SubstitutionPrefix = "$(";
+        public const string SubstitutionSuffix = ")";
+        public const string Separator = ".";
+
+        private const string ProcessInfoReference = "Process";
+        private const string RuntimeId = "RuntimeId";
+        public static readonly string RuntimeIdReference = FormattableString.Invariant($"{SubstitutionPrefix}{ProcessInfoReference}{Separator}{RuntimeId}{SubstitutionSuffix}");
+
+        public ConfigurationTokenParser(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public object SubstituteOptionValues(object originalSettings, TokenContext context)
+        {
+            object settings = originalSettings;
+
+            foreach (PropertyInfo propertyInfo in GetPropertiesFromSettings(settings))
+            {
+                string originalPropertyValue = (string)propertyInfo.GetValue(settings);
+                if (string.IsNullOrEmpty(originalPropertyValue))
+                {
+                    continue;
+                }
+
+                string replacement = originalPropertyValue.Replace(RuntimeIdReference, context.RuntimeId.ToString("D"), StringComparison.Ordinal);
+
+                if (!ReferenceEquals(replacement, originalPropertyValue))
+                {
+                    if (context.CloneOnSubstitution && !TryCloneSettings(originalSettings, ref settings))
+                    {
+                        return settings;
+                    }
+                    propertyInfo.SetValue(settings, replacement);
+                }
+            }
+
+            return settings;
+        }
+
+        public bool TryCloneSettings(object originalSettings, ref object settings)
+        {
+            if (originalSettings == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(originalSettings, settings))
+            {
+                if (originalSettings is BaseRecordOptions baseRecord)
+                {
+                    //Creates a copy using record's Clone method.
+                    settings = baseRecord with { };
+                    return true;
+                }
+                else
+                {
+                    _logger.ActionSettingsTokenizationNotSupported(settings.GetType().FullName);
+                    settings = originalSettings;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public IEnumerable<PropertyInfo> GetPropertiesFromSettings(object settings, Predicate<PropertyInfo> predicate = null) =>
+            settings?.GetType()
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.PropertyType == typeof(string) && (predicate?.Invoke(p) ?? true)) ??
+            Enumerable.Empty<PropertyInfo>();
+    }
+}


### PR DESCRIPTION
- Rename InstanceId to RuntimeId
- Fix issue with values that contain both dependencies and RuntimeId. We were replacing values in the wrong order.
- Add unit tests for above scenario.
- Refactor token replacement code to its own class so that it can be reused by egress in the future.
