### PR TITLE
Pin Microsoft.Extensions.* dependabot updates to major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,22 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:
       interval: "daily"
     target-branch: "release/6.x"
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:
       interval: "daily"
     target-branch: "release/7.x"
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
###### Summary

Prevent the Microsoft.Extensions.* libraries from being updated outside of their current major version so that they stay in sync with the target framework version for dotnet-monitor. Major version changes to these libraries will require manual changes.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
