### PR TITLE
Bump backport's Node.js version

### DIFF
--- a/eng/actions/backport/action.yml
+++ b/eng/actions/backport/action.yml
@@ -22,5 +22,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
###### Summary

Node.js 12 GitHub action support is being deprecated, as v12 is officially out of support since April 2022. Bump the backport action to use v16.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
