### PR TITLE
Bump blame timeout to 15m

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-    <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=3m"</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=15m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <!-- Filter tests based on specified TestGroup -->


### PR DESCRIPTION
###### Summary

This PR updates the test blame timeout from 3m to 15m, which was missed in https://github.com/dotnet/dotnet-monitor/pull/2914.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
