### PR TITLE
Unwrap ChainedConfigurationProvider to get real provider

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/DefaultProcess.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/DefaultProcess.json
@@ -1,8 +1,8 @@
 {
   "Filters": [
     {
-      "Key": "ProcessId" /*Microsoft.Extensions.Configuration.ChainedConfigurationProvider*/,
-      "Value": "12345" /*Microsoft.Extensions.Configuration.ChainedConfigurationProvider*/
+      "Key": "ProcessId" /*MemoryConfigurationProvider*/,
+      "Value": "12345" /*MemoryConfigurationProvider*/
     }
   ]
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/DiagnosticPort.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/DiagnosticPort.json
@@ -1,4 +1,4 @@
 {
-  "ConnectionMode": "Listen" /*Microsoft.Extensions.Configuration.ChainedConfigurationProvider*/,
-  "EndpointName": "\\\\.\\pipe\\dotnet-monitor-pipe" /*Microsoft.Extensions.Configuration.ChainedConfigurationProvider*/
+    "ConnectionMode": "Listen" /*MemoryConfigurationProvider*/,
+    "EndpointName": "\\\\.\\pipe\\dotnet-monitor-pipe" /*MemoryConfigurationProvider*/
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/URLs.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExpectedShowSourcesConfigurations/URLs.json
@@ -1,1 +1,1 @@
-"https://localhost:44444"/*Microsoft.Extensions.Configuration.ChainedConfigurationProvider*/
+"https://localhost:44444"/*CommandLineConfigurationProvider*/

--- a/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static class ConfigurationExtensions
+    {
+        public static bool TryGetProviderAndValue(this IConfiguration configuration, string key, out IConfigurationProvider provider, out string value)
+        {
+            if (configuration is IConfigurationRoot configurationRoot)
+            {
+                return configurationRoot.TryGetProviderAndValue(key, out provider, out value);
+            }
+
+            provider = null;
+            value = null;
+            return false;
+        }
+
+        public static bool TryGetProviderAndValue(this IConfigurationRoot configurationRoot, string key, out IConfigurationProvider provider, out string value)
+        {
+            foreach (IConfigurationProvider candidate in configurationRoot.Providers.Reverse())
+            {
+                if (candidate is ChainedConfigurationProvider chainedProvider &&
+                    chainedProvider.TryGetInnerConfiguration(out IConfiguration innerConfiguration) &&
+                    innerConfiguration.TryGetProviderAndValue(key, out provider, out value))
+                {
+                    return true;
+                }
+
+                if (candidate.TryGet(key, out value))
+                {
+                    provider = candidate;
+                    return true;
+                }
+            }
+
+            provider = null;
+            value = null;
+            return false;
+        }
+
+        private static bool TryGetInnerConfiguration(this ChainedConfigurationProvider provider, out IConfiguration configuration)
+        {
+#if NET7_0_OR_GREATER
+            configuration = provider.Configuration;
+            return true;
+#else
+            FieldInfo configField = provider.GetType().GetField("_config", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (null != configField)
+            {
+                configuration = configField.GetValue(provider) as IConfiguration;
+                return null != configuration;
+            }
+
+            configuration = null;
+            return false;
+#endif
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -269,24 +269,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private string GetConfigurationProvider(IConfigurationSection section, bool showSources)
         {
-            if (showSources)
+            if (showSources && _configuration.TryGetProviderAndValue(section.Path, out IConfigurationProvider provider, out _))
             {
-                var configurationProviders = ((IConfigurationRoot)_configuration).Providers.Reverse();
-
-                string comment = string.Empty;
-
-                foreach (var provider in configurationProviders)
-                {
-                    provider.TryGet(section.Path, out string value);
-
-                    if (!string.IsNullOrEmpty(value))
-                    {
-                        comment = provider.ToString();
-                        break;
-                    }
-                }
-
-                return comment;
+                return provider.ToString();
             }
 
             return string.Empty;

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static string FormatCmdLineArgument(string key, string value)
         {
-            return $"{key}={value}";
+            return FormattableString.Invariant($"{key}={value}");
         }
     }
 }

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -23,12 +23,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return new HostBuilder()
                 .ConfigureHostConfiguration((IConfigurationBuilder builder) =>
                 {
-                    //Note these are in precedence order.
-                    ConfigureEndpointInfoSource(builder, settings.DiagnosticPort);
-                    ConfigureMetricsEndpoint(builder, settings.EnableMetrics, settings.MetricsUrls ?? Array.Empty<string>());
-                    ConfigureGlobalMetrics(builder);
+                    // Configure default values
+                    ConfigureGlobalMetricsDefaults(builder);
+                    ConfigureMetricsDefaults(builder);
 
-                    builder.AddCommandLine(new[] { "--urls", ConfigurationHelper.JoinValue(settings.Urls ?? Array.Empty<string>()) });
+                    // These are configured via the command line configuration source so that
+                    // the "show config" command will report these are from the command line
+                    // rather than an in-memory collection.
+                    List<string> arguments = new();
+                    AddDiagnosticPortArguments(arguments, settings);
+                    AddMetricsArguments(arguments, settings);
+                    AddUrlsArguments(arguments, settings);
+
+                    builder.AddCommandLine(arguments.ToArray());
                 })
                 .ConfigureDefaults(args: null)
                 .UseContentRoot(settings.ContentRootDirectory)
@@ -65,7 +72,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     if (settings.Authentication.KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey)
                     {
-                        ConfigureTempApiHashKey(builder, settings.Authentication);
+                        // These are configured via the command line configuration source so that
+                        // the "show config" command will report these are from the command line
+                        // rather than an in-memory collection.
+                        List<string> arguments = new();
+                        AddTempApiKeyArguments(arguments, settings);
+
+                        builder.AddCommandLine(arguments.ToArray());
                     }
 
                     // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources
@@ -164,30 +177,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return new AuthConfiguration(authMode);
         }
 
-        private static void ConfigureTempApiHashKey(IConfigurationBuilder builder, IAuthConfiguration authenticationOptions)
-        {
-            if (authenticationOptions.TemporaryJwtKey != null)
-            {
-                builder.AddInMemoryCollection(new Dictionary<string, string>
-                {
-                    { ConfigurationPath.Combine(ConfigurationKeys.Authentication, ConfigurationKeys.MonitorApiKey, nameof(MonitorApiKeyOptions.Subject)), authenticationOptions.TemporaryJwtKey.Subject },
-                    { ConfigurationPath.Combine(ConfigurationKeys.Authentication, ConfigurationKeys.MonitorApiKey, nameof(MonitorApiKeyOptions.PublicKey)), authenticationOptions.TemporaryJwtKey.PublicKey },
-                });
-            }
-        }
-
-        private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, bool enableMetrics, string[] metricEndpoints)
+        private static void ConfigureMetricsDefaults(IConfigurationBuilder builder)
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
-                {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.Enabled)), enableMetrics.ToString()},
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.MetricCount)), MetricsOptionsDefaults.MetricCount.ToString()},
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.IncludeDefaultProviders)), MetricsOptionsDefaults.IncludeDefaultProviders.ToString()}
             });
         }
 
-        private static void ConfigureGlobalMetrics(IConfigurationBuilder builder)
+        private static void ConfigureGlobalMetricsDefaults(IConfigurationBuilder builder)
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
@@ -195,16 +194,55 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             });
         }
 
-        private static void ConfigureEndpointInfoSource(IConfigurationBuilder builder, string diagnosticPort)
+        private static void AddDiagnosticPortArguments(List<string> arguments, HostBuilderSettings settings)
         {
-            if (!string.IsNullOrEmpty(diagnosticPort))
+            if (!string.IsNullOrEmpty(settings.DiagnosticPort))
             {
-                builder.AddInMemoryCollection(new Dictionary<string, string>
-                {
-                    {ConfigurationPath.Combine(ConfigurationKeys.DiagnosticPort, nameof(DiagnosticPortOptions.ConnectionMode)), DiagnosticPortConnectionMode.Listen.ToString()},
-                    {ConfigurationPath.Combine(ConfigurationKeys.DiagnosticPort, nameof(DiagnosticPortOptions.EndpointName)), diagnosticPort}
-                });
+                arguments.Add(FormatCmdLineArgument(
+                    ConfigurationPath.Combine(ConfigurationKeys.DiagnosticPort, nameof(DiagnosticPortOptions.ConnectionMode)),
+                    DiagnosticPortConnectionMode.Listen.ToString()));
+
+                arguments.Add(FormatCmdLineArgument(
+                    ConfigurationPath.Combine(ConfigurationKeys.DiagnosticPort, nameof(DiagnosticPortOptions.EndpointName)),
+                    settings.DiagnosticPort));
             }
+        }
+
+        private static void AddMetricsArguments(List<string> arguments, HostBuilderSettings settings)
+        {
+            arguments.Add(FormatCmdLineArgument(
+                ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.Endpoints)),
+                ConfigurationHelper.JoinValue(settings.MetricsUrls ?? Array.Empty<string>())));
+
+            arguments.Add(FormatCmdLineArgument(
+                ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.Enabled)),
+                settings.EnableMetrics.ToString()));
+        }
+
+        private static void AddTempApiKeyArguments(List<string> arguments, HostBuilderSettings settings)
+        {
+            if (settings.Authentication.TemporaryJwtKey != null)
+            {
+                arguments.Add(FormatCmdLineArgument(
+                    ConfigurationPath.Combine(ConfigurationKeys.Authentication, ConfigurationKeys.MonitorApiKey, nameof(MonitorApiKeyOptions.Subject)),
+                    settings.Authentication.TemporaryJwtKey.Subject));
+
+                arguments.Add(FormatCmdLineArgument(
+                    ConfigurationPath.Combine(ConfigurationKeys.Authentication, ConfigurationKeys.MonitorApiKey, nameof(MonitorApiKeyOptions.PublicKey)),
+                    settings.Authentication.TemporaryJwtKey.PublicKey));
+            }
+        }
+
+        private static void AddUrlsArguments(List<string> arguments, HostBuilderSettings settings)
+        {
+            arguments.Add(FormatCmdLineArgument(
+                WebHostDefaults.ServerUrlsKey,
+                ConfigurationHelper.JoinValue(settings.Urls ?? Array.Empty<string>())));
+        }
+
+        private static string FormatCmdLineArgument(string key, string value)
+        {
+            return $"{key}={value}";
         }
     }
 }


### PR DESCRIPTION
Currently, all of the configuration that is added as part of host configuration (this would largely be anything from the command line, the DOTNET_* variables, the ASPNETCORE_* variables) will have a reported source of `ChainedConfigurationProvider` when executing `config show --show-sources`. This is not particular helpful in understanding from where these values are provided.

This change effectively unwraps the occurrence of `ChainedConfigurationProvider` instances in the configuration writing algorithm to search within the chained configuration for the real configuration sources. Additionally, values that are provided from the command line have been changed to be represented by the `CommandLineConfigurationProvider` instead of by `MemoryConfigurationProvider`.