### PR TITLE
Add VSCode launch/debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.2.0",
+    "inputs": [
+        {
+            "id": "args",
+            "description": "Enter arguments for dotnet-monitor",
+            "default": "collect --no-auth",
+            "type": "promptString",
+        }
+    ],
+    "configurations": [
+        {
+            "name": "Build & Launch",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build (Debug)",
+            "program": "${workspaceFolder}/artifacts/bin/dotnet-monitor/Debug/net7.0/dotnet-monitor.dll",
+            "args": "${input:args}",
+            "stopAtEntry": false,
+            "justMyCode": false
+        },
+        {
+            "name": "Launch",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/artifacts/bin/dotnet-monitor/Debug/net7.0/dotnet-monitor.dll",
+            "args": "${input:args}",
+            "stopAtEntry": false,
+            "justMyCode": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "justMyCode": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,14 +6,9 @@
         {
             "label": "Build",
             "type": "shell",
+            "command": "./build.sh",
             "windows": {
                 "command": ".\\build.cmd"
-            },
-            "linux": {
-                "command": "./build.sh"
-            },
-            "osx": {
-                "command": "./build.sh"
             },
             "args": [
                 "-ci",
@@ -29,16 +24,30 @@
             ]
         },
         {
+            "label": "Build (Debug)",
+            "type": "shell",
+            "command": "./build.sh",
+            "windows": {
+                "command": ".\\build.cmd"
+            },
+            "args": [
+                "-ci",
+                "-c",
+                "Debug"
+            ],
+            "group": {
+                "kind": "build",
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
             "label": "Test",
             "type": "shell",
+            "command": "./test.sh",
             "windows": {
                 "command": ".\\test.cmd"
-            },
-            "linux": {
-                "command": "./test.sh"
-            },
-            "osx": {
-                "command": "./test.sh"
             },
             "args": [
                 "-ci",
@@ -55,14 +64,9 @@
         {
             "label": "Regenerate schema.json",
             "type": "shell",
+            "command": "./dotnet.sh",
             "windows": {
                 "command": ".\\dotnet.cmd"
-            },
-            "linux": {
-                "command": "./dotnet.sh"
-            },
-            "osx": {
-                "command": "./dotnet.sh"
             },
             "args": [
                 "run",
@@ -77,14 +81,9 @@
         {
             "label": "Regenerate openapi.json",
             "type": "shell",
+            "command": "./dotnet.sh",
             "windows": {
                 "command": ".\\dotnet.cmd"
-            },
-            "linux": {
-                "command": "./dotnet.sh"
-            },
-            "osx": {
-                "command": "./dotnet.sh"
             },
             "args": [
                 "run",


### PR DESCRIPTION
This PR adds a new launchconfig for both GitHub codespaces and local VSCode, enabling these scenarios to launch and debug `dotnet-monitor`. It also adds a new `Build (Debug)` task to simplify the launch process.

As a minor cleanup it also deduplicates the `osx`/`linux` specific commands by setting it as the default.
