### PR TITLE
Disable use of static web assets

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -16,6 +16,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <OutputType>Library</OutputType>
+    <!--
+      Workaround for https://github.com/dotnet/aspnetcore/issues/42200
+      Required as of 7.0 Preview 5 SDK
+      -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -10,6 +10,11 @@
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <RollForward>Major</RollForward>
+    <!--
+      Workaround for https://github.com/dotnet/aspnetcore/issues/42200
+      Required as of 7.0 Preview 5 SDK
+      -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
An arcade update brough in .NET 7 SDK Preview 5, which contains the following issue: https://github.com/dotnet/aspnetcore/issues/42200

The workaround is to disable the use of static web assets. These typically are only available when running in a development hosting environment, which is not the case for the typical dotnet-monitor deployment (this would be an environment where the `Environment` environment variable or configuration key is set to `Development`). I am also not aware of any feature of dotnet-monitor that makes use of static web assets.