### PR TITLE
[release/6.x] Assign dotnet-monitor reviewers by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
-
-# We should just make everything require review of at least one team member.
-# However, we need /eng/ and global.json excluded for automatic updates
-# but there's no include syntax. At least make sure source and documentation
-# have proper ownership.
-/src/                       @dotnet/dotnet-monitor
-/documentation/             @dotnet/dotnet-monitor @IEvangelist
+*                           @dotnet/dotnet-monitor
+# We need /eng/ and global.json excluded for automatic updates
+/eng/
+global.json


### PR DESCRIPTION
Backport of #2231 to release/6.x