### PR TITLE
Update to newer Windows build machines

### DIFF
--- a/dotnet-monitor-codeql.yml
+++ b/dotnet-monitor-codeql.yml
@@ -25,7 +25,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+          demands: ImageOverride -equals 1es-windows-2019
 
         steps:
         - checkout: self
@@ -57,7 +57,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+          demands: ImageOverride -equals 1es-windows-2019
 
         steps:
         - checkout: self

--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -181,7 +181,7 @@ stages:
         - MacOS_arm64_Release
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+          demands: ImageOverride -equals 1es-windows-2019
         enablePublishUsingPipelines: true
         enableMicrobuild: true
         artifacts:
@@ -213,7 +213,7 @@ stages:
         publishUsingPipelines: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+          demands: ImageOverride -equals 1es-windows-2019
 # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/PrepareRelease.yml
+++ b/eng/PrepareRelease.yml
@@ -10,10 +10,10 @@ stages:
     pool: 
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Public
-        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+        demands: ImageOverride -equals 1es-windows-2019-open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+        demands: ImageOverride -equals 1es-windows-2019
     variables:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:
       - group: DotNet-Diagnostics-Storage

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -59,11 +59,11 @@ jobs:
       ${{ if eq(parameters.osGroup, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Public
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+          demands: ImageOverride -equals windows.vs2019.amd64.open
 
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+          demands: ImageOverride -equals windows.vs2019.amd64
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       ${{ if eq(parameters.architecture, 'arm64') }}:

--- a/eng/release.yml
+++ b/eng/release.yml
@@ -31,7 +31,7 @@ stages:
 
   pool:
     name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+    demands: ImageOverride -equals 1es-windows-2019
 
   jobs:
   - job: Validate
@@ -95,7 +95,7 @@ stages:
 
   pool:
     name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+    demands: ImageOverride -equals 1es-windows-2019
 
   jobs:
   - deployment: PublishToStorageAccounts


### PR DESCRIPTION
Per guidance from .NET Core engineering, update the Windows build images to newer images.