### PR TITLE
Assign dotnet-monitor reviewers by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 *                           @dotnet/dotnet-monitor
-/documentation/             @dotnet/dotnet-monitor @IEvangelist
 # We need /eng/ and global.json excluded for automatic updates
 /eng/
 global.json


### PR DESCRIPTION
While working on some files in the root of the repo I noticed that automatic reviewers weren't being applied. Rework the CODEOWNERS file to assign `dotnet/dotnet-monitor` as a reviewer by default, except for automatic update changes.