### PR TITLE
Consolidate waiting for process availability into ScenarioHelper

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -73,9 +73,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.AsyncWait.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     using ResponseStreamHolder holder = await client.CaptureDumpAsync(processId, type);
                     Assert.NotNull(holder);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
@@ -174,10 +174,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         {
             int processId = await runner.ProcessIdTask;
 
-            var _ = await client.GetProcessesWithRetryAsync(
-                _outputHelper,
-                new[] { processId });
-
             ResponseStreamHolder holder = await client.CaptureTraceAsync(processId, TraceDuration, WebApi.Models.TraceProfile.Http);
             Assert.NotNull(holder);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -7,8 +7,10 @@ using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -57,6 +59,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             await appRunner.ExecuteAsync(async () =>
             {
+                // Wait for the process to be discovered.
+                int processId = await appRunner.ProcessIdTask;
+                _ = await apiClient.GetProcessWithRetryAsync(outputHelper, pid: processId);
+
                 await appValidate(appRunner, apiClient);
             });
             Assert.Equal(0, appRunner.ExitCode);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -7,7 +7,6 @@ using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
-using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -9,7 +9,6 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
 using System.Net.Http;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -57,9 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.Stacks.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, WebApi.StackFormat.PlainText);
                     Assert.NotNull(holder);
@@ -115,9 +113,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.Stacks.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Json);
                     Assert.NotNull(holder);
@@ -156,9 +152,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.Stacks.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Speedscope);
                     Assert.NotNull(holder);
@@ -204,9 +198,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.Stacks.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     using ResponseStreamHolder holder1 = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Json);
                     Assert.NotNull(holder1);
@@ -256,9 +248,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.Stacks.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
                     Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
@@ -290,9 +280,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 TestAppScenarios.Stacks.Name,
                 appValidate: async (runner, client) =>
                 {
-                    // Wait for the process to be discovered.
                     int processId = await runner.ProcessIdTask;
-                    _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
                     ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
                     Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);


### PR DESCRIPTION
###### Summary

Instead of having each test determine when a process is available to get used via the dotnet-monitor HTTP API, consolidate this check for any test that is using `ScenarioHelper.SingleTarget`. I took a look at each one of the tests and it appears that none of them rely on being able to interact with the target process before it becomes available the process list.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
