### PR TITLE
Update dotnet-docker links

### DIFF
--- a/documentation/docker.md
+++ b/documentation/docker.md
@@ -12,7 +12,6 @@ In addition to its availability as a .NET CLI tool, the `dotnet monitor` tool is
 | 7.0 (Preview) | Linux (Alpine) | arm64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/7.0/alpine/arm64v8/Dockerfile |
 | 6.2 (Current, Latest) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/6.2/alpine/amd64/Dockerfile |
 | 6.2 (Current, Latest) | Linux (Alpine) | arm64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/6.2/alpine/arm64v8/Dockerfile |
-| 6.1 | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/6.1/alpine/amd64/Dockerfile |
 
 ### Nightly Dockerfiles
 
@@ -20,9 +19,12 @@ In addition to its availability as a .NET CLI tool, the `dotnet monitor` tool is
 |---|---|---|---|
 | 7.0 (Preview, Latest) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile |
 | 7.0 (Preview, Latest) | Linux (Alpine) | arm64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/arm64v8/Dockerfile |
+| 7.0 (Preview, Latest) | Linux (Ubuntu, Chiseled) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/jammy-chiseled/amd64/Dockerfile |
+| 7.0 (Preview, Latest) | Linux (Ubuntu, Chiseled) | arm64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/jammy-chiseled/arm64v8/Dockerfile |
 | 6.2 (Current) | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/amd64/Dockerfile |
 | 6.2 (Current) | Linux (Alpine) | arm64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/arm64v8/Dockerfile |
-| 6.1 | Linux (Alpine) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile |
+| 6.2 (Current) | Linux (Ubuntu, Chiseled) | amd64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/jammy-chiseled/amd64/Dockerfile |
+| 6.2 (Current) | Linux (Ubuntu, Chiseled) | arm64 | https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/jammy-chiseled/arm64v8/Dockerfile |
 
 ## Image Repositories
 


### PR DESCRIPTION
PR builds are failing due to 6.1 being removed from dotnet-docker repository. This change removes those links and adds new links for the Ubuntu Chiseled images