### PR TITLE
[release/6.x] Make dependabot manage framework package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- Import references updated by Dependabot. This file is for package references updated manually or by Maestro. -->
   <Import Project="dependabot/Versions.props" />
+  <Import Project="dependabot/net6.0/Versions.props" />
+  <Import Project="dependabot/netcoreapp3.1/Versions.props" />
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>6.3.1</VersionPrefix>
@@ -53,11 +55,9 @@
     <MicrosoftFileFormatsVersion>1.0.250401</MicrosoftFileFormatsVersion>
   </PropertyGroup>
   <PropertyGroup Label="Runtime Versions">
-    <MicrosoftNETCoreApp31Version>3.1.30</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.17</MicrosoftNETCoreApp50Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
-    <MicrosoftNETCoreApp60Version>6.0.10</MicrosoftNETCoreApp60Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
   </PropertyGroup>
   <PropertyGroup Label="Manual">

--- a/eng/dependabot/net6.0/Directory.Build.props
+++ b/eng/dependabot/net6.0/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Dependendabot is configured to read package versions from Directory.Build.props, so just use this file as a shim. -->
+  <Import Project="Versions.props" />
+</Project>

--- a/eng/dependabot/net6.0/Packages.props
+++ b/eng/dependabot/net6.0/Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    Packages in this file have versions updated periodically by Dependabot specifically for .NET 6.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp60Version)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/net6.0/Versions.props
+++ b/eng/dependabot/net6.0/Versions.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Import references updated by Dependabot. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreApp60Version>6.0.10</MicrosoftNETCoreApp60Version>
+  </PropertyGroup>
+</Project>

--- a/eng/dependabot/net6.0/dependabot.csproj
+++ b/eng/dependabot/net6.0/dependabot.csproj
@@ -1,0 +1,2 @@
+<!-- This isn't a real project, but Dependabot requires a project. -->
+<Project/>

--- a/eng/dependabot/netcoreapp3.1/Directory.Build.props
+++ b/eng/dependabot/netcoreapp3.1/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Dependendabot is configured to read package versions from Directory.Build.props, so just use this file as a shim. -->
+  <Import Project="Versions.props" />
+</Project>

--- a/eng/dependabot/netcoreapp3.1/Packages.props
+++ b/eng/dependabot/netcoreapp3.1/Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    Packages in this file have versions updated periodically by Dependabot specifically for .NET Core 3.1.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp31Version)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/netcoreapp3.1/Versions.props
+++ b/eng/dependabot/netcoreapp3.1/Versions.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Import references updated by Dependabot. -->
+  <PropertyGroup>
+    <MicrosoftNETCoreApp31Version>3.1.30</MicrosoftNETCoreApp31Version>
+  </PropertyGroup>
+</Project>

--- a/eng/dependabot/netcoreapp3.1/dependabot.csproj
+++ b/eng/dependabot/netcoreapp3.1/dependabot.csproj
@@ -1,0 +1,2 @@
+<!-- This isn't a real project, but Dependabot requires a project. -->
+<Project/>


### PR DESCRIPTION
###### Summary

Manual backport of #2951 to `release/6.x`. Notable changes are the removal of the `net7.0` updates (since that doesn't exist in `release/6.x`) and the removal of the NuGet.config files to match the common dependabot versioning folder.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
