### PR TITLE
Operations API - Specify PID/UID/Name to see operations for specific process

### DIFF
--- a/documentation/api/operations-list.md
+++ b/documentation/api/operations-list.md
@@ -5,12 +5,24 @@ Lists all operations that have been created, as well as their status.
 ## HTTP Route
 
 ```http
-GET /operations HTTP/1.1
+GET /operations?pid={pid}&uid={uid}&name={name} HTTP/1.1
 ```
 
 ## Host Address
 
 The default host address for these routes is `https://localhost:52323`. This route is only available on the addresses configured via the `--urls` command line parameter and the `DOTNETMONITOR_URLS` environment variable.
+
+## URI Parameters
+
+| Name | In | Required | Type | Description |
+|---|---|---|---|---|
+| `pid` | query | false | int | The ID of the process. |
+| `uid` | query | false | guid | A value that uniquely identifies a runtime instance within a process. |
+| `name` | query | false | string | The name of the process. |
+
+See [ProcessIdentifier](definitions.md#ProcessIdentifier) for more details about the `pid`, `uid`, and `name` parameters.
+
+If none of `pid`, `uid`, or `name` are specified, all operations will be listed.
 
 ## Authentication
 
@@ -30,7 +42,7 @@ Allowed schemes:
 
 ## Examples
 
-### Sample Request
+### Sample Request 1
 
 ```http
 GET /operations HTTP/1.1
@@ -38,7 +50,7 @@ Host: localhost:52323
 Authorization: Bearer fffffffffffffffffffffffffffffffffffffffffff=
 ```
 
-### Sample Response
+### Sample Response 1
 
 ```http
 HTTP/1.1 200 OK
@@ -65,6 +77,35 @@ Content-Type: application/json
             "pid":11782,
             "uid":"23c289b3-b5ce-428a-aaa8-c864b3766bc2",
             "name":"dotnet-monitor-demo2"
+        }
+    }
+]
+```
+
+### Sample Request 2
+
+```http
+GET /operations?name=dotnet-monitor-demo HTTP/1.1
+Host: localhost:52323
+Authorization: Bearer fffffffffffffffffffffffffffffffffffffffffff=
+```
+
+### Sample Response 2
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+    {
+        "operationId": "67f07e40-5cca-4709-9062-26302c484f18",
+        "createdDateTime": "2021-07-21T06:21:15.315861Z",
+        "status": "Succeeded", 
+        "process":
+        {
+            "pid":1,
+            "uid":"95b0202a-4ed3-44a6-98f1-767d270ec783",
+            "name":"dotnet-monitor-demo"
         }
     }
 ]

--- a/documentation/api/operations-list.md
+++ b/documentation/api/operations-list.md
@@ -24,6 +24,8 @@ See [ProcessIdentifier](definitions.md#processidentifier) for more details about
 
 If none of `pid`, `uid`, or `name` are specified, all operations will be listed.
 
+> **NOTE:** If multiple processes match the provided parameters (e.g., two processes named "MyProcess"), the operations for all matching processes will be listed.
+
 ## Authentication
 
 Authentication is enforced for this route. See [Authentication](./../authentication.md) for further information.

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1130,6 +1130,41 @@
         "tags": [
           "Operations"
         ],
+        "summary": "Gets the operations list for the specified process (or all processes if left unspecified).",
+        "parameters": [
+          {
+            "name": "pid",
+            "in": "query",
+            "description": "Process ID used to identify the target process.",
+            "schema": {
+              "type": "integer",
+              "description": "Process ID used to identify the target process.",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          {
+            "name": "uid",
+            "in": "query",
+            "description": "The Runtime instance cookie used to identify the target process.",
+            "schema": {
+              "type": "string",
+              "description": "The Runtime instance cookie used to identify the target process.",
+              "format": "uuid",
+              "nullable": true
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Process name used to identify the target process.",
+            "schema": {
+              "type": "string",
+              "description": "Process name used to identify the target process.",
+              "nullable": true
+            }
+          }
+        ],
         "responses": {
           "401": {
             "$ref": "#/components/responses/UnauthorizedResponse"

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(async (processInfo) =>
             {
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(async (processInfo) =>
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string name = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess<Models.ProcessInfo>(processInfo =>
             {
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string name = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess<Dictionary<string, string>>(async processInfo =>
             {
@@ -215,7 +215,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(async processInfo =>
             {
@@ -272,7 +272,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(processInfo =>
             {
@@ -335,7 +335,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(processInfo =>
             {
@@ -379,7 +379,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(processInfo =>
             {
@@ -430,7 +430,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(processInfo =>
             {
@@ -486,7 +486,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string egressProvider = null)
         {
-            ProcessKey? processKey = GetProcessKey(pid, uid, name);
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
             return InvokeForProcess(processInfo =>
             {
@@ -553,7 +553,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             {
                 return _collectionRuleService.GetCollectionRulesDescriptions(processInfo.EndpointInfo);
             },
-            GetProcessKey(pid, uid, name));
+            Utilities.GetProcessKey(pid, uid, name));
         }
 
         /// <summary>
@@ -579,7 +579,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             {
                 return _collectionRuleService.GetCollectionRuleDetailedDescription(collectionRuleName, processInfo.EndpointInfo);
             },
-            GetProcessKey(pid, uid, name));
+            Utilities.GetProcessKey(pid, uid, name));
         }
 
         private static string GetDotnetMonitorVersion()
@@ -660,11 +660,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 contentType,
                 processInfo,
                 format != LogFormat.PlainText);
-        }
-
-        private static ProcessKey? GetProcessKey(int? pid, Guid? uid, string name)
-        {
-            return (pid == null && uid == null && name == null) ? null : new ProcessKey(pid, uid, name);
         }
 
         private static LogFormat? ComputeLogFormat(IList<MediaTypeHeaderValue> acceptedHeaders)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
@@ -30,14 +30,28 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             _operationsStore = serviceProvider.GetRequiredService<EgressOperationStore>();
         }
 
+        /// <summary>
+        /// Gets the operations list for the specified process (or all processes if left unspecified).
+        /// </summary>
+        /// <param name="pid">Process ID used to identify the target process.</param>
+        /// <param name="uid">The Runtime instance cookie used to identify the target process.</param>
+        /// <param name="name">Process name used to identify the target process.</param>
         [HttpGet]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<Models.OperationSummary>), StatusCodes.Status200OK)]
-        public ActionResult<IEnumerable<Models.OperationSummary>> GetOperations()
+        public ActionResult<IEnumerable<Models.OperationSummary>> GetOperations(
+            [FromQuery]
+            int? pid = null,
+            [FromQuery]
+            Guid? uid = null,
+            [FromQuery]
+            string name = null)
         {
+            ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
+
             return this.InvokeService(() =>
             {
-                return new ActionResult<IEnumerable<Models.OperationSummary>>(_operationsStore.GetOperations());
+                return new ActionResult<IEnumerable<Models.OperationSummary>>(_operationsStore.GetOperations(processKey));
             }, _logger);
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 {
@@ -40,7 +39,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         [HttpGet]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<Models.OperationSummary>), StatusCodes.Status200OK)]
-        public Task<ActionResult<IEnumerable<Models.OperationSummary>>> GetOperations(
+        public ActionResult<IEnumerable<Models.OperationSummary>> GetOperations(
             [FromQuery]
             int? pid = null,
             [FromQuery]
@@ -50,10 +49,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
-            return this.InvokeService(async () =>
+            return this.InvokeService(() =>
             {
-                var operations = await _operationsStore.GetOperationsAsync(processKey, HttpContext.RequestAborted);
-                return new ActionResult<IEnumerable<Models.OperationSummary>>(operations);
+                return new ActionResult<IEnumerable<Models.OperationSummary>>(_operationsStore.GetOperations(processKey));
             }, _logger);
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 {
@@ -39,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         [HttpGet]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<Models.OperationSummary>), StatusCodes.Status200OK)]
-        public ActionResult<IEnumerable<Models.OperationSummary>> GetOperations(
+        public Task<ActionResult<IEnumerable<Models.OperationSummary>>> GetOperations(
             [FromQuery]
             int? pid = null,
             [FromQuery]
@@ -49,9 +50,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
-            return this.InvokeService(() =>
+            return this.InvokeService(async () =>
             {
-                return new ActionResult<IEnumerable<Models.OperationSummary>>(_operationsStore.GetOperations(processKey));
+                var operations = await _operationsStore.GetOperationsAsync(processKey, HttpContext.RequestAborted);
+                return new ActionResult<IEnumerable<Models.OperationSummary>>(operations);
             }, _logger);
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -125,39 +125,40 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             lock (_requests)
             {
-                return _requests.Select((kvp) =>
-                {
-                    EgressProcessInfo processInfo = kvp.Value.EgressRequest.EgressOperation.ProcessInfo;
+                IEnumerable<KeyValuePair<Guid, EgressEntry>> requests = _requests;
 
-                    if (processKey != null)
+                if (null != processKey)
+                {
+                    requests = requests.Where((kvp) =>
                     {
-                        bool isValid = true;
+                        EgressProcessInfo processInfo = kvp.Value.EgressRequest.EgressOperation.ProcessInfo;
 
                         // Check that if a field is specified, it meets the conditions.
                         if (!string.IsNullOrEmpty(processKey.Value.ProcessName)
                             && processInfo.ProcessName != processKey.Value.ProcessName)
                         {
-                            isValid = false;
+                            return false;
                         }
 
                         if (processKey.Value.ProcessId.HasValue
                             && processInfo.ProcessId != processKey.Value.ProcessId.Value)
                         {
-                            isValid = false;
+                            return false;
                         }
 
                         if (processKey.Value.RuntimeInstanceCookie.HasValue
                             && processInfo.RuntimeInstanceCookie != processKey.Value.RuntimeInstanceCookie.Value)
                         {
-                            isValid = false;
+                            return false;
                         }
 
-                        if (!isValid)
-                        {
-                            return null;
-                        }
-                    }
+                        return true;
+                    });
+                }
 
+                return requests.Select((kvp) =>
+                {
+                    EgressProcessInfo processInfo = kvp.Value.EgressRequest.EgressOperation.ProcessInfo;
                     return new Models.OperationSummary
                     {
                         OperationId = kvp.Key,
@@ -171,7 +172,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                                 Uid = processInfo.RuntimeInstanceCookie
                             } : null
                     };
-                }).Where(summary => summary != null).ToList();
+                }).ToList();
             }
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
@@ -34,5 +34,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             scope.AddArtifactEndpointInfo(endpointInfo);
             return scope;
         }
+
+        public static ProcessKey? GetProcessKey(int? pid, Guid? uid, string name)
+        {
+            return (pid == null && uid == null && name == null) ? null : new ProcessKey(pid, uid, name);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public static ProcessKey? GetProcessKey(int? pid, Guid? uid, string name)
         {
-            return (pid == null && uid == null && name == null) ? null : new ProcessKey(pid, uid, name);
+            return (!pid.HasValue && !uid.HasValue && string.IsNullOrEmpty(name)) ? null : new ProcessKey(pid, uid, name);
         }
     }
 }


### PR DESCRIPTION
Part 2 of #2122; allows users to specify a PID/UID/Name to only see the operations list for that specific process. 