### PR TITLE
Operations Api shows RuntimeId, ProcessId, and ProcessName

### DIFF
--- a/documentation/api/operations-get.md
+++ b/documentation/api/operations-get.md
@@ -49,7 +49,11 @@ Content-Type: application/json
     "error": null,
     "operationId": "67f07e40-5cca-4709-9062-26302c484f18",
     "createdDateTime": "2021-07-21T06:21:15.315861Z",
-    "status": "Succeeded"  
+    "status": "Succeeded",
+    "processInfo":
+    {
+        "pid":1 "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783","processName":"dotnet-monitor-demo"
+    }
 }
 ```
 

--- a/documentation/api/operations-get.md
+++ b/documentation/api/operations-get.md
@@ -54,7 +54,7 @@ Content-Type: application/json
     {
         "pid":1,
         "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783",
-        "processName":"dotnet-monitor-demo"
+        "name":"dotnet-monitor-demo"
     }
 }
 ```

--- a/documentation/api/operations-get.md
+++ b/documentation/api/operations-get.md
@@ -50,9 +50,11 @@ Content-Type: application/json
     "operationId": "67f07e40-5cca-4709-9062-26302c484f18",
     "createdDateTime": "2021-07-21T06:21:15.315861Z",
     "status": "Succeeded",
-    "processInfo":
+    "process":
     {
-        "pid":1 "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783","processName":"dotnet-monitor-demo"
+        "pid":1,
+        "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783",
+        "processName":"dotnet-monitor-demo"
     }
 }
 ```

--- a/documentation/api/operations-list.md
+++ b/documentation/api/operations-list.md
@@ -53,7 +53,7 @@ Content-Type: application/json
         {
             "pid":1,
             "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783",
-            "processName":"dotnet-monitor-demo"
+            "name":"dotnet-monitor-demo"
         }
     },
     {
@@ -64,7 +64,7 @@ Content-Type: application/json
         {
             "pid":11782,
             "uid":"23c289b3-b5ce-428a-aaa8-c864b3766bc2",
-            "processName":"dotnet-monitor-demo2"
+            "name":"dotnet-monitor-demo2"
         }
     }
 ]

--- a/documentation/api/operations-list.md
+++ b/documentation/api/operations-list.md
@@ -46,10 +46,18 @@ Content-Type: application/json
 
 [
     {
-        "operationId": "67f07e40-5cca-4709-9062-26302c484f18","createdDateTime": "2021-07-21T06:21:15.315861Z","status": "Succeeded"
+        "operationId": "67f07e40-5cca-4709-9062-26302c484f18","createdDateTime": "2021-07-21T06:21:15.315861Z","status": "Succeeded", 
+        "processInfo":
+        {
+            "pid":1 "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783","processName":"dotnet-monitor-demo"
+        }
     },
     {
-        "operationId": "26e74e52-0a16-4e84-84bb-27f904bfaf85","createdDateTime": "2021-07-21T23:30:22.3058272Z","status": "Failed"
+        "operationId": "26e74e52-0a16-4e84-84bb-27f904bfaf85","createdDateTime": "2021-07-21T23:30:22.3058272Z","status": "Failed", 
+        "processInfo":
+        {
+            "pid":11782 "uid":"23c289b3-b5ce-428a-aaa8-c864b3766bc2","processName":"dotnet-monitor-demo2"
+        }
     }
 ]
 ```

--- a/documentation/api/operations-list.md
+++ b/documentation/api/operations-list.md
@@ -46,17 +46,25 @@ Content-Type: application/json
 
 [
     {
-        "operationId": "67f07e40-5cca-4709-9062-26302c484f18","createdDateTime": "2021-07-21T06:21:15.315861Z","status": "Succeeded", 
-        "processInfo":
+        "operationId": "67f07e40-5cca-4709-9062-26302c484f18",
+        "createdDateTime": "2021-07-21T06:21:15.315861Z",
+        "status": "Succeeded", 
+        "process":
         {
-            "pid":1 "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783","processName":"dotnet-monitor-demo"
+            "pid":1,
+            "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783",
+            "processName":"dotnet-monitor-demo"
         }
     },
     {
-        "operationId": "26e74e52-0a16-4e84-84bb-27f904bfaf85","createdDateTime": "2021-07-21T23:30:22.3058272Z","status": "Failed", 
-        "processInfo":
+        "operationId": "26e74e52-0a16-4e84-84bb-27f904bfaf85",
+        "createdDateTime": "2021-07-21T23:30:22.3058272Z",
+        "status": "Failed", 
+        "process":
         {
-            "pid":11782 "uid":"23c289b3-b5ce-428a-aaa8-c864b3766bc2","processName":"dotnet-monitor-demo2"
+            "pid":11782,
+            "uid":"23c289b3-b5ce-428a-aaa8-c864b3766bc2",
+            "processName":"dotnet-monitor-demo2"
         }
     }
 ]

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1660,7 +1660,7 @@
             "type": "string",
             "format": "uuid"
           },
-          "processName": {
+          "name": {
             "type": "string",
             "nullable": true
           }

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1684,7 +1684,7 @@
           "status": {
             "$ref": "#/components/schemas/OperationState"
           },
-          "processInfo": {
+          "process": {
             "$ref": "#/components/schemas/OperationProcessInfo"
           }
         },
@@ -1719,7 +1719,7 @@
           "status": {
             "$ref": "#/components/schemas/OperationState"
           },
-          "processInfo": {
+          "process": {
             "$ref": "#/components/schemas/OperationProcessInfo"
           },
           "resourceLocation": {

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1654,13 +1654,11 @@
         "properties": {
           "pid": {
             "type": "integer",
-            "format": "int32",
-            "nullable": true
+            "format": "int32"
           },
           "uid": {
             "type": "string",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "processName": {
             "type": "string",

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1649,6 +1649,27 @@
         ],
         "type": "string"
       },
+      "OperationProcessInfo": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "uid": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "processName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents the details of a given process used in an operation."
+      },
       "OperationSummary": {
         "type": "object",
         "properties": {
@@ -1662,6 +1683,9 @@
           },
           "status": {
             "$ref": "#/components/schemas/OperationState"
+          },
+          "processInfo": {
+            "$ref": "#/components/schemas/OperationProcessInfo"
           }
         },
         "additionalProperties": false,
@@ -1694,6 +1718,9 @@
           },
           "status": {
             "$ref": "#/components/schemas/OperationState"
+          },
+          "processInfo": {
+            "$ref": "#/components/schemas/OperationProcessInfo"
           },
           "resourceLocation": {
             "type": "string",

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                     action,
                     fileName,
                     ContentTypes.ApplicationJsonSequence,
-                    processInfo.EndpointInfo);
+                    processInfo);
             }, processKey, Utilities.ArtifactType_Metrics);
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                     action,
                     fileName,
                     ContentTypes.ApplicationJsonSequence,
-                    processInfo.EndpointInfo);
+                    processInfo);
             }, processKey, Utilities.ArtifactType_Metrics);
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                         token => _dumpService.DumpAsync(processInfo.EndpointInfo, type, token),
                         egressProvider,
                         dumpFileName,
-                        processInfo.EndpointInfo,
+                        processInfo,
                         ContentTypes.ApplicationOctetStream,
                         scope), limitKey: Utilities.ArtifactType_Dump);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                     },
                     fileName,
                     ContentTypes.ApplicationOctetStream,
-                    processInfo.EndpointInfo);
+                    processInfo);
             }, processKey, Utilities.ArtifactType_GCDump);
         }
 
@@ -632,7 +632,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 },
                 fileName,
                 ContentTypes.ApplicationOctetStream,
-                processInfo.EndpointInfo);
+                processInfo);
         }
 
         private Task<ActionResult> StartLogs(
@@ -655,7 +655,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 (outputStream, token) => LogsUtilities.CaptureLogsAsync(null, format.Value, processInfo.EndpointInfo, settings, outputStream, token),
                 fileName,
                 contentType,
-                processInfo.EndpointInfo,
+                processInfo,
                 format != LogFormat.PlainText);
         }
 
@@ -704,10 +704,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             Func<Stream, CancellationToken, Task> action,
             string fileName,
             string contentType,
-            IEndpointInfo endpointInfo,
+            IProcessInfo processInfo,
             bool asAttachment = true)
         {
-            KeyValueLogScope scope = Utilities.CreateArtifactScope(artifactType, endpointInfo);
+            KeyValueLogScope scope = Utilities.CreateArtifactScope(artifactType, processInfo.EndpointInfo);
 
             if (string.IsNullOrEmpty(providerName))
             {
@@ -723,7 +723,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                     action,
                     providerName,
                     fileName,
-                    endpointInfo,
+                    processInfo,
                     contentType,
                     scope),
                     limitKey: artifactType);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public OperationProcessInfo ProcessInfo { get; set; }
     }
 
+    /// <summary>
+    /// Represents the details of a given process used in an operation.
+    /// </summary>
     public class OperationProcessInfo
     {
         [JsonPropertyName("pid")]

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     public class OperationProcessInfo
     {
         [JsonPropertyName("pid")]
-        public int? ProcessId { get; set; }
+        public int ProcessId { get; set; }
 
         [JsonPropertyName("uid")]
-        public Guid? Uid { get; set; }
+        public Guid Uid { get; set; }
 
         [JsonPropertyName("processName")]
         public string ProcessName { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -20,6 +20,21 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 
         [JsonPropertyName("status")]
         public OperationState Status { get; set; }
+
+        [JsonPropertyName("processInfo")]
+        public OperationProcessInfo ProcessInfo { get; set; }
+    }
+
+    public class OperationProcessInfo
+    {
+        [JsonPropertyName("pid")]
+        public int? ProcessID { get; set; }
+
+        [JsonPropertyName("uid")]
+        public Guid? UID { get; set; }
+
+        [JsonPropertyName("processName")]
+        public string ProcessName { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         [JsonPropertyName("uid")]
         public Guid Uid { get; set; }
 
-        [JsonPropertyName("processName")]
-        public string ProcessName { get; set; }
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         [JsonPropertyName("status")]
         public OperationState Status { get; set; }
 
-        [JsonPropertyName("processInfo")]
-        public OperationProcessInfo ProcessInfo { get; set; }
+        [JsonPropertyName("process")]
+        public OperationProcessInfo Process { get; set; }
     }
 
     /// <summary>
@@ -31,10 +31,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     public class OperationProcessInfo
     {
         [JsonPropertyName("pid")]
-        public int? ProcessID { get; set; }
+        public int? ProcessId { get; set; }
 
         [JsonPropertyName("uid")]
-        public Guid? UID { get; set; }
+        public Guid? Uid { get; set; }
 
         [JsonPropertyName("processName")]
         public string ProcessName { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private readonly Func<IEgressService, CancellationToken, Task<EgressResult>> _egress;
         private readonly string _egressProvider;
         private readonly KeyValueLogScope _scope;
-        private readonly EgressProcessInfo _egressProcessInfo;
+
+        public EgressProcessInfo ProcessInfo { get; private set; }
+
 
         public EgressOperation(Func<CancellationToken, Task<Stream>> action, string endpointName, string artifactName, IProcessInfo processInfo, string contentType, KeyValueLogScope scope)
         {
@@ -25,7 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _egressProvider = endpointName;
             _scope = scope;
 
-            _egressProcessInfo = new EgressProcessInfo(processInfo.ProcessName, processInfo.EndpointInfo.ProcessId, processInfo.EndpointInfo.RuntimeInstanceCookie);
+            ProcessInfo = new EgressProcessInfo(processInfo.ProcessName, processInfo.EndpointInfo.ProcessId, processInfo.EndpointInfo.RuntimeInstanceCookie);
         }
 
         public EgressOperation(Func<Stream, CancellationToken, Task> action, string endpointName, string artifactName, IProcessInfo processInfo, string contentType, KeyValueLogScope scope)
@@ -34,7 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _egressProvider = endpointName;
             _scope = scope;
 
-            _egressProcessInfo = new EgressProcessInfo(processInfo.ProcessName, processInfo.EndpointInfo.ProcessId, processInfo.EndpointInfo.RuntimeInstanceCookie);
+            ProcessInfo = new EgressProcessInfo(processInfo.ProcessName, processInfo.EndpointInfo.ProcessId, processInfo.EndpointInfo.RuntimeInstanceCookie);
         }
 
         // The below constructors don't need EgressProcessInfo as their callers don't store to the operations table.
@@ -77,12 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 return ExecutionResult<EgressResult>.Succeeded(egressResult);
             }, logger, token);
         }
-
-        public EgressProcessInfo GetEgressProcessInfo()
-        {
-            return _egressProcessInfo;
-        }
-
+        
         public void Validate(IServiceProvider serviceProvider)
         {
             serviceProvider

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
@@ -91,13 +91,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         }
     }
 
-    internal readonly struct EgressProcessInfo
+    internal class EgressProcessInfo
     {
-        public readonly string ProcessName { get; }
-        public readonly int ProcessId { get; }
-        public readonly Guid RuntimeInstanceCookie { get; }
+        public string ProcessName { get; }
+        public int ProcessId { get; }
+        public Guid RuntimeInstanceCookie { get; }
 
-        public EgressProcessInfo(string processName, int processId, Guid runtimeInstanceCookie) : this()
+        public EgressProcessInfo(string processName, int processId, Guid runtimeInstanceCookie)
         {
             this.ProcessName = processName;
             this.ProcessId = processId;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private readonly Func<IEgressService, CancellationToken, Task<EgressResult>> _egress;
         private readonly string _egressProvider;
         private readonly KeyValueLogScope _scope;
-
         public EgressProcessInfo ProcessInfo { get; private set; }
-
 
         public EgressOperation(Func<CancellationToken, Task<Stream>> action, string endpointName, string artifactName, IProcessInfo processInfo, string contentType, KeyValueLogScope scope)
         {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -133,12 +133,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                         OperationId = kvp.Key,
                         CreatedDateTime = kvp.Value.CreatedDateTime,
                         Status = kvp.Value.State,
-                        ProcessInfo = new Models.OperationProcessInfo
-                        {
-                            ProcessName = processInfo.ProcessName,
-                            ProcessID = processInfo.ProcessId,
-                            UID = processInfo.RuntimeInstanceCookie
-                        }
+                        ProcessInfo = processInfo != null ?
+                            new Models.OperationProcessInfo
+                            {
+                                ProcessName = processInfo.ProcessName,
+                                ProcessID = processInfo.ProcessId,
+                                UID = processInfo.RuntimeInstanceCookie
+                            } : null
                     };
                 }).ToList();
             }
@@ -159,12 +160,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     OperationId = entry.EgressRequest.OperationId,
                     Status = entry.State,
                     CreatedDateTime = entry.CreatedDateTime,
-                    ProcessInfo = new Models.OperationProcessInfo
-                    {
-                        ProcessName = processInfo.ProcessName,
-                        ProcessID = processInfo.ProcessId,
-                        UID = processInfo.RuntimeInstanceCookie
-                    }
+                    ProcessInfo = processInfo != null ?
+                        new Models.OperationProcessInfo
+                        {
+                            ProcessName = processInfo.ProcessName,
+                            ProcessID = processInfo.ProcessId,
+                            UID = processInfo.RuntimeInstanceCookie
+                        } : null
                 };
 
                 if (entry.State == Models.OperationState.Succeeded)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -127,18 +127,18 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             {
                 return _requests.Select((kvp) =>
                 {
-                    EgressProcessInfo processInfo = kvp.Value.EgressRequest.EgressOperation.GetEgressProcessInfo();
+                    EgressProcessInfo processInfo = kvp.Value.EgressRequest.EgressOperation.ProcessInfo;
                     return new Models.OperationSummary
                     {
                         OperationId = kvp.Key,
                         CreatedDateTime = kvp.Value.CreatedDateTime,
                         Status = kvp.Value.State,
-                        ProcessInfo = processInfo != null ?
+                        Process = processInfo != null ?
                             new Models.OperationProcessInfo
                             {
                                 ProcessName = processInfo.ProcessName,
-                                ProcessID = processInfo.ProcessId,
-                                UID = processInfo.RuntimeInstanceCookie
+                                ProcessId = processInfo.ProcessId,
+                                Uid = processInfo.RuntimeInstanceCookie
                             } : null
                     };
                 }).ToList();
@@ -153,19 +153,19 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_OperationNotFound);
                 }
-                EgressProcessInfo processInfo = entry.EgressRequest.EgressOperation.GetEgressProcessInfo();
+                EgressProcessInfo processInfo = entry.EgressRequest.EgressOperation.ProcessInfo;
 
                 var status = new Models.OperationStatus()
                 {
                     OperationId = entry.EgressRequest.OperationId,
                     Status = entry.State,
                     CreatedDateTime = entry.CreatedDateTime,
-                    ProcessInfo = processInfo != null ?
+                    Process = processInfo != null ?
                         new Models.OperationProcessInfo
                         {
                             ProcessName = processInfo.ProcessName,
-                            ProcessID = processInfo.ProcessId,
-                            UID = processInfo.RuntimeInstanceCookie
+                            ProcessId = processInfo.ProcessId,
+                            Uid = processInfo.RuntimeInstanceCookie
                         } : null
                 };
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                         Process = processInfo != null ?
                             new Models.OperationProcessInfo
                             {
-                                ProcessName = processInfo.ProcessName,
+                                Name = processInfo.ProcessName,
                                 ProcessId = processInfo.ProcessId,
                                 Uid = processInfo.RuntimeInstanceCookie
                             } : null
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Process = processInfo != null ?
                         new Models.OperationProcessInfo
                         {
-                            ProcessName = processInfo.ProcessName,
+                            Name = processInfo.ProcessName,
                             ProcessId = processInfo.ProcessId,
                             Uid = processInfo.RuntimeInstanceCookie
                         } : null

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 throw new TooManyRequestsException();
             }
 
-            EgressProcessInfo processInfo = egressOperation.GetEgressProcessInfo();
-
-            var request = new EgressRequest(operationId, processInfo, egressOperation, limitTracker);
+            var request = new EgressRequest(operationId, egressOperation.GetEgressProcessInfo(), egressOperation, limitTracker);
             lock (_requests)
             {
                 //Add operation object to central table.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressRequest.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressRequest.cs
@@ -19,9 +19,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private bool _disposed;
         private IDisposable _limitTracker;
 
-        public EgressRequest(Guid operationId, IEgressOperation egressOperation, IDisposable limitTracker)
+        public EgressRequest(Guid operationId, EgressProcessInfo processInfo, IEgressOperation egressOperation, IDisposable limitTracker)
         {
             OperationId = operationId;
+            ProcessInfo = processInfo;
             EgressOperation = egressOperation;
             _limitTracker = limitTracker;
         }
@@ -29,6 +30,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public CancellationTokenSource CancellationTokenSource { get; } = new();
 
         public Guid OperationId { get; }
+
+        public EgressProcessInfo  ProcessInfo { get; }
 
         public IEgressOperation EgressOperation { get; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressRequest.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressRequest.cs
@@ -19,10 +19,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private bool _disposed;
         private IDisposable _limitTracker;
 
-        public EgressRequest(Guid operationId, EgressProcessInfo processInfo, IEgressOperation egressOperation, IDisposable limitTracker)
+        public EgressRequest(Guid operationId, IEgressOperation egressOperation, IDisposable limitTracker)
         {
             OperationId = operationId;
-            ProcessInfo = processInfo;
             EgressOperation = egressOperation;
             _limitTracker = limitTracker;
         }
@@ -30,8 +29,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public CancellationTokenSource CancellationTokenSource { get; } = new();
 
         public Guid OperationId { get; }
-
-        public EgressProcessInfo  ProcessInfo { get; }
 
         public IEgressOperation EgressOperation { get; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         Task<ExecutionResult<EgressResult>> ExecuteAsync(IServiceProvider serviceProvider, CancellationToken token);
 
         void Validate(IServiceProvider serviceProvider);
+
+        EgressProcessInfo GetEgressProcessInfo();
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal interface IEgressOperation
     {
+        public EgressProcessInfo ProcessInfo { get; }
+
         Task<ExecutionResult<EgressResult>> ExecuteAsync(IServiceProvider serviceProvider, CancellationToken token);
 
         void Validate(IServiceProvider serviceProvider);
-
-        EgressProcessInfo GetEgressProcessInfo();
     }
 }


### PR DESCRIPTION
This is for #2122. It updates the /operations and /operations/operationId api to show the RuntimeId, ProcessId, and ProcessName as a sub-object shown in the results.

Main question I wanted to bring up for discussion in this PR: 

Most EgressOperations created can't really take in an `IProcessInfo` object since they pull an endpoint directly, which doesn't have the ProcessName stored. There are a few ways I'm thinking we can use to fix this - 

1. Leave as-is and let most operations not have a processName that we can use.
2. If the processName isn't that relevant we can remove it from the API update so we only show RuntimeId and ProcessId.
3. We can query for the processInfo object using the found RuntimeId and get the name from that, similar to what's done [in DiagController.GetProcessInfo()](https://github.com/dotnet/dotnet-monitor/blob/b98c2d9c04746f6489cf9f2fbed2e3027a9414e9/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs#L128). Not sure how much I like this.
4. Update `IEndpointInfo` to have the processName inside it. Not sure how doable it is but I'm investigating.

Let me know what you think would be best, I'm not entirely sure myself but I'm leaning towards the 4th option, if possible.