### PR TITLE
Reorder assertion arguments

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             {
                 CollectDumpOptions options = ActionTestsHelper.GetActionOptions<CollectDumpOptions>(host, DefaultRuleName);
 
-                Assert.Equal(options.Egress, ActionTestsConstants.ExpectedEgressProvider);
+                Assert.Equal(ActionTestsConstants.ExpectedEgressProvider, options.Egress);
             });
         }
 
@@ -97,7 +97,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             {
                 CollectDumpOptions options = ActionTestsHelper.GetActionOptions<CollectDumpOptions>(host, DefaultRuleName);
 
-                Assert.Equal(options.Egress, ActionTestsConstants.ExpectedEgressProvider);
+                Assert.Equal(ActionTestsConstants.ExpectedEgressProvider, options.Egress);
             });
         }
 


### PR DESCRIPTION
xUnit analyzer will fail the build on these lines because the expected value and actual value are swapped. Flip them around to correctly specify the expected and actual values.