### PR TITLE
Make dependabot manage framework package versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,30 @@ updates:
       - dependency-name: "Microsoft.Extensions.*"
         update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net6.0"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net7.0"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/netcoreapp3.1"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:
       interval: "daily"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,9 @@
 <Project>
   <!-- Import references updated by Dependabot. This file is for package references updated manually or by Maestro. -->
   <Import Project="dependabot/Versions.props" />
+  <Import Project="dependabot/net6.0/Versions.props" />
+  <Import Project="dependabot/net7.0/Versions.props" />
+  <Import Project="dependabot/netcoreapp3.1/Versions.props" />
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>8.0.0</VersionPrefix>
@@ -65,14 +68,11 @@
     <MicrosoftFileFormatsVersion>1.0.357801</MicrosoftFileFormatsVersion>
   </PropertyGroup>
   <PropertyGroup Label="Runtime Versions">
-    <MicrosoftNETCoreApp31Version>3.1.30</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.17</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
-    <MicrosoftNETCoreApp60Version>6.0.10</MicrosoftNETCoreApp60Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
-    <MicrosoftNETCoreApp70Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp70Version>
-    <MicrosoftAspNetCoreApp70Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp70Version>
+    <MicrosoftAspNetCoreApp70Version>$(MicrosoftNETCoreApp70Version)</MicrosoftAspNetCoreApp70Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet6>6.0.10</MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet6>

--- a/eng/dependabot/net6.0/Directory.Build.props
+++ b/eng/dependabot/net6.0/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Dependendabot is configured to read package versions from Directory.Build.props, so just use this file as a shim. -->
+  <Import Project="Versions.props" />
+</Project>

--- a/eng/dependabot/net6.0/NuGet.config
+++ b/eng/dependabot/net6.0/NuGet.config
@@ -1,0 +1,1 @@
+../../../NuGet.config

--- a/eng/dependabot/net6.0/Packages.props
+++ b/eng/dependabot/net6.0/Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    Packages in this file have versions updated periodically by Dependabot specifically for .NET 6.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp60Version)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/net6.0/Versions.props
+++ b/eng/dependabot/net6.0/Versions.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Import references updated by Dependabot. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreApp60Version>6.0.10</MicrosoftNETCoreApp60Version>
+  </PropertyGroup>
+</Project>

--- a/eng/dependabot/net6.0/dependabot.csproj
+++ b/eng/dependabot/net6.0/dependabot.csproj
@@ -1,0 +1,2 @@
+<!-- This isn't a real project, but Dependabot requires a project. -->
+<Project/>

--- a/eng/dependabot/net7.0/Directory.Build.props
+++ b/eng/dependabot/net7.0/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Dependendabot is configured to read package versions from Directory.Build.props, so just use this file as a shim. -->
+  <Import Project="Versions.props" />
+</Project>

--- a/eng/dependabot/net7.0/NuGet.config
+++ b/eng/dependabot/net7.0/NuGet.config
@@ -1,0 +1,1 @@
+../../../NuGet.config

--- a/eng/dependabot/net7.0/Packages.props
+++ b/eng/dependabot/net7.0/Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    Packages in this file have versions updated periodically by Dependabot specifically for .NET 7.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp70Version)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/net7.0/Versions.props
+++ b/eng/dependabot/net7.0/Versions.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Import references updated by Dependabot. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreApp70Version>7.0.0</MicrosoftNETCoreApp70Version>
+  </PropertyGroup>
+</Project>

--- a/eng/dependabot/net7.0/dependabot.csproj
+++ b/eng/dependabot/net7.0/dependabot.csproj
@@ -1,0 +1,2 @@
+<!-- This isn't a real project, but Dependabot requires a project. -->
+<Project/>

--- a/eng/dependabot/netcoreapp3.1/Directory.Build.props
+++ b/eng/dependabot/netcoreapp3.1/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Dependendabot is configured to read package versions from Directory.Build.props, so just use this file as a shim. -->
+  <Import Project="Versions.props" />
+</Project>

--- a/eng/dependabot/netcoreapp3.1/NuGet.config
+++ b/eng/dependabot/netcoreapp3.1/NuGet.config
@@ -1,0 +1,1 @@
+../../../NuGet.config

--- a/eng/dependabot/netcoreapp3.1/Packages.props
+++ b/eng/dependabot/netcoreapp3.1/Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    Packages in this file have versions updated periodically by Dependabot specifically for .NET Core 3.1.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp31Version)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/netcoreapp3.1/Versions.props
+++ b/eng/dependabot/netcoreapp3.1/Versions.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Import references updated by Dependabot. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreApp31Version>3.1.30</MicrosoftNETCoreApp31Version>
+  </PropertyGroup>
+</Project>

--- a/eng/dependabot/netcoreapp3.1/dependabot.csproj
+++ b/eng/dependabot/netcoreapp3.1/dependabot.csproj
@@ -1,0 +1,2 @@
+<!-- This isn't a real project, but Dependabot requires a project. -->
+<Project/>


### PR DESCRIPTION
###### Summary

Make Depdenabot update the runtime framework versions per runtime version. This is done by creating a runtime specific subfolder for each runtime framework version and updating the dependabot registration to only update these folders within each major version instead of getting the latest.

This can be used in the future for updating runtime framework version packages, such as the ASP.NET authentication package versions.

I'm only applying this to the main branch for now to fix any issues that may arise over the course of the next patch updates for the runtimes.

Example PRs: [net6.0](https://github.com/jander-msft/dotnet-monitor/pull/34) and [netcoreapp3.1](https://github.com/jander-msft/dotnet-monitor/pull/35)

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
