### PR TITLE
Fix race condition in HttpEgressStopTest

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     await drainResponseTask.WaitAsync(timeoutCancellation.Token);
                     await traceFileWriter.DisposeAsync();
 
-                    operationResult = await apiClient.GetOperationStatus(operationUri);
+                    operationResult = await apiClient.PollOperationToCompletion(operationUri);
                     Assert.Equal(HttpStatusCode.Created, operationResult.StatusCode);
                     Assert.Equal(OperationState.Succeeded, operationResult.OperationStatus.Status);
 


### PR DESCRIPTION
###### Summary

Fix a race condition in HttpEgressStopTest, where if a test host had limited resources the operation state wouldn't be updated in-time after the operation completed. Switch to a polling wait for the new state to propagate.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
