### PR TITLE
Fix version file names that are published to blob storage

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -97,23 +97,33 @@
           Inputs="@(PackageToPublish)"
           Outputs="%(PackageToPublish.Identity).notexist">
 
-    <!-- Find the artifact files next to the package file. -->
-    <PropertyGroup>
-      <_ChecksumFilePath>%(PackageToPublish.FullPath).sha512</_ChecksumFilePath>
-      <_BuildVersionFilePath>%(PackageToPublish.FullPath).buildversion</_BuildVersionFilePath>
-      <_PackageVersionFilePath>%(PackageToPublish.FullPath).version</_PackageVersionFilePath>
-    </PropertyGroup>
-
     <!-- Read in project file name -->
     <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectpath">
       <Output TaskParameter="Lines" PropertyName="_ProjectPath"/>
     </ReadLinesFromFile>
+
+    <!-- Get package name from project as if its version was set to the build version -->
+    <MSBuild Projects="$(_ProjectPath)"
+             Targets="GetPackageFileName"
+             Properties="Version=$(_BuildVersion)">
+      <Output ItemName="_PackageWithBuildVersionFileName" TaskParameter="TargetOutputs" />
+    </MSBuild>
 
     <!-- Get package version from project -->
     <MSBuild Projects="$(_ProjectPath)"
              Targets="GetPackageVersion">
       <Output ItemName="_PackageVersion" TaskParameter="TargetOutputs" />
     </MSBuild>
+
+    <!-- Package artifact file paths -->
+    <PropertyGroup>
+      <!-- Example file name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg -->
+      <_PackageWithBuildVersionFileName>@(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFileName>
+      <_PackageWithBuildVersionFilePath>%(PackageToPublish.RootDir)%(PackageToPublish.Directory)$(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFilePath>
+      <_ChecksumFilePath>%(PackageToPublish.FullPath).sha512</_ChecksumFilePath>
+      <_BuildVersionFilePath>$(_PackageWithBuildVersionFilePath).buildversion</_BuildVersionFilePath>
+      <_PackageVersionFilePath>$(_PackageWithBuildVersionFilePath).version</_PackageVersionFilePath>
+    </PropertyGroup>
 
     <!--
       A file that contains the version of the package.

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -23,4 +23,7 @@
   <Target Name="GetPackageVersion"
           Returns="$(PackageVersion)" />
 
+  <Target Name="GetPackageFileName"
+          Returns="$(PackageId).$(PackageVersion).nupkg" />
+
 </Project>


### PR DESCRIPTION
The naming of the *.buildverion and *.version files that are uploaded to blob storage was regressed in #1834. The prior naming convention would include the build version in the file name regardless of final versions were used, for example:

```
dotnet-monitor.6.2.1-servicing.22330.6.nupkg.buildversion
dotnet-monitor.6.2.1-servicing.22330.6.nupkg.version
```

whereas with the changes in #1834 only used the package version in the file names:

```
dotnet-monitor.6.2.1.nupkg.buildversion
dotnet-monitor.6.2.1.nupkg.version
```

The problem is that these are uploaded to a container and prefix named `diagnostics/monitor6.2/release`. If more than one build is produced from the same final version, then the uploaded files will collide with what's already on blob storage from the first build.

This change restores the naming scheme for these files such that they contain the build version regardless of whether final versions are used or not.