### PR TITLE
Update filter for skipping CI builds

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -13,6 +13,8 @@ pr:
     - .devcontainer
     - .github
     - .vscode
+    - .gitignore
+    - eng/actions
     - '**.md'
 
 schedules:


### PR DESCRIPTION
https://github.com/dotnet/dotnet-monitor/pull/2608 is triggering our CI builds despite not having any impacting code changes. Update our path filtering to fix this:
- Ignore changes to `.gitignore`
- Ignore changes to actions stored under `eng/actions`