### PR TITLE
[release/6.x] Allow dependabot to manage Microsoft.Diagnostics.Monitoring.* libraries

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,9 +43,6 @@
     <VSRedistCommonAspNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21526.8</VSRedistCommonAspNetCoreSharedFrameworkx6460Version>
     <!-- dotnet/command-line-api references -->
     <SystemCommandLineVersion>2.0.0-beta4.22504.1</SystemCommandLineVersion>
-    <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringVersion>5.0.328102</MicrosoftDiagnosticsMonitoringVersion>
-    <MicrosoftDiagnosticsMonitoringEventPipeVersion>5.0.328102</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/runtime references -->
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-rtm.21522.10</VSRedistCommonNetCoreSharedFrameworkx6460Version>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -22,5 +22,21 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreSwaggerGenVersion)" />
+
+    <!-- Release-branch specific reference -->
+    <!-- dotnet/diagnostics references -->
+    <!--
+      Keep MicrosoftDiagnosticsMonitoringVersion in-sync with the latest publicly shipped version of dotnet-dump:
+      - In release branches we want to only use versions of Microsoft.Diagnostics.Monitoring.* packages that
+        were built together with other packages from dotnet/diagnostics that have publicly shipped on nuget.org.
+      - Microsoft.Diagnostics.Monitoring.* packages are not shipped via nuget.org, and instead are available via
+        the dotnet-tools feed, but it contains additional (often newer) versions that don't correspond to
+        the publicly shipped related packages.
+      - dotnet-dump, and select other packages from dotnet/diagnostics, share the same version tag as the
+        Microsoft.Diagnostics.Monitoring.* packages so we can use them to manage MicrosoftDiagnosticsMonitoringVersion.
+      - This is part of a shim project for dependabot and will never actually be built or restored, so we
+        can add a package reference to the dotnet-dump tool.
+    -->
+    <PackageReference Include="dotnet-dump" Version="$(MicrosoftDiagnosticsMonitoringVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/Versions.props
+++ b/eng/dependabot/Versions.props
@@ -20,5 +20,9 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NJsonSchemaVersion>10.8.0</NJsonSchemaVersion>
     <SwashbuckleAspNetCoreSwaggerGenVersion>6.4.0</SwashbuckleAspNetCoreSwaggerGenVersion>
+    
+    <!-- Release-branch specific reference -->
+    <!-- dotnet/diagnostics references -->
+    <MicrosoftDiagnosticsMonitoringVersion>5.0.328102</MicrosoftDiagnosticsMonitoringVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">
-    <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringEventPipeVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' != ''">


### PR DESCRIPTION
Manual backport of #2610 and #2639 to `release/6.x`

I kept the version the same so that way we can test that dependabot will bump it correctly.