### PR TITLE
Enable dependabot for github-actions on release/7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.x"
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:


### PR DESCRIPTION
###### Summary

We have workflows and actions that run on release branches, update our dependabot config to keep them up-to-date on `release/7.x`.

NOTE: Enabling this for `release/6.x` can be done after https://github.com/dotnet/dotnet-monitor/pull/2662 is ported to `release/6.x`.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
