### PR TITLE
Handle exceptions when collecting additional info for discovered processes

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_StoppingTraceEventPayloadFilterMismatch);
 
+        private static readonly Action<ILogger, int, Exception> _diagnosticRequestFailed =
+            LoggerMessage.Define<int>(
+                eventId: new EventId(10, "DiagnosticRequestFailed"),
+                logLevel: LogLevel.Debug,
+                formatString: Strings.LogFormatString_DiagnosticRequestFailed);
+
         public static void RequestFailed(this ILogger logger, Exception ex)
         {
             _requestFailed(logger, ex);
@@ -107,6 +113,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public static void StoppingTraceEventPayloadFilterMismatch(this ILogger logger, TraceEvent traceEvent)
         {
             _stoppingTraceEventPayloadFilterMismatch(logger, traceEvent.ProviderName, traceEvent.EventName, string.Join(' ', traceEvent.PayloadNames), null);
+        }
+
+        public static void DiagnosticRequestFailed(this ILogger logger, int processId, Exception ex)
+        {
+            _diagnosticRequestFailed(logger, processId, ex);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -250,6 +250,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to get diagnostic response from runtime in process {processId}..
+        /// </summary>
+        internal static string LogFormatString_DiagnosticRequestFailed {
+            get {
+                return ResourceManager.GetString("LogFormatString_DiagnosticRequestFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Egressed artifact to {location}.
         /// </summary>
         internal static string LogFormatString_EgressedArtifact {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -205,6 +205,9 @@
     <comment>Gets the format string that is printed in the 7:DefaultProcessUnexpectedFailure event.
 0 Format Parameters</comment>
   </data>
+  <data name="LogFormatString_DiagnosticRequestFailed" xml:space="preserve">
+    <value>Failed to get diagnostic response from runtime in process {processId}.</value>
+  </data>
   <data name="LogFormatString_EgressedArtifact" xml:space="preserve">
     <value>Egressed artifact to {location}</value>
     <comment>Gets the format string that is printed in the 4:EgressedArtifact event.


### PR DESCRIPTION
###### Summary

If a process exits between when it was discovered and getting additional information about it, then it will fail the entire process discovery mechanism. Misbehaving processes or processes at the end of their lifetime can cause this issue. To mitigate this, catch exceptions when trying to create the `IProcessInfo` instance for each process, log it, and continue enumerating the remaining processes.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Handle exceptions when determining additional information about discovered processes.