### PR TITLE
Avoid Kestrel override warning for .NET 7

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/KestrelTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/KestrelTests.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    [Collection(DefaultCollectionFixture.Name)]
+    public sealed class KestrelTests
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ITestOutputHelper _outputHelper;
+
+        public KestrelTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
+        {
+            _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_CmdLine()
+        {
+            return ExecuteNoOverridWarning();
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_DotNet()
+        {
+            return ExecuteNoOverridWarning((runner, url) =>
+            {
+                runner.DotNetUrls = url;
+            });
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_AspNetCore()
+        {
+            return ExecuteNoOverridWarning((runner, url) =>
+            {
+                runner.AspNetCoreUrls = url;
+            });
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_DotNetMonitor()
+        {
+            return ExecuteNoOverridWarning((runner, url) =>
+            {
+                runner.DotNetMonitorUrls = url;
+            });
+        }
+
+        private async Task ExecuteNoOverridWarning(Action<MonitorCollectRunner, string> configure = null)
+        {
+            await using MonitorCollectRunner runner = new(_outputHelper);
+
+            runner.DisableAuthentication = true;
+
+            configure?.Invoke(runner, "http://+:0");
+
+            await runner.StartAsync();
+
+            string address = await runner.GetDefaultAddressAsync(CancellationToken.None);
+            UriBuilder builder = new(address);
+            builder.Host = "localhost";
+
+            using HttpClient httpClient = await runner.CreateHttpClientAsync(_httpClientFactory, builder.Uri.ToString());
+            ApiClient apiClient = new(_outputHelper, httpClient);
+
+            // Test that the route (thus the URL) is viable
+            DotnetMonitorInfo info = await apiClient.GetInfoAsync();
+            Assert.NotNull(info);
+
+            // Test that the URL override warning is not present
+            Assert.False(runner.OverrodeServerUrls, "Override URL warning should not be present.");
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -78,6 +78,26 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         /// </summary>
         public bool DisableMetricsViaCommandLine { get; set; }
 
+        /// <summary>
+        /// Reports whether the server URLs were overriden by UseKestrel/ConfigureKestrel code.
+        /// </summary>
+        public bool OverrodeServerUrls { get; private set; }
+
+        /// <summary>
+        /// Urls used for the DOTNET_Urls environment variable.
+        /// </summary>
+        public string DotNetUrls { get; set; }
+
+        /// <summary>
+        /// Urls used for the ASPNETCORE_Urls environment variable.
+        /// </summary>
+        public string AspNetCoreUrls { get; set; }
+
+        /// <summary>
+        /// Urls used for the DOTNETMONITOR_Urls environment variable.
+        /// </summary>
+        public string DotNetMonitorUrls { get; set; }
+
 
         public MonitorCollectRunner(ITestOutputHelper outputHelper)
             : base(outputHelper)
@@ -108,6 +128,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             argsList.Add("--urls");
             argsList.Add("http://127.0.0.1:0");
+
+            if (!string.IsNullOrEmpty(DotNetUrls))
+            {
+                SetEnvironmentVariable("DOTNET_Urls", DotNetUrls);
+            }
+            if (!string.IsNullOrEmpty(AspNetCoreUrls))
+            {
+                SetEnvironmentVariable("ASPNETCORE_Urls", AspNetCoreUrls);
+            }
+            if (!string.IsNullOrEmpty(DotNetMonitorUrls))
+            {
+                SetEnvironmentVariable("DOTNETMONITOR_Urls", DotNetMonitorUrls);
+            }
 
             if (DisableMetricsViaCommandLine)
             {
@@ -165,6 +198,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             switch (logEvent.Category)
             {
+                case "Microsoft.AspNetCore.Server.Kestrel":
+                    HandleKestrelEvent(logEvent);
+                    break;
                 case "Microsoft.Hosting.Lifetime":
                     HandleLifetimeEvent(logEvent);
                     break;
@@ -243,6 +279,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                         Assert.True(_monitorApiKeySource.TrySetResult(monitorApiKey));
                     }
                     break;
+            }
+        }
+
+        private void HandleKestrelEvent(ConsoleLogEvent logEvent)
+        {
+            if (logEvent.Message.StartsWith("Overriding address(es)"))
+            {
+                OverrodeServerUrls = true;
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -220,5 +220,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             _outputHelper.WriteLine("Wrote user settings.");
         }
+
+        protected void SetEnvironmentVariable(string name, string value)
+        {
+            _adapter.Environment[name] = value;
+        }
     }
 }


### PR DESCRIPTION
The change in #2481 was not sufficient to avoid the Kestrel warning about overriding the URLs for .NET 7. This change adds additional configuration to clear and restore the server URLs around the ASP.NET Core configuration and provides tests to validate that the warning does not appear.