### PR TITLE
Enable linting on release/7.* PRs

### DIFF
--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -2,7 +2,7 @@ name: 'C# linting'
 on:
   pull_request:
     paths: ['src/**.cs']
-    branches: ['main', 'release/6.x', 'release/7.x']
+    branches: ['main', 'release/6.x', 'release/7.*']
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Enables the C# linter on PRs targeting any `release/7.*` branches