### PR TITLE
Enable dependabot framework version updates on release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,10 +46,82 @@ updates:
       - dependency-name: "Microsoft.Extensions.*"
         update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net6.0"
+    schedule:
+      interval: "daily"
+    target-branch: "release/6.x"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/netcoreapp3.1"
+    schedule:
+      interval: "daily"
+    target-branch: "release/6.x"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.0"
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net6.0"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.0"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net7.0"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.0"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/netcoreapp3.1"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.0"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:
       interval: "daily"
     target-branch: "release/7.x"
     ignore:
       - dependency-name: "Microsoft.Extensions.*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net6.0"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.x"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/net7.0"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.x"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot/netcoreapp3.1"
+    schedule:
+      interval: "daily"
+    target-branch: "release/7.x"
+    ignore:
+      - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
###### Summary

Enable dependabot framework version updates on release branches and enable dependabot on the `release/7.0` branch.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
