### PR TITLE
Convert logger string format and arguments to native platform string width

### DIFF
--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -17,7 +17,9 @@ set(SOURCES
     Environment/EnvironmentHelper.cpp
     Environment/ProfilerEnvironment.cpp
     Logging/AggregateLogger.cpp
+    Logging/Logger.cpp
     Logging/NullLogger.cpp
+    Logging/StdErrLogger.cpp
     MainProfiler/ExceptionTracker.cpp
     MainProfiler/MainProfiler.cpp
     MainProfiler/ThreadData.cpp

--- a/src/MonitorProfiler/Communication/CommandServer.cpp
+++ b/src/MonitorProfiler/Communication/CommandServer.cpp
@@ -65,7 +65,7 @@ void CommandServer::ListeningThread()
         hr = client->Receive(message);
         if (FAILED(hr))
         {
-            _logger->Log(LogLevel::Error, _T("Unexpected error when receiving data: 0x%08x"), hr);
+            _logger->Log(LogLevel::Error, _LS("Unexpected error when receiving data: 0x%08x"), hr);
             continue;
         }
 
@@ -76,13 +76,13 @@ void CommandServer::ListeningThread()
         hr = client->Send(response);
         if (FAILED(hr))
         {
-            _logger->Log(LogLevel::Error, _T("Unexpected error when sending data: 0x%08x"), hr);
+            _logger->Log(LogLevel::Error, _LS("Unexpected error when sending data: 0x%08x"), hr);
             continue;
         }
         hr = client->Shutdown();
         if (FAILED(hr))
         {
-            _logger->Log(LogLevel::Warning, _T("Unexpected error during shutdown: 0x%08x"), hr);
+            _logger->Log(LogLevel::Warning, _LS("Unexpected error during shutdown: 0x%08x"), hr);
         }
 
         _clientQueue.Enqueue(message);
@@ -103,7 +103,7 @@ void CommandServer::ClientProcessingThread()
         hr = _callback(message);
         if (hr != S_OK)
         {
-            _logger->Log(LogLevel::Warning, _T("IpcMessage callback failed: 0x%08x"), hr);
+            _logger->Log(LogLevel::Warning, _LS("IpcMessage callback failed: 0x%08x"), hr);
         }
     }
 }

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
@@ -52,6 +52,21 @@ HRESULT EnvironmentHelper::GetRuntimeInstanceId(tstring& instanceId)
     return S_OK;
 }
 
+HRESULT EnvironmentHelper::GetStdErrLoggerLevel(LogLevel& level)
+{
+    HRESULT hr = S_OK;
+
+    tstring tstrLevel;
+    IfFailRet(_environment->GetEnvironmentVariable(
+        StdErrLoggerLevelEnvVar,
+        tstrLevel
+    ));
+
+    IfFailRet(LogLevelHelper::ToLogLevel(tstrLevel, level));
+
+    return S_OK;
+}
+
 HRESULT EnvironmentHelper::GetTempFolder(tstring& tempFolder)
 {
     HRESULT hr = S_OK;

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.h
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.h
@@ -21,6 +21,7 @@ private:
     static constexpr LPCWSTR DebugLoggerLevelEnvVar = _T("DotnetMonitorProfiler_DebugLogger_Level");
     static constexpr LPCWSTR ProfilerVersionEnvVar = _T("DotnetMonitorProfiler_ProductVersion");
     static constexpr LPCWSTR RuntimeInstanceEnvVar = _T("DotnetMonitorProfiler_RuntimeId");
+    static constexpr LPCWSTR StdErrLoggerLevelEnvVar = _T("DotnetMonitorProfiler_StdErrLogger_Level");
 
     std::shared_ptr<IEnvironment> _environment;
     std::shared_ptr<ILogger> _logger;
@@ -52,6 +53,11 @@ public:
     HRESULT SetProductVersion();
 
     HRESULT GetRuntimeInstanceId(tstring& instanceId);
+
+    /// <summary>
+    /// Gets the log level for the stderr logger from the environment.
+    /// </summary>
+    HRESULT GetStdErrLoggerLevel(LogLevel& level);
 
     HRESULT GetTempFolder(tstring& tempFolder);
 };

--- a/src/MonitorProfiler/Logging/AggregateLogger.cpp
+++ b/src/MonitorProfiler/Logging/AggregateLogger.cpp
@@ -30,7 +30,7 @@ STDMETHODIMP_(bool) AggregateLogger::IsEnabled(LogLevel level)
     return false;
 }
 
-STDMETHODIMP AggregateLogger::Log(LogLevel level, const tstring format, va_list args)
+STDMETHODIMP AggregateLogger::Log(LogLevel level, const lstring& message)
 {
     HRESULT hr = S_OK;
 
@@ -42,7 +42,7 @@ STDMETHODIMP AggregateLogger::Log(LogLevel level, const tstring format, va_list 
         // not need to check if the level is enabled for each Log call.
         if (pLogger->IsEnabled(level))
         {
-            IfFailRet(pLogger->Log(level, format, args));
+            IfFailRet(pLogger->Log(level, message));
         }
     }
 

--- a/src/MonitorProfiler/Logging/AggregateLogger.h
+++ b/src/MonitorProfiler/Logging/AggregateLogger.h
@@ -35,5 +35,5 @@ public:
     /// <summary>
     /// Invokes the Log method on each registered ILogger implementation.
     /// </summary>
-    STDMETHOD(Log)(LogLevel level, const tstring format, va_list args) override;
+    STDMETHOD(Log)(LogLevel level, const lstring& message) override;
 };

--- a/src/MonitorProfiler/Logging/LogLevelHelper.h
+++ b/src/MonitorProfiler/Logging/LogLevelHelper.h
@@ -16,35 +16,36 @@ public:
     /// <summary>
     /// Gets the short name of the log level.
     /// </summary>
-    static HRESULT GetShortName(LogLevel level, tstring& strName)
+    static HRESULT GetShortName(LogLevel level, lstring& strName)
     {
         // The log levels are intentionally four characters long
         // to allow for easy horizontal alignment.
         switch (level)
         {
         case LogLevel::Critical:
-            strName.assign(_T("crit"));
+            strName.assign(_LS("crit"));
             return S_OK;
         case LogLevel::Debug:
-            strName.assign(_T("dbug"));
+            strName.assign(_LS("dbug"));
             return S_OK;
         case LogLevel::Error:
-            strName.assign(_T("fail"));
+            strName.assign(_LS("fail"));
             return S_OK;
         case LogLevel::Information:
-            strName.assign(_T("info"));
+            strName.assign(_LS("info"));
             return S_OK;
         case LogLevel::None:
-            strName.assign(_T("none"));
+            strName.assign(_LS("none"));
             return S_OK;
         case LogLevel::Trace:
-            strName.assign(_T("trce"));
+            strName.assign(_LS("trce"));
             return S_OK;
         case LogLevel::Warning:
-            strName.assign(_T("warn"));
+            strName.assign(_LS("warn"));
             return S_OK;
         default:
-            return E_FAIL;
+            strName.assign(_LS("ukwn"));
+            return S_OK;
         }
     }
 

--- a/src/MonitorProfiler/Logging/Logger.cpp
+++ b/src/MonitorProfiler/Logging/Logger.cpp
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "Logger.h"
+#include "macros.h"
+
+using namespace std;
+
+const LCHAR* ILogger::ConvertArg(const char*& str, std::vector<lstring>& argStrings)
+{
+#ifdef TARGET_WINDOWS
+    return ConvertArg(std::string(str), argStrings);
+#else
+    return str;
+#endif
+}
+
+const LCHAR* ILogger::ConvertArg(const std::string& str, std::vector<lstring>& argStrings)
+{
+#ifdef TARGET_WINDOWS
+    // Convert the string, place it in the argStrings vector, and return the raw string for formatting.
+    return argStrings.emplace(argStrings.end(), to_tstring(str))->c_str();
+#else
+    // string and lstring have the same width on non-Windows
+    return str.c_str();
+#endif
+}
+
+const LCHAR* ILogger::ConvertArg(const tstring& str, std::vector<lstring>& argStrings)
+{
+#ifdef TARGET_WINDOWS
+    // tstring and lstring have the same width on Windows
+    return str.c_str();
+#else
+    // Convert the string, place it in the argStrings vector, and return the raw string for formatting.
+    return argStrings.emplace(argStrings.end(), to_string(str))->c_str();
+#endif
+}
+
+STDMETHODIMP ILogger::LogV(LogLevel level, const lstring format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    LCHAR message[MaxEntrySize];
+
+    // The result of the string formatting APIs will return a negative
+    // number when truncation occurs, however this is not an error condition.
+    // Clear errno in order to use it to indicate if an actual error occurs.
+    int result = 0;
+    int previousError = errno;
+    errno = 0;
+
+#ifdef TARGET_WINDOWS
+    result = _vsnwprintf_s(
+        message,
+        _TRUNCATE,
+        format.c_str(),
+        args);
+#else
+    result = vsnprintf(
+        message,
+        MaxEntrySize,
+        format.c_str(),
+        args);
+#endif
+    va_end(args);
+
+    // Result may be negative if truncation occurs, however this is not an
+    // error condition. Check the value of errno before assuming an error
+    // occurred.
+    if (result < 0 && errno != 0)
+    {
+        return HRESULT_FROM_ERRNO(errno);
+    }
+
+    // Successful invocations of platform APIs typically do not modify errno
+    // if no failure occurs. To maintain this behavior, restore the value of
+    // errno prior to invoking the string formatting API.
+    errno = previousError;
+
+    return Log(level, message);
+}

--- a/src/MonitorProfiler/Logging/Logger.h
+++ b/src/MonitorProfiler/Logging/Logger.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include "corhlpr.h"
 #include "tstring.h"
 
@@ -22,11 +23,29 @@ enum class LogLevel
     None
 };
 
+#ifdef TARGET_WINDOWS
+#define _LS(str) L##str
+#else
+#define _LS(str) str
+#endif 
+
+#ifdef TARGET_WINDOWS
+typedef std::wstring lstring;
+typedef wchar_t LCHAR;
+#else
+typedef std::string lstring;
+typedef char LCHAR;
+#endif
+
 /// <summary>
 /// Interface for logging messages.
 /// </summary>
 DECLARE_INTERFACE(ILogger)
 {
+private:
+    const static size_t MaxEntrySize = 1000;
+
+public:
     /// <summary>
     /// Determines if the logger accepts a message at the given LogLevel.
     /// </summary>
@@ -35,16 +54,51 @@ DECLARE_INTERFACE(ILogger)
     /// <summary>
     /// Writes a log message.
     /// </summary>
-    STDMETHOD(Log)(LogLevel level, const tstring format, va_list args) PURE;
+    STDMETHOD(Log)(LogLevel level, const lstring& message) PURE;
 
-    inline STDMETHODIMP Log(LogLevel level, const tstring format, ...)
+    template <typename... T>
+    inline STDMETHODIMP Log(LogLevel level, const lstring format, const T&... args)
     {
-        va_list args;
-        va_start(args, format);
-        HRESULT hr = Log(level, format, args);
-        va_end(args);
-        return hr;
+        // A cache of strings that were converted from their original width
+        // to the string width for the target platform. This prevents freeing of the
+        // converted strings before logging can complete.
+        std::vector<lstring> argStrings;
+        argStrings.reserve(sizeof...(args));
+
+        // Call LogV method with the pack expansion converting strings to the
+        // appropriate string width for the target platform.
+        return LogV(level, format, ConvertArg(args, argStrings)...);
     }
+
+private:
+    /// <summary>
+    /// Convert char* strings to logging string width for the target platform.
+    /// </summary>
+    static const LCHAR* ConvertArg(const char*& str, std::vector<lstring>& argStrings);
+
+    /// <summary>
+    /// Convert narrow strings to logging string width for the target platform.
+    /// </summary>
+    static const LCHAR* ConvertArg(const std::string& str, std::vector<lstring>& argStrings);
+
+    /// <summary>
+    /// Convert tstrings to logging string width for the target platform.
+    /// </summary>
+    static const LCHAR* ConvertArg(const tstring& str, std::vector<lstring>& argStrings);
+
+    /// <summary>
+    /// Pass through all other argument types as-is.
+    /// </summary>
+    template <typename T>
+    inline static T ConvertArg(const T& value, std::vector<lstring>& argStrings)
+    {
+        return value;
+    }
+
+    /// <summary>
+    /// Formats the format string with the variable arguments and calls the Log(level, message) function.
+    /// </summary>
+    STDMETHODIMP LogV(LogLevel level, const lstring format, ...);
 };
 
 // Checks if EXPR is a failed HRESULT
@@ -58,8 +112,8 @@ DECLARE_INTERFACE(ILogger)
                 { \
                     pLogger->Log(\
                         LogLevel::Error, \
-                        _T("IfFailLogRet(" #EXPR ") failed in function %s: 0x%08x"), \
-                        to_tstring(__func__).c_str(), \
+                        _LS("IfFailLogRet(" #EXPR ") failed in function %s: 0x%08x"), \
+                        __func__, \
                         hr); \
                 } \
             } \
@@ -77,8 +131,8 @@ DECLARE_INTERFACE(ILogger)
                 { \
                     pLogger->Log(\
                         LogLevel::Error, \
-                        _T("IfFalseLogRet(" #EXPR ") is false in function %s: 0x%08x"), \
-                        to_tstring(__func__).c_str(), \
+                        _LS("IfFalseLogRet(" #EXPR ") is false in function %s: 0x%08x"), \
+                        __func__, \
                         hr); \
                 } \
             } \
@@ -96,8 +150,8 @@ DECLARE_INTERFACE(ILogger)
                 { \
                     pLogger->Log( \
                         LogLevel::Error, \
-                        _T("IfNullLogRetPtr(" #EXPR ") failed in function %s"), \
-                        to_tstring(__func__).c_str()); \
+                        _LS("IfNullLogRetPtr(" #EXPR ") failed in function %s"), \
+                        __func__); \
                 } \
             } \
             return E_POINTER; \
@@ -109,7 +163,7 @@ DECLARE_INTERFACE(ILogger)
 #define LogV_(pLogger, level, format, ...) \
     if (pLogger->IsEnabled(level)) \
     { \
-        IfFailRet(pLogger->Log(level, format, __VA_ARGS__)); \
+        IfFailRet(pLogger->Log(level, _LS(format), __VA_ARGS__)); \
     }
 
 // Logs a message at the Trace level

--- a/src/MonitorProfiler/Logging/NullLogger.h
+++ b/src/MonitorProfiler/Logging/NullLogger.h
@@ -25,7 +25,7 @@ public:
     }
 
     /// <inheritdoc />
-    STDMETHOD(Log)(LogLevel level, const tstring format, va_list args) override
+    STDMETHOD(Log)(LogLevel level, const lstring& message) override
     {
         return S_OK;
     }

--- a/src/MonitorProfiler/Logging/StdErrLogger.cpp
+++ b/src/MonitorProfiler/Logging/StdErrLogger.cpp
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "StdErrLogger.h"
+#include "LogLevelHelper.h"
+#include "../Environment/EnvironmentHelper.h"
+#include "NullLogger.h"
+#include "macros.h"
+
+using namespace std;
+
+StdErrLogger::StdErrLogger(const shared_ptr<IEnvironment>& pEnvironment)
+{
+    // Try to get log level from environment
+
+    EnvironmentHelper helper(pEnvironment, NullLogger::Instance);
+    if (FAILED(helper.GetStdErrLoggerLevel(_level)))
+    {
+        // Fallback to default level
+        _level = DefaultLevel;
+    }
+}
+
+STDMETHODIMP_(bool) StdErrLogger::IsEnabled(LogLevel level)
+{
+    return LogLevelHelper::IsEnabled(level, _level);
+}
+
+STDMETHODIMP StdErrLogger::Log(LogLevel level, const lstring& message)
+{
+    if (!IsEnabled(level))
+    {
+        return S_FALSE;
+    }
+
+    HRESULT hr = S_OK;
+
+    lstring levelStr;
+    IfFailRet(LogLevelHelper::GetShortName(level, levelStr));
+
+    // The result of the stream writing APIs will return a negative
+    // number when an error occurs, however errno may or may not be
+    // set depending on the type of error. Clear errno in order to
+    // use it to indicate if an actual error occurs.
+    int result = 0;
+    int previousError = errno;
+    errno = 0;
+
+#ifdef TARGET_WINDOWS
+    result = fwprintf_s(
+        stderr,
+        L"[profiler]%s: %s\r\n",
+        levelStr.c_str(),
+        message.c_str());
+#else
+    result = fprintf(
+        stderr,
+        "[profiler]%s: %s\r\n",
+        levelStr.c_str(),
+        message.c_str());
+#endif
+
+    if (result < 0)
+    {
+        // Writing errors will set errno to non-zero value
+        if (0 != errno)
+        {
+            return HRESULT_FROM_ERRNO(errno);
+        }
+        else
+        {
+            // errno was not set; restore its previous value.
+            errno = previousError;
+
+            // Multibyte encoding errors will set the stream to an error state.
+            // Get the error indicator from the stream.
+            result = ferror(stderr);
+            if (0 != result)
+            {
+                return HRESULT_FROM_ERRNO(result);
+            }
+            else
+            {
+                // This is an undocumented condition.
+                return E_UNEXPECTED;
+            }
+        }
+    }
+
+    // Successful invocations of platform APIs typically do not modify errno
+    // if no failure occurs. To maintain this behavior, restore the value of
+    // errno prior to invoking the string formatting API.
+    errno = previousError;
+
+    return S_OK;
+}

--- a/src/MonitorProfiler/Logging/StdErrLogger.h
+++ b/src/MonitorProfiler/Logging/StdErrLogger.h
@@ -10,19 +10,19 @@
 #include "../Environment/Environment.h"
 
 /// <summary>
-/// Logs messages to the debug output window when running under a debugger.
+/// Logs messages to the stderr stream.
 /// </summary>
-class DebugLogger final :
+class StdErrLogger final :
     public ILogger
 {
 private:
-    const static LogLevel DefaultLevel = LogLevel::Information;
-    const static size_t MaxEntrySize = 1000;
+    const static LogLevel DefaultLevel = LogLevel::None;
+    const static int MaxEntrySize = 1000;
 
     LogLevel _level = DefaultLevel;
 
 public:
-    DebugLogger(const std::shared_ptr<IEnvironment>& environment);
+    StdErrLogger(const std::shared_ptr<IEnvironment>& pEnvironment);
 
 public:
     // ILogger Members

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -97,7 +97,7 @@ HRESULT ExceptionTracker::ExceptionThrown(ThreadID threadId, ObjectID objectId)
 
         if (FAILED(hr) && hr != CORPROF_E_STACKSNAPSHOT_ABORTED)
         {
-            LogErrorV(_T("DoStackSnapshot failed in function %s: 0x%08x"), to_tstring(__func__).c_str(), hr);
+            LogErrorV("DoStackSnapshot failed in function %s: 0x%08x", __func__, hr);
             return hr;
         }
     }
@@ -127,7 +127,7 @@ HRESULT ExceptionTracker::ExceptionUnwindFunctionEnter(ThreadID threadId, Functi
     {
         tstring methodName;
         IfFailLogRet(GetFullyQualifiedMethodName(functionId, methodName));
-        LogInformationV(_T("Exception unhandled: %s"), methodName.c_str());
+        LogInformationV("Exception unhandled: %s", methodName);
 
         // Future: Block thread until collection is initiated of the desired artifact.
         // Possible serialization of some context of the exception and surrounding method
@@ -142,7 +142,7 @@ HRESULT ExceptionTracker::ExceptionUnwindFunctionEnter(ThreadID threadId, Functi
         {
             tstring methodName;
             IfFailLogRet(GetFullyQualifiedMethodName(functionId, methodName));
-            LogDebugV(_T("Exception handled: %s"), methodName.c_str());
+            LogDebugV("Exception handled: %s", methodName);
         }
     }
 
@@ -365,7 +365,7 @@ HRESULT ExceptionTracker::LogExceptionThrownFrame(FunctionID functionId, COR_PRF
 
     tstring methodName;
     IfFailLogRet(GetFullyQualifiedMethodName(functionId, frameInfo, methodName));
-    LogDebugV(_T("Exception thrown: %s"), methodName.c_str());
+    LogDebugV("Exception thrown: %s", methodName);
 
     return S_OK;
 }

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -7,6 +7,7 @@
 #include "../Environment/ProfilerEnvironment.h"
 #include "../Logging/AggregateLogger.h"
 #include "../Logging/DebugLogger.h"
+#include "../Logging/StdErrLogger.h"
 #include "corhlpr.h"
 #include "macros.h"
 #include <memory>
@@ -160,6 +161,10 @@ HRESULT MainProfiler::InitializeLogging()
     unique_ptr<AggregateLogger> pAggregateLogger(new (nothrow) AggregateLogger());
     IfNullRet(pAggregateLogger);
 
+    shared_ptr<StdErrLogger> pStdErrLogger = make_shared<StdErrLogger>(m_pEnvironment);
+    IfNullRet(pStdErrLogger);
+    pAggregateLogger->Add(pStdErrLogger);
+
 #ifdef _DEBUG
 #ifdef TARGET_WINDOWS
     // Add the debug output logger for when debugging on Windows
@@ -200,6 +205,6 @@ HRESULT MainProfiler::InitializeCommandServer()
 
 HRESULT MainProfiler::MessageCallback(const IpcMessage& message)
 {
-    m_pLogger->Log(LogLevel::Information, _T("Message received from client: %d %d"), message.MessageType, message.Parameters);
+    m_pLogger->Log(LogLevel::Information, _LS("Message received from client: %d %d"), message.MessageType, message.Parameters);
     return S_OK;
 }

--- a/src/inc/macros.h
+++ b/src/inc/macros.h
@@ -7,3 +7,8 @@
 #ifndef ExpectedPtr
 #define ExpectedPtr(ptr) { if (nullptr == ptr) return E_POINTER; }
 #endif
+
+#ifndef HRESULT_FROM_ERRNO
+#define HRESULT_FROM_ERRNO(value) \
+        MAKE_HRESULT(value == 0 ? SEVERITY_SUCCESS : SEVERITY_ERROR, FACILITY_NULL, HRESULT_CODE(value))
+#endif


### PR DESCRIPTION
These changes update the logger infrastructure to convert the format and argument strings to appropriate widths that are natively understood by the target platform. This allows for using the C formatting functions that are native to each target platform. This is achieved using a variadic template function to convert each argument as appropriate. To minimize conversions, the format string is required to already be in the string width of the target platform.

Additionally, another logger has been added that will log to the stderr stream. Its default level is None, but can be changed using the `DotnetMonitorProfiler_StdErrLogger_Level` environment variable.

Finally, result checking has been added to the string formatting and stream writing API usage to validate that strings are written correctly.

Tested these changes with a .NET 6 application that throws exceptions with the stderr logger enabled on both Windows and WSL Ubuntu.