### PR TITLE
Avoid restore and multi binlogs during test phase

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -66,7 +66,7 @@ if (-not $skipnative) {
 # Run the xunit tests
 if ($test) {
     if (-not $crossbuild) {
-        Invoke-Expression "& `"$engroot\common\build.ps1`" -test -configuration $configuration -verbosity $verbosity /p:BuildArch=$architecture /bl:$logdir\Test.binlog /p:TestGroup=$testgroup $remainingargs"
+        Invoke-Expression "& `"$engroot\common\build.ps1`" -test -configuration $configuration -verbosity $verbosity -nobl /p:BuildArch=$architecture /bl:$logdir\Test.binlog /p:TestGroup=$testgroup $remainingargs"
         if ($lastExitCode -ne 0) {
             exit $lastExitCode
         }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -228,6 +228,7 @@ if [[ "$__Test" == 1 ]]; then
       "$__RepoRootDir/eng/common/build.sh" \
         --test \
         --configuration "$__BuildType" \
+        -nobl \
         /bl:"$__LogsDir"/Test.binlog \
         /p:BuildArch="$__BuildArch" \
         /p:TestGroup="$__TestGroup" \

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -213,7 +213,7 @@ jobs:
 
     - ${{ if ne(parameters.testGroup, 'None') }}:
       - script: >-
-          $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
+          $(Build.SourcesDirectory)/eng/citest$(scriptExt)
           -configuration ${{ parameters.configuration }}
           -architecture ${{ parameters.architecture }}
           $(_TestArgs)

--- a/eng/citest.cmd
+++ b/eng/citest.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0build.ps1""" -ci %*"
+exit /b %ErrorLevel%

--- a/eng/citest.sh
+++ b/eng/citest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where 
+  # the symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+"$scriptroot/build.sh" -ci $@
+if [[ $? != 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
###### Summary

- Avoid using the default binlog output by disabling it during test phase; the test phase already specifies its own log file.
- Do not install runtimes and restore the projects since they've been installed and restored during the build phase. This is accomplished with the `citest.[cmd|sh]` scripts that do not specify the `-restore` and `-preparemachine` flags.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
