### PR TITLE
Remove unused native TraceEvent libraries from consideration

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -26,4 +26,13 @@
   <Target Name="GetPackageFileName"
           Returns="$(PackageId).$(PackageVersion).nupkg" />
 
+  <!-- Remove native libraries from transitive dependencies -->
+  <ItemGroup>
+    <!--
+      These assets are Windows-specific native libraries and are not used in the trace event usage
+      by dotnet-monitor. Removing them saves about 20 MBs from the unpacked dotnet-monitor installation.
+      -->
+    <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\3.0.3\build\native\*" />
+  </ItemGroup>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,7 +32,7 @@
       These assets are Windows-specific native libraries and are not used in the trace event usage
       by dotnet-monitor. Removing them saves about 20 MBs from the unpacked dotnet-monitor installation.
       -->
-    <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\3.0.3\build\native\*" />
+    <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\3.0.3\build\native\**" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Recent upgrade of the Microsoft.Diagnostics.Tracing.TraceEvent library that is transitively included by direct dependencies of dotnet-monitor include Windows-only native libraries. These libraries in total are about ~10 MBs; when packaged into dotnet-monitor, they take up ~20 MBs of space due to multitargeting.

This change removes those native libraries as they are not used by dotnet-monitor in order to reduce the package size.