### PR TITLE
Add automation to manage release version information

### DIFF
--- a/.github/workflows/update-release-version.yml
+++ b/.github/workflows/update-release-version.yml
@@ -53,7 +53,7 @@ jobs:
           declare -i new_prerelease_iteration
 
           current_branch_name=$(git symbolic-ref --short HEAD)
-          if [[ "$qualified_release_version" =~ "^release\/" ]]; then
+          if [[ "$current_branch_name" =~ ^release\/* ]]; then
               new_build_quality="release"
           fi
 


### PR DESCRIPTION
Add a new workflow that can managed the release version information specified in `./eng/Versions.props` (Steps 3, 4, and first half of 7 in [release-process.md#merge-to-release-branch](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/release-process.md#merge-to-release-branch)).
- To simplify things, the concepts of `servicing` and `rtm` releases have been simplified to just `rtm` in the workflow's "Release type" dropdown.  The workflow will automatically determine if the servicing tag is needed.
- The workflow will update all of the relevant version-specific tags and open a PR if any changes are needed.
- It will automatically manage the `PreReleaseVersionIteration` tag, bumping it if this is a consecutive release of the same version+quality of a non-rtm build, clearing if it's rtm, or adding it back if was previously cleared.
- It will also automatically manage the `<BlobGroupBuildQuality>` and `<DotnetFinalVersionKind>` tags.


Example PRs resulting from this workflow:
- https://github.com/schmittjoseph/dotnet-monitor/pull/91
- https://github.com/schmittjoseph/dotnet-monitor/pull/88

Example workflow invocation:
![image](https://user-images.githubusercontent.com/1146681/194155178-0c832676-608a-404e-814b-c1e2e71defd3.png)


Release process documentation will be updates separately.

Depends on https://github.com/dotnet/dotnet-monitor/pull/2608.