### PR TITLE
Update CODEOWNERS for new dependabot integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 # We need /eng/ and global.json excluded for automatic updates
 /eng/
 global.json
+/eng/dependabot             @dotnet/dotnet-monitor


### PR DESCRIPTION
With https://github.com/dotnet/dotnet-monitor/pull/2387 merged, we're now getting automatic PRs opened for NuGet dependency updates. However, reviewers are not getting added automatically on resulting PRs since we excluded all of `/eng` in the CODEOWNERS file. This PR fixes that.