### PR TITLE
Update FabricBot Stale-Checker To Use Actual Timeframes and Apply to All PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -175,13 +175,7 @@
           {
             "name": "noActivitySince",
             "parameters": {
-              "days": 1
-            }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "test-fabric-bot"
+              "days": 28
             }
           },
           {
@@ -283,13 +277,7 @@
           {
             "name": "noActivitySince",
             "parameters": {
-              "days": 1
-            }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "test-fabric-bot"
+              "days": 42
             }
           }
         ],
@@ -360,12 +348,6 @@
                   }
                 }
               ]
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "test-fabric-bot"
-              }
             }
           ]
         },


### PR DESCRIPTION
There had been some discussion on https://github.com/dotnet/dotnet-monitor/pull/2374#issuecomment-1227595984 about what timeframes we want to use - this PR currently has the original ones, but once we settle on what we want to use I can update this as needed.