### PR TITLE
FabricBot Adjustments

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -183,6 +183,12 @@
             "parameters": {
               "label": "test-fabric-bot"
             }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
           }
         ],
         "actions": [
@@ -316,8 +322,33 @@
               "parameters": {}
             },
             {
-              "name": "isAction",
-              "parameters": {}
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "reopened"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "synchronize"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "edited"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "review_requested"
+                  }
+                }
+              ]
             },
             {
               "operator": "not",


### PR DESCRIPTION
The current FabricBot experiment doesn't appear to be removing the `no-recent-activity` label when a user does an action - I plan to continue the experiment with these changes. Also adds logic so that the `no-recent-activity` label doesn't get added when it's already on the PR.