### PR TITLE
Specify Json Configuration File Source Via Command Line

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -4,7 +4,7 @@
 
 ## Configuration Sources
 
-`dotnet monitor` can read and combine configuration from multiple sources. The configuration sources are listed below in the order in which they are read (Environment variables are highest precedence) :
+`dotnet monitor` can read and combine configuration from multiple sources. The configuration sources are listed below in the order in which they are read (User-specified path is highest precedence) :
 
 - Command line parameters
 - User settings path
@@ -16,6 +16,8 @@
     - On \*nix, `/etc/dotnet-monitor`
 
 - Environment variables
+- User-Specified json file
+  - Use the `--configuration-file-path` flag from the command line to specify your own configuration file (using its full path).
 
 ### Translating configuration between providers
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -4,7 +4,7 @@
 
 ## Configuration Sources
 
-`dotnet monitor` can read and combine configuration from multiple sources. The configuration sources are listed below in the order in which they are read (User-specified path is highest precedence) :
+`dotnet monitor` can read and combine configuration from multiple sources. The configuration sources are listed below in the order in which they are read (User-specified json file is highest precedence) :
 
 - Command line parameters
 - User settings path

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
                 metricUrls: null,
                 metrics: false,
                 diagnosticPort: null,
-                authConfiguration: HostBuilderHelper.CreateAuthConfiguration(noAuth: false, tempApiKey: false));
+                authConfiguration: HostBuilderHelper.CreateAuthConfiguration(noAuth: false, tempApiKey: false),
+                userProvidedConfigFilePath: null);
 
             // Create all of the same services as dotnet-monitor and add
             // OpenAPI generation in order to have it inspect the ASP.NET Core

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
         private const string SampleConfigurationsDirectory = "SampleConfigurations";
 
-        private const string UserProvidedSettingsFileName = "UserSpecifiedFile.json";
+        private const string UserProvidedSettingsFileName = "UserSpecifiedFile.json"; // Note: if this name is updated, it must also be updated in the expected show sources configuration files
 
         private readonly ITestOutputHelper _outputHelper;
 
@@ -161,10 +161,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             }
             if (level >= ConfigurationLevel.UserProvidedFileSettings)
             {
-                // This is the settings.json file in the shared configuration directory that is visible
-                // to all users on the machine e.g. /etc/dotnet-monitor on Unix systems.
+                // This is the user-provided file in the directory specified on the command-line
                 string userSpecifiedFileSettingsContent = JsonSerializer.Serialize(UserProvidedFileSettingsContent);
-
                 File.WriteAllText(userProvidedConfigFullPath, userSpecifiedFileSettingsContent);
             }
 
@@ -268,7 +266,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             settings.Urls = new[] { "https://localhost:44444" }; // This corresponds to the value in SampleConfigurations/URLs.json
 
-            // This is the settings.json file in the user profile directory.
+            // This is the user-provided file in the directory specified on the command-line
             File.WriteAllText(userProvidedConfigFullPath, ConstructSettingsJson("Egress.json"));
 
             // This is the settings.json file in the user profile directory.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             { WebHostDefaults.ServerUrlsKey, nameof(ConfigurationLevel.UserSettings) }
         };
 
+        private static readonly Dictionary<string, string> UserProvidedFileSettingsContent = new(StringComparer.Ordinal)
+        {
+            { WebHostDefaults.ServerUrlsKey, nameof(ConfigurationLevel.UserProvidedFileSettings) }
+        };
+
         // This needs to be updated and kept in order for any future configuration sections
         private static readonly List<string> OrderedConfigurationKeys = new()
         {
@@ -79,6 +84,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
         private const string SampleConfigurationsDirectory = "SampleConfigurations";
 
+        private const string UserProvidedSettingsFileName = "UserSpecifiedFile.json";
+
         private readonly ITestOutputHelper _outputHelper;
 
         public ConfigurationTests(ITestOutputHelper outputHelper)
@@ -101,11 +108,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [InlineData(ConfigurationLevel.SharedSettings)]
         [InlineData(ConfigurationLevel.SharedKeyPerFile)]
         [InlineData(ConfigurationLevel.MonitorEnvironment)]
+        [InlineData(ConfigurationLevel.UserProvidedFileSettings)]
         public void ConfigurationOrderingTest(ConfigurationLevel level)
         {
             using TemporaryDirectory contentRootDirectory = new(_outputHelper);
             using TemporaryDirectory sharedConfigDir = new(_outputHelper);
             using TemporaryDirectory userConfigDir = new(_outputHelper);
+            using TemporaryDirectory userProvidedConfigDir = new(_outputHelper);
+
+            string userProvidedConfigFullPath = Path.Combine(userProvidedConfigDir.FullName, UserProvidedSettingsFileName);
 
             // Set up the initial settings used to create the host builder.
             HostBuilderSettings settings = new()
@@ -113,7 +124,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 Authentication = HostBuilderHelper.CreateAuthConfiguration(noAuth: false, tempApiKey: false),
                 ContentRootDirectory = contentRootDirectory.FullName,
                 SharedConfigDirectory = sharedConfigDir.FullName,
-                UserConfigDirectory = userConfigDir.FullName
+                UserConfigDirectory = userConfigDir.FullName,
+                UserProvidedConfigFilePath = level >= ConfigurationLevel.UserProvidedFileSettings ? userProvidedConfigFullPath : null
             };
             if (level >= ConfigurationLevel.HostBuilderSettingsUrl)
             {
@@ -146,6 +158,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 // This is a key-per-file file in the shared configuration directory. This configuration
                 // is typically used when mounting secrets from a Docker volume.
                 File.WriteAllText(Path.Combine(sharedConfigDir.FullName, WebHostDefaults.ServerUrlsKey), nameof(ConfigurationLevel.SharedKeyPerFile));
+            }
+            if (level >= ConfigurationLevel.UserProvidedFileSettings)
+            {
+                // This is the settings.json file in the shared configuration directory that is visible
+                // to all users on the machine e.g. /etc/dotnet-monitor on Unix systems.
+                string userSpecifiedFileSettingsContent = JsonSerializer.Serialize(UserProvidedFileSettingsContent);
+
+                File.WriteAllText(userProvidedConfigFullPath, userSpecifiedFileSettingsContent);
             }
 
             // Create the initial host builder.
@@ -232,6 +252,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             using TemporaryDirectory contentRootDirectory = new(_outputHelper);
             using TemporaryDirectory sharedConfigDir = new(_outputHelper);
             using TemporaryDirectory userConfigDir = new(_outputHelper);
+            using TemporaryDirectory userProvidedConfigDir = new(_outputHelper);
+
+            string userProvidedConfigFullPath = Path.Combine(userProvidedConfigDir.FullName, UserProvidedSettingsFileName);
 
             // Set up the initial settings used to create the host builder.
             HostBuilderSettings settings = new()
@@ -239,13 +262,17 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 Authentication = HostBuilderHelper.CreateAuthConfiguration(noAuth: false, tempApiKey: false),
                 ContentRootDirectory = contentRootDirectory.FullName,
                 SharedConfigDirectory = sharedConfigDir.FullName,
-                UserConfigDirectory = userConfigDir.FullName
+                UserConfigDirectory = userConfigDir.FullName,
+                UserProvidedConfigFilePath = userProvidedConfigFullPath
             };
 
             settings.Urls = new[] { "https://localhost:44444" }; // This corresponds to the value in SampleConfigurations/URLs.json
 
             // This is the settings.json file in the user profile directory.
-            File.WriteAllText(Path.Combine(userConfigDir.FullName, "settings.json"), ConstructSettingsJson("Egress.json", "CollectionRules.json", "CollectionRuleDefaults.json", "Templates.json"));
+            File.WriteAllText(userProvidedConfigFullPath, ConstructSettingsJson("Egress.json"));
+
+            // This is the settings.json file in the user profile directory.
+            File.WriteAllText(Path.Combine(userConfigDir.FullName, "settings.json"), ConstructSettingsJson("CollectionRules.json", "CollectionRuleDefaults.json", "Templates.json"));
 
             // This is the appsettings.json file that is normally next to the entrypoint assembly.
             // The location of the appsettings.json is determined by the content root in configuration.
@@ -434,7 +461,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             UserSettings,
             SharedSettings,
             SharedKeyPerFile,
-            MonitorEnvironment
+            MonitorEnvironment,
+            UserProvidedFileSettings
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/EgressFull.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/EgressFull.json
@@ -1,18 +1,18 @@
 {
   "AzureBlobStorage": {
     "monitorBlob": {
-      "accountKeyName": "MonitorBlobAccountKey" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
-      "accountUri": "https://exampleaccount.blob.core.windows.net" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
-      "blobPrefix": "artifacts" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
-      "containerName": "dotnet-monitor" /*JsonConfigurationProvider for 'settings.json' (Optional)*/
+      "accountKeyName": "MonitorBlobAccountKey" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
+      "accountUri": "https://exampleaccount.blob.core.windows.net" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
+      "blobPrefix": "artifacts" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
+      "containerName": "dotnet-monitor" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/
     }
   },
   "FileSystem": {
     "artifacts": {
-      "directoryPath": "/artifacts" /*JsonConfigurationProvider for 'settings.json' (Optional)*/
+      "directoryPath": "/artifacts" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/
     }
   },
   "Properties": {
-    "MonitorBlobAccountKey": "accountKey" /*JsonConfigurationProvider for 'settings.json' (Optional)*/
+    "MonitorBlobAccountKey": "accountKey" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/
   }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/EgressRedacted.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/EgressRedacted.json
@@ -1,25 +1,25 @@
 {
   "Properties": {
-    "MonitorBlobAccountKey": ":REDACTED:" /*JsonConfigurationProvider for 'settings.json' (Optional)*/
+    "MonitorBlobAccountKey": ":REDACTED:" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/
   },
   "AzureBlobStorage": {
     "monitorBlob": {
-      "AccountUri": "https://exampleaccount.blob.core.windows.net" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
-      "BlobPrefix": "artifacts" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
-      "ContainerName": "dotnet-monitor" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
+      "AccountUri": "https://exampleaccount.blob.core.windows.net" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
+      "BlobPrefix": "artifacts" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
+      "ContainerName": "dotnet-monitor" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
       "CopyBufferSize": ":NOT PRESENT:",
       "QueueName": ":NOT PRESENT:",
       "QueueAccountUri": ":NOT PRESENT:",
       "SharedAccessSignature": ":NOT PRESENT:",
       "AccountKey": ":NOT PRESENT:",
       "SharedAccessSignatureName": ":NOT PRESENT:",
-      "AccountKeyName": "MonitorBlobAccountKey" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
+      "AccountKeyName": "MonitorBlobAccountKey" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
       "ManagedIdentityClientId": ":NOT PRESENT:"
     }
   },
   "FileSystem": {
     "artifacts": {
-      "DirectoryPath": " /artifacts" /*JsonConfigurationProvider for 'settings.json' (Optional)*/,
+      "DirectoryPath": " /artifacts" /*JsonConfigurationProvider for 'UserSpecifiedFile.json' (Optional)*/,
       "IntermediateDirectoryPath": ":NOT PRESENT:",
       "CopyBufferSize": ":NOT PRESENT:"
     }

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 {
     internal static class CollectCommandHandler
     {
-        public static async Task<int> Invoke(CancellationToken token, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress)
+        public static async Task<int> Invoke(CancellationToken token, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, string configurationFilePath)
         {
             try
             {
                 AuthConfiguration authConfiguration = HostBuilderHelper.CreateAuthConfiguration(noAuth, tempApiKey);
-                HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(urls, metricUrls, metrics, diagnosticPort, authConfiguration);
+                HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(urls, metricUrls, metrics, diagnosticPort, authConfiguration, configurationFilePath);
 
                 IHost host = HostBuilderHelper.CreateHostBuilder(settings)
                     .ConfigureServices(authConfiguration, noHttpEgress)

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         // Although the "noHttpEgress" parameter is unused, it keeps the entire command parameter set a superset
         // of the "collect" command so that users can take the same arguments from "collect" and use it on "config show"
         // to get the same configuration without telling them to drop specific command line arguments.
-        public static void Invoke(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, ConfigDisplayLevel level, bool showSources)
+        public static void Invoke(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, string configurationFilePath, ConfigDisplayLevel level, bool showSources)
         {
             Stream stream = Console.OpenStandardOutput();
 
@@ -26,13 +26,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             writer.WriteLine();
             writer.Flush();
 
-            Write(Console.OpenStandardOutput(), urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, level, showSources);
+            Write(Console.OpenStandardOutput(), urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, configurationFilePath, level, showSources);
         }
 
-        public static void Write(Stream stream, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, ConfigDisplayLevel level, bool showSources)
+        public static void Write(Stream stream, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, string configurationFilePath, ConfigDisplayLevel level, bool showSources)
         {
             IAuthConfiguration authConfiguration = HostBuilderHelper.CreateAuthConfiguration(noAuth, tempApiKey);
-            HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(urls, metricUrls, metrics, diagnosticPort, authConfiguration);
+            HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(urls, metricUrls, metrics, diagnosticPort, authConfiguration, configurationFilePath);
             IHost host = HostBuilderHelper.CreateHostBuilder(settings).Build();
             IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
             using ConfigurationJsonWriter jsonWriter = new ConfigurationJsonWriter(stream);

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         try
                         {
-
                             File.OpenRead(userFilePath).Dispose(); // If this succeeds, we have read-permissions
                             builder.AddJsonFile(userFilePath, optional: true, reloadOnChange: true);
                         }

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -69,17 +69,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources
                     string userFilePath = settings.UserProvidedConfigFilePath;
 
-                    if (!string.IsNullOrEmpty(userFilePath))
+                    if (File.Exists(userFilePath))
                     {
-                        using (FileStream filestream = new FileStream(userFilePath, FileMode.Open))
+                        try
                         {
-                            if (filestream.CanRead)
-                            {
-                                builder.AddJsonFile(userFilePath, optional: true, reloadOnChange: true);
-                            }
+                            File.OpenRead(userFilePath).Dispose(); // If this succeeds, we have read-permissions
+                            builder.AddJsonFile(userFilePath, optional: true, reloadOnChange: true);
                         }
-
-                        builder.AddJsonFile(settings.UserProvidedConfigFilePath, optional: true, reloadOnChange: true);
+                        catch (Exception)
+                        {
+                            // Don't currently log to tell the user that their configuration file was not loaded
+                        }
                     }
                 })
                 //Note this is necessary for config only because Kestrel configuration

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -69,10 +69,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources
                     string userFilePath = settings.UserProvidedConfigFilePath;
 
-                    if (File.Exists(userFilePath))
+                    if (File.Exists(userFilePath) && Path.GetExtension(userFilePath).ToLower().Equals(".json"))
                     {
                         try
                         {
+
                             File.OpenRead(userFilePath).Dispose(); // If this succeeds, we have read-permissions
                             builder.AddJsonFile(userFilePath, optional: true, reloadOnChange: true);
                         }

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -65,6 +65,22 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         ConfigureTempApiHashKey(builder, settings.Authentication);
                     }
+
+                    // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources
+                    string userFilePath = settings.UserProvidedConfigFilePath;
+
+                    if (!string.IsNullOrEmpty(userFilePath))
+                    {
+                        using (FileStream filestream = new FileStream(userFilePath, FileMode.Open))
+                        {
+                            if (filestream.CanRead)
+                            {
+                                builder.AddJsonFile(userFilePath, optional: true, reloadOnChange: true);
+                            }
+                        }
+
+                        builder.AddJsonFile(settings.UserProvidedConfigFilePath, optional: true, reloadOnChange: true);
+                    }
                 })
                 //Note this is necessary for config only because Kestrel configuration
                 //is not added until WebHostDefaults are added.

--- a/src/Tools/dotnet-monitor/HostBuilderSettings.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderSettings.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public string UserConfigDirectory { get; set; }
 
+        public string UserProvidedConfigFilePath { get; set; }
+
         /// <summary>
         /// Create settings for dotnet-monitor hosting.
         /// </summary>
@@ -66,7 +68,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             string[] metricUrls, 
             bool metrics,
             string diagnosticPort,
-            IAuthConfiguration authConfiguration)
+            IAuthConfiguration authConfiguration,
+            string userProvidedConfigFilePath)
         {
             return new HostBuilderSettings()
             {
@@ -77,7 +80,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 Authentication = authConfiguration,
                 ContentRootDirectory = AppContext.BaseDirectory,
                 SharedConfigDirectory = SharedConfigDirectoryPath,
-                UserConfigDirectory = UserConfigDirectoryPath
+                UserConfigDirectory = UserConfigDirectoryPath,
+                UserProvidedConfigFilePath = userProvidedConfigFilePath
             };
         }
 

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 SharedOptions()
             };
 
-            command.SetHandler<CancellationToken, string[], string[], bool, string, bool, bool, bool>(CollectCommandHandler.Invoke, command.Children.OfType<IValueDescriptor>().ToArray());
+            command.SetHandler<CancellationToken, string[], string[], bool, string, bool, bool, bool, string>(CollectCommandHandler.Invoke, command.Children.OfType<IValueDescriptor>().ToArray());
  
             return command;
         }
@@ -56,7 +56,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 ShowSources()
             };
 
-            showCommand.SetHandler<string[], string[], bool, string, bool, bool, bool, ConfigDisplayLevel, bool>(ConfigShowCommandHandler.Invoke, showCommand.Children.OfType<IValueDescriptor>().ToArray());
+            showCommand.SetHandler<string[], string[], bool, string, bool, bool, bool, string, ConfigDisplayLevel, bool>(ConfigShowCommandHandler.Invoke, showCommand.Children.OfType<IValueDescriptor>().ToArray());
 
             Command configCommand = new Command(
                 name: "config",
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static IEnumerable<Option> SharedOptions() => new Option[]
         {
-            Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth(), TempApiKey(), NoHttpEgress()
+            Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort(), NoAuth(), TempApiKey(), NoHttpEgress(), ConfigurationFilePath()
         };
         
         private static Option Urls() =>
@@ -106,6 +106,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 description: Strings.HelpDescription_OptionDiagnosticPort)
             {
                 ArgumentHelpName = "diagnosticPort"
+            };
+
+        private static Option ConfigurationFilePath() =>
+            new Option<string>(
+                name: "--configuration-file-path",
+                description: Strings.HelpDescription_OptionConfigurationFilePath)
+            {
+                ArgumentHelpName = "configurationFilePath"
             };
 
         private static Option NoAuth() =>

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -457,6 +457,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The fully qualified path and filename of the configuration file you&apos;d like to add to the list of configuration sources..
+        /// </summary>
+        internal static string HelpDescription_OptionConfigurationFilePath {
+            get {
+                return ResourceManager.GetString("HelpDescription_OptionConfigurationFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The fully qualified path and filename of the diagnostic port to which runtime instances can connect..
         /// </summary>
         internal static string HelpDescription_OptionDiagnosticPort {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -340,6 +340,10 @@
     <value>Shows configuration, as if dotnet-monitor collect was executed with these parameters.</value>
     <comment>Gets the string to display in help that explains what the 'show' command does.</comment>
   </data>
+  <data name="HelpDescription_OptionConfigurationFilePath" xml:space="preserve">
+    <value>The fully qualified path and filename of the configuration file you'd like to add to the list of configuration sources.</value>
+    <comment>Gets the string to display in help that explains what the '--configuration-file-path' option does.</comment>
+  </data>
   <data name="HelpDescription_OptionDiagnosticPort" xml:space="preserve">
     <value>The fully qualified path and filename of the diagnostic port to which runtime instances can connect.</value>
     <comment>Gets the string to display in help that explains what the '--diagnostic-port' option does.</comment>


### PR DESCRIPTION
Users can now specify a configuration file via the command line (`--configuration-file-path`); if provided, this takes highest precedence but **does not** override the other configuration sources.

Closes #1760 