### PR TITLE
[draft] Skip running CI builds on documentation and .github changes

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -12,7 +12,7 @@ pr:
     include:
     - '*'
     exclude:
-    - .github
+    - .github/*
     - '**.md'
 
 schedules:


### PR DESCRIPTION
Skip queuing our Azure Pipeline CI builds for PRs that only affect the `.github` folder or markdown files.