### PR TITLE
Include release/7.0 in automated branch sync

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'dotnet/dotnet-monitor'
     strategy:
       matrix:
-        branch: ["release/6.x", "release/7.x"]
+        branch: ["release/6.x", "release/7.x", "release/7.0"]
     name: 'Sync ${{ matrix.branch }}'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
###### Summary

Include `release/7.0` in the automated branch syncing.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
