### PR TITLE
Move metrics services configuration out of Startup class

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptionsExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptionsExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    internal static class MetricsOptionsExtensions
+    {
+        public static bool GetEnabled(this MetricsOptions options)
+        {
+            return options.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             return this.InvokeService(() =>
             {
-                if (!_metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled))
+                if (!_metricsOptions.GetEnabled())
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_MetricsDisabled);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            if (!_optionsMonitor.CurrentValue.GetEnabled())
+            {
+                return;
+            }
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 stoppingToken.ThrowIfCancellationRequested();

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         listenResults.Listen(
                             options,
                             urls,
-                            metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled) ? metricUrls : Array.Empty<string>(),
+                            metricsOptions.GetEnabled() ? metricUrls : Array.Empty<string>(),
                             settings.Authentication.KeyAuthenticationMode != KeyAuthenticationMode.NoAuth);
 
                         // Since the endpoints have already been defined on the KestrelServerOptions, clear out the urls

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -56,7 +56,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static IServiceCollection ConfigureMetrics(this IServiceCollection services, IConfiguration configuration)
         {
             return ConfigureOptions<MetricsOptions>(services, configuration, ConfigurationKeys.Metrics)
-                .AddSingleton<IValidateOptions<MetricsOptions>, DataAnnotationValidateOptions<MetricsOptions>>();
+                .AddSingleton<IValidateOptions<MetricsOptions>, DataAnnotationValidateOptions<MetricsOptions>>()
+                .AddSingleton<MetricsStoreService>()
+                .AddHostedService<MetricsService>()
+                .AddSingleton<IMetricsPortsProvider, MetricsPortsProvider>();
         }
 
         public static IServiceCollection ConfigureMonitorApiKeyOptions(this IServiceCollection services, IConfiguration configuration)

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -64,16 +64,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 configureOptions.Providers.Add<BrotliCompressionProvider>();
                 configureOptions.MimeTypes = new List<string> { ContentTypes.ApplicationOctetStream };
             });
-
-            var metricsOptions = new MetricsOptions();
-            Configuration.Bind(ConfigurationKeys.Metrics, metricsOptions);
-            if (metricsOptions.Enabled.GetValueOrDefault(MetricsOptionsDefaults.Enabled))
-            {
-                services.AddSingleton<MetricsStoreService>();
-                services.AddHostedService<MetricsService>();
-            }
-
-            services.AddSingleton<IMetricsPortsProvider, MetricsPortsProvider>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
When using the `config show` command, sometimes it can throw an unhandled exception when configuring the ASP.NET Core portions of the host builder. The issue is that the metrics services are added as part of the Startup class; in the case of the `config show` command, the dependencies of these services are not added to the host builder. This change refactors service registration for the metrics services to only occur for the `collect` command since they are not needed by the `config show` command.

Fixes #2526