### PR TITLE
Allow rebuild during packaging

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -57,7 +57,6 @@ stages:
       configuration: Release
       publishArtifactsSubPaths:
       - source: 'bin'
-      - source: 'obj'
       testGroup: ${{ parameters.TestGroup }}
   - template: /eng/build.yml
     parameters:

--- a/eng/cipacksignpublish.cmd
+++ b/eng/cipacksignpublish.cmd
@@ -4,5 +4,5 @@ setlocal
 set "_commonArgs=-restore -ci -prepareMachine -verbosity minimal -configuration Release"
 set "_logDir=%~dp0..\artifacts\log\Release\"
 
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" %_commonArgs% -pack -sign -publish /p:NoBuild=true -noBl /bl:'%_logDir%PackSignPublish.binlog' %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0common\Build.ps1""" %_commonArgs% -pack -sign -publish -noBl /bl:'%_logDir%PackSignPublish.binlog' %*"
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
PR #1681 was an attempt to cache the obj folder from build and reuse it without having to build again while packaging. The motivation was to have the generated .NET tool package to have the same exact binaries as those that were tested in the build jobs.

This has not worked since updating to the .NET 7 Preview 5 SDK because some intermediate assets that are required by publish from the build phase that are not produced if /p:NoBuild=true is used during packaging. See [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=1852254&view=logs&j=8302af6e-291f-54bf-6d61-b832e4017e5a&t=31c4598f-342a-52ea-54df-47052f2aafdf) as example build demonstrating this problem.

To fix this, I've reverted the /p:NoBuild=true usage in the CI builds. See [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=1852451&view=results) as an example of this change. It's okay that the pack phase rebuilds the assemblies since the build version is based on the pipeline version, a rebuild should produce the same functional assemblies, and matching symbols will be regenerated during the pack phase.