### PR TITLE
[release/6.x] Use servicing build pools

### DIFF
--- a/dotnet-monitor-codeql.yml
+++ b/dotnet-monitor-codeql.yml
@@ -24,7 +24,7 @@ stages:
         displayName: Windows (C++)
         timeoutInMinutes: 90
         pool:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals 1es-windows-2019
 
         steps:
@@ -56,7 +56,7 @@ stages:
         displayName: Windows (C#)
         timeoutInMinutes: 90
         pool:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals 1es-windows-2019
 
         steps:

--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -188,7 +188,7 @@ stages:
         - MacOS_x64_Release
         - MacOS_arm64_Release
         pool:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals 1es-windows-2019
         enablePublishUsingPipelines: true
         enableMicrobuild: true
@@ -220,7 +220,7 @@ stages:
         - Pack_Sign
         publishUsingPipelines: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals 1es-windows-2019
 # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/PrepareRelease.yml
+++ b/eng/PrepareRelease.yml
@@ -9,10 +9,10 @@ stages:
     displayName: Prepare release with Darc
     pool: 
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore-Public
+        name: NetCore-Svc-Public
         demands: ImageOverride -equals 1es-windows-2019-open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Internal
+        name: NetCore1ESPool-Svc-Internal
         demands: ImageOverride -equals 1es-windows-2019
     variables:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -41,12 +41,12 @@ jobs:
       # Public Linux Build Pool
       ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
+          name: NetCore-Svc-Public
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
       # Build OSX Pool
@@ -56,11 +56,11 @@ jobs:
       # Public Windows Build Pool
       ${{ if eq(parameters.osGroup, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
+          name: NetCore-Svc-Public
           demands: ImageOverride -equals windows.vs2019.amd64.open
 
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:


### PR DESCRIPTION
###### Summary

The `release/6.x` branch should be using the servicing pools since it is a release branch and it is no longer in active development.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
