### PR TITLE
Automatically label bot PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -76,6 +76,18 @@
             "parameters": {
               "comment": "Automatically approving dependency update."
             }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "automatic-pr"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "dependencies"
+            }
           }
         ]
       },


### PR DESCRIPTION
This PR updates fabric bot to automatically label dependency update PRs from `dotnet-maestro` with `dependencies` and `automatic-pr` labels. This will allow people to easily filter out bot PRs when looking through open/closed PRs by using 
`-label:automatic-pr` in the search query.