### PR TITLE
Add cancellation support to DelayedCallbackAction

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRules/Actions/CallbackAction.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRules/Actions/CallbackAction.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.CollectionRules.Action
             while (_service.Clock.UtcNow == currentTime)
             {
                 // waiting for clock to be ticked (simulated time)
+                token.ThrowIfCancellationRequested();
             }
 
             return Task.FromResult(new CollectionRuleActionResult());


### PR DESCRIPTION
Some of the collection rule unit tests are not advancing the simulated clock correctly, which is causing the DelayedCallbackAction to not complete since it spin waits. I've added cancellation support to hopefully alleviate long test hangs until the simulated clock issue is resolved.