### PR TITLE
Clear server URLs after setting endpoints on KestrelServerOptions

### DIFF
--- a/src/Tools/dotnet-monitor/AddressListenResults.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResults.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             foreach (string url in metricsUrls)
             {
-                if (Listen(options, url, false))
+                if (Listen(options, url, isAuthEnabled: false))
                 {
                     _metricsAddressCount++;
                 }

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -130,6 +130,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                             options,
                             urls,
                             metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled) ? metricUrls : Array.Empty<string>());
+
+                        // Since the endpoints have already been defined on the KestrelServerOptions, clear out the urls
+                        // so that the address binder does not log a warning about overriding urls as specified by configuration.
+                        context.Configuration[WebHostDefaults.ServerUrlsKey] = string.Empty;
                     })
                     .UseStartup<Startup>();
                 });

--- a/src/Tools/dotnet-monitor/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilderHelper.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         listenResults.Listen(
                             options,
                             urls,
-                            metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled) ? metricUrls : Array.Empty<string>());
+                            metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled) ? metricUrls : Array.Empty<string>(),
+                            settings.Authentication.KeyAuthenticationMode != KeyAuthenticationMode.NoAuth);
 
                         // Since the endpoints have already been defined on the KestrelServerOptions, clear out the urls
                         // so that the address binder does not log a warning about overriding urls as specified by configuration.

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -147,28 +147,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     logger.LogTempKey(options.TemporaryJwtKey.Token);
                 }
+
                 //Auth is enabled and we are binding on http. Make sure we log a warning.
-
-                string hostingUrl = Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
-                string[] urls = ConfigurationHelper.SplitValue(hostingUrl);
-                foreach (string url in urls)
+                if (listenResults.HasInsecureAuthentication)
                 {
-                    BindingAddress address = null;
-                    try
-                    {
-                        address = BindingAddress.Parse(url);
-                    }
-                    catch (FormatException ex)
-                    {
-                        logger.ParsingUrlFailed(url, ex);
-                        continue;
-                    }
-
-                    if (string.Equals(Uri.UriSchemeHttp, address.Scheme, StringComparison.OrdinalIgnoreCase))
-                    {
-                        logger.InsecureAuthenticationConfiguration();
-                        break;
-                    }
+                    logger.InsecureAuthenticationConfiguration();
                 }
             }
 


### PR DESCRIPTION
This change clears the server URLs from configuration since the URLs are represented as endpoints in the KestrelServerOptions. This removes the warning that is displayed about overriding URLs from configuration:

```
12:15:26 warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://localhost:52323'. Binding to endpoints defined via IConfiguration and/or UseKestrel() instead.
```

The above warning will no longer be logged since there are no URLs in configuration, yet the endpoints are still bound.