### PR TITLE
Remove .NET 5 installation

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,13 +4,11 @@
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",
-        "$(MicrosoftAspNetCoreApp50Version)",
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(VSRedistCommonAspNetCoreSharedFrameworkx6470Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp31Version)",
-        "$(MicrosoftNETCoreApp50Version)",
         "$(MicrosoftNETCoreApp60Version)",
         "$(VSRedistCommonNetCoreSharedFrameworkx6470Version)"
       ]


### PR DESCRIPTION
The .NET 5 runtimes are not used; remove the steps to install them.