### PR TITLE
Update runtimes and SDK to latest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,11 +59,11 @@
     <MicrosoftFileFormatsVersion>1.0.340801</MicrosoftFileFormatsVersion>
   </PropertyGroup>
   <PropertyGroup Label="Runtime Versions">
-    <MicrosoftNETCoreApp31Version>3.1.26</MicrosoftNETCoreApp31Version>
+    <MicrosoftNETCoreApp31Version>3.1.28</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.17</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
-    <MicrosoftNETCoreApp60Version>6.0.6</MicrosoftNETCoreApp60Version>
+    <MicrosoftNETCoreApp60Version>6.0.8</MicrosoftNETCoreApp60Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
     <MicrosoftNETCoreApp70Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp70Version>
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp70Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,8 +72,10 @@
     <AzureIdentityVersion>1.6.0</AzureIdentityVersion>
     <AzureStorageBlobsVersion>12.13.0</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.11.0</AzureStorageQueuesVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>6.0.5</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>6.0.5</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet6>6.0.5</MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet6>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet7>7.0.0-preview.7.22376.6</MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet7>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersionNet6>6.0.5</MicrosoftAspNetCoreAuthenticationNegotiateVersionNet6>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersionNet7>7.0.0-preview.7.22376.6</MicrosoftAspNetCoreAuthenticationNegotiateVersionNet7>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>6.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationKeyPerFileVersion>6.0.5</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
@@ -96,5 +98,13 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
+  </PropertyGroup>
+  <PropertyGroup Label=".NET 6 Dependent" Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet6)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiateVersionNet6)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+  </PropertyGroup>
+  <PropertyGroup Label=".NET 7 Dependent" Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet7)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiateVersionNet7)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-preview.5.22307.18",
+    "dotnet": "7.0.100-preview.7.22377.5",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
                 case SecurityAlgorithms.HmacSha256:
                 case SecurityAlgorithms.HmacSha384:
                 case SecurityAlgorithms.HmacSha512:
-                    HMAC hmac = HMAC.Create(GetHmacAlgorithmFromName(algorithmName));
+                    HMAC hmac = GetHmacAlgorithmFromName(algorithmName);
                     SymmetricSecurityKey hmacSecKey = new SymmetricSecurityKey(hmac.Key);
                     signingCreds = new SigningCredentials(hmacSecKey, algorithmName);
                     exportableJwk = JsonWebKeyConverter.ConvertFromSymmetricSecurityKey(hmacSecKey);
@@ -162,16 +162,16 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             return options;
         }
 
-        private static string GetHmacAlgorithmFromName(string algorithmName)
+        private static HMAC GetHmacAlgorithmFromName(string algorithmName)
         {
             switch (algorithmName)
             {
                 case SecurityAlgorithms.HmacSha256:
-                    return typeof(HMACSHA256).FullName;
+                    return new HMACSHA256();
                 case SecurityAlgorithms.HmacSha384:
-                    return typeof(HMACSHA384).FullName;
+                    return new HMACSHA384();
                 case SecurityAlgorithms.HmacSha512:
-                    return typeof(HMACSHA512).FullName;
+                    return new HMACSHA512();
                 default:
                     throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
@@ -4,9 +4,13 @@
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,11 +25,15 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
             using ServiceProvider hostServices = new ServiceCollection()
                 .AddLogging(builder =>
                 {
-                    builder.AddFilter(typeof(Program).FullName, LogLevel.Debug)
-                        .AddJsonConsole(options =>
-                        {
-                            options.UseUtcTimestamp = true;
-                        });
+                    builder.AddFilter(typeof(Program).FullName, LogLevel.Debug);
+                    // Console logger infra is not writing out all lines during process lifetime
+                    // which causes the coordination between the unit test and the test app to fail.
+                    // Temporarily replace with custom JSON console logger.
+                    //builder.AddJsonConsole(options =>
+                    //{
+                    //    options.UseUtcTimestamp = true;
+                    //});
+                    builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, JsonConsoleLoggerProvider>());
                 }).BuildServiceProvider();
 
             // All test host communication should be sent through this logger.
@@ -91,6 +99,88 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
             }
 
             return commandReceived;
+        }
+
+        private class JsonConsoleLoggerProvider : ILoggerProvider
+        {
+            private readonly ConcurrentDictionary<string, JsonConsoleLogger> _loggers = new();
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return _loggers.GetOrAdd(categoryName, name => new JsonConsoleLogger(name));
+            }
+
+            public void Dispose()
+            {
+            }
+
+            private class JsonConsoleLogger : ILogger
+            {
+                private string _categoryName;
+
+                public JsonConsoleLogger(string categoryName)
+                {
+                    _categoryName = categoryName;
+                }
+
+                public IDisposable BeginScope<TState>(TState state)
+                {
+                    return null;
+                }
+
+                public bool IsEnabled(LogLevel logLevel)
+                {
+                    return true;
+                }
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                    using Utf8JsonWriter writer = new(Console.OpenStandardOutput());
+
+                    writer.WriteStartObject();
+
+                    writer.WriteNumber("EventId", eventId.Id);
+                    writer.WriteString("Level", logLevel.ToString("G"));
+                    writer.WriteString("Category", _categoryName);
+                    writer.WriteString("Message", formatter(state, exception));
+
+                    if (null != state)
+                    {
+                        writer.WriteStartObject("State");
+                        writer.WriteString("Message", state.ToString());
+
+                        if ((object)state is IReadOnlyCollection<KeyValuePair<string, object>> readOnlyCollection)
+                        {
+                            foreach (KeyValuePair<string, object> item in readOnlyCollection)
+                            {
+                                if (item.Value is string stringValue)
+                                {
+                                    writer.WriteString(item.Key, stringValue);
+                                }
+                                else if (item.Value is Enum enumValue)
+                                {
+                                    writer.WriteString(item.Key, enumValue.ToString("G"));
+                                }
+                                else if (item.Value is bool booleanValue)
+                                {
+                                    writer.WriteBoolean(item.Key, booleanValue);
+                                }
+                                else
+                                {
+                                    writer.WriteString(item.Key, "[UNHANDLED]");
+                                }
+                            }
+                        }
+                        writer.WriteEndObject();
+                    }
+
+                    writer.WriteEndObject();
+
+                    writer.Flush();
+
+                    Console.WriteLine();
+                }
+            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -9,7 +9,6 @@
     <Description>.NET Core Diagnostic Monitoring Tool</Description>
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
-    <RollForward>Major</RollForward>
     <!--
       Workaround for https://github.com/dotnet/aspnetcore/issues/42200
       Required as of 7.0 Preview 5 SDK


### PR DESCRIPTION
This change includes splitting the versions of the authentication libraries along the .NET versions. This is necessary because there are changes in .NET 7 Preview 7 that prevent usage of the .NET 6 version of the libraries from being used in .NET 7. Because the .NET 6 libraries cannot be used in .NET 7 any longer, I've also removed the ability to have dotnet-monitor roll forward to newer major versions of .NET.

Another issue is that the Microsoft.Extensions.Logging.Console library is not writing out all of the logged entries in a timely manner. The tests use this library for controlling coordination between the unit tests and the unit test app. I've replaced the standard JSON console logger with a custom implementation that effectively does the same logging without using a message queue. 

Additional changes were made to change from the `HMAC.create` function to using concrete constructors due to the obsoletion of this function in the newer SDK.