### PR TITLE
Enable docker-in-docker support in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
                 "ms-vscode.powershell",
                 "tintoy.msbuild-project-tools",
                 "streetsidesoftware.code-spell-checker"
-			],
+            ],
             "settings": {
                 "files.associations": {
                     "*.csproj": "msbuild",


### PR DESCRIPTION
Update our codespace's devcontainer to include docker support.

Also update the `features` list to use the new syntax.