### PR TITLE
Add profiler attach support and initialization unit tests

### DIFF
--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -33,9 +33,11 @@ public:
     STDMETHOD(ExceptionThrown)(ObjectID thrownObjectId) override;
     STDMETHOD(ExceptionSearchCatcherFound)(FunctionID functionId) override;
     STDMETHOD(ExceptionUnwindFunctionEnter)(FunctionID functionId) override;
+    STDMETHOD(InitializeForAttach)(IUnknown* pCorProfilerInfoUnk, void* pvClientData, UINT cbClientData);
     STDMETHOD(LoadAsNotficationOnly)(BOOL *pbNotificationOnly) override;
 
 private:
+    HRESULT InitializeCommon();
     HRESULT InitializeEnvironment();
     HRESULT InitializeEnvironmentHelper();
     HRESULT InitializeLogging();

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -33,7 +33,7 @@ public:
     STDMETHOD(ExceptionThrown)(ObjectID thrownObjectId) override;
     STDMETHOD(ExceptionSearchCatcherFound)(FunctionID functionId) override;
     STDMETHOD(ExceptionUnwindFunctionEnter)(FunctionID functionId) override;
-    STDMETHOD(InitializeForAttach)(IUnknown* pCorProfilerInfoUnk, void* pvClientData, UINT cbClientData);
+    STDMETHOD(InitializeForAttach)(IUnknown* pCorProfilerInfoUnk, void* pvClientData, UINT cbClientData) override;
     STDMETHOD(LoadAsNotficationOnly)(BOOL *pbNotificationOnly) override;
 
 private:

--- a/src/MonitorProfiler/ProfilerBase.cpp
+++ b/src/MonitorProfiler/ProfilerBase.cpp
@@ -408,6 +408,14 @@ STDMETHODIMP ProfilerBase::HandleDestroyed(GCHandleID handleId)
 
 STDMETHODIMP ProfilerBase::InitializeForAttach(IUnknown *pCorProfilerInfoUnk, void *pvClientData, UINT cbClientData)
 {
+    ExpectedPtr(pCorProfilerInfoUnk);
+
+    HRESULT hr = S_OK;
+
+    IfFailRet(pCorProfilerInfoUnk->QueryInterface(
+        IID_ICorProfilerInfo12,
+        reinterpret_cast<void**>(&m_pCorProfilerInfo)));
+
     return S_OK;
 }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
@@ -34,14 +34,14 @@ namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
         }
 
         [Theory]
-        [MemberData(nameof(GetArchitectureProfilerPath))]
+        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
         public Task ExceptionThrowCatch(Architecture architecture, string profilerPath)
         {
             return RunAndCompare(nameof(ExceptionThrowCatch), architecture, profilerPath);
         }
 
         [Theory]
-        [MemberData(nameof(GetArchitectureProfilerPath))]
+        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
         public Task ExceptionThrowCrash(Architecture architecture, string profilerPath)
         {
             return RunAndCompare(nameof(ExceptionThrowCrash), architecture, profilerPath);
@@ -179,28 +179,6 @@ namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
                 }
             }
             return false;
-        }
-
-        public static IEnumerable<object[]> GetArchitectureProfilerPath()
-        {
-            // There isn't a good way to check which architecture to use when running unit tests.
-            // Each build job builds one specific architecture, but from a test perspective,
-            // it cannot tell which one was built. Gather all of the profilers for every architecture
-            // so long as they exist.
-            List<object[]> arguments = new();
-            AddTestCases(arguments, Architecture.X64);
-            AddTestCases(arguments, Architecture.X86);
-            AddTestCases(arguments, Architecture.Arm64);
-            return arguments;
-
-            static void AddTestCases(List<object[]> arguments, Architecture architecture)
-            {
-                string profilerPath = ProfilerHelper.GetPath(architecture);
-                if (File.Exists(profilerPath))
-                {
-                    arguments.Add(new object[] { architecture, profilerPath });
-                }
-            }
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ProfilerInitializationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ProfilerInitializationTests.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
+{
+    public sealed class ProfilerInitializationTests
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public ProfilerInitializationTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Theory]
+        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        public async Task LoadAtStart(Architecture architecture, string profilerPath)
+        {
+            if (Architecture.X86 == architecture)
+            {
+                _outputHelper.WriteLine("Skipping x86 architecture since x86 host is not used at this time.");
+                return;
+            }
+
+            await using AppRunner runner = new(_outputHelper, Assembly.GetExecutingAssembly());
+            runner.ScenarioName = TestAppScenarios.AsyncWait.Name;
+
+            // Environment variables necessary for running the profiler + enable all logging to stderr
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarEnableNotificationProfilers, ProfilerHelper.ClrEnvVarEnabledValue);
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarEnableProfiling, ProfilerHelper.ClrEnvVarEnabledValue);
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarProfiler, ProfilerHelper.Clsid.ToString("B"));
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarProfilerPath64, profilerPath);
+            runner.Environment.Add(ProfilerHelper.ProfilerEnvVarRuntimeId, Guid.NewGuid().ToString("D"));
+            runner.Environment.Add(ProfilerHelper.ProfilerEnvVarStdErrLoggerLevel, LogLevel.Trace.ToString("G"));
+
+            await runner.ExecuteAsync(async () =>
+            {
+                // At this point, the profiler has already been initialized and managed code is already running.
+                // Use any of the initialization state of the profiler to validate that it is loaded.
+                await ProfilerHelper.VerifyProductVersionEnvironmentVariableAsync(runner, _outputHelper);
+
+                await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        public async Task AttachAfterStarted(Architecture architecture, string profilerPath)
+        {
+            if (Architecture.X86 == architecture)
+            {
+                _outputHelper.WriteLine("Skipping x86 architecture since x86 host is not used at this time.");
+                return;
+            }
+
+            await using AppRunner runner = new(_outputHelper, Assembly.GetExecutingAssembly());
+            runner.ScenarioName = TestAppScenarios.AsyncWait.Name;
+
+            await runner.ExecuteAsync(async () =>
+            {
+                DiagnosticsClient client = new(await runner.ProcessIdTask);
+
+                client.SetEnvironmentVariable(
+                    ProfilerHelper.ProfilerEnvVarRuntimeId,
+                    Guid.NewGuid().ToString("D"));
+
+                client.SetEnvironmentVariable(
+                    ProfilerHelper.ProfilerEnvVarStdErrLoggerLevel,
+                    LogLevel.Trace.ToString("G"));
+
+                // Profiler will attach and initialize before this returns.
+                // All settings must be applied before issuing attach profiler call.
+                client.AttachProfiler(
+                    TimeSpan.FromSeconds(10),
+                    ProfilerHelper.Clsid,
+                    profilerPath);
+
+                await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+
+                // At this point, the profiler has already been initialized and managed code is already running.
+                // Use any of the initialization state of the profiler to validate that it is loaded.
+                await ProfilerHelper.VerifyProductVersionEnvironmentVariableAsync(runner, _outputHelper);
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
@@ -72,9 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     // At this point, the profiler has already been initialized and managed code is already running.
                     // Use any of the initialization state of the profiler to validate that it is loaded.
-                    string productVersion = await runner.GetEnvironmentVariable(ProfilerHelper.ProfilerEnvVarProductVersion, CommonTestTimeouts.EnvVarsTimeout);
-                    Assert.False(string.IsNullOrEmpty(productVersion), "Expected product version to not be null or empty.");
-                    _outputHelper.WriteLine("{0} = {1}", ProfilerHelper.ProfilerEnvVarProductVersion, productVersion);
+                    await ProfilerHelper.VerifyProductVersionEnvironmentVariableAsync(runner, _outputHelper);
 
                     await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
                 });


### PR DESCRIPTION
Refactor profiler initialization to be callable by `Initialize` and `InitializeForAttach`.
Add unit tests for validating profiling at startup and attaching profiler.