### PR TITLE
Skip pipeline builds for documentation and development infrastructure PRs

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -13,7 +13,7 @@ pr:
     - .devcontainer
     - .github
     - .vscode
-    - **.md
+    - '**.md'
 
 schedules:
 - cron: 15 11 * * 6


### PR DESCRIPTION
Avoid running the full suite of dotnet-monitor builds and test runs on PRs that only impact documentation and/or development infrastructure changes.