### PR TITLE
Remove StaticWebAssets disablement workaround

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -16,11 +16,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <OutputType>Library</OutputType>
-    <!--
-      Workaround for https://github.com/dotnet/aspnetcore/issues/42200
-      Required as of 7.0 Preview 5 SDK
-      -->
-    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -9,11 +9,6 @@
     <Description>.NET Core Diagnostic Monitoring Tool</Description>
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
-    <!--
-      Workaround for https://github.com/dotnet/aspnetcore/issues/42200
-      Required as of 7.0 Preview 5 SDK
-      -->
-    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The StaticWebAssets [issue](https://github.com/dotnet/aspnetcore/issues/42200) was fixed in the Preview 7 timeframe. The disablement workaround is no longer needed.