### PR TITLE
Fix System.CommandLine version information

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,5 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="System.CommandLine.Experimental" Version="&gt;0.2.0-alpha.19213.1">
-      <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>166610c56ff732093f0145a2911d4f6c40b786da</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.0-preview.22354.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>dfb3b8887d27640c56e701cbddeab29e153c9158</Sha>
@@ -11,6 +7,10 @@
     <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.0-preview.22354.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>dfb3b8887d27640c56e701cbddeab29e153c9158</Sha>
+    </Dependency>
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22326.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>58b77e47bb0bb771b33768ff46736bf6cf0e5eef</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,6 +47,8 @@
     <!-- dotnet/aspnetcore references -->
     <MicrosoftAspNetCoreAppRuntimewinx64Version>7.0.0-preview.7.22354.2</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-preview.7.22354.2</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
+    <!-- dotnet/command-line-api references -->
+    <SystemCommandLineVersion>2.0.0-beta4.22326.1</SystemCommandLineVersion>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>5.0.0-preview.22354.1</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.0-preview.22354.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
@@ -80,7 +82,6 @@
     <MicrosoftIdentityModelTokensVersion>6.17.0</MicrosoftIdentityModelTokensVersion>
     <MicrosoftOpenApiReadersVersion>1.2.3</MicrosoftOpenApiReadersVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-    <SystemCommandLineVersion>2.0.0-beta3.22173.1</SystemCommandLineVersion>
     <SystemIdentityModelTokensJwtVersion>6.17.0</SystemIdentityModelTokensJwtVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>


### PR DESCRIPTION
The System.CommandLine dependency hasn't been updated because the version information does not match the package. I've fixed it up to use the same version that is in [dotnet/installer](https://github.com/dotnet/sdk/blob/main/eng/Version.Details.xml#L267).