### PR TITLE
Check Read Permissions For JSON Configuration Sources

### DIFF
--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -76,11 +76,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         if (!userFilePath.Exists)
                         {
-                            hostBuilderResults.Warnings.Add(string.Format(Strings.Message_ConfigurationFileDoesNotExist, userFilePath));
+                            hostBuilderResults.Warnings.Add(string.Format(Strings.Message_ConfigurationFileDoesNotExist, userFilePath.FullName));
                         }
                         else if (!".json".Equals(userFilePath.Extension, StringComparison.OrdinalIgnoreCase))
                         {
-                            hostBuilderResults.Warnings.Add(string.Format(Strings.Message_ConfigurationFileNotJson, userFilePath));
+                            hostBuilderResults.Warnings.Add(string.Format(Strings.Message_ConfigurationFileNotJson, userFilePath.FullName));
                         }
                         else
                         {

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -36,11 +36,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 .UseContentRoot(settings.ContentRootDirectory)
                 .ConfigureAppConfiguration((HostBuilderContext context, IConfigurationBuilder builder) =>
                 {
+                    HostBuilderResults hostBuilderResults = new HostBuilderResults();
+                    context.Properties.Add(HostBuilderResults.ResultKey, hostBuilderResults);
+
                     string userSettingsPath = Path.Combine(settings.UserConfigDirectory, SettingsFileName);
-                    builder.AddJsonFile(userSettingsPath, optional: true, reloadOnChange: true);
+                    AddJsonFileHelper(builder, hostBuilderResults, userSettingsPath);
 
                     string sharedSettingsPath = Path.Combine(settings.SharedConfigDirectory, SettingsFileName);
-                    builder.AddJsonFile(sharedSettingsPath, optional: true, reloadOnChange: true);
+                    AddJsonFileHelper(builder, hostBuilderResults, sharedSettingsPath);
 
                     //HACK Workaround for https://github.com/dotnet/runtime/issues/36091
                     //KeyPerFile provider uses a file system watcher to trigger changes.
@@ -71,27 +74,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     if (null != userFilePath)
                     {
-                        HostBuilderResults hostBuilderResults = new HostBuilderResults();
-                        context.Properties.Add(HostBuilderResults.ResultKey, hostBuilderResults);
-
                         if (!userFilePath.Exists)
                         {
-                            hostBuilderResults.Warnings.Add(Strings.Message_ConfigurationFileDoesNotExist);
+                            hostBuilderResults.Warnings.Add(string.Format(Strings.Message_ConfigurationFileDoesNotExist, userFilePath));
                         }
                         else if (!".json".Equals(userFilePath.Extension, StringComparison.OrdinalIgnoreCase))
                         {
-                            hostBuilderResults.Warnings.Add(Strings.Message_ConfigurationFileNotJson);
+                            hostBuilderResults.Warnings.Add(string.Format(Strings.Message_ConfigurationFileNotJson, userFilePath));
                         }
                         else
                         {
-                            try
-                            {
-                                builder.AddJsonFile(userFilePath.FullName, optional: true, reloadOnChange: true);
-                            }
-                            catch (Exception ex)
-                            {
-                                hostBuilderResults.Warnings.Add(ex.Message);
-                            }
+                            AddJsonFileHelper(builder, hostBuilderResults, userFilePath.FullName);
                         }
                     }
                 })
@@ -139,6 +132,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     })
                     .UseStartup<Startup>();
                 });
+        }
+
+        private static void AddJsonFileHelper(IConfigurationBuilder builder, HostBuilderResults hostBuilderResults, string filePath)
+        {
+            try
+            {
+                File.OpenRead(filePath).Dispose(); // If this succeeds, we have read permissions
+                builder.AddJsonFile(filePath, optional: true, reloadOnChange: true);
+            }
+            catch (Exception ex)
+            {
+                hostBuilderResults.Warnings.Add(ex.Message);
+            }
         }
 
         public static AuthConfiguration CreateAuthConfiguration(bool noAuth, bool tempApiKey)

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         }
                     }
 
+                    // If a file at this path does not have read permissions, the application will fail to launch.
                     builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ConfigPrefix);
 
@@ -141,15 +142,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 File.OpenRead(filePath).Dispose(); // If this succeeds, we have read permissions
                 builder.AddJsonFile(filePath, optional: true, reloadOnChange: true);
             }
+            catch (FileNotFoundException)
+            {
+                // JSON configuration files are optional; not logging if a file isn't found
+            }
             catch (Exception ex)
             {
-                if (ex is UnauthorizedAccessException || ex is FileNotFoundException)
-                {
-                    hostBuilderResults.Warnings.Add(ex.Message);
-                    return;
-                }
-
-                throw;
+                hostBuilderResults.Warnings.Add(ex.Message);
             }
         }
 

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -139,12 +139,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             try
             {
-                File.OpenRead(filePath).Dispose(); // If this succeeds, we have read permissions
-                builder.AddJsonFile(filePath, optional: true, reloadOnChange: true);
-            }
-            catch (FileNotFoundException)
-            {
-                // JSON configuration files are optional; not logging if a file isn't found
+                if (File.Exists(filePath))
+                {
+                    File.OpenRead(filePath).Dispose(); // If this succeeds, we have read permissions
+                    builder.AddJsonFile(filePath, optional: true, reloadOnChange: true);
+                }
             }
             catch (Exception ex)
             {

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -143,7 +143,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
             catch (Exception ex)
             {
-                hostBuilderResults.Warnings.Add(ex.Message);
+                if (ex is UnauthorizedAccessException || ex is FileNotFoundException)
+                {
+                    hostBuilderResults.Warnings.Add(ex.Message);
+                    return;
+                }
+
+                throw;
             }
         }
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file {0} could not be found..
+        ///   Looks up a localized string similar to The provided configuration file {filePath} could not be found..
         /// </summary>
         internal static string Message_ConfigurationFileDoesNotExist {
             get {
@@ -1114,7 +1114,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file {0} must have the .json extension..
+        ///   Looks up a localized string similar to The provided configuration file {filePath} must have the .json extension..
         /// </summary>
         internal static string Message_ConfigurationFileNotJson {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file {0} could not be found..
+        ///   Looks up a localized string similar to The provided configuration file &apos;{0}&apos; could not be found..
         /// </summary>
         internal static string Message_ConfigurationFileDoesNotExist {
             get {
@@ -1114,7 +1114,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file {0} must have the .json extension..
+        ///   Looks up a localized string similar to The provided configuration file &apos;{0}&apos; must have the .json extension..
         /// </summary>
         internal static string Message_ConfigurationFileNotJson {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file {filePath} could not be found..
+        ///   Looks up a localized string similar to The provided configuration file {0} could not be found..
         /// </summary>
         internal static string Message_ConfigurationFileDoesNotExist {
             get {
@@ -1114,7 +1114,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file {filePath} must have the .json extension..
+        ///   Looks up a localized string similar to The provided configuration file {0} must have the .json extension..
         /// </summary>
         internal static string Message_ConfigurationFileNotJson {
             get {

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file could not be found..
+        ///   Looks up a localized string similar to The provided configuration file {0} could not be found..
         /// </summary>
         internal static string Message_ConfigurationFileDoesNotExist {
             get {
@@ -1114,7 +1114,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided configuration file must have the .json extension..
+        ///   Looks up a localized string similar to The provided configuration file {0} must have the .json extension..
         /// </summary>
         internal static string Message_ConfigurationFileNotJson {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -668,12 +668,12 @@
 1. queueName: The name of the Azure Queue where messages are egressed</comment>
   </data>
   <data name="Message_ConfigurationFileDoesNotExist" xml:space="preserve">
-    <value>The provided configuration file {0} could not be found.</value>
-    <comment>Gets a string similar to "The provided configuration file {0] could not be found."</comment>
+    <value>The provided configuration file {filePath} could not be found.</value>
+    <comment>Gets a string similar to "The provided configuration file {filePath] could not be found."</comment>
   </data>
   <data name="Message_ConfigurationFileNotJson" xml:space="preserve">
-    <value>The provided configuration file {0} must have the .json extension.</value>
-    <comment>Gets a string similar to "The provided configuration file {0} must have the .json extension."</comment>
+    <value>The provided configuration file {filePath} must have the .json extension.</value>
+    <comment>Gets a string similar to "The provided configuration file {filePath} must have the .json extension."</comment>
   </data>
   <data name="Message_ExperienceSurvey" xml:space="preserve">
     <value>Tell us about your experience with dotnet monitor: {0}</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -668,12 +668,12 @@
 1. queueName: The name of the Azure Queue where messages are egressed</comment>
   </data>
   <data name="Message_ConfigurationFileDoesNotExist" xml:space="preserve">
-    <value>The provided configuration file {0} could not be found.</value>
-    <comment>Gets a string similar to "The provided configuration file {0} could not be found."</comment>
+    <value>The provided configuration file '{0}' could not be found.</value>
+    <comment>Gets a string similar to "The provided configuration file '{0}' could not be found."</comment>
   </data>
   <data name="Message_ConfigurationFileNotJson" xml:space="preserve">
-    <value>The provided configuration file {0} must have the .json extension.</value>
-    <comment>Gets a string similar to "The provided configuration file {0} must have the .json extension."</comment>
+    <value>The provided configuration file '{0}' must have the .json extension.</value>
+    <comment>Gets a string similar to "The provided configuration file '{0}' must have the .json extension."</comment>
   </data>
   <data name="Message_ExperienceSurvey" xml:space="preserve">
     <value>Tell us about your experience with dotnet monitor: {0}</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -668,12 +668,12 @@
 1. queueName: The name of the Azure Queue where messages are egressed</comment>
   </data>
   <data name="Message_ConfigurationFileDoesNotExist" xml:space="preserve">
-    <value>The provided configuration file {filePath} could not be found.</value>
-    <comment>Gets a string similar to "The provided configuration file {filePath] could not be found."</comment>
+    <value>The provided configuration file {0} could not be found.</value>
+    <comment>Gets a string similar to "The provided configuration file {0} could not be found."</comment>
   </data>
   <data name="Message_ConfigurationFileNotJson" xml:space="preserve">
-    <value>The provided configuration file {filePath} must have the .json extension.</value>
-    <comment>Gets a string similar to "The provided configuration file {filePath} must have the .json extension."</comment>
+    <value>The provided configuration file {0} must have the .json extension.</value>
+    <comment>Gets a string similar to "The provided configuration file {0} must have the .json extension."</comment>
   </data>
   <data name="Message_ExperienceSurvey" xml:space="preserve">
     <value>Tell us about your experience with dotnet monitor: {0}</value>

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -668,12 +668,12 @@
 1. queueName: The name of the Azure Queue where messages are egressed</comment>
   </data>
   <data name="Message_ConfigurationFileDoesNotExist" xml:space="preserve">
-    <value>The provided configuration file could not be found.</value>
-    <comment>Gets a string similar to "The provided configuration file could not be found."</comment>
+    <value>The provided configuration file {0} could not be found.</value>
+    <comment>Gets a string similar to "The provided configuration file {0] could not be found."</comment>
   </data>
   <data name="Message_ConfigurationFileNotJson" xml:space="preserve">
-    <value>The provided configuration file must have the .json extension.</value>
-    <comment>Gets a string similar to "The provided configuration file must have the .json extension."</comment>
+    <value>The provided configuration file {0} must have the .json extension.</value>
+    <comment>Gets a string similar to "The provided configuration file {0} must have the .json extension."</comment>
   </data>
   <data name="Message_ExperienceSurvey" xml:space="preserve">
     <value>Tell us about your experience with dotnet monitor: {0}</value>


### PR DESCRIPTION
Warnings will be logged in the event of file not found or unauthorized access for JSON configuration files.

closes #2020 