### PR TITLE
Remove installation of .NET Core 3.1 frameworks

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,22 +3,18 @@
     "dotnet": "7.0.100-rc.1.22431.12",
     "runtimes": {
       "aspnetcore": [
-        "$(MicrosoftAspNetCoreApp31Version)",
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(VSRedistCommonAspNetCoreSharedFrameworkx6470Version)"
       ],
       "aspnetcore/x86": [
-        "$(MicrosoftAspNetCoreApp31Version)",
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(VSRedistCommonAspNetCoreSharedFrameworkx6470Version)"
       ],
       "dotnet": [
-        "$(MicrosoftNETCoreApp31Version)",
         "$(MicrosoftNETCoreApp60Version)",
         "$(VSRedistCommonNetCoreSharedFrameworkx6470Version)"
       ],
       "dotnet/x86": [
-        "$(MicrosoftNETCoreApp31Version)",
         "$(MicrosoftNETCoreApp60Version)",
         "$(VSRedistCommonNetCoreSharedFrameworkx6470Version)"
       ]


### PR DESCRIPTION
Since `netcoreapp3.1` assets are no longer built nor tested, the frameworks for 3.1 do not need to be installed anymore.