### PR TITLE
Disable Dependabot for github actions in release/7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "release/7.x"
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:


### PR DESCRIPTION
###### Summary

Version updates to Github actions in release branches is now taken care of by the main->release branch syncing workflows.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
