### PR TITLE
Run collection rule action tests serially

### DIFF
--- a/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public sealed class ActionListExecutorTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public sealed class CollectDumpActionTests
     {
         private const string DefaultRuleName = nameof(CollectDumpActionTests);

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public sealed class CollectGCDumpActionTests
     {
         private const string DefaultRuleName = "GCDumpTestRule";

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public class CollectLiveMetricsActionTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
@@ -32,6 +32,7 @@ using DisposableHelper = Microsoft.Diagnostics.Monitoring.TestCommon.DisposableH
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public class CollectLogsActionTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public sealed class CollectTraceActionTests
     {
         private const string DefaultRuleName = "TraceTestRule";

--- a/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public class EnvironmentVariableActionTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
@@ -19,6 +19,7 @@ using DisposableHelper = Microsoft.Diagnostics.Monitoring.TestCommon.DisposableH
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public sealed class ExecuteActionTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [Collection(TestCollections.CollectionRuleActions)]
     public sealed class LoadProfilerActionTests
     {
         private const string DefaultRuleName = "ProfilerTestRule";

--- a/src/Tests/CollectionRuleActions.UnitTests/TestCollections.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/TestCollections.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CollectionRuleActions.UnitTests
+{
+    internal static class TestCollections
+    {
+        // This test collection is used to force all of the collection rule action tests
+        // to be invoked serially in order to avoid thread pool exhaustion issues that
+        // impact the ability for the collection rule actions to start asynchronously in
+        // a reasonable amount of time.
+        public const string CollectionRuleActions = nameof(CollectionRuleActions);
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/PassThroughAction.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/PassThroughAction.cs
@@ -15,29 +15,36 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
     {
         public ICollectionRuleAction Create(IEndpointInfo endpointInfo, PassThroughOptions options)
         {
-            return new PassThroughAction(endpointInfo, options);
+            return new PassThroughAction(options);
         }
     }
 
-    internal sealed class PassThroughAction : CollectionRuleActionBase<PassThroughOptions>
+    internal sealed class PassThroughAction : ICollectionRuleAction
     {
-        public PassThroughAction(IEndpointInfo endpointInfo, PassThroughOptions settings)
-            : base(endpointInfo, settings)
+        private readonly PassThroughOptions _options;
+
+        public PassThroughAction(PassThroughOptions options)
         {
+            _options = options;
         }
 
-        protected override Task<CollectionRuleActionResult> ExecuteCoreAsync(
-            TaskCompletionSource<object> startCompletionSource,
-            CollectionRuleMetadata collectionRuleMetadata,
-            CancellationToken token)
+        public Task StartAsync(CollectionRuleMetadata collectionRuleMetadata, CancellationToken token)
         {
-            startCompletionSource.TrySetResult(null);
+            return StartAsync(token);
+        }
 
+        public Task StartAsync(CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<CollectionRuleActionResult> WaitForCompletionAsync(CancellationToken token)
+        {
             CollectionRuleActionResult result = new CollectionRuleActionResult() { OutputValues = new Dictionary<string, string>() };
 
-            result.OutputValues.Add("Output1", Options.Input1);
-            result.OutputValues.Add("Output2", Options.Input2);
-            result.OutputValues.Add("Output3", Options.Input3);
+            result.OutputValues.Add("Output1", _options.Input1);
+            result.OutputValues.Add("Output2", _options.Input2);
+            result.OutputValues.Add("Output3", _options.Input3);
 
             return Task.FromResult(result);
         }


### PR DESCRIPTION
###### Summary

This change runs the collection action tests serially so that they do not apply thread pool pressure to each other. The `PassThrough` action has also been rewritten to avoid using the `CollectionRuleActionBase` class, which is susceptible to delayed execution when the thread pool is starved.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
