### PR TITLE
Address "Swallow Everything" Exceptions

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -82,6 +82,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 catch (InvalidOperationException)
                 {
                 }
+                catch (Exception ex) when (!(ex is OperationCanceledException))
+                {
+                    _logger.LogWarning(ex.Message);
+                }
 
                 IList<Models.ProcessIdentifier> processesIdentifiers = new List<Models.ProcessIdentifier>();
                 foreach (IProcessInfo p in await _diagnosticServices.GetProcessesAsync(processFilter: null, HttpContext.RequestAborted))

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 }
                 catch (ArgumentException ex)
                 {
+                    // Unable to locate a default process; no action required
                     _logger.LogInformation(ex.Message);
                 }
                 catch (InvalidOperationException ex)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -75,14 +75,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 {
                     defaultProcessInfo = await _diagnosticServices.GetProcessAsync(null, HttpContext.RequestAborted);
                 }
-                catch (ArgumentException ex)
+                catch (ArgumentException)
                 {
                     // Unable to locate a default process; no action required
-                    _logger.LogInformation(ex.Message);
                 }
-                catch (InvalidOperationException ex)
+                catch (InvalidOperationException)
                 {
-                    _logger.LogInformation(ex.Message);
                 }
 
                 IList<Models.ProcessIdentifier> processesIdentifiers = new List<Models.ProcessIdentifier>();

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 }
                 catch (Exception ex) when (!(ex is OperationCanceledException))
                 {
-                    _logger.LogWarning(ex.Message);
+                    _logger.DefaultProcessUnexpectedFailure(ex);
                 }
 
                 IList<Models.ProcessIdentifier> processesIdentifiers = new List<Models.ProcessIdentifier>();

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -75,9 +75,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 {
                     defaultProcessInfo = await _diagnosticServices.GetProcessAsync(null, HttpContext.RequestAborted);
                 }
-                catch (Exception)
+                catch (ArgumentException ex)
                 {
-                    // Unable to locate a default process; no action required
+                    _logger.LogInformation(ex.Message);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    _logger.LogInformation(ex.Message);
                 }
 
                 IList<Models.ProcessIdentifier> processesIdentifiers = new List<Models.ProcessIdentifier>();

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ThrottledEndpoint);
 
+        private static readonly Action<ILogger, Exception> _defaultProcessUnexpectedFailure =
+            LoggerMessage.Define(
+                eventId: new EventId(7, "DefaultProcessUnexpectedFailure"),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_DefaultProcessUnexpectedFailure);
+
         public static void RequestFailed(this ILogger logger, Exception ex)
         {
             _requestFailed(logger, ex);
@@ -73,6 +79,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public static void WrittenToHttpStream(this ILogger logger)
         {
             _writtenToHttpStream(logger, null);
+        }
+
+        public static void DefaultProcessUnexpectedFailure(this ILogger logger, Exception ex)
+        {
+            _defaultProcessUnexpectedFailure(logger, ex);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -92,16 +92,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
                     commandLine = await commandLineSource.Task;
                 }
-                catch (ObjectDisposedException)
-                {
-                }
                 catch (PipelineException)
-                {
-                }
-                catch (ArgumentNullException)
-                {
-                }
-                catch (ArgumentException)
                 {
                 }
                 catch (OperationCanceledException)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -104,6 +104,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 catch (ArgumentException)
                 {
                 }
+                catch (OperationCanceledException)
+                {
+                }
                 finally
                 {
                     if (null != pipeline)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -92,7 +92,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
                     commandLine = await commandLineSource.Task;
                 }
-                catch
+                catch (ObjectDisposedException)
+                {
+                }
+                catch (PipelineException)
+                {
+                }
+                catch (ArgumentNullException)
+                {
+                }
+                catch (ArgumentException)
                 {
                 }
                 finally

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -223,6 +223,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An unexpected error occurred while getting the default process..
+        /// </summary>
+        internal static string LogFormatString_DefaultProcessUnexpectedFailure {
+            get {
+                return ResourceManager.GetString("LogFormatString_DefaultProcessUnexpectedFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Egressed artifact to {location}.
         /// </summary>
         internal static string LogFormatString_EgressedArtifact {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An unexpected error occurred while getting the default process..
+        ///   Looks up a localized string similar to Failed to determine the default process..
         /// </summary>
         internal static string LogFormatString_DefaultProcessUnexpectedFailure {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -194,6 +194,11 @@
     <value>Value must be of type string.</value>
     <comment>Gets a string similar to "Value must be of type string.".</comment>
   </data>
+  <data name="LogFormatString_DefaultProcessUnexpectedFailure" xml:space="preserve">
+    <value>An unexpected error occurred while getting the default process.</value>
+    <comment>Gets the format string that is printed in the 7:DefaultProcessUnexpectedFailure event.
+0 Format Parameters</comment>
+  </data>
   <data name="LogFormatString_EgressedArtifact" xml:space="preserve">
     <value>Egressed artifact to {location}</value>
     <comment>Gets the format string that is printed in the 4:EgressedArtifact event.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -195,7 +195,7 @@
     <comment>Gets a string similar to "Value must be of type string.".</comment>
   </data>
   <data name="LogFormatString_DefaultProcessUnexpectedFailure" xml:space="preserve">
-    <value>An unexpected error occurred while getting the default process.</value>
+    <value>Failed to determine the default process.</value>
     <comment>Gets the format string that is printed in the 7:DefaultProcessUnexpectedFailure event.
 0 Format Parameters</comment>
   </data>

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
@@ -18,9 +18,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
     internal class FileSystemEgressProvider :
         EgressProvider<FileSystemEgressProviderOptions>
     {
+        ILogger<FileSystemEgressProvider> _logger;
+
         public FileSystemEgressProvider(ILogger<FileSystemEgressProvider> logger)
             : base(logger)
         {
+            _logger = logger;
         }
 
         public override async Task<string> EgressAsync(
@@ -75,8 +78,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
                             File.Delete(intermediateFilePath);
                         }
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
+                        _logger.LogTrace(ex.Message);
                     }
                 }
             }

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogTrace(ex.Message);
+                        _logger.IntermediateFileDeletionFailed(intermediateFilePath, ex);
                     }
                 }
             }

--- a/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
                 catch (Exception ex)
                 {
-                    clientSourceLogger.LogTrace(ex.Message);
+                    clientSourceLogger.RuntimeInstanceCookieFailedToFilterSelf(ex);
                 }
 
                 // If connecting to runtime instances, filter self out. In listening mode, it's likely

--- a/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
@@ -63,8 +63,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         _runtimeInstanceCookieToFilterOut = runtimeInstanceCookie;
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    clientSourceLogger.LogTrace(ex.Message);
                 }
 
                 // If connecting to runtime instances, filter self out. In listening mode, it's likely

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -71,7 +71,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         QueueOptionsPartiallySet = 58,
         WritingMessageToQueueFailed = 59,
         ExperienceSurvey = 60,
-        DiagnosticPortNotInListenModeForCollectionRules = 61
+        DiagnosticPortNotInListenModeForCollectionRules = 61,
+        RuntimeInstanceCookieFailedToFilterSelf = 62,
+        ParsingUrlFailed = 63,
+        IntermediateFileDeletionFailed = 64
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -339,6 +339,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DiagnosticPortNotInListenModeForCollectionRules);
 
+        private static readonly Action<ILogger, Exception> _runtimeInstanceCookieFailedToFilterSelf =
+            LoggerMessage.Define(
+                eventId: LoggingEventIds.RuntimeInstanceCookieFailedToFilterSelf.EventId(),
+                logLevel: LogLevel.Debug,
+                formatString: Strings.LogFormatString_RuntimeInstanceCookieFailedToFilterSelf);
+
+        private static readonly Action<ILogger, string, Exception> _parsingUrlFailed =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.ParsingUrlFailed.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_ParsingUrlFailed);
+
+        private static readonly Action<ILogger, string, Exception> _intermediateFileDeletionFailed =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.IntermediateFileDeletionFailed.EventId(),
+                logLevel: LogLevel.Debug,
+                formatString: Strings.LogFormatString_IntermediateFileDeletionFailed);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -622,6 +640,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void DiagnosticPortNotInListenModeForCollectionRules(this ILogger logger)
         {
             _diagnosticPortNotInListenModeForCollectionRules(logger, null);
+        }
+
+        public static void RuntimeInstanceCookieFailedToFilterSelf(this ILogger logger, Exception ex)
+        {
+            _runtimeInstanceCookieFailedToFilterSelf(logger, ex);
+        }
+
+        public static void ParsingUrlFailed(this ILogger logger, string url, Exception ex)
+        {
+            _parsingUrlFailed(logger, url, ex);
+        }
+
+        public static void IntermediateFileDeletionFailed(this ILogger logger, string intermediateFilePath, Exception ex)
+        {
+            _intermediateFileDeletionFailed(logger, intermediateFilePath, ex);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     catch (FormatException ex)
                     {
                         logger.LogInformation(ex.Message);
+                        continue;
                     }
 
                     if (string.Equals(Uri.UriSchemeHttp, address.Scheme, StringComparison.OrdinalIgnoreCase))

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     }
                     catch (FormatException ex)
                     {
-                        logger.LogInformation(ex.Message);
+                        logger.ParsingUrlFailed(url, ex);
                         continue;
                     }
 

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -155,9 +155,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         address = BindingAddress.Parse(url);
                     }
-                    catch (Exception)
+                    catch (FormatException ex)
                     {
-                        continue;
+                        logger.LogInformation(ex.Message);
                     }
 
                     if (string.Equals(Uri.UriSchemeHttp, address.Scheme, StringComparison.OrdinalIgnoreCase))

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -916,7 +916,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The intermediate file at the following path could not be deleted: {0}.
+        ///   Looks up a localized string similar to The intermediate file at the following path could not be deleted: {path}.
         /// </summary>
         internal static string LogFormatString_IntermediateFileDeletionFailed {
             get {
@@ -997,7 +997,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided url could not be parsed: {0}.
+        ///   Looks up a localized string similar to The provided url could not be parsed: {url}.
         /// </summary>
         internal static string LogFormatString_ParsingUrlFailed {
             get {
@@ -1033,7 +1033,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The runtime instance cookie failed to filter out the current process..
+        ///   Looks up a localized string similar to Unable to get the runtime instance cookie of the current process..
         /// </summary>
         internal static string LogFormatString_RuntimeInstanceCookieFailedToFilterSelf {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -916,6 +916,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The intermediate file at the following path could not be deleted: {0}.
+        /// </summary>
+        internal static string LogFormatString_IntermediateFileDeletionFailed {
+            get {
+                return ResourceManager.GetString("LogFormatString_IntermediateFileDeletionFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid action reference &apos;{actionReference}&apos;..
         /// </summary>
         internal static string LogFormatString_InvalidActionReference {
@@ -988,6 +997,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The provided url could not be parsed: {0}.
+        /// </summary>
+        internal static string LogFormatString_ParsingUrlFailed {
+            get {
+                return ResourceManager.GetString("LogFormatString_ParsingUrlFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The queue {0} does not exist; ensure that the {queueName} and {queueAccountUri} fields are set correctly..
         /// </summary>
         internal static string LogFormatString_QueueDoesNotExist {
@@ -1011,6 +1029,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string LogFormatString_RunningElevated {
             get {
                 return ResourceManager.GetString("LogFormatString_RunningElevated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The runtime instance cookie failed to filter out the current process..
+        /// </summary>
+        internal static string LogFormatString_RuntimeInstanceCookieFailedToFilterSelf {
+            get {
+                return ResourceManager.GetString("LogFormatString_RuntimeInstanceCookieFailedToFilterSelf", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -566,7 +566,7 @@
 0 Format Parameters</comment>
   </data>
   <data name="LogFormatString_IntermediateFileDeletionFailed" xml:space="preserve">
-    <value>The intermediate file at the following path could not be deleted: {0}</value>
+    <value>The intermediate file at the following path could not be deleted: {path}</value>
   </data>
   <data name="LogFormatString_InvalidActionReference" xml:space="preserve">
     <value>Invalid action reference '{actionReference}'.</value>
@@ -609,7 +609,7 @@
 1. failure: The failure message from validation</comment>
   </data>
   <data name="LogFormatString_ParsingUrlFailed" xml:space="preserve">
-    <value>The provided url could not be parsed: {0}</value>
+    <value>The provided url could not be parsed: {url}</value>
   </data>
   <data name="LogFormatString_QueueDoesNotExist" xml:space="preserve">
     <value>The queue {0} does not exist; ensure that the {queueName} and {queueAccountUri} fields are set correctly.</value>
@@ -632,7 +632,7 @@
 0 Format Parameters</comment>
   </data>
   <data name="LogFormatString_RuntimeInstanceCookieFailedToFilterSelf" xml:space="preserve">
-    <value>The runtime instance cookie failed to filter out the current process.</value>
+    <value>Unable to get the runtime instance cookie of the current process.</value>
   </data>
   <data name="LogFormatString_SetEnvironmentVariable" xml:space="preserve">
     <value>Setting the environment variable {variableName} in process {processId}.</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -565,6 +565,9 @@
     <comment>Gets the format string that is printed in the 14:InsecureAutheticationConfiguration event.
 0 Format Parameters</comment>
   </data>
+  <data name="LogFormatString_IntermediateFileDeletionFailed" xml:space="preserve">
+    <value>The intermediate file at the following path could not be deleted: {0}</value>
+  </data>
   <data name="LogFormatString_InvalidActionReference" xml:space="preserve">
     <value>Invalid action reference '{actionReference}'.</value>
   </data>
@@ -605,6 +608,9 @@
 1 Format Parameter:
 1. failure: The failure message from validation</comment>
   </data>
+  <data name="LogFormatString_ParsingUrlFailed" xml:space="preserve">
+    <value>The provided url could not be parsed: {0}</value>
+  </data>
   <data name="LogFormatString_QueueDoesNotExist" xml:space="preserve">
     <value>The queue {0} does not exist; ensure that the {queueName} and {queueAccountUri} fields are set correctly.</value>
     <comment>Gets the format string that is printed in the 57:QueueDoesNotExist event.
@@ -624,6 +630,9 @@
     <value>The process was launched elevated and will have access to all processes on the system. Do not run elevated unless you need to monitor processes launched by another user (e.g., IIS worker processes)</value>
     <comment>Gets the format string that is printed in the 19:RunningElevated event.
 0 Format Parameters</comment>
+  </data>
+  <data name="LogFormatString_RuntimeInstanceCookieFailedToFilterSelf" xml:space="preserve">
+    <value>The runtime instance cookie failed to filter out the current process.</value>
   </data>
   <data name="LogFormatString_SetEnvironmentVariable" xml:space="preserve">
     <value>Setting the environment variable {variableName} in process {processId}.</value>


### PR DESCRIPTION
Part of the security review is to address "swallow everything" exceptions; this is an initial pass at adding logging to some of the places where we `catch` as well as expanding to specify which exceptions we want to catch. Things to consider:

- Where we should/shouldn't log (and what level makes the most sense)
- What exceptions we need to handle that were previously being encompassed by `Exception`
- Places where the exception handling should not be altered (and the reasoning)

If there are other places where we should make changes that aren't included here, please let me know and I'll add them in.