### PR TITLE
[release/7.x] Handle exceptions when collecting additional info for discovered processes

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DefaultProcessUnexpectedFailure);
 
+        private static readonly Action<ILogger, int, Exception> _diagnosticRequestFailed =
+            LoggerMessage.Define<int>(
+                eventId: new EventId(10, "DiagnosticRequestFailed"),
+                logLevel: LogLevel.Debug,
+                formatString: Strings.LogFormatString_DiagnosticRequestFailed);
+
         public static void RequestFailed(this ILogger logger, Exception ex)
         {
             _requestFailed(logger, ex);
@@ -84,6 +90,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public static void DefaultProcessUnexpectedFailure(this ILogger logger, Exception ex)
         {
             _defaultProcessUnexpectedFailure(logger, ex);
+        }
+
+        public static void DiagnosticRequestFailed(this ILogger logger, int processId, Exception ex)
+        {
+            _diagnosticRequestFailed(logger, processId, ex);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -250,6 +250,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to get diagnostic response from runtime in process {processId}..
+        /// </summary>
+        internal static string LogFormatString_DiagnosticRequestFailed {
+            get {
+                return ResourceManager.GetString("LogFormatString_DiagnosticRequestFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Egressed artifact to {location}.
         /// </summary>
         internal static string LogFormatString_EgressedArtifact {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -205,6 +205,9 @@
     <comment>Gets the format string that is printed in the 7:DefaultProcessUnexpectedFailure event.
 0 Format Parameters</comment>
   </data>
+  <data name="LogFormatString_DiagnosticRequestFailed" xml:space="preserve">
+    <value>Failed to get diagnostic response from runtime in process {processId}.</value>
+  </data>
   <data name="LogFormatString_EgressedArtifact" xml:space="preserve">
     <value>Egressed artifact to {location}</value>
     <comment>Gets the format string that is printed in the 4:EgressedArtifact event.


### PR DESCRIPTION
Manual backport of #2806 to `release/7.x`