### PR TITLE
Disable exception tracking via profiler

### DIFF
--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -22,10 +22,7 @@ set(SOURCES
     Logging/LoggerHelper.cpp
     Logging/NullLogger.cpp
     Logging/StdErrLogger.cpp
-    MainProfiler/ExceptionTracker.cpp
     MainProfiler/MainProfiler.cpp
-    MainProfiler/ThreadData.cpp
-    MainProfiler/ThreadDataManager.cpp
     Stacks/StacksEventProvider.cpp
     Stacks/StackSampler.cpp
     Utilities/NameCache.cpp

--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -22,7 +22,10 @@ set(SOURCES
     Logging/LoggerHelper.cpp
     Logging/NullLogger.cpp
     Logging/StdErrLogger.cpp
+    MainProfiler/ExceptionTracker.cpp
     MainProfiler/MainProfiler.cpp
+    MainProfiler/ThreadData.cpp
+    MainProfiler/ThreadDataManager.cpp
     Stacks/StacksEventProvider.cpp
     Stacks/StackSampler.cpp
     Utilities/NameCache.cpp
@@ -34,6 +37,9 @@ set(SOURCES
     Communication/IpcCommClient.cpp
     Communication/CommandServer.cpp
     )
+
+# Include exceptions tracking feature
+#add_compile_options(-DDOTNETMONITOR_FEATURE_EXCEPTIONS)
 
 # Build library and split symbols
 add_library_clr(MonitorProfiler SHARED ${SOURCES})

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include "ExceptionTracker.h"
 #include "../Utilities/NameCache.h"
 #include "../Utilities/TypeNameUtilities.h"
@@ -226,3 +227,4 @@ HRESULT ExceptionTracker::LogExceptionThrownFrameCallback(
     // Cancel stack snapshot callbacks after the top frame.
     return S_FALSE;
 }
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include <memory>
 #include "../Logging/Logger.h"
 #include "ThreadDataManager.h"
@@ -51,3 +52,4 @@ private:
         BYTE context[],
         void* clientData);
 };
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -52,7 +52,7 @@ STDMETHODIMP MainProfiler::ThreadCreated(ThreadID threadId)
 {
     HRESULT hr = S_OK;
 
-    IfFailLogRet(_threadDataManager->ThreadCreated(threadId));
+    //IfFailLogRet(_threadDataManager->ThreadCreated(threadId));
 
     return S_OK;
 }
@@ -61,7 +61,7 @@ STDMETHODIMP MainProfiler::ThreadDestroyed(ThreadID threadId)
 {
     HRESULT hr = S_OK;
 
-    IfFailLogRet(_threadDataManager->ThreadDestroyed(threadId));
+    //IfFailLogRet(_threadDataManager->ThreadDestroyed(threadId));
 
     return S_OK;
 }
@@ -70,10 +70,10 @@ STDMETHODIMP MainProfiler::ExceptionThrown(ObjectID thrownObjectId)
 {
     HRESULT hr = S_OK;
 
-    ThreadID threadId;
-    IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
+    //ThreadID threadId;
+    //IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    IfFailLogRet(_exceptionTracker->ExceptionThrown(threadId, thrownObjectId));
+    //IfFailLogRet(_exceptionTracker->ExceptionThrown(threadId, thrownObjectId));
 
     return S_OK;
 }
@@ -82,10 +82,10 @@ STDMETHODIMP MainProfiler::ExceptionSearchCatcherFound(FunctionID functionId)
 {
     HRESULT hr = S_OK;
 
-    ThreadID threadId;
-    IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
+    //ThreadID threadId;
+    //IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    IfFailLogRet(_exceptionTracker->ExceptionSearchCatcherFound(threadId, functionId));
+    //IfFailLogRet(_exceptionTracker->ExceptionSearchCatcherFound(threadId, functionId));
 
     return S_OK;
 }
@@ -94,10 +94,10 @@ STDMETHODIMP MainProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
 {
     HRESULT hr = S_OK;
 
-    ThreadID threadId;
-    IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
+    //ThreadID threadId;
+    //IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    IfFailLogRet(_exceptionTracker->ExceptionUnwindFunctionEnter(threadId, functionId));
+    //IfFailLogRet(_exceptionTracker->ExceptionUnwindFunctionEnter(threadId, functionId));
 
     return S_OK;
 }
@@ -134,10 +134,10 @@ HRESULT MainProfiler::InitializeCommon()
 
     // Logging is initialized and can now be used
 
-    _threadDataManager = make_shared<ThreadDataManager>(m_pLogger);
-    IfNullRet(_threadDataManager);
-    _exceptionTracker.reset(new (nothrow) ExceptionTracker(m_pLogger, _threadDataManager, m_pCorProfilerInfo));
-    IfNullRet(_exceptionTracker);
+    //_threadDataManager = make_shared<ThreadDataManager>(m_pLogger);
+    //IfNullRet(_threadDataManager);
+    //_exceptionTracker.reset(new (nothrow) ExceptionTracker(m_pLogger, _threadDataManager, m_pCorProfilerInfo));
+    //IfNullRet(_exceptionTracker);
 
     IfFailLogRet(InitializeCommandServer());
 
@@ -147,8 +147,8 @@ HRESULT MainProfiler::InitializeCommon()
     IfFailLogRet(_environmentHelper->SetProductVersion());
 
     DWORD eventsLow = COR_PRF_MONITOR::COR_PRF_MONITOR_NONE;
-    ThreadDataManager::AddProfilerEventMask(eventsLow);
-    _exceptionTracker->AddProfilerEventMask(eventsLow);
+    //ThreadDataManager::AddProfilerEventMask(eventsLow);
+    //_exceptionTracker->AddProfilerEventMask(eventsLow);
     StackSampler::AddProfilerEventMask(eventsLow);
 
     IfFailRet(m_pCorProfilerInfo->SetEventMask2(

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -52,7 +52,9 @@ STDMETHODIMP MainProfiler::ThreadCreated(ThreadID threadId)
 {
     HRESULT hr = S_OK;
 
-    //IfFailLogRet(_threadDataManager->ThreadCreated(threadId));
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    IfFailLogRet(_threadDataManager->ThreadCreated(threadId));
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
     return S_OK;
 }
@@ -61,7 +63,9 @@ STDMETHODIMP MainProfiler::ThreadDestroyed(ThreadID threadId)
 {
     HRESULT hr = S_OK;
 
-    //IfFailLogRet(_threadDataManager->ThreadDestroyed(threadId));
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    IfFailLogRet(_threadDataManager->ThreadDestroyed(threadId));
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
     return S_OK;
 }
@@ -70,10 +74,12 @@ STDMETHODIMP MainProfiler::ExceptionThrown(ObjectID thrownObjectId)
 {
     HRESULT hr = S_OK;
 
-    //ThreadID threadId;
-    //IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    ThreadID threadId;
+    IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    //IfFailLogRet(_exceptionTracker->ExceptionThrown(threadId, thrownObjectId));
+    IfFailLogRet(_exceptionTracker->ExceptionThrown(threadId, thrownObjectId));
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
     return S_OK;
 }
@@ -82,10 +88,12 @@ STDMETHODIMP MainProfiler::ExceptionSearchCatcherFound(FunctionID functionId)
 {
     HRESULT hr = S_OK;
 
-    //ThreadID threadId;
-    //IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    ThreadID threadId;
+    IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    //IfFailLogRet(_exceptionTracker->ExceptionSearchCatcherFound(threadId, functionId));
+    IfFailLogRet(_exceptionTracker->ExceptionSearchCatcherFound(threadId, functionId));
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
     return S_OK;
 }
@@ -94,10 +102,12 @@ STDMETHODIMP MainProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
 {
     HRESULT hr = S_OK;
 
-    //ThreadID threadId;
-    //IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    ThreadID threadId;
+    IfFailLogRet(m_pCorProfilerInfo->GetCurrentThreadID(&threadId));
 
-    //IfFailLogRet(_exceptionTracker->ExceptionUnwindFunctionEnter(threadId, functionId));
+    IfFailLogRet(_exceptionTracker->ExceptionUnwindFunctionEnter(threadId, functionId));
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
     return S_OK;
 }
@@ -134,10 +144,12 @@ HRESULT MainProfiler::InitializeCommon()
 
     // Logging is initialized and can now be used
 
-    //_threadDataManager = make_shared<ThreadDataManager>(m_pLogger);
-    //IfNullRet(_threadDataManager);
-    //_exceptionTracker.reset(new (nothrow) ExceptionTracker(m_pLogger, _threadDataManager, m_pCorProfilerInfo));
-    //IfNullRet(_exceptionTracker);
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    _threadDataManager = make_shared<ThreadDataManager>(m_pLogger);
+    IfNullRet(_threadDataManager);
+    _exceptionTracker.reset(new (nothrow) ExceptionTracker(m_pLogger, _threadDataManager, m_pCorProfilerInfo));
+    IfNullRet(_exceptionTracker);
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
     IfFailLogRet(InitializeCommandServer());
 
@@ -147,8 +159,10 @@ HRESULT MainProfiler::InitializeCommon()
     IfFailLogRet(_environmentHelper->SetProductVersion());
 
     DWORD eventsLow = COR_PRF_MONITOR::COR_PRF_MONITOR_NONE;
-    //ThreadDataManager::AddProfilerEventMask(eventsLow);
-    //_exceptionTracker->AddProfilerEventMask(eventsLow);
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    ThreadDataManager::AddProfilerEventMask(eventsLow);
+    _exceptionTracker->AddProfilerEventMask(eventsLow);
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
     StackSampler::AddProfilerEventMask(eventsLow);
 
     IfFailRet(m_pCorProfilerInfo->SetEventMask2(

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -10,8 +10,8 @@
 #include "../Logging/Logger.h"
 #include "../Communication/CommandServer.h"
 #include <memory>
-#include "ThreadDataManager.h"
-#include "ExceptionTracker.h"
+//#include "ThreadDataManager.h"
+//#include "ExceptionTracker.h"
 
 class MainProfiler final :
     public ProfilerBase
@@ -20,8 +20,8 @@ private:
     std::shared_ptr<IEnvironment> m_pEnvironment;
     std::shared_ptr<EnvironmentHelper> _environmentHelper;
     std::shared_ptr<ILogger> m_pLogger;
-    std::shared_ptr<ThreadDataManager> _threadDataManager;
-    std::unique_ptr<ExceptionTracker> _exceptionTracker;
+    //std::shared_ptr<ThreadDataManager> _threadDataManager;
+    //std::unique_ptr<ExceptionTracker> _exceptionTracker;
 
 public:
     static GUID GetClsid();

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -10,8 +10,10 @@
 #include "../Logging/Logger.h"
 #include "../Communication/CommandServer.h"
 #include <memory>
-//#include "ThreadDataManager.h"
-//#include "ExceptionTracker.h"
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+#include "ThreadDataManager.h"
+#include "ExceptionTracker.h"
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
 class MainProfiler final :
     public ProfilerBase
@@ -20,8 +22,10 @@ private:
     std::shared_ptr<IEnvironment> m_pEnvironment;
     std::shared_ptr<EnvironmentHelper> _environmentHelper;
     std::shared_ptr<ILogger> m_pLogger;
-    //std::shared_ptr<ThreadDataManager> _threadDataManager;
-    //std::unique_ptr<ExceptionTracker> _exceptionTracker;
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
+    std::shared_ptr<ThreadDataManager> _threadDataManager;
+    std::unique_ptr<ExceptionTracker> _exceptionTracker;
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS
 
 public:
     static GUID GetClsid();

--- a/src/MonitorProfiler/MainProfiler/ThreadData.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include "ThreadData.h"
 #include "macros.h"
 
@@ -52,3 +53,4 @@ HRESULT ThreadData::SetExceptionCatcherFunction(FunctionID functionId)
 
     return S_OK;
 }
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include <memory>
 #include "corhlpr.h"
 #include "corprof.h"
@@ -31,3 +32,4 @@ public:
     HRESULT SetHasException();
     HRESULT SetExceptionCatcherFunction(FunctionID functionId);
 };
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include "ThreadDataManager.h"
 #include "macros.h"
 #include <utility>
@@ -104,3 +105,4 @@ HRESULT ThreadDataManager::GetThreadData(ThreadID threadId, shared_ptr<ThreadDat
 
     return S_OK;
 }
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -43,3 +44,4 @@ public:
 private:
     HRESULT GetThreadData(ThreadID threadId, std::shared_ptr<ThreadData>& threadData);
 };
+#endif // DOTNETMONITOR_FEATURE_EXCEPTIONS

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
@@ -33,19 +33,19 @@ namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
             _outputHelper = outputHelper;
         }
 
-        [Theory]
-        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
-        public Task ExceptionThrowCatch(Architecture architecture, string profilerPath)
-        {
-            return RunAndCompare(nameof(ExceptionThrowCatch), architecture, profilerPath);
-        }
+        // [Theory]
+        // [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        // public Task ExceptionThrowCatch(Architecture architecture, string profilerPath)
+        // {
+        //     return RunAndCompare(nameof(ExceptionThrowCatch), architecture, profilerPath);
+        // }
 
-        [Theory]
-        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
-        public Task ExceptionThrowCrash(Architecture architecture, string profilerPath)
-        {
-            return RunAndCompare(nameof(ExceptionThrowCrash), architecture, profilerPath);
-        }
+        // [Theory]
+        // [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        // public Task ExceptionThrowCrash(Architecture architecture, string profilerPath)
+        // {
+        //     return RunAndCompare(nameof(ExceptionThrowCrash), architecture, profilerPath);
+        // }
 
         private async Task RunAndCompare(string scenarioName, Architecture architecture, string profilerPath)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
@@ -33,19 +33,19 @@ namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
             _outputHelper = outputHelper;
         }
 
-        // [Theory]
-        // [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
-        // public Task ExceptionThrowCatch(Architecture architecture, string profilerPath)
-        // {
-        //     return RunAndCompare(nameof(ExceptionThrowCatch), architecture, profilerPath);
-        // }
+        [Theory(Skip = "Exception tracking via profiler is currently disabled")]
+        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        public Task ExceptionThrowCatch(Architecture architecture, string profilerPath)
+        {
+            return RunAndCompare(nameof(ExceptionThrowCatch), architecture, profilerPath);
+        }
 
-        // [Theory]
-        // [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
-        // public Task ExceptionThrowCrash(Architecture architecture, string profilerPath)
-        // {
-        //     return RunAndCompare(nameof(ExceptionThrowCrash), architecture, profilerPath);
-        // }
+        [Theory(Skip = "Exception tracking via profiler is currently disabled")]
+        [MemberData(nameof(ProfilerHelper.GetArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        public Task ExceptionThrowCrash(Architecture architecture, string profilerPath)
+        {
+            return RunAndCompare(nameof(ExceptionThrowCrash), architecture, profilerPath);
+        }
 
         private async Task RunAndCompare(string scenarioName, Architecture architecture, string profilerPath)
         {


### PR DESCRIPTION
Remove exception tracking while evaluating future designs and allow the profiler to ship without it.