### PR TITLE
Faster logs unit tests and eventing workaround updates

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -79,7 +79,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string LoggerCategory1 = nameof(LoggerCategory1);
                 public const string LoggerCategory2 = nameof(LoggerCategory2);
                 public const string LoggerCategory3 = nameof(LoggerCategory3);
+                // Used to denote that no more relevant data will be sent via logging.
                 public const string SentinelCategory = nameof(SentinelCategory);
+                // Use to flush the event entries through eventing buffers.
+                public const string FlushCategory = nameof(FlushCategory);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
@@ -135,8 +135,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     {
                         { TestAppScenarios.Logger.Categories.LoggerCategory1, LogLevel.Error },
                         { TestAppScenarios.Logger.Categories.LoggerCategory2, null },
-                        { TestAppScenarios.Logger.Categories.LoggerCategory3, LogLevel.Warning },
-                        { TestAppScenarios.Logger.Categories.SentinelCategory, LogLevel.Critical }
+                        { TestAppScenarios.Logger.Categories.LoggerCategory3, LogLevel.Warning }
                     },
                     LogLevel = LogLevel.Information,
                     UseAppFilters = false
@@ -410,7 +409,18 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             LogFormat logFormat)
         {
             Func<ApiClient, int, Task<ResponseStreamHolder>> captureLogs =
-                (client, pid) => client.CaptureLogsAsync(pid, CommonTestTimeouts.LogsDuration, configuration, logFormat);
+                (client, pid) =>
+                {
+                    // The Sentinel and Flush categories are implementation details of the logs test infrastructure.
+                    // Instead of having each test understand to add these, add them to the configuration
+                    // if the test is using FilterSpecs.
+                    if (null != configuration.FilterSpecs)
+                    {
+                        configuration.FilterSpecs.Add(TestAppScenarios.Logger.Categories.SentinelCategory, LogLevel.Critical);
+                        configuration.FilterSpecs.Add(TestAppScenarios.Logger.Categories.FlushCategory, LogLevel.Critical);
+                    }
+                    return client.CaptureLogsAsync(pid, CommonTestTimeouts.LogsDuration, configuration, logFormat);
+                };
 
             return Retry(() => ValidateLogsAsyncCore(mode, captureLogs, callback, logFormat));
         }
@@ -445,6 +455,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.NotNull(holder);
 
                     await LogsTestUtilities.ValidateLogsEquality(holder.Stream, callback, logFormat, _outputHelper);
+
+                    // Note: Do not wait for completion of the HTTP response. No more relevant data will be produced;
+                    // the code would only be waiting for the response to end. Ideally the operation is gracefully stopped at
+                    // this point.
                 },
                 configureTool: runner =>
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/Pipe/PipeEgressConfigureOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/Pipe/PipeEgressConfigureOptions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Options;
+using System.IO.Pipelines;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.Pipe
+{
+    internal sealed class PipeEgressConfigureNamedOptions : IConfigureNamedOptions<PipeEgressOptions>
+    {
+        private readonly PipeWriter _writer;
+
+        public PipeEgressConfigureNamedOptions(PipeWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void Configure(string name, PipeEgressOptions options)
+        {
+            options.Writer = _writer;
+        }
+
+        public void Configure(PipeEgressOptions options)
+        {
+            Configure(Microsoft.Extensions.Options.Options.DefaultName, options);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/Pipe/PipeEgressOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/Pipe/PipeEgressOptions.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Pipelines;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.Pipe
+{
+    internal sealed class PipeEgressOptions
+    {
+        public PipeWriter Writer { get; set; }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/Pipe/PipeEgressProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/Pipe/PipeEgressProvider.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using System;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.Pipe
+{
+    internal sealed class PipeEgressProvider : IEgressProvider<PipeEgressOptions>
+    {
+        public const string Name = "Pipe";
+
+        public async Task<string> EgressAsync(PipeEgressOptions options, Func<CancellationToken, Task<Stream>> action, EgressArtifactSettings artifactSettings, CancellationToken token)
+        {
+            using Stream stream = await action(token);
+
+            await stream.CopyToAsync(options.Writer, token);
+
+            return null;
+        }
+
+        public async Task<string> EgressAsync(PipeEgressOptions options, Func<Stream, CancellationToken, Task> action, EgressArtifactSettings artifactSettings, CancellationToken token)
+        {
+            using Stream stream = options.Writer.AsStream();
+
+            await action(stream, token);
+
+            return null;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return services;
         }
 
-        private static IServiceCollection RegisterProvider<TOptions, TProvider>(this IServiceCollection services, string name)
+        public static IServiceCollection RegisterProvider<TOptions, TProvider>(this IServiceCollection services, string name)
             where TProvider : class, IEgressProvider<TOptions>
             where TOptions : class
         {


### PR DESCRIPTION
###### Summary

- CollectLogs actions unit tests have been updated to proactively validate the log stream while logs are produced and immediately end when the sentinel category is encountered. This is done by adding a test-only egress provider that writes log data to a pipe writer and is consumed by the validation immediately instead of egressing to the file system.
- The event buffering workarounds have been updated to send several flushing events with brief waits between each iteration to help unblock buffering behaviors in the runtime and in the trace event library.
- Moved the knowledge of the sentinel and flushing categories to the testing infrastructure instead of the tests.

On my local machine, each one of the CollectLogs action unit tests used to take about 10-11 seconds; with these changes, each test takes about 1 second.