### PR TITLE
Add unsupported versions entry

### DIFF
--- a/documentation/releases.md
+++ b/documentation/releases.md
@@ -1,13 +1,19 @@
 # Releases
 
-## Supported Versions
+## Supported versions
 
 | Version | Original Release Date | Latest Patch Version | Patch Release Date | End of Support | Runtime Frameworks |
 |---|---|---|---|---|---|
 | 6.2 | June 14, 2022 | [6.2.0](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v6.2.0.md) | June 14, 2022 |  | .NET Core 3.1 (with major roll forward)<br/>.NET 6 |
 | 6.1 | February 17, 2022 | [6.1.2](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v6.1.2.md) | June 14, 2022 |  September 14, 2022 | .NET Core 3.1 (with major roll forward)<br/>.NET 6 |
 
-## Preview Versions
+## Out of support versions
+
+| Version | Original Release Date | Latest Patch Version | Patch Release Date | End of Support | Runtime Frameworks |
+|---|---|---|---|---|---|
+| 6.0 | November 8, 2021 | [6.0.2](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releaseNotes/releaseNotes.v6.0.2.md) | February 8, 2022 | May 17, 2022 | .NET Core 3.1 (with major roll forward)<br/>.NET 6 |
+
+## Preview releases
 
 | Version  | Latest Version | Release Date | Runtime Frameworks |
 |---|---|---|---|


### PR DESCRIPTION
Add the 6.0 unsupported version information into a separate table. This largely mirrors the format of the [.NET Core support policy page](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)