### PR TITLE
Auto label dependency update PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -82,16 +82,29 @@
             "parameters": {
               "label": "automatic-pr"
             }
-          },
-          {
-            "name": "addLabel",
-            "parameters": {
-              "label": "dependencies"
-            }
           }
         ]
       },
       "id": "PUcyzKaH6va"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "PrAutoLabel",
+      "subCapability": "Path",
+      "version": "1.0",
+      "config": {
+        "taskName": "Add tags (paths)",
+        "configs": [
+          {
+            "label": "dependencies",
+            "pathFilter": [
+              "global.json",
+              "eng/Versions.props",
+              "eng/Version.Details.xml"
+            ]
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
This PR updates fabric bot to auto label PRs that update dependencies, including PRs not made by bots.