### PR TITLE
Only create default diagnostic port when running in listen mode

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -1213,7 +1213,7 @@
             "null",
             "string"
           ],
-          "description": "The default path where assets will be shared between dotnet-monitor and target processes. Dumps are temporarily stored under this path or in a sub folder unless DumpTempFolder is specified. Shared libraries are stored under this path or in a sub folder unless SharedLibraryPath is specified. On non-Windows, dotnet-monitor runs in listen mode with a Unix domain socket named 'dotnet-monitor.sock' immediately under this path unless the diagnostic port is specified on the command line or the DiagnosticPort options are specified."
+          "description": "The default path where assets will be shared between dotnet-monitor and target processes. Dumps are temporarily stored under this path or in a sub folder unless DumpTempFolder is specified. Shared libraries are stored under this path or in a sub folder unless SharedLibraryPath is specified. On non-Windows platforms, a server diagnostic port is created with the name of 'dotnet-monitor.sock' immediately under this path if running in listen mode unless the diagnostic port is specified on the command line or the DiagnosticPort options are specified."
         },
         "DumpTempFolder": {
           "type": [

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -1329,7 +1329,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The default path where assets will be shared between dotnet-monitor and target processes. Dumps are temporarily stored under this path or in a sub folder unless DumpTempFolder is specified. Shared libraries are stored under this path or in a sub folder unless SharedLibraryPath is specified. On non-Windows, dotnet-monitor runs in listen mode with a Unix domain socket named &apos;dotnet-monitor.sock&apos; immediately under this path unless the diagnostic port is specified on the command line or the DiagnosticPort optio [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to The default path where assets will be shared between dotnet-monitor and target processes. Dumps are temporarily stored under this path or in a sub folder unless DumpTempFolder is specified. Shared libraries are stored under this path or in a sub folder unless SharedLibraryPath is specified. On non-Windows platforms, a server diagnostic port is created with the name of &apos;dotnet-monitor.sock&apos; immediately under this path if running in listen mode unless the diagnostic port is specified on the command line or th [rest of string was truncated]&quot;;.
         /// </summary>
         public static string DisplayAttributeDescription_StorageOptions_DefaultSharedPath {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -717,7 +717,7 @@
     <comment>The description provided for the SharedLibraryPath parameter on StorageOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_StorageOptions_DefaultSharedPath" xml:space="preserve">
-    <value>The default path where assets will be shared between dotnet-monitor and target processes. Dumps are temporarily stored under this path or in a sub folder unless DumpTempFolder is specified. Shared libraries are stored under this path or in a sub folder unless SharedLibraryPath is specified. On non-Windows, dotnet-monitor runs in listen mode with a Unix domain socket named 'dotnet-monitor.sock' immediately under this path unless the diagnostic port is specified on the command line or the DiagnosticPort options are specified.</value>
+    <value>The default path where assets will be shared between dotnet-monitor and target processes. Dumps are temporarily stored under this path or in a sub folder unless DumpTempFolder is specified. Shared libraries are stored under this path or in a sub folder unless SharedLibraryPath is specified. On non-Windows platforms, a server diagnostic port is created with the name of 'dotnet-monitor.sock' immediately under this path if running in listen mode unless the diagnostic port is specified on the command line or the DiagnosticPort options are specified.</value>
     <comment>The description provided for the DefaultSharedPath parameter on StorageOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_InProcessFeaturesOptions_Enabled" xml:space="preserve">

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 out string diagnosticPortPath);
 
             await using MonitorCollectRunner toolRunner = new(_outputHelper);
-            toolRunner.ConnectionMode = mode;
+            toolRunner.ConnectionModeViaCommandLine = mode;
             toolRunner.DiagnosticPortPath = diagnosticPortPath;
             toolRunner.DisableAuthentication = true;
 
@@ -323,7 +323,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 out string diagnosticPortPath);
 
             await using MonitorCollectRunner toolRunner = new(_outputHelper);
-            toolRunner.ConnectionMode = mode;
+            toolRunner.ConnectionModeViaCommandLine = mode;
             toolRunner.DiagnosticPortPath = diagnosticPortPath;
             toolRunner.DisableAuthentication = true;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DiagnosticPortTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DiagnosticPortTests.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    [Collection(DefaultCollectionFixture.Name)]
+    public sealed class DiagnosticPortTests
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ITestOutputHelper _outputHelper;
+
+        public DiagnosticPortTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
+        {
+            _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
+            _outputHelper = outputHelper;
+        }
+
+        /// <summary>
+        /// When setting the default shared path in connect mode, a server socket should not be created.
+        /// </summary>
+        [Fact]
+        public async Task DefaultDiagnosticPort_NotSupported_ConnectMode()
+        {
+            using TemporaryDirectory tempDir = new(_outputHelper);
+
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.ConnectionModeViaCommandLine = WebApi.DiagnosticPortConnectionMode.Connect;
+            toolRunner.ConfigurationFromEnvironment.SetDefaultSharedPath(tempDir.FullName);
+
+            await toolRunner.StartAsync();
+
+            string expectedMissingSocketPath = GetDefaultSharedSocketPath(tempDir.FullName);
+            Assert.False(File.Exists(expectedMissingSocketPath), $"Expected socket to not exist at '{expectedMissingSocketPath}'.");
+        }
+
+        /// <summary>
+        /// When setting the default shared path in listen mode, a server socket should not be created
+        /// under the default shared path if the endpoint for the diagnostic port is specified.
+        /// </summary>
+        [Fact]
+        public async Task DefaultDiagnosticPort_NotSupported_ListenModeWithSpecifiedPort()
+        {
+            using TemporaryDirectory tempDir = new(_outputHelper);
+
+            DiagnosticPortHelper.Generate(
+                DiagnosticPortConnectionMode.Listen,
+                out _,
+                out string diagnosticPortPath);
+
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.ConnectionModeViaCommandLine = DiagnosticPortConnectionMode.Listen;
+            toolRunner.DiagnosticPortPath = diagnosticPortPath;
+            toolRunner.ConfigurationFromEnvironment.SetDefaultSharedPath(tempDir.FullName);
+
+            await toolRunner.StartAsync();
+
+            string expectedMissingSocketPath = GetDefaultSharedSocketPath(tempDir.FullName);
+            Assert.False(File.Exists(expectedMissingSocketPath), $"Expected socket to not exist at '{expectedMissingSocketPath}'.");
+        }
+
+        /// <summary>
+        /// When setting the default shared path in listen mode on non-Windows platform,
+        /// a server socket should be created under the default shared path.
+        /// </summary>
+        [ConditionalFact(typeof(TestConditions), nameof(TestConditions.IsNotWindows))]
+        public async Task DefaultDiagnosticPort_Supported_ListenModeOnNonWindows()
+        {
+            using TemporaryDirectory tempDir = new(_outputHelper);
+
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.ConfigurationFromEnvironment.SetConnectionMode(DiagnosticPortConnectionMode.Listen);
+            toolRunner.ConfigurationFromEnvironment.SetDefaultSharedPath(tempDir.FullName);
+
+            await toolRunner.StartAsync();
+
+            string expectedSocketPath = GetDefaultSharedSocketPath(tempDir.FullName);
+            Assert.True(File.Exists(expectedSocketPath), $"Expected socket to exist at '{expectedSocketPath}'.");
+        }
+
+        /// <summary>
+        /// When setting the default shared path in listen mode on Windows platform,
+        /// a server socket should not be created under the default shared path.
+        /// </summary>
+        [ConditionalFact(typeof(TestConditions), nameof(TestConditions.IsWindows))]
+        public async Task DefaultDiagnosticPort_NotSupported_ListenModeOnWindows()
+        {
+            using TemporaryDirectory tempDir = new(_outputHelper);
+
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.ConfigurationFromEnvironment.SetConnectionMode(DiagnosticPortConnectionMode.Listen);
+            toolRunner.ConfigurationFromEnvironment.SetDefaultSharedPath(tempDir.FullName);
+
+            // dotnet-monitor will fail to start due to misconfigured diagnostic port
+            await Assert.ThrowsAsync<InvalidOperationException>(() => toolRunner.StartAsync());
+
+            string expectedMissingSocketPath = GetDefaultSharedSocketPath(tempDir.FullName);
+            Assert.False(File.Exists(expectedMissingSocketPath), $"Expected socket to not exist at '{expectedMissingSocketPath}'.");
+        }
+
+        private static string GetDefaultSharedSocketPath(string defaultSharedPath)
+        {
+            return Path.Combine(defaultSharedPath, ToolIdentifiers.DefaultSocketName);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -65,6 +65,30 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             return options;
         }
 
+        public static RootOptions SetConnectionMode(this RootOptions options, DiagnosticPortConnectionMode connectionMode)
+        {
+            if (null == options.DiagnosticPort)
+            {
+                options.DiagnosticPort = new DiagnosticPortOptions();
+            }
+
+            options.DiagnosticPort.ConnectionMode = connectionMode;
+
+            return options;
+        }
+
+        public static RootOptions SetDefaultSharedPath(this RootOptions options, string directoryPath)
+        {
+            if (null == options.Storage)
+            {
+                options.Storage = new StorageOptions();
+            }
+
+            options.Storage.DefaultSharedPath = directoryPath;
+
+            return options;
+        }
+
         public static RootOptions SetDumpTempFolder(this RootOptions options, string directoryPath)
         {
             if (null == options.Storage)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 out string diagnosticPortPath);
 
             await using MonitorCollectRunner toolRunner = new(_outputHelper);
-            toolRunner.ConnectionMode = mode;
+            toolRunner.ConnectionModeViaCommandLine = mode;
             toolRunner.DiagnosticPortPath = diagnosticPortPath;
             toolRunner.DisableAuthentication = true;
             await toolRunner.StartAsync();

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -45,16 +45,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         public event Action<string> WarnPrivateKey;
 
         /// <summary>
-        /// The mode of the diagnostic port connection. Default is <see cref="DiagnosticPortConnectionMode.Connect"/>
-        /// (the tool is searching for apps that are in listen mode).
+        /// The mode of the diagnostic port connection.
         /// </summary>
         /// <remarks>
+        /// Set to <see cref="DiagnosticPortConnectionMode.Connect"/> if tool needs to discover the diagnostic port for each target process.
         /// Set to <see cref="DiagnosticPortConnectionMode.Listen"/> if tool needs to establish the diagnostic port listener.
         /// </remarks>
-        public DiagnosticPortConnectionMode ConnectionMode { get; set; } = DiagnosticPortConnectionMode.Connect;
+        public DiagnosticPortConnectionMode? ConnectionModeViaCommandLine { get; set; }
 
         /// <summary>
-        /// Path of the diagnostic port to establish when <see cref="ConnectionMode"/> is <see cref="DiagnosticPortConnectionMode.Listen"/>.
+        /// Path of the diagnostic port to establish when <see cref="ConnectionModeViaCommandLine"/> is <see cref="DiagnosticPortConnectionMode.Listen"/>.
         /// </summary>
         public string DiagnosticPortPath { get; set; }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 argsList.Add("http://127.0.0.1:0");
             }
 
-            if (ConnectionMode == DiagnosticPortConnectionMode.Listen)
+            if (ConnectionModeViaCommandLine == DiagnosticPortConnectionMode.Listen)
             {
                 argsList.Add("--diagnostic-port");
                 if (string.IsNullOrEmpty(DiagnosticPortPath))

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 out string diagnosticPortPath);
 
             await using MonitorCollectRunner toolRunner = new(outputHelper);
-            toolRunner.ConnectionMode = mode;
+            toolRunner.ConnectionModeViaCommandLine = mode;
             toolRunner.DiagnosticPortPath = diagnosticPortPath;
             toolRunner.DisableAuthentication = true;
             toolRunner.DisableHttpEgress = disableHttpEgress;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
@@ -28,5 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         public static bool IsNetCore31 => DotNetHost.BuiltTargetFrameworkMoniker == TargetFrameworkMoniker.NetCoreApp31;
 
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static bool IsNotWindows => !IsWindows;
     }
 }

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortPostConfigureOptions.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal sealed class DiagnosticPortPostConfigureOptions :
         IPostConfigureOptions<DiagnosticPortOptions>
     {
-        private const string DefaultSocketName = "dotnet-monitor.sock";
-
         private readonly IConfiguration _configuration;
         private readonly IOptions<StorageOptions> _storageOptions;
 
@@ -37,13 +35,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 options.EndpointName = diagPortSection.Value;
             }
 
-            // Create a default server socket under the default shared path if diagnostic port was not configured
+            // Create a default server socket under the default shared path if
+            // diagnostic port name was not configured but is configured for listen mode.
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                !options.ConnectionMode.HasValue && string.IsNullOrEmpty(options.EndpointName) &&
+                DiagnosticPortConnectionMode.Listen == options.GetConnectionMode() &&
+                string.IsNullOrEmpty(options.EndpointName) &&
                 !string.IsNullOrEmpty(_storageOptions.Value.DefaultSharedPath))
             {
-                options.ConnectionMode = DiagnosticPortConnectionMode.Listen;
-                options.EndpointName = Path.Combine(_storageOptions.Value.DefaultSharedPath, DefaultSocketName);
+                options.EndpointName = Path.Combine(_storageOptions.Value.DefaultSharedPath, ToolIdentifiers.DefaultSocketName);
             }
         }
     }

--- a/src/Tools/dotnet-monitor/ToolIdentifiers.cs
+++ b/src/Tools/dotnet-monitor/ToolIdentifiers.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         /// </summary>
         public const string StandardPrefix = "DotnetMonitor_";
 
+        public const string DefaultSocketName = "dotnet-monitor.sock";
+
         public static class EnvironmentVariables
         {
             // This environment variable is manually applied to target processes to inform dotnet-monitor


### PR DESCRIPTION
As part of the stacks experimental feature, a default shared path configuration property was added to provide a unified default directory where all file communication and sharing can be performed while preserving the ability to configure individual file sharing aspects. This work also enabled the creation of a listening diagnostic port socket in the default shared path if the diagnostic port was not otherwise configured and "flips" dotnet-monitor into listen mode.

This change modifies the behavior of the default diagnostic port by having the user opt into the behavior by having them specify the connection mode to be listen. Hence, if the user configures the connection mode to be listen AND the default shared path is specified AND the diagnostic port name is not specified, then a default diagnostic port will be created under the default shared path. This change allows the tool to potentially allow sharing of files while it is running in connect mode without having to explicitly force connect mode (it is the default) when the default shared path is specified.

With this change, the following example is the minimum necessary for configuring all features that require file sharing across container boundaries with the tool running in listen mode:

```yml
containers:
- name: app
  image: mcr.microsoft.com/dotnet/samples:aspnetapp
  env:
  - name: DOTNET_DiagnosticPorts
    value: /diag/dotnet-monitor.sock
  - name: DotnetMonitorProfiler_RuntimeIdentifier
    value: linux-x64
  volumeMounts:
  - mountPath: /diag
    name: diagvol
- name: monitor
  image: mcr.microsoft.com/dotnet/nightly/monitor:6
  env:
  - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
    value: Listen
  - name: DOTNETMONITOR_Storage__DefaultSharedPath
    value: /diag
  volumeMounts:
  - mountPath: /diag
    name: diagvol