### PR TITLE
Provide one-liner backport commands when automation fails

### DIFF
--- a/eng/actions/backport/index.js
+++ b/eng/actions/backport/index.js
@@ -91,7 +91,7 @@ async function run() {
     await exec.exec(`curl -sSL "${patch_url}" --output changes.patch`);
 
     const git_am_command_without_patch = `git am --3way --ignore-whitespace --exclude="${excluded_path}" --keep-non-patch`;
-    const git_am_command = `${git_am_command_without_patch}" changes.patch`;
+    const git_am_command = `${git_am_command_without_patch} changes.patch`;
     let git_am_output = `$ ${git_am_command}\n\n`;
     let git_am_failed = false;
     try {
@@ -108,28 +108,28 @@ async function run() {
 
     if (git_am_failed) {
       const git_am_failed_body = `
-        @${github.context.payload.comment.user.login} backporting to ${target_branch} failed, the patch most likely resulted in conflicts.
+@${github.context.payload.comment.user.login} backporting to ${target_branch} failed, the patch most likely resulted in conflicts.
 
-        Please backport manually using one of the below commands, followed by \`git am --continue\` once the merge conflict has been resolved.
+Please backport manually using one of the below commands, followed by \`git am --continue\` once the merge conflict has been resolved.
         
-        Windows
-        \`\`\`ps1
-        (Invoke-WebRequest "${patch_url}").Content | ${git_am_command_without_patch}
-        \`\`\`
+PowerShell
+\`\`\`ps1
+(Invoke-WebRequest "${patch_url}").Content | ${git_am_command_without_patch}
+\`\`\`
 
-        Linux
-        \`\`\`shell
-        curl -sSL "${patch_url}" | ${git_am_command_without_patch}
-        \`\`\`
+Bash
+\`\`\`shell
+curl -sSL "${patch_url}" | ${git_am_command_without_patch}
+\`\`\`
 
 
-        ---
-        \`git am\` output:
+---
+\`git am\` error output:
 
-        \`\`\`shell
-        ${git_am_output}
-        \`\`\`
-        `;
+\`\`\`shell
+${git_am_output}
+\`\`\`
+`;
 
       await octokit.rest.issues.createComment({
         owner: repo_owner,


### PR DESCRIPTION
###### Summary

This PR updates the backporting automation to include instructions how to quickly start manually backporting a PR with one-liner commands when the automation fails.

Example: https://github.com/schmittjoseph/dotnet-monitor/pull/8#issuecomment-1310991460


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
