### PR TITLE
Add kubectl, helm, and minikube to codespaces and update minimum specs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
             "NODE_VERSION": "lts/*"
         }
     },
+    "hostRequirements": {
+        "cpus": 4
+    },
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
###### Summary

- Add `kubectl`, `helm`, and `minikube` to the codespace's devcontainer by default.
- Set minimum devcontainer specs to 4 cpu cores. The default is 2, which is under-resourced for full dotnet-monitor builds.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
