### PR TITLE
Revert SDK to Preview 4

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-preview.5.22307.18",
+    "dotnet": "7.0.100-preview.4.22252.9",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",


### PR DESCRIPTION
Builds are failing due to https://github.com/dotnet/aspnetcore/issues/42200; I have tried the latest SDK and the issue seems to persist. Revert to the Preview 4 SDK until the issue is fixed. Internal validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1852879&view=results