### PR TITLE
Split process stop from disposal and use disposal helpers

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly TimeSpan StartProcess = TimeSpan.FromMinutes(1);
 
         /// <summary>
+        /// Default timeout for stopping an executable.
+        /// </summary>
+        public static readonly TimeSpan StopProcess = TimeSpan.FromSeconds(10);
+
+        /// <summary>
         /// Default timeout for waiting for an executable to exit.
         /// </summary>
         public static readonly TimeSpan WaitForExit = TimeSpan.FromSeconds(15);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/EnumerableExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/EnumerableExtensions.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     public static class EnumerableExtensions
     {
+        public static IAsyncDisposable CreateItemDisposer<T>(this IEnumerable<T> items) where T : IAsyncDisposable
+        {
+            return new DisposeItemsDisposable<T>(items);
+        }
+
         public static async Task DisposeItemsAsync<T>(this IEnumerable<T> items) where T : IAsyncDisposable
         {
             foreach (IAsyncDisposable disposable in items)
@@ -18,6 +23,30 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 {
                     await disposable.DisposeAsync();
                 }
+            }
+        }
+
+        private sealed class DisposeItemsDisposable<T> :
+            IAsyncDisposable
+            where T : IAsyncDisposable
+        {
+            private readonly IEnumerable<T> _items;
+
+            private long _disposedState;
+
+            public DisposeItemsDisposable(IEnumerable<T> items)
+            {
+                _items = items;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (!DisposableHelper.CanDispose(ref _disposedState))
+                {
+                    return;
+                }
+
+                await _items.DisposeItemsAsync();
             }
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             await toolRunner.StartAsync();
 
-            AppRunner appRunner = new(_outputHelper, Assembly.GetExecutingAssembly());
+            await using AppRunner appRunner = new(_outputHelper, Assembly.GetExecutingAssembly());
             appRunner.ConnectionMode = appConnectionMode;
             appRunner.DiagnosticPortPath = diagnosticPortPath;
             appRunner.ScenarioName = TestAppScenarios.AsyncWait.Name;
@@ -342,7 +342,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             await toolRunner.StartAsync();
 
-            AppRunner appRunner = new(_outputHelper, Assembly.GetExecutingAssembly());
+            await using AppRunner appRunner = new(_outputHelper, Assembly.GetExecutingAssembly());
             appRunner.ConnectionMode = appConnectionMode;
             appRunner.DiagnosticPortPath = diagnosticPortPath;
             appRunner.ScenarioName = TestAppScenarios.AsyncWait.Name;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -125,6 +125,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 appRunners[i] = runner;
             }
 
+            await using IAsyncDisposable _ = appRunners.CreateItemDisposer();
+
             IList<ProcessIdentifier> identifiers;
             await appRunners.ExecuteAsync(async () =>
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         private readonly TaskCompletionSource<string> _readySource =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private bool _isDisposed;
+        private long _disposedState;
 
         /// <summary>
         /// Event callback for when a Private Key warning message is seen.
@@ -106,13 +106,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         public override async ValueTask DisposeAsync()
         {
-            lock (_lock)
+            if (!DisposableHelper.CanDispose(ref _disposedState))
             {
-                if (_isDisposed)
-                {
-                    return;
-                }
-                _isDisposed = true;
+                return;
             }
 
             CancelCompletionSources(CancellationToken.None);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
@@ -118,6 +118,17 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             await runner.StartAsync(cancellation.Token);
         }
 
+        public static Task StopAsync(this MonitorCollectRunner runner)
+        {
+            return runner.StopAsync(CommonTestTimeouts.StopProcess);
+        }
+
+        public static async Task StopAsync(this MonitorCollectRunner runner, TimeSpan timeout)
+        {
+            using CancellationTokenSource cancellation = new(timeout);
+            await runner.StopAsync(cancellation.Token);
+        }
+
         public static Task WaitForCollectionRuleActionsCompletedAsync(this MonitorCollectRunner runner, string ruleName)
         {
             return runner.WaitForCollectionRuleActionsCompletedAsync(ruleName, TestTimeouts.CollectionRuleActionsCompletedTimeout);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(httpClientFactory);
             ApiClient apiClient = new(outputHelper, httpClient);
 
-            AppRunner appRunner = new(outputHelper, Assembly.GetExecutingAssembly());
+            await using AppRunner appRunner = new(outputHelper, Assembly.GetExecutingAssembly());
             appRunner.ProfilerLogLevel = profilerLogLevel;
             appRunner.ConnectionMode = appConnectionMode;
             appRunner.DiagnosticPortPath = diagnosticPortPath;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectDumpActionTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 EndpointInfoSourceCallback callback = new(_outputHelper);
                 await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback);
 
-                AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
 
                 Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectGCDumpActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectGCDumpActionTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 EndpointInfoSourceCallback callback = new(_outputHelper);
                 await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback);
 
-                AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
 
                 Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLiveMetricsActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLiveMetricsActionTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 EndpointInfoSourceCallback callback = new(_outputHelper);
                 await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback);
 
-                AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
 
                 Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLogsActionTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
                 await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
 
-                AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
                 runner.ScenarioName = TestAppScenarios.Logger.Name;
 
                 Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectTraceActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectTraceActionTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             EndpointInfoSourceCallback callback = new(_outputHelper);
             await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback);
 
-            AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+            await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
 
             Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTestsHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             EndpointUtilities endpointUtilities = new(outputHelper);
             await using ServerSourceHolder sourceHolder = await endpointUtilities.StartServerAsync(endpointInfoCallback);
 
-            AppRunner runner = new(outputHelper, Assembly.GetExecutingAssembly(), tfm: tfm);
+            await using AppRunner runner = new(outputHelper, Assembly.GetExecutingAssembly(), tfm: tfm);
             runner.ConnectionMode = DiagnosticPortConnectionMode.Connect;
             runner.DiagnosticPortPath = sourceHolder.TransportName;
             runner.ScenarioName = scenarioName;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             var endpointInfos = await _endpointUtilities.GetEndpointInfoAsync(sourceHolder.Source);
             Assert.Empty(endpointInfos);
 
-            AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, appTfm);
+            await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, appTfm);
 
             Task addedEndpointTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
             Task removedEndpointTask = callback.WaitRemovedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
@@ -112,6 +112,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 removedEndpointTasks[i] = callback.WaitRemovedEndpointInfoAsync(runners[i], CommonTestTimeouts.StartProcess);
             }
 
+            await using IAsyncDisposable _ = runners.CreateItemDisposer();
+
             await runners.ExecuteAsync(async () =>
             {
                 _outputHelper.WriteLine("Waiting for all added endpoint notifications.");
@@ -165,7 +167,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             MockDumpService dumpService = new(operationTrackerService);
             await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback, dumpService, operationTrackerService);
 
-            AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, appTfm);
+            await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, appTfm);
 
             Task<IEndpointInfo> addedEndpointTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
             Task<IEndpointInfo> removedEndpointTask = callback.WaitRemovedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -203,13 +203,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             dumpService.CompleteOperation();
             await dumpTask;
 
-            // Process should no longer exist
-            endpointInfos = await _endpointUtilities.GetEndpointInfoAsync(sourceHolder.Source);
-            Assert.Empty(endpointInfos);
-
-            // Test that process removal sent notification
+            // Wait for process removal notification; this may take a few seconds for process pruning to occur
             endpointInfo = await removedEndpointTask;
             Assert.Equal(processId, endpointInfo.ProcessId);
+
+            // Test that process should no longer exist
+            endpointInfos = await _endpointUtilities.GetEndpointInfoAsync(sourceHolder.Source);
+            Assert.Empty(endpointInfos);
         }
 
         private static void ValidateEndpointInfo(IEndpointInfo endpointInfo)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EnvironmentVariableActionTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
                     await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
 
-                    AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                    await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
                     runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
 
                     Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
                     await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
 
-                    AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                    await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
                     runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
 
                     Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
@@ -178,7 +178,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     EndpointInfoSourceCallback endpointInfoCallback = new(_outputHelper);
                     await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(endpointInfoCallback);
 
-                    AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                    await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
                     runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
 
                     Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 LoadProfilerCallback callback = new(_outputHelper, host);
                 await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback);
 
-                AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
+                await using AppRunner runner = _endpointUtilities.CreateAppRunner(sourceHolder.TransportName, tfm);
                 runner.Architecture = architecture;
                 runner.ScenarioName = TestAppScenarios.AsyncWait.Name;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestHostHelper.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             }
             finally
             {
-                await DisposeHost(host);
+                await DisposableHelper.DisposeAsync(host);
             }
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             }
             finally
             {
-                await DisposeHost(host);
+                await DisposableHelper.DisposeAsync(host);
             }
         }
 
@@ -111,18 +111,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     servicesCallback?.Invoke(services);
                 })
                 .Build();
-        }
-
-        public static async Task DisposeHost(IHost host)
-        {
-            if (host is IAsyncDisposable asyncDisposable)
-            {
-                await asyncDisposable.DisposeAsync();
-            }
-            else
-            {
-                host.Dispose();
-            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
@@ -35,14 +35,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
         public async ValueTask DisposeAsync()
         {
-            if (DisposableHelper.CanDispose(ref _disposedState))
+            if (!DisposableHelper.CanDispose(ref _disposedState))
             {
-                _disposalTokenSource.SafeCancel();
-
-                await _completionTask.SafeAwait();
-
-                _disposalTokenSource.Dispose();
+                return;
             }
+
+            _disposalTokenSource.SafeCancel();
+
+            await _completionTask.SafeAwait();
+
+            _disposalTokenSource.Dispose();
         }
 
         public async Task StartAsync(CollectionRuleMetadata collectionRuleMetadata, CancellationToken token)

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
@@ -58,10 +58,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         public async ValueTask DisposeAsync()
         {
-            if (DisposableHelper.CanDispose(ref _disposalState))
+            if (!DisposableHelper.CanDispose(ref _disposalState))
             {
-                await StopRulesCore(CancellationToken.None);
+                return;
             }
+
+            await StopRulesCore(CancellationToken.None);
         }
 
         public async Task StartRulesAsync(

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -63,24 +63,26 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         public async ValueTask DisposeAsync()
         {
-            if (DisposableHelper.CanDispose(ref _disposalState))
+            if (!DisposableHelper.CanDispose(ref _disposalState))
             {
-                _containersToRemoveWriter.TryComplete();
+                return;
+            }
 
-                CollectionRuleContainer[] containers;
-                lock (_containersMap)
-                {
-                    containers = _containersMap.Values.ToArray();
-                }
+            _containersToRemoveWriter.TryComplete();
 
-                // This will cancel the background execution if
-                // BackgroundService.StopAsync wasn't called.
-                Dispose();
+            CollectionRuleContainer[] containers;
+            lock (_containersMap)
+            {
+                containers = _containersMap.Values.ToArray();
+            }
 
-                foreach (CollectionRuleContainer container in containers)
-                {
-                    await container.DisposeAsync();
-                }
+            // This will cancel the background execution if
+            // BackgroundService.StopAsync wasn't called.
+            Dispose();
+
+            foreach (CollectionRuleContainer container in containers)
+            {
+                await container.DisposeAsync();
             }
         }
 

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -60,14 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 }
                 finally
                 {
-                    if (host is IAsyncDisposable asyncDisposable)
-                    {
-                        await asyncDisposable.DisposeAsync();
-                    }
-                    else
-                    {
-                        host.Dispose();
-                    }
+                    await DisposableHelper.DisposeAsync(host);
                 }
             }
             catch (FormatException ex)

--- a/src/Tools/dotnet-monitor/DisposableHelper.cs
+++ b/src/Tools/dotnet-monitor/DisposableHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Tools/dotnet-monitor/DisposableHelper.cs
+++ b/src/Tools/dotnet-monitor/DisposableHelper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
This change splits out the behavior of stopping the process runners from disposing the process runners. This allows consistent access to process information after the process has stopped but before it is disposed (which the process information, such as exit code, are no longer available). As it was before, owners of the process runner are NOT required to call `StopAsync` before calling `DisposeAsync`.

The `AppRunner.ExecuteAsync` extension methods have been updated to call `StopAsync` instead of `DisposeAsync` in order to maintain the symmetry with the method starting the runner rather than creating and owning the runner. Callers are now responsible for disposing the runners.

Additional changes were made to unify the disposal patterns to use the common disposal helpers.