### PR TITLE
Enable building net7.0 in Visual Studio

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,18 +15,19 @@
     <BlobGroupBuildQuality>daily</BlobGroupBuildQuality>
   </PropertyGroup>
   <PropertyGroup Label="TargetFrameworks">
+    <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
+    <ExcludeLatestTargetFramework>false</ExcludeLatestTargetFramework>
+    <!-- <ExcludeLatestTargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework> -->
     <!-- The TFMs of the dotnet-monitor tool.  -->
     <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
-    <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
-    <ToolTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(ToolTargetFrameworks);net7.0</ToolTargetFrameworks>
+    <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);net7.0</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
     <TestTargetFrameworks>netcoreapp3.1;net6.0</TestTargetFrameworks>
-    <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
-    <TestTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(TestTargetFrameworks);net7.0</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);net7.0</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
     <SchemaTargetFramework>net6.0</SchemaTargetFramework>
     <!-- Defines for including the next .NET version -->
-    <DefineConstants Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(DefineConstants);INCLUDE_NEXT_DOTNET</DefineConstants>
+    <DefineConstants Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(DefineConstants);INCLUDE_NEXT_DOTNET</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Label="Arcade">
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
Now that the .NET 7 SDK is stable enough, this change enables building the `net7.0` TFM when building in Visual Studio. I've left in the commented-out condition that would allow the conditional inclusion of the latest TFM for when this branch forks for .NET 8.

Note that this will require installing the latest .NET 7 SDK on dev machines and requires using a preview version of Visual Studio to build.