### PR TITLE
Minor fixes to HttpResponseEgressOperation

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/HttpResponseEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/HttpResponseEgressOperation.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Http;
 using System;
+using System.Globalization;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     internal sealed class HttpResponseEgressOperation : IEgressOperation
     {
         private readonly HttpContext _httpContext;
-        private readonly TaskCompletionSource<int> _responseFinishedCompletionSource = new();
+        private readonly TaskCompletionSource<int> _responseFinishedCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public EgressProcessInfo ProcessInfo { get; private set; }
         public string EgressProviderName { get { return null; } }
@@ -44,7 +45,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             return statusCode >= (int)HttpStatusCode.OK && statusCode < (int)HttpStatusCode.Ambiguous
                 ? ExecutionResult<EgressResult>.Empty()
-                : ExecutionResult<EgressResult>.Failed(new Exception($"HTTP request failed with status code: ${statusCode}"));
+                : ExecutionResult<EgressResult>.Failed(
+                    new Exception(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.ErrorMessage_HttpOperationFailed,
+                        statusCode)));
         }
 
         public void Validate(IServiceProvider serviceProvider)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -88,6 +88,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTP request failed with status code: &apos;{0}&apos;.
+        /// </summary>
+        internal static string ErrorMessage_HttpOperationFailed {
+            get {
+                return ResourceManager.GetString("ErrorMessage_HttpOperationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid metric count..
         /// </summary>
         internal static string ErrorMessage_InvalidMetricCount {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -128,6 +128,9 @@
     <value>HTTP egress is not enabled.</value>
     <comment>Gets a string similar to "HTTP egress is not enabled.".</comment>
   </data>
+  <data name="ErrorMessage_HttpOperationFailed" xml:space="preserve">
+    <value>HTTP request failed with status code: '{0}'</value>
+  </data>
   <data name="ErrorMessage_InvalidMetricCount" xml:space="preserve">
     <value>Invalid metric count.</value>
     <comment>Gets a string similar to "Invalid metric count.".</comment>


### PR DESCRIPTION
###### Summary

While writing some tests I noticed a couple minor, non-breaking, issues with `HttpResponseEgressOperation`. The following fixes were made:
- Set `TaskCreationOptions.RunContinuationsAsynchronously`.
- Move the error message on http response failed to `Strings.resx`.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
