### PR TITLE
Remove .NET Core 3.1 build and testing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
     <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);net7.0</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
-    <TestTargetFrameworks>netcoreapp3.1;net6.0</TestTargetFrameworks>
+    <TestTargetFrameworks>net6.0</TestTargetFrameworks>
     <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);net7.0</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
     <SchemaTargetFramework>net6.0</SchemaTargetFramework>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -17,8 +17,6 @@ parameters:
   testGroup: Default
   # TFMs for which test results are uploaded
   testResultTfms:
-  - key: netcoreapp3.1
-    value: Core 3.1
   - key: net6.0
     value: .NET 6
   - key: net7.0


### PR DESCRIPTION
With .NET Core 3.1 going EOL in December 2022 and libraries starting to not support the `netcoreapp3.1` TFM, remove building and testing .NET Core 3.1 apps.