### PR TITLE
Fix handling of empty changelog entries in PRs

### DIFF
--- a/.github/actions/generate-release-notes/index.js
+++ b/.github/actions/generate-release-notes/index.js
@@ -106,8 +106,8 @@ async function generateChangelog(octokit, branchName, additionalBranch, repoOwne
         }
 
         const changelogRegex=/^###### Release Notes Entry\r?\n(?<releaseNotesEntry>.*)/m
-        const userDefinedChangelogEntry = pr.body?.match(changelogRegex)?.groups?.releaseNotesEntry;
-        if (userDefinedChangelogEntry !== undefined) {
+        const userDefinedChangelogEntry = pr.body?.match(changelogRegex)?.groups?.releaseNotesEntry?.trim();
+        if (userDefinedChangelogEntry !== undefined && userDefinedChangelogEntry.length !== 0) {
             entry += ` ${userDefinedChangelogEntry}`
         } else {
             entry += ` ${pr.title}`


### PR DESCRIPTION
###### Summary

PRs that had the `update-release-notes` label but a whitespace-only release notes entry would should up in the changelog as an empty entry.  This PR fixes that.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
