### PR TITLE
Improve backport regex in generate-release-notes

### DIFF
--- a/.github/actions/generate-release-notes/index.js
+++ b/.github/actions/generate-release-notes/index.js
@@ -125,7 +125,7 @@ async function getPRs(octokit, branchName, additionalBranch, repoOwner, repoName
 }
 
 async function resolveBackportPrToReleaseNotePr(octokit, pr, repoOwner, repoName, minMergeDate, maxRecursion) {
-    const backportRegex=/backport (of )? #(?<prNumber>\d+)/mi
+    const backportRegex=/backport (of )?#(?<prNumber>\d+)/mi
     const backportOriginPrNumber = pr.body?.match(backportRegex)?.groups?.prNumber;
     if (backportOriginPrNumber === undefined) {
         console.log(`Unable to determine origin PR for backport: ${pr.html_url}`)


### PR DESCRIPTION
###### Summary

The current regex used to identify origin PRs for backports does not correctly handle our manual backport messages. This PR updates that regex to handle both manual and automated backports.

e.g. https://github.com/dotnet/dotnet-monitor/pull/2733

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
