### PR TITLE
Fallback to the system's copy of dotnet when running tests under Visual Studio

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -35,9 +35,18 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             }
 
             string absoluteExecutablePath = Path.GetFullPath(Path.Combine(dotnetDirPath, ExeName));
-            if (!File.Exists(absoluteExecutablePath) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("VSAPPIDDIR")))
+
+            // If the current repo enlistment has only ever been built and tested with Visual Studio,
+            // the repo's private copy of dotnet will have never been setup.
+            //
+            // In this scenario fall back to the system's copy.
+            // Limit this fallback behavior to only happen when running under Visual Studio.
+            // (i.e. when on Windows and a well-defined VS-specific environment variable set)
+            if (!File.Exists(absoluteExecutablePath)
+                && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("VSAPPIDDIR")))
             {
-                Console.WriteLine($"Could not find '{absoluteExecutablePath}', falling back to the system's version.");
+                Console.WriteLine($"'{absoluteExecutablePath}' does not exist, falling back to the system's version.");
                 return ExeName;
             }
 


### PR DESCRIPTION
Currently if you have a cloned version of this repo and exclusively build & test it with Visual Studio, a portion of the tests will fail, as they rely on the repo's copy of `dotnet` which is only hydrated when using the scripts at the root of the repo to build and test.

Update our testing code to fallback to the system's copy of dotnet when testing under VisualStudio and the repo's copy of `dotnet` has not yet been hydrated.