### PR TITLE
Pin net6.0 version for test apps

### DIFF
--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -10,6 +10,7 @@
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftNETCoreApp50Version)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In the event that the SDK starts implicitly requiring a unrelease version of .NET 6, the version of the runtime should be pinned to what is installed so that the apps will run on what's available at build time.