### PR TITLE
[release/6.x] Avoid Kestrel address override warning

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/KestrelTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/KestrelTests.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    [Collection(DefaultCollectionFixture.Name)]
+    public sealed class KestrelTests
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ITestOutputHelper _outputHelper;
+
+        public KestrelTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
+        {
+            _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_CmdLine()
+        {
+            return ExecuteNoOverrideWarning();
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_DotNet()
+        {
+            return ExecuteNoOverrideWarning((runner, url) =>
+            {
+                runner.DotNetUrls = url;
+            });
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_AspNetCore()
+        {
+            return ExecuteNoOverrideWarning((runner, url) =>
+            {
+                // This should be overriden by the ASPNETCORE_Urls entry. If it is not,
+                // it will cause dotnet-monitor to not bind correctly and the /info route
+                // check will fail.
+                runner.DotNetUrls = "dotnet_invalid";
+                runner.AspNetCoreUrls = url;
+            });
+        }
+
+        [Fact]
+        public Task UrlBinding_NoOverrideWarning_DotNetMonitor()
+        {
+            return ExecuteNoOverrideWarning((runner, url) =>
+            {
+                // These should be overriden by the DotnetMonitor_Urls entry. If it is not,
+                // it will cause dotnet-monitor to not bind correctly and the /info route
+                // check will fail.
+                runner.DotNetUrls = "dotnet_invalid";
+                runner.AspNetCoreUrls = "aspnetcore_invalid";
+
+                runner.DotNetMonitorUrls = url;
+            });
+        }
+
+        private async Task ExecuteNoOverrideWarning(Action<MonitorCollectRunner, string> configure = null)
+        {
+            await using MonitorCollectRunner runner = new(_outputHelper);
+
+            runner.DisableAuthentication = true;
+
+            configure?.Invoke(runner, "http://+:0");
+
+            await runner.StartAsync();
+
+            string address = await runner.GetDefaultAddressAsync(CancellationToken.None);
+            UriBuilder builder = new(address);
+            builder.Host = "localhost";
+
+            using HttpClient httpClient = await runner.CreateHttpClientAsync(_httpClientFactory, builder.Uri.ToString());
+            ApiClient apiClient = new(_outputHelper, httpClient);
+
+            // Test that the route (thus the URL) is viable
+            DotnetMonitorInfo info = await apiClient.GetInfoAsync();
+            Assert.NotNull(info);
+
+            // Test that the URL override warning is not present
+            Assert.False(runner.OverrodeServerUrls, "Override URL warning should not be present.");
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -78,6 +78,26 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         /// </summary>
         public bool DisableMetricsViaCommandLine { get; set; }
 
+        /// <summary>
+        /// Reports whether the server URLs were overriden by UseKestrel/ConfigureKestrel code.
+        /// </summary>
+        public bool OverrodeServerUrls { get; private set; }
+
+        /// <summary>
+        /// Urls used for the DOTNET_Urls environment variable.
+        /// </summary>
+        public string DotNetUrls { get; set; }
+
+        /// <summary>
+        /// Urls used for the ASPNETCORE_Urls environment variable.
+        /// </summary>
+        public string AspNetCoreUrls { get; set; }
+
+        /// <summary>
+        /// Urls used for the DOTNETMONITOR_Urls environment variable.
+        /// </summary>
+        public string DotNetMonitorUrls { get; set; }
+
 
         public MonitorCollectRunner(ITestOutputHelper outputHelper)
             : base(outputHelper)
@@ -108,6 +128,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             argsList.Add("--urls");
             argsList.Add("http://127.0.0.1:0");
+
+            if (!string.IsNullOrEmpty(DotNetUrls))
+            {
+                SetEnvironmentVariable("DOTNET_Urls", DotNetUrls);
+            }
+            if (!string.IsNullOrEmpty(AspNetCoreUrls))
+            {
+                SetEnvironmentVariable("ASPNETCORE_Urls", AspNetCoreUrls);
+            }
+            if (!string.IsNullOrEmpty(DotNetMonitorUrls))
+            {
+                SetEnvironmentVariable("DOTNETMONITOR_Urls", DotNetMonitorUrls);
+            }
 
             if (DisableMetricsViaCommandLine)
             {
@@ -167,6 +200,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
                 switch (logEvent.Category)
                 {
+                    case "Microsoft.AspNetCore.Server.Kestrel":
+                        HandleKestrelEvent(logEvent);
+                        break;
                     case "Microsoft.Hosting.Lifetime":
                         HandleLifetimeEvent(logEvent);
                         break;
@@ -251,6 +287,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                         Assert.True(_monitorApiKeySource.TrySetResult(monitorApiKey));
                     }
                     break;
+            }
+        }
+
+        private void HandleKestrelEvent(ConsoleLogEvent logEvent)
+        {
+            if (logEvent.Message.StartsWith("Overriding address(es)"))
+            {
+                OverrodeServerUrls = true;
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -189,5 +189,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             _outputHelper.WriteLine("Wrote user settings.");
         }
+
+        protected void SetEnvironmentVariable(string name, string value)
+        {
+            _adapter.Environment[name] = value;
+        }
     }
 }

--- a/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
@@ -4,12 +4,30 @@
 
 using Microsoft.Extensions.Configuration;
 using System.Linq;
+#if !NET7_0_OR_GREATER
 using System.Reflection;
+#endif
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ConfigurationExtensions
     {
+        public static bool TryGetProvider(this IConfigurationBuilder builder, string key, out IConfigurationProvider provider)
+        {
+            foreach (IConfigurationSource source in builder.Sources.Reverse())
+            {
+                if (source is ChainedConfigurationSource chainedSource &&
+                    null != chainedSource.Configuration &&
+                    chainedSource.Configuration.TryGetProviderAndValue(key, out provider, out _))
+                {
+                    return true;
+                }
+            }
+
+            provider = null;
+            return false;
+        }
+
         public static bool TryGetProviderAndValue(this IConfiguration configuration, string key, out IConfigurationProvider provider, out string value)
         {
             if (configuration is IConfigurationRoot configurationRoot)

--- a/src/Tools/dotnet-monitor/ServerUrlsBlockingConfigurationManager.cs
+++ b/src/Tools/dotnet-monitor/ServerUrlsBlockingConfigurationManager.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// A managing class that contains the state that determines whether the
+    /// ServerUrlsBlockingConfigurationProvider should block reading the Urls
+    /// option from the providers configured at a lower precedence.
+    /// </summary>
+    internal sealed class ServerUrlsBlockingConfigurationManager
+    {
+        public bool IsBlocking { get; set; }
+    }
+}

--- a/src/Tools/dotnet-monitor/ServerUrlsBlockingConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/ServerUrlsBlockingConfigurationProvider.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class ServerUrlsBlockingConfigurationProvider :
+        ConfigurationProvider
+    {
+        private readonly ServerUrlsBlockingConfigurationManager _manager;
+
+        public ServerUrlsBlockingConfigurationProvider(ServerUrlsBlockingConfigurationManager manager)
+        {
+            _manager = manager;
+        }
+
+        public override void Set(string key, string value)
+        {
+            // Overridden to prevent set of data since this provider does not
+            // provide any real data from any source.
+        }
+
+        public override bool TryGet(string key, out string value)
+        {
+            // Block reading of the Urls option if the manager says to block. This will prevent other
+            // configuration providers that were configured at a lower priority from providing their
+            // value of the Urls option to configuration.
+            if (_manager.IsBlocking && WebHostDefaults.ServerUrlsKey.Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = string.Empty;
+                return true;
+            }
+            return base.TryGet(key, out value);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ServerUrlsBlockingConfigurationSource.cs
+++ b/src/Tools/dotnet-monitor/ServerUrlsBlockingConfigurationSource.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// A configuration source that allows blocking the reading of the Urls option
+    /// from configuration providers that are configured at a lower priority.
+    /// </summary>
+    internal sealed class ServerUrlsBlockingConfigurationSource :
+        IConfigurationSource
+    {
+        private readonly ServerUrlsBlockingConfigurationManager _manager;
+
+        public ServerUrlsBlockingConfigurationSource(ServerUrlsBlockingConfigurationManager manager)
+        {
+            _manager = manager;
+        }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new ServerUrlsBlockingConfigurationProvider(_manager);
+        }
+    }
+}


### PR DESCRIPTION
Manual backport of #2535 to `release/6.x`