### PR TITLE
Use FabricBot to add stale label and close PRs that are stale

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -278,6 +278,17 @@
             {
               "name": "isAction",
               "parameters": {}
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "msftbot"
+                  }
+                }
+              ]
             }
           ]
         },

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -105,6 +105,198 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 28
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "stale"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "The 'stale' label has been added to this pull request due to four weeks without any activity. If there is no activity in the next six weeks, this pull request will automatically be closed."
+            }
+          }
+        ],
+        "taskName": "Stale PR Search"
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "stale"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 42
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ],
+        "taskName": "Close Stale PR"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "stale"
+              }
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "isAction",
+              "parameters": {}
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove Stale Label",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "stale"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -175,17 +175,17 @@
           {
             "name": "addLabel",
             "parameters": {
-              "label": "stale"
+              "label": "no-recent-activity"
             }
           },
           {
             "name": "addReply",
             "parameters": {
-              "comment": "The 'stale' label has been added to this pull request due to four weeks without any activity. If there is no activity in the next six weeks, this pull request will automatically be closed. You can learn more about our stale PR policy here: https://github.com/dotnet/dotnet-monitor/blob/main/CONTRIBUTING.md#stale-pr-policy"
+              "comment": "The 'no-recent-activity' label has been added to this pull request due to four weeks without any activity. If there is no activity in the next six weeks, this pull request will automatically be closed. You can learn more about our stale PR policy here: https://github.com/dotnet/dotnet-monitor/blob/main/CONTRIBUTING.md#stale-pr-policy"
             }
           }
         ],
-        "taskName": "Stale PR Search"
+        "taskName": "No Recent Activity PR Search"
       }
     },
     {
@@ -243,7 +243,7 @@
           {
             "name": "hasLabel",
             "parameters": {
-              "label": "stale"
+              "label": "no-recent-activity"
             }
           },
           {
@@ -265,7 +265,7 @@
             "parameters": {}
           }
         ],
-        "taskName": "Close Stale PR"
+        "taskName": "Close No Recent Activity PR"
       }
     },
     {
@@ -280,7 +280,7 @@
             {
               "name": "hasLabel",
               "parameters": {
-                "label": "stale"
+                "label": "no-recent-activity"
               }
             },
             {
@@ -316,12 +316,12 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Remove Stale Label",
+        "taskName": "Remove No Recent Activity Label",
         "actions": [
           {
             "name": "removeLabel",
             "parameters": {
-              "label": "stale"
+              "label": "no-recent-activity"
             }
           }
         ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -175,7 +175,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "The 'stale' label has been added to this pull request due to four weeks without any activity. If there is no activity in the next six weeks, this pull request will automatically be closed."
+              "comment": "The 'stale' label has been added to this pull request due to four weeks without any activity. If there is no activity in the next six weeks, this pull request will automatically be closed. You can learn more about our stale PR policy here: https://github.com/dotnet/dotnet-monitor/blob/main/CONTRIBUTING.md#stale-pr-policy"
             }
           }
         ],

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -161,7 +161,13 @@
           {
             "name": "noActivitySince",
             "parameters": {
-              "days": 28
+              "days": 1
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "test-fabric-bot"
             }
           }
         ],
@@ -243,7 +249,13 @@
           {
             "name": "noActivitySince",
             "parameters": {
-              "days": 42
+              "days": 1
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "test-fabric-bot"
             }
           }
         ],
@@ -289,6 +301,12 @@
                   }
                 }
               ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "test-fabric-bot"
+              }
             }
           ]
         },


### PR DESCRIPTION
I haven't been able to test this, but this PR is intended to do the following:

- If a PR hasn't had any activity in 4 weeks (28 days), we add a 'stale' label to it, and leave a comment saying that the PR will be closed if there is no activity
- If a PR hasn't had any activity in 10 weeks total (4 weeks + 6 weeks after the comment), we close the PR
- If a PR has the stale label and has activity, we remove the stale label. This piece I'm not confident in, because I'm not sure if this will immediately remove the stale label as soon as it's added (because it'll be seen as new activity), but I believe I've mitigated that by saying the activity sender cannot be the fabric bot.


Follow-up to #2344 