### PR TITLE
Standardize environment variable prefix

### DIFF
--- a/src/MonitorProfiler/Environment/EnvironmentHelper.h
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.h
@@ -18,11 +18,11 @@
 class EnvironmentHelper final
 {
 private:
-    static constexpr LPCWSTR DebugLoggerLevelEnvVar = _T("DotnetMonitorProfiler_DebugLogger_Level");
-    static constexpr LPCWSTR ProfilerVersionEnvVar = _T("DotnetMonitorProfiler_ProductVersion");
-    static constexpr LPCWSTR RuntimeInstanceEnvVar = _T("DotnetMonitorProfiler_RuntimeInstanceId");
-    static constexpr LPCWSTR SharedPathEnvVar = _T("DotnetMonitorProfiler_SharedPath");
-    static constexpr LPCWSTR StdErrLoggerLevelEnvVar = _T("DotnetMonitorProfiler_StdErrLogger_Level");
+    static constexpr LPCWSTR DebugLoggerLevelEnvVar = _T("DotnetMonitor_Profiler_DebugLogger_Level");
+    static constexpr LPCWSTR ProfilerVersionEnvVar = _T("DotnetMonitor_Profiler_ProductVersion");
+    static constexpr LPCWSTR RuntimeInstanceEnvVar = _T("DotnetMonitor_Profiler_RuntimeInstanceId");
+    static constexpr LPCWSTR SharedPathEnvVar = _T("DotnetMonitor_Profiler_SharedPath");
+    static constexpr LPCWSTR StdErrLoggerLevelEnvVar = _T("DotnetMonitor_Profiler_StdErrLogger_Level");
 
     std::shared_ptr<IEnvironment> _environment;
     std::shared_ptr<ILogger> _logger;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Microsoft.Diagnostics.Monitoring.TestCommon.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Microsoft.Diagnostics.Monitoring.TestCommon.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\..\Tools\dotnet-monitor\Profiler\ProfilerIdentifiers.cs" Link="ProfilerIdentifiers.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\TaskCompletionSourceExtensions.cs" Link="TaskCompletionSourceExtensions.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\TaskExtensions.cs" Link="TaskExtensions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\ToolIdentifiers.cs" Link="ToolIdentifiers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             if (SetRuntimeIdentifier)
             {
                 _adapter.Environment.Add(
-                    ProfilerIdentifiers.EnvironmentVariables.RuntimeIdentifier,
+                    ToolIdentifiers.EnvironmentVariables.RuntimeIdentifier,
                     ProfilerHelper.GetTargetRuntimeIdentifier(Architecture));
             }
             if (ProfilerLogLevel != null)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HostBuilderExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HostBuilderExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.Diagnostics.Tools.Monitor.Profiler;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.Configuration.Memory;
@@ -70,7 +71,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         {
             return builder.ConfigureAppConfiguration(builder =>
             {
-                ReplaceEnvironment(builder.Sources, HostBuilderHelper.ConfigPrefix, values);
+                ReplaceEnvironment(builder.Sources, ToolIdentifiers.StandardPrefix, values);
             });
         }
 

--- a/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if UNITTEST
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+#endif
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections;
@@ -15,7 +18,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class CommonOptionsExtensions
     {
-        private const string EnvironmentVariablePrefix = "DotnetMonitor_";
         private const string KeySegmentSeparator = "__";
 
         /// <summary>
@@ -40,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static IDictionary<string, string> ToEnvironmentConfiguration(this RootOptions options, bool useDotnetMonitorPrefix = false)
         {
             Dictionary<string, string> variables = new(StringComparer.OrdinalIgnoreCase);
-            MapObject(options, useDotnetMonitorPrefix ? EnvironmentVariablePrefix : string.Empty, KeySegmentSeparator, variables);
+            MapObject(options, useDotnetMonitorPrefix ? ToolIdentifiers.StandardPrefix : string.Empty, KeySegmentSeparator, variables);
             return variables;
         }
 

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -5,6 +5,7 @@
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Profiler;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -141,7 +142,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         private static void AddMetadata(EgressArtifactSettings settings, string key, string value)
         {
-            settings.Metadata.Add($"DotnetMonitor_{key}", value);
+            settings.Metadata.Add($"{ToolIdentifiers.StandardPrefix}{key}", value);
         }
 
         private void Reload()

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.Profiler;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,7 +17,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class HostBuilderHelper
     {
-        public const string ConfigPrefix = "DotnetMonitor_";
         private const string SettingsFileName = "settings.json";
 
         public static IHostBuilder CreateHostBuilder(HostBuilderSettings settings)
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     // If a file at this path does not have read permissions, the application will fail to launch.
                     builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
-                    builder.AddEnvironmentVariables(ConfigPrefix);
+                    builder.AddEnvironmentVariables(ToolIdentifiers.StandardPrefix);
 
                     if (settings.Authentication.KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey)
                     {

--- a/src/Tools/dotnet-monitor/Profiler/ProfilerIdentifiers.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ProfilerIdentifiers.cs
@@ -26,28 +26,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
 
         public static class EnvironmentVariables
         {
-            private const string Prefix = "DotnetMonitorProfiler_";
+            private const string ProfilerPrefix = ToolIdentifiers.StandardPrefix + "Profiler_";
 
             // This environment variable is automatically applied to a target process by the tool to inform
             // the profiler which directory it should use to share files and information with dotnet-monitor.
-            public const string SharedPath = Prefix + nameof(SharedPath);
+            public const string SharedPath = ProfilerPrefix + nameof(SharedPath);
 
             // This environment variable name is embedded into the profiler and set at profiler initialization.
             // The value is determined BEFORE native build by the generation of the product version into the
             // _productversion.h header file.
-            public const string ProductVersion = Prefix + nameof(ProductVersion);
-
-            // This environment variable is manually applied to target processes to inform dotnet-monitor
-            // which runtime variant of the profiler should be applied to the process.
-            public const string RuntimeIdentifier = Prefix + nameof(RuntimeIdentifier);
+            public const string ProductVersion = ProfilerPrefix + nameof(ProductVersion);
 
             // This environment variable is automatically applied to a target process by the tool to inform
             // the profiler running in the target process the value of the runtime instance.
-            public const string RuntimeInstanceId = Prefix + nameof(RuntimeInstanceId);
+            public const string RuntimeInstanceId = ProfilerPrefix + nameof(RuntimeInstanceId);
 
             // (Optional) This environment variable is manually applied to the target process to override the
             // default level of the stderr logger.
-            public const string StdErrLogger_Level = Prefix + nameof(StdErrLogger_Level);
+            public const string StdErrLogger_Level = ProfilerPrefix + nameof(StdErrLogger_Level);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Profiler/ProfilerService.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ProfilerService.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
                 // - For Windows and OSX, build identifier from platform + architecture of target process.
                 // - Lookup same environment variable on dotnet-monitor itself.
                 // - Check libc type of dotnet-monitor.
-                env.TryGetValue(ProfilerIdentifiers.EnvironmentVariables.RuntimeIdentifier, out string runtimeIdentifier);
+                env.TryGetValue(ToolIdentifiers.EnvironmentVariables.RuntimeIdentifier, out string runtimeIdentifier);
 
                 if (string.IsNullOrEmpty(runtimeIdentifier))
                 {

--- a/src/Tools/dotnet-monitor/ToolIdentifiers.cs
+++ b/src/Tools/dotnet-monitor/ToolIdentifiers.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if UNITTEST
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+#else
+namespace Microsoft.Diagnostics.Tools.Monitor
+#endif
+{
+    internal static class ToolIdentifiers
+    {
+        /// <summary>
+        /// The standard prefix for environment variables and dotnet-monitor specific configuration.
+        /// </summary>
+        public const string StandardPrefix = "DotnetMonitor_";
+
+        public static class EnvironmentVariables
+        {
+            // This environment variable is manually applied to target processes to inform dotnet-monitor
+            // which runtime variant of the shared libraries should be loaded into target processes.
+            public const string RuntimeIdentifier = StandardPrefix + nameof(RuntimeIdentifier);
+        }
+    }
+}


### PR DESCRIPTION
Standardize all environment variables to start with `DotnetMonitor_`
Standardize all profiler environment variables to start with `DotnetMonitor_Profiler_` (these are not user facing)
Rename the runtime identifier environment variable to not be specific to the profiler.