### PR TITLE
[release/7.x] Add support for speedscope format (#2795)

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -904,6 +904,11 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "application/speedscope+json": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -1658,11 +1658,13 @@
       "description": "",
       "x-enumNames": [
         "Json",
-        "PlainText"
+        "PlainText",
+        "Speedscope"
       ],
       "enum": [
         "Json",
-        "PlainText"
+        "PlainText",
+        "Speedscope"
       ]
     },
     "CollectTraceOptions": {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypeUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypeUtilities.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Net.Http.Headers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    internal static class ContentTypeUtilities
+    {
+        public static readonly MediaTypeHeaderValue ApplicationJsonHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationJson);
+        public static readonly MediaTypeHeaderValue NdJsonHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationNdJson);
+        public static readonly MediaTypeHeaderValue JsonSequenceHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationJsonSequence);
+        public static readonly MediaTypeHeaderValue TextPlainHeader = new MediaTypeHeaderValue(ContentTypes.TextPlain);
+        public static readonly MediaTypeHeaderValue SpeedscopeJsonHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationSpeedscopeJson);
+
+        public static StackFormat? ComputeStackFormat(IList<MediaTypeHeaderValue> acceptedHeaders)
+        {
+            // CONSIDER We currently don't factor quality into account.
+            // CONSIDER Centralize content negotiation across logs, stacks, and any other types that need it.
+
+            if (acceptedHeaders == null) return null;
+            if (acceptedHeaders.Contains(TextPlainHeader)) return StackFormat.PlainText;
+            if (acceptedHeaders.Contains(ApplicationJsonHeader)) return StackFormat.Json;
+            if (acceptedHeaders.Contains(SpeedscopeJsonHeader)) return StackFormat.Speedscope;
+            if (acceptedHeaders.Any(TextPlainHeader.IsSubsetOf)) return StackFormat.PlainText;
+            if (acceptedHeaders.Any(ApplicationJsonHeader.IsSubsetOf)) return StackFormat.Json;
+            if (acceptedHeaders.Any(SpeedscopeJsonHeader.IsSubsetOf)) return StackFormat.Speedscope;
+            return null;
+        }
+
+        public static bool IsPlainText(StackFormat format) => format == StackFormat.PlainText;
+
+        public static string MapFormatToContentType(StackFormat stackFormat) =>
+            stackFormat switch
+            {
+                StackFormat.PlainText => ContentTypes.TextPlain,
+                StackFormat.Json => ContentTypes.ApplicationJson,
+                StackFormat.Speedscope => ContentTypes.ApplicationSpeedscopeJson,
+                _ => throw new InvalidOperationException()
+            };
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypes.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public const string ApplicationNdJson = "application/x-ndjson";
         public const string ApplicationOctetStream = "application/octet-stream";
         public const string ApplicationProblemJson = "application/problem+json";
+        public const string ApplicationSpeedscopeJson = "application/speedscope+json";
         public const string TextPlain = "text/plain";
         public const string TextPlain_v0_0_4 = TextPlain + "; version=0.0.4";
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -37,9 +37,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
     public partial class DiagController : ControllerBase
     {
         private const Models.TraceProfile DefaultTraceProfiles = Models.TraceProfile.Cpu | Models.TraceProfile.Http | Models.TraceProfile.Metrics;
-        private static readonly MediaTypeHeaderValue NdJsonHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationNdJson);
-        private static readonly MediaTypeHeaderValue JsonSequenceHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationJsonSequence);
-        private static readonly MediaTypeHeaderValue TextPlainHeader = new MediaTypeHeaderValue(ContentTypes.TextPlain);
 
         private readonly ILogger<DiagController> _logger;
         private readonly IDiagnosticServices _diagnosticServices;
@@ -569,7 +566,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         }
 
         [HttpGet("stacks", Name = nameof(CaptureStacks))]
-        [ProducesWithProblemDetails(ContentTypes.ApplicationJson, ContentTypes.TextPlain)]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationJson, ContentTypes.TextPlain, ContentTypes.ApplicationSpeedscopeJson)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status202Accepted)]
@@ -593,13 +590,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 
             return await InvokeForProcess(async processInfo =>
             {
-                bool plainText = Request.GetTypedHeaders().Accept?.Contains(TextPlainHeader) ?? false;
+                //Stack format based on Content-Type
+
+                StackFormat stackFormat = ContentTypeUtilities.ComputeStackFormat(Request.GetTypedHeaders().Accept) ?? StackFormat.PlainText;
+                bool plainText = ContentTypeUtilities.IsPlainText(stackFormat);
 
                 return await Result(Utilities.ArtifactType_Stacks, egressProvider, async (stream, token) =>
                 {
-                    await StackUtilities.CollectStacksAsync(null, processInfo.EndpointInfo, _profilerChannel, plainText, stream, token);
+                    await StackUtilities.CollectStacksAsync(null, processInfo.EndpointInfo, _profilerChannel, stackFormat, stream, token);
 
-                }, StackUtilities.GenerateStacksFilename(processInfo.EndpointInfo, plainText), plainText ? ContentTypes.TextPlain : ContentTypes.ApplicationJson, processInfo, asAttachment: false);
+                }, StackUtilities.GenerateStacksFilename(processInfo.EndpointInfo, plainText), ContentTypeUtilities.MapFormatToContentType(stackFormat), processInfo, asAttachment: false);
 
             }, processKey, Utilities.ArtifactType_Stacks);
         }
@@ -662,32 +662,32 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 
         private static LogFormat? ComputeLogFormat(IList<MediaTypeHeaderValue> acceptedHeaders)
         {
-            if (acceptedHeaders == null)
+            if (acceptedHeaders == null || acceptedHeaders.Count == 0)
             {
                 return null;
             }
 
-            if (acceptedHeaders.Contains(TextPlainHeader))
+            if (acceptedHeaders.Contains(ContentTypeUtilities.TextPlainHeader))
             {
                 return LogFormat.PlainText;
             }
-            if (acceptedHeaders.Contains(NdJsonHeader))
+            if (acceptedHeaders.Contains(ContentTypeUtilities.NdJsonHeader))
             {
                 return LogFormat.NewlineDelimitedJson;
             }
-            if (acceptedHeaders.Contains(JsonSequenceHeader))
+            if (acceptedHeaders.Contains(ContentTypeUtilities.JsonSequenceHeader))
             {
                 return LogFormat.JsonSequence;
             }
-            if (acceptedHeaders.Any(TextPlainHeader.IsSubsetOf))
+            if (acceptedHeaders.Any(ContentTypeUtilities.TextPlainHeader.IsSubsetOf))
             {
                 return LogFormat.PlainText;
             }
-            if (acceptedHeaders.Any(NdJsonHeader.IsSubsetOf))
+            if (acceptedHeaders.Any(ContentTypeUtilities.NdJsonHeader.IsSubsetOf))
             {
                 return LogFormat.NewlineDelimitedJson;
             }
-            if (acceptedHeaders.Any(JsonSequenceHeader.IsSubsetOf))
+            if (acceptedHeaders.Any(ContentTypeUtilities.JsonSequenceHeader.IsSubsetOf))
             {
                 return LogFormat.JsonSequence;
             }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/SpeedScopeStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/SpeedScopeStackResults.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
+{
+    public class SpeedscopeResult
+    {
+        [JsonPropertyName("exporter")]
+        public string Exporter { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("activeProfileIndex")]
+        public int ActiveProfileIndex { get; set; }
+
+        [JsonPropertyName("$schema")]
+        public string Schema { get; set; } = "https://www.speedscope.app/file-format-schema.json";
+
+        [JsonPropertyName("profiles")]
+        public List<Profile> Profiles { get; set; }
+
+        [JsonPropertyName("shared")]
+        public SharedFrames Shared { get; set; }
+    }
+
+    public class SharedFrames
+    {
+        [JsonPropertyName("frames")]
+        public List<SharedFrame> Frames { get; set; }
+    }
+
+    public class SharedFrame
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("col")]
+        public int? Column { get; set; }
+
+        [JsonPropertyName("line")]
+        public int? Line { get; set; }
+
+        [JsonPropertyName("file")]
+        public string File { get; set; }
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ProfileType
+    {
+        evented,
+        sampled
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum UnitType
+    {
+        none,
+        nanoseconds,
+        microseconds,
+        milliseconds,
+        seconds,
+        bytes,
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ProfileEventType
+    {
+        O,
+        C
+    }
+
+    public class ProfileEvent
+    {
+        [JsonPropertyName("type")]
+        public ProfileEventType Type { get; set; }
+
+        [JsonPropertyName("frame")]
+        public int Frame { get; set; }
+
+        [JsonPropertyName("at")]
+        public double At { get; set; }
+    }
+
+    public class Profile
+    {
+        [JsonPropertyName("type")]
+        public ProfileType Type { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("unit")]
+        public UnitType Unit { get; set; }
+
+        [JsonPropertyName("startValue")]
+        public double StartValue { get; set; }
+
+        [JsonPropertyName("endValue")]
+        public double EndValue { get; set; }
+
+        [JsonPropertyName("events")]
+        public List<ProfileEvent> Events { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProfilerChannel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProfilerChannel.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public async Task<ProfilerMessage> SendMessage(IEndpointInfo endpointInfo, ProfilerMessage message, CancellationToken token)
         {
-#if NET6_0_OR_GREATER
             string channelPath = ComputeChannelPath(endpointInfo);
             var endpoint = new UnixDomainSocketEndPoint(channelPath);
             using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
@@ -71,9 +70,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 MessageType = (ProfilerMessageType)BitConverter.ToInt16(buffer, startIndex: 0),
                 Parameter = BitConverter.ToInt32(buffer, startIndex: 2)
             };
-#else
-            return await Task.FromException<ProfilerMessage>(new NotImplementedException());
-#endif
         }
 
         private string ComputeChannelPath(IEndpointInfo endpointInfo)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
+{
+    internal sealed class SpeedscopeStacksFormatter : StacksFormatter
+    {
+        private const double FixedStart = 0.0;
+        private const double FixedEnd = 1.0;
+        private static readonly string Exporter = FormattableString.Invariant($"dotnetmonitor@{Assembly.GetExecutingAssembly().GetInformationalVersionString()}");
+        private const string Name = "speedscope.json";
+        private static readonly ProfileEvent NativeProfileEvent = new ProfileEvent { At = FixedStart, Frame = 0, Type = ProfileEventType.O };
+        private static readonly ProfileEvent UnknownProfileEvent = new ProfileEvent { At = FixedStart, Frame = 1, Type = ProfileEventType.O };
+
+        public SpeedscopeStacksFormatter(Stream outputStream) : base(outputStream)
+        {
+        }
+
+        public override async Task FormatStack(CallStackResult stackResult, CancellationToken token)
+        {
+            // Speedscope contains a shared set of frames and each callstack references an index
+            // into the shared frame pool.
+            // We map each FunctionId to a corresponding index.
+            // Index 0 is reserved for Native frames
+            // Index 1 has no corresponding FunctionId and is reserved for Unknown.
+            var functionToSharedFrameMap = new Dictionary<ulong, int>()
+            {
+                {0, 0}
+            };
+
+            var speedscopeResult = new Models.SpeedscopeResult();
+
+            speedscopeResult.ActiveProfileIndex = 0;
+            speedscopeResult.Profiles = new List<Models.Profile>(stackResult.Stacks.Count);
+            speedscopeResult.Exporter = Exporter;
+            speedscopeResult.Name = Name;
+            speedscopeResult.Shared = new Models.SharedFrames
+            {
+                Frames = new List<Models.SharedFrame>()
+                {
+                    new Models.SharedFrame{ Name = NativeFrame },
+                    new Models.SharedFrame{ Name = UnknownClass }
+                }
+            };
+
+            NameCache cache = stackResult.NameCache;
+            var builder = new StringBuilder();
+
+            foreach (CallStack stack in stackResult.Stacks)
+            {
+                Models.Profile profile = new Profile()
+                {
+                    Events = new List<ProfileEvent>(),
+                    StartValue = FixedStart,
+                    EndValue = FixedEnd,
+                    Unit = UnitType.none,
+                    Name = string.Format(CultureInfo.CurrentCulture, Strings.CallstackThreadHeader, stack.ThreadId),
+                };
+
+                speedscopeResult.Profiles.Add(profile);
+
+                foreach (CallStackFrame frame in stack.Frames)
+                {
+                    if (frame.FunctionId == 0)
+                    {
+                        profile.Events.Add(NativeProfileEvent);
+
+                    }
+                    else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData functionData))
+                    {
+                        if (!functionToSharedFrameMap.TryGetValue(frame.FunctionId, out int mapping))
+                        {
+                            // Note this may imply some duplicate frames because we use FunctionId as a unique identifier for a frame,
+                            // but Speedscope uses the name.
+
+                            builder.Clear();
+                            builder.Append(GetModuleName(cache, functionData.ModuleId));
+                            builder.Append(ModuleSeparator);
+                            BuildClassName(builder, cache, functionData);
+                            builder.Append(ClassSeparator);
+                            builder.Append(functionData.Name);
+                            BuildGenericParameters(builder, cache, functionData.TypeArgs);
+
+                            speedscopeResult.Shared.Frames.Add(new SharedFrame { Name = builder.ToString() });
+                            mapping = speedscopeResult.Shared.Frames.Count - 1;
+                            functionToSharedFrameMap.Add(frame.FunctionId, mapping);
+                        }
+
+                        var profileEvent = new ProfileEvent
+                        {
+                            At = FixedStart,
+                            Frame = mapping,
+                            Type = ProfileEventType.O,
+                        };
+
+                        profile.Events.Add(profileEvent);
+
+                    }
+                    else
+                    {
+                        profile.Events.Add(UnknownProfileEvent);
+                    }
+                }
+
+                // Speedscope requires a close event for each open event.
+                for (int i = profile.Events.Count - 1; i >= 0; i--)
+                {
+                    profile.Events.Add(new ProfileEvent { At = FixedEnd, Frame = profile.Events[i].Frame, Type = ProfileEventType.C });
+                }
+            }
+
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+            };
+            await JsonSerializer.SerializeAsync(OutputStream, speedscopeResult, options, cancellationToken: token);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
         protected const char GenericSeparator = ',';
         protected const char GenericEnd = ']';
 
+        protected const char ModuleSeparator = '!';
+        protected const char ClassSeparator = '.';
+
         protected Stream OutputStream { get; }
 
         public StacksFormatter(Stream outputStream)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 {
     internal sealed class TextStacksFormatter : StacksFormatter
     {
-        private const char ModuleSeparator = '!';
-        private const char ClassSeparator = '.';
         private const string Indent = "  ";
 
         public TextStacksFormatter(Stream outputStream) : base(outputStream)
@@ -38,6 +36,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                 }
                 await writer.WriteLineAsync();
             }
+
+            await writer.FlushAsync();
         }
 
         private void BuildFrame(StringBuilder builder, NameCache cache, CallStackFrame frame)

--- a/src/MonitorProfiler/CMakeLists.txt
+++ b/src/MonitorProfiler/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
     Stacks/StacksEventProvider.cpp
     Stacks/StackSampler.cpp
     Utilities/NameCache.cpp
+    Utilities/ThreadUtilities.cpp
     Utilities/TypeNameUtilities.cpp
     ClassFactory.cpp
     DllMain.cpp

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -10,6 +10,7 @@
 #include "../Logging/StdErrLogger.h"
 #include "../Stacks/StacksEventProvider.h"
 #include "../Stacks/StackSampler.h"
+#include "../Utilities/ThreadUtilities.h"
 #include "corhlpr.h"
 #include "macros.h"
 #include <memory>
@@ -289,6 +290,11 @@ HRESULT MainProfiler::ProcessCallstackMessage()
     {
         IfFailLogRet(eventProvider->WriteCallstack(stackState->GetStack()));
     }
+
+    //HACK See https://github.com/dotnet/runtime/issues/76704
+    // We sleep here for 200ms to ensure that our event is timestamped. Since we are on a dedicated message
+    // thread we should not be interfering with the app itself.
+    ThreadUtilities::Sleep(200);
 
     IfFailLogRet(eventProvider->WriteEndEvent());
 

--- a/src/MonitorProfiler/Utilities/ThreadUtilities.cpp
+++ b/src/MonitorProfiler/Utilities/ThreadUtilities.cpp
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "ThreadUtilities.h"
+#if TARGET_UNIX
+#include <time.h>
+#include <errno.h>
+#else
+#include <Windows.h>
+#endif
+
+void ThreadUtilities::Sleep(unsigned int milliseconds)
+{
+#if TARGET_WINDOWS
+    ::Sleep(milliseconds);
+#else
+    // Mostly copied from Pal
+
+    timespec req;
+    timespec rem;
+    int result;
+
+    req.tv_sec = milliseconds / 1000;
+    req.tv_nsec = (milliseconds % 1000) * 1000000;
+
+    do
+    {
+        // Sleep for the requested time.
+        result = nanosleep(&req, &rem);
+
+        // Save the remaining time (used if the loop runs another iteration).
+        req = rem;
+    } while (result == -1 && errno == EINTR);
+
+#endif
+}

--- a/src/MonitorProfiler/Utilities/ThreadUtilities.h
+++ b/src/MonitorProfiler/Utilities/ThreadUtilities.h
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+class ThreadUtilities
+{
+    public:
+        static void Sleep(unsigned int milliseconds);
+};

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
@@ -5,6 +5,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Diagnostics.Monitoring.Options;
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -477,10 +478,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
             throw await CreateUnexpectedStatusCodeExceptionAsync(responseBox.Value).ConfigureAwait(false);
         }
 
-        public async Task<ResponseStreamHolder> CaptureStacksAsync(int processId, bool plainText, CancellationToken token)
+        public async Task<ResponseStreamHolder> CaptureStacksAsync(int processId, StackFormat format, CancellationToken token)
         {
             string uri = FormattableString.Invariant($"/stacks?pid={processId}");
-            var contentType = plainText ? ContentTypes.TextPlain : ContentTypes.ApplicationJson;
+            var contentType = ContentTypeUtilities.MapFormatToContentType(format);
             using HttpRequestMessage request = new(HttpMethod.Get, uri);
             request.Headers.Add(HeaderNames.Accept, contentType);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
@@ -319,18 +319,18 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         /// <summary>
         /// GET /stacks
         /// </summary>
-        public static Task<ResponseStreamHolder> CaptureStacksAsync(this ApiClient client, int pid, bool plainText)
+        public static Task<ResponseStreamHolder> CaptureStacksAsync(this ApiClient client, int pid, WebApi.StackFormat format)
         {
-            return client.CaptureStacksAsync(pid, plainText, TestTimeouts.HttpApi);
+            return client.CaptureStacksAsync(pid, format, TestTimeouts.HttpApi);
         }
 
         /// <summary>
         /// GET /stacks
         /// </summary>
-        public static async Task<ResponseStreamHolder> CaptureStacksAsync(this ApiClient client, int pid, bool plainText, TimeSpan timeout)
+        public static async Task<ResponseStreamHolder> CaptureStacksAsync(this ApiClient client, int pid, WebApi.StackFormat format, TimeSpan timeout)
         {
             using CancellationTokenSource timeoutSource = new(timeout);
-            return await client.CaptureStacksAsync(pid, plainText, timeoutSource.Token).ConfigureAwait(false);
+            return await client.CaptureStacksAsync(pid, format, timeoutSource.Token).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     int processId = await runner.ProcessIdTask;
                     _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
-                    using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, plainText: true);
+                    using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, WebApi.StackFormat.PlainText);
                     Assert.NotNull(holder);
 
                     using StreamReader reader = new StreamReader(holder.Stream);
@@ -119,12 +119,58 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     int processId = await runner.ProcessIdTask;
                     _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
-                    using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, plainText: false);
+                    using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Json);
                     Assert.NotNull(holder);
 
                     WebApi.Models.CallStackResult result = await JsonSerializer.DeserializeAsync<WebApi.Models.CallStackResult>(holder.Stream);
                     WebApi.Models.CallStackFrame[] expectedFrames = ExpectedFrames();
                     IList<WebApi.Models.CallStackFrame> actualFrames = GetActualFrames(result, expectedFrames.First(), expectedFrames.Length);
+
+                    Assert.Equal(expectedFrames.Length, actualFrames.Count);
+                    for (int i = 0; i < expectedFrames.Length; i++)
+                    {
+                        Assert.True(AreFramesEqual(expectedFrames[i], actualFrames[i]));
+                    }
+
+                    await runner.SendCommandAsync(TestAppScenarios.Stacks.Commands.Continue);
+                },
+                configureApp: runner =>
+                {
+                    runner.Architecture = targetArchitecture;
+                },
+                configureTool: runner =>
+                {
+                    runner.ConfigurationFromEnvironment.EnableInProcessFeatures();
+                    runner.EnableCallStacksFeature = true;
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
+        public Task TestSpeedscopeStacks(Architecture targetArchitecture)
+        {
+            return ScenarioRunner.SingleTarget(
+                _outputHelper,
+                _httpClientFactory,
+                WebApi.DiagnosticPortConnectionMode.Listen,
+                TestAppScenarios.Stacks.Name,
+                appValidate: async (runner, client) =>
+                {
+                    int processId = await runner.ProcessIdTask;
+
+                    using ResponseStreamHolder holder = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Speedscope);
+                    Assert.NotNull(holder);
+
+                    WebApi.Models.SpeedscopeResult result = await JsonSerializer.DeserializeAsync<WebApi.Models.SpeedscopeResult>(holder.Stream);
+
+                    int bottomIndex = result.Shared.Frames.FindIndex(f => f.Name == FormatFrame(ExpectedModule, ExpectedClass, ExpectedFunction));
+                    Assert.NotEqual(-1, bottomIndex);
+                    string topFrameName = FormatFrame(ExpectedModule, ExpectedClass, ExpectedCallbackFunction);
+                    int topIndex = result.Shared.Frames.FindIndex(f => f.Name == topFrameName);
+                    Assert.NotEqual(-1, topIndex);
+
+                    var expectedFrames = ExpectedSpeedscopeFrames(topIndex, bottomIndex);
+                    var actualFrames = GetActualFrames(result, topFrameName, 3);
 
                     Assert.Equal(expectedFrames.Length, actualFrames.Count);
                     for (int i = 0; i < expectedFrames.Length; i++)
@@ -160,7 +206,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     int processId = await runner.ProcessIdTask;
                     _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
-                    using ResponseStreamHolder holder1 = await client.CaptureStacksAsync(processId, plainText: false);
+                    using ResponseStreamHolder holder1 = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Json);
                     Assert.NotNull(holder1);
 
                     WebApi.Models.CallStackResult result1 = await JsonSerializer.DeserializeAsync<WebApi.Models.CallStackResult>(holder1.Stream);
@@ -169,7 +215,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     // and may not be fast enough for this test on systems with limited resources.
                     _ = await client.PollOperationToCompletion(holder1.Response.Headers.Location);
 
-                    using ResponseStreamHolder holder2 = await client.CaptureStacksAsync(processId, plainText: false);
+                    using ResponseStreamHolder holder2 = await client.CaptureStacksAsync(processId, WebApi.StackFormat.Json);
                     Assert.NotNull(holder2);
 
                     WebApi.Models.CallStackResult result2 = await JsonSerializer.DeserializeAsync<WebApi.Models.CallStackResult>(holder2.Stream);
@@ -212,7 +258,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     int processId = await runner.ProcessIdTask;
                     _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
-                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, plainText: false));
+                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
                     Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
 
                     await runner.SendCommandAsync(TestAppScenarios.Stacks.Commands.Continue);
@@ -246,7 +292,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     int processId = await runner.ProcessIdTask;
                     _ = await client.GetProcessWithRetryAsync(_outputHelper, pid: processId);
 
-                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, plainText: false));
+                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
                     Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
 
                     await runner.SendCommandAsync(TestAppScenarios.Stacks.Commands.Continue);
@@ -324,6 +370,40 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         private static bool AreFramesEqual(WebApi.Models.CallStackFrame left, WebApi.Models.CallStackFrame right) =>
             (left.ModuleName == right.ModuleName) && (left.ClassName == right.ClassName) && (left.MethodName == right.MethodName);
 
+        private static bool AreFramesEqual(WebApi.Models.ProfileEvent left, WebApi.Models.ProfileEvent right) =>
+            (left.Frame == right.Frame) && (left.At == right.At) && (left.Type == right.Type);
+
+        private static IList<WebApi.Models.ProfileEvent> GetActualFrames(WebApi.Models.SpeedscopeResult result, string expectedFirstFrame, int expectedFrameCount)
+        {
+            int matchingFrameIndex = -1;
+            var actualFrames = new List<WebApi.Models.ProfileEvent>();
+            for (int i = 0; i < result.Shared.Frames.Count; i++)
+            {
+                WebApi.Models.SharedFrame frame = result.Shared.Frames[i];
+                if (frame.Name == expectedFirstFrame)
+                {
+                    matchingFrameIndex = i;
+                }
+            }
+
+            foreach (WebApi.Models.Profile callstack in result.Profiles)
+            {
+                actualFrames.Clear();
+                foreach (WebApi.Models.ProfileEvent frame in callstack.Events)
+                {
+                    if ((frame.Frame == matchingFrameIndex) || actualFrames.Count > 0)
+                    {
+                        actualFrames.Add(frame);
+                        if (actualFrames.Count == expectedFrameCount)
+                        {
+                            return actualFrames;
+                        }
+                    }
+                }
+            }
+            return actualFrames;
+        }
+
         private static IList<WebApi.Models.CallStackFrame> GetActualFrames(WebApi.Models.CallStackResult result, WebApi.Models.CallStackFrame expectedFirstFrame, int expectedFrameCount)
         {
             var actualFrames = new List<WebApi.Models.CallStackFrame>();
@@ -344,6 +424,29 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             }
             return actualFrames;
         }
+
+        private static WebApi.Models.ProfileEvent[] ExpectedSpeedscopeFrames(int topFrameIndex, int bottomFrameIndex) => new WebApi.Models.ProfileEvent[]
+        {
+            new WebApi.Models.ProfileEvent
+            {
+                Frame = topFrameIndex,
+                At = 0.0,
+                Type = WebApi.Models.ProfileEventType.O
+            },
+            new WebApi.Models.ProfileEvent
+            {
+                Frame = 0,
+                At = 0.0,
+                Type = WebApi.Models.ProfileEventType.O
+            },
+            new WebApi.Models.ProfileEvent
+            {
+                Frame = bottomFrameIndex,
+                At = 0.0,
+                Type = WebApi.Models.ProfileEventType.O
+            },
+
+        };
 
         private static WebApi.Models.CallStackFrame[] ExpectedFrames() => new WebApi.Models.CallStackFrame[]
             {

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectStacksAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectStacksAction.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             EgressOperation egressOperation = new EgressOperation(
                 async (outputStream, token) =>
                 {
-                    await StackUtilities.CollectStacksAsync(startCompletionSource, EndpointInfo, _profilerChannel, isPlainText, outputStream, token);
+                    await StackUtilities.CollectStacksAsync(startCompletionSource, EndpointInfo, _profilerChannel, MapCallstackFormat(Options.GetFormat()), outputStream, token);
                 },
                 Options.Egress,
                 fileName,
@@ -82,5 +82,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 }
             };
         }
+
+        private static StackFormat MapCallstackFormat(CallStackFormat format) =>
+            format switch
+            {
+                CallStackFormat.Json => StackFormat.Json,
+                CallStackFormat.PlainText => StackFormat.PlainText,
+                CallStackFormat.Speedscope => StackFormat.Speedscope,
+                _ => throw new InvalidOperationException()
+            };
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     internal enum CallStackFormat
     {
         Json,
-        PlainText
+        PlainText,
+        Speedscope
     }
 
     [DebuggerDisplay("CollectStacks")]


### PR DESCRIPTION
* Add support for speedscope format

* Add comments and actually cache frames

* PR feedback

* Fix sleep for unix

* Update openapi schema

* PR feedback + unit test start

* Finish speedscope unit test

* Update src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs

Co-authored-by: Joe Schmitt <joschmit@microsoft.com>

Co-authored-by: Joe Schmitt <joschmit@microsoft.com>

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
