### PR TITLE
Use auth library versions that correspond with target framework

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,14 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>166610c56ff732093f0145a2911d4f6c40b786da</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0-preview.7.22328.8">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f4f4835635a812cfe24b724b8a1c4aab6cee8705</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Negotiate" Version="7.0.0-preview.7.22328.8">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>f4f4835635a812cfe24b724b8a1c4aab6cee8705</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.22328.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>5ad37d8dc3128a21d6070aa23fa706c26930ee8c</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,6 +46,8 @@
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22327.2</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
     <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.7.22328.8</MicrosoftAspNetCoreAppRuntimewinx64Version>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>7.0.0-preview.7.22328.8</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>7.0.0-preview.7.22328.8</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.7.22328.8</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.22328.1</MicrosoftDiagnosticsMonitoringVersion>
@@ -70,8 +72,8 @@
     <AzureIdentityVersion>1.6.0</AzureIdentityVersion>
     <AzureStorageBlobsVersion>12.12.0</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.10.0</AzureStorageQueuesVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>6.0.5</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>6.0.5</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion60>6.0.5</MicrosoftAspNetCoreAuthenticationJwtBearerVersion60>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion60>6.0.5</MicrosoftAspNetCoreAuthenticationNegotiateVersion60>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.5</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
@@ -94,5 +96,14 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
+  </PropertyGroup>
+  <!-- Pivot versions depending on TFM -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersionForTargetFramework>$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion60)</MicrosoftAspNetCoreAuthenticationJwtBearerVersionForTargetFramework>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersionForTargetFramework>$(MicrosoftAspNetCoreAuthenticationNegotiateVersion60)</MicrosoftAspNetCoreAuthenticationNegotiateVersionForTargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersionForTargetFramework>$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion)</MicrosoftAspNetCoreAuthenticationJwtBearerVersionForTargetFramework>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersionForTargetFramework>$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)</MicrosoftAspNetCoreAuthenticationNegotiateVersionForTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerVersionForTargetFramework)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersionForTargetFramework)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)" />
   </ItemGroup>


### PR DESCRIPTION
This change makes it so that the dotnet-monitor for each TFM uses the corresponding Microsoft.AspNetCore.Authentication.* libraries that best match the TFM. Thus the net6.0 dotnet-monitor will use the 6.0.* versions whereas the net7.0 dotnet-monitor will use the 7.0.* versions.