### PR TITLE
Automatically sync select paths across branches

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   sync-branch:
+    if: github.repository == 'dotnet/dotnet-monitor'
     strategy:
       matrix:
         branch: ["release/6.x", "release/7.x"]


### PR DESCRIPTION
###### Summary

Add a workflow that'll run every monday morning (or on-demand) to sync certain paths from `main` to release branches. It'll automatically open a PR with any files that need to be synced.

Example PRs:
- https://github.com/schmittjoseph/dotnet-monitor/pull/10
- https://github.com/schmittjoseph/dotnet-monitor/pull/9

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
