### PR TITLE
Use host architecture instead of x64 for runtimes

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "7.0.100-rc.1.22431.12",
     "runtimes": {
-      "aspnetcore/x64": [
+      "aspnetcore": [
         "$(MicrosoftAspNetCoreApp31Version)",
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(VSRedistCommonAspNetCoreSharedFrameworkx6470Version)"
@@ -12,7 +12,7 @@
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(VSRedistCommonAspNetCoreSharedFrameworkx6470Version)"
       ],
-      "dotnet/x64": [
+      "dotnet": [
         "$(MicrosoftNETCoreApp31Version)",
         "$(MicrosoftNETCoreApp60Version)",
         "$(VSRedistCommonNetCoreSharedFrameworkx6470Version)"


### PR DESCRIPTION
This change removes the `x64` architecture from the list of runtimes that are installed as part of bootstrapping the build. This would allow for building and testing the repository on non-x64 machines (e.g. Windows x86 or arm64, Linux arm64). This change has no effect on x64 machines.