### PR TITLE
Gracefully handle stdout that is not JSON formatted during tests runs

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -161,22 +161,30 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         protected override void StandardOutputCallback(string line)
         {
-            ConsoleLogEvent logEvent = JsonSerializer.Deserialize<ConsoleLogEvent>(line);
-
-            switch (logEvent.Category)
+            try
             {
-                case "Microsoft.Hosting.Lifetime":
-                    HandleLifetimeEvent(logEvent);
-                    break;
-                case "Microsoft.Diagnostics.Tools.Monitor.Startup":
-                    HandleStartupEvent(logEvent);
-                    break;
-                case "Microsoft.Diagnostics.Tools.Monitor.CollectionRules.CollectionRuleService":
-                    HandleCollectionRuleEvent(logEvent);
-                    break;
-                default:
-                    HandleGenericLogEvent(logEvent);
-                    break;
+                ConsoleLogEvent logEvent = JsonSerializer.Deserialize<ConsoleLogEvent>(line);
+
+                switch (logEvent.Category)
+                {
+                    case "Microsoft.Hosting.Lifetime":
+                        HandleLifetimeEvent(logEvent);
+                        break;
+                    case "Microsoft.Diagnostics.Tools.Monitor.Startup":
+                        HandleStartupEvent(logEvent);
+                        break;
+                    case "Microsoft.Diagnostics.Tools.Monitor.CollectionRules.CollectionRuleService":
+                        HandleCollectionRuleEvent(logEvent);
+                        break;
+                    default:
+                        HandleGenericLogEvent(logEvent);
+                        break;
+                }
+            }
+            catch (JsonException)
+            {
+                // Unable to parse the output. These could be lines writen to stdout that are not JSON formatted.
+                _outputHelper.WriteLine("Unable to JSON parse stdout line: {0}", line);
             }
         }
 


### PR DESCRIPTION
Currently if `dotnet-monitor` writes any text to stdout that is not JSON formatted during a functional test, it'll result in an unhandled exception and prematurely stop the test.

Under normal circumstances this is acceptable, however it prevents easily adding log statements for the purpose of debugging (e.g. adhoc `Console.WriteLine` when debugging a test failure). Update our test runner to handle this situation gracefully, not stopping the test.