### PR TITLE
Update Kubernetes sample and docs

### DIFF
--- a/documentation/kubernetes.md
+++ b/documentation/kubernetes.md
@@ -9,7 +9,10 @@ For Dockerfiles and repository information, see [Running in Docker](./docker.md)
 
 ## Example Deployment
 
-The following example demonstrates a deployment of the dotnet-monitor container image monitoring two application containers within the same pod.
+The following examples demonstrate a deployment of the dotnet-monitor container image monitoring an application container within the same pod.
+
+<details>
+  <summary>.NET Monitor 6</summary>
 
 ```yaml
 # Tell us about your experience using dotnet monitor: https://aka.ms/dotnet-monitor-survey
@@ -29,29 +32,14 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - name: app1
+      - name: app
         image: mcr.microsoft.com/dotnet/samples:aspnetapp
         imagePullPolicy: Always
         env:
         - name: ASPNETCORE_URLS
           value: http://+:80
         - name: DOTNET_DiagnosticPorts
-          value: /diag/port.sock
-        volumeMounts:
-        - mountPath: /diag
-          name: diagvol
-        resources:
-          limits:
-            cpu: 250m
-            memory: 512Mi
-      - name: app2
-        image: mcr.microsoft.com/dotnet/samples:aspnetapp
-        imagePullPolicy: Always
-        env:
-        - name: ASPNETCORE_URLS
-          value: http://+:81
-        - name: DOTNET_DiagnosticPorts
-          value: /diag/port.sock
+          value: /diag/dotnet-monitor.sock
         volumeMounts:
         - mountPath: /diag
           name: diagvol
@@ -60,7 +48,7 @@ spec:
             cpu: 250m
             memory: 512Mi
       - name: monitor
-        image: mcr.microsoft.com/dotnet/monitor
+        image: mcr.microsoft.com/dotnet/monitor:6
         # DO NOT use the --no-auth argument for deployments in production; this argument is used for demonstration
         # purposes only in this example. Please continue reading after this example for further details.
         args: [ "--no-auth" ]
@@ -69,7 +57,7 @@ spec:
         - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
           value: Listen
         - name: DOTNETMONITOR_DiagnosticPort__EndpointName
-          value: /diag/port.sock
+          value: /diag/dotnet-monitor.sock
         - name: DOTNETMONITOR_Storage__DumpTempFolder
           value: /diag/dumps
         # ALWAYS use the HTTPS form of the URL for deployments in production; the removal of HTTPS is done for
@@ -91,13 +79,90 @@ spec:
         emptyDir: {}
 ```
 
+</details>
+
+<details>
+  <summary>.NET Monitor 7+</summary>
+
+```yaml
+# Tell us about your experience using dotnet monitor: https://aka.ms/dotnet-monitor-survey
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-exampleapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: exampleapp
+  template:
+    metadata:
+      labels:
+        app: exampleapp
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: app
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
+        imagePullPolicy: Always
+        env:
+        - name: ASPNETCORE_URLS
+          value: http://+:80
+        - name: DOTNET_DiagnosticPorts
+          value: /diag/dotnet-monitor.sock
+        volumeMounts:
+        - mountPath: /diag
+          name: diagvol
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+      - name: monitor
+        image: mcr.microsoft.com/dotnet/monitor
+        # DO NOT use the --no-auth argument for deployments in production; this argument is used for demonstration
+        # purposes only in this example. Please continue reading after this example for further details.
+        args: [ "collect", "--no-auth" ]
+        imagePullPolicy: Always
+        env:
+        - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
+          value: Listen
+        - name: DOTNETMONITOR_Storage__DefaultSharedPath
+          value: /diag
+        # ALWAYS use the HTTPS form of the URL for deployments in production; the removal of HTTPS is done for
+        # demonstration purposes only in this example. Please continue reading after this example for further details.
+        - name: DOTNETMONITOR_Urls
+          value: http://localhost:52323
+        # The metrics URL is set in the CMD instruction of the image by default. However, this deployment overrides that with the args setting; manually set the URL to the same value using configuration.
+        - name: DOTNETMONITOR_Metrics__Endpoints
+          value: http://+:52325
+        volumeMounts:
+        - mountPath: /diag
+          name: diagvol
+        resources:
+          requests:
+            cpu: 50m
+            memory: 32Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+      volumes:
+      - name: diagvol
+        emptyDir: {}
+```
+
+</details>
+
 ## Example Details
 
 * __Listen Mode__: The `dotnet monitor` tool is configured to run in `listen` mode. The tool establishes a diagnostic communication channel at the specified Unix Domain Socket path by the `DOTNETMONITOR_DiagnosticPort__EndpointName` environment variable. The application container has a `DOTNET_DiagnosticPorts` environment variable specified so that the application's runtime will communicate with the `dotnet monitor` instance at the specified Unix Domain Socket path. The application runtime will be suspended (e.g. no managed code execution) until it establishes communication with `dotnet monitor`. Application startup time will depend on how long it takes for the `dotnet monitor` container to run, but this should be quick.
+> **7.0+**: Setting `DOTNETMONITOR_DiagnosticPort__EndpointName` is not necessary if (1) `DOTNETMONITOR_Storage__DefaultSharedPath` is set and (2) `DOTNETMONITOR_DiagnosticPort__ConnectionMode` is set to `Listen`; the combination of these settings automatically creates a Unix Domain Socket named `dotnet-monitor.sock` under the default shared path.  The `DOTNETMONITOR_DiagnosticPort__EndpointName` setting is still available to use if the default behavior needs to be overridden.
 * __Multiple Application Containers__: The `dotnet monitor` tool is capable of monitoring multiple processes at the same time. When running in `listen` mode, each of the applications can connect to the same communication channel path in order to allow `dotnet monitor` to observe them.
 * __Dumps Temporary Folder__: The `dotnet monitor` tool is configured to instruct the application runtime to produce dump files at the path specified by the `DOTNETMONITOR_Storage__DumpTempFolder` environment variable. Without specifying this variable, the application runtime will create dump files in the `/tmp` directory of its container, which is not accessible by the `dotnet monitor` container in this example.
+> **7.0+**: Setting `DOTNETMONITOR_Storage__DumpTempFolder` is not necessary if `DOTNETMONITOR_Storage__DefaultSharedPath` is set; dumps will be produced in a subfolder under the specified shared path. The `DOTNETMONITOR_Storage__DumpTempFolder` setting is still available to use if the default behavior needs to be overridden.
 * __Disabled Authentication__: By default, the `dotnet monitor` tool requires authentication for any of the URLs specified by the `--urls` command line parameter or configured via the `ASPNETCORE_Urls`/`DOTNETMONITOR_Urls` environment variables (see [Authentication](./authentication.md) for further details). For the purposes of this example, authentication has been disabled by using the `--no-auth` command line switch. __Use of this command line switch is NOT recommended for production scenarios__ as it would allow anything with access to the URLs to be able to capture dumps, traces, etc (which may contain sensitive information, such as keys) of any process that `dotnet monitor` is able to monitor.
 * __Disabled HTTPS__: By default, the `dotnet monitor` tool has HTTPS enabled on the default artifact URLs, which are configured to be `https://+:52323` in the Docker image. For the purposes of this example, the artifact URLs have been changed to `http://localhost:52323` using the `DOTNETMONITOR_Urls` environment variable such that a TLS certificate is not required. __Disabling HTTPS is NOT recommended for production scenarios.__
+* __Command Line Arguments (7.0+)__: Starting in 7.0, the default command line arguments for the `dotnet monitor` tool have been moved to the CMD instruction of the Docker image (previously, they were part of the ENTRYPOINT instruction). If the arguments of the image are overridden, then the default arguments must be explicitly specified in the overridden setting or set via configuration. See [7.0 Compatibility](compatibility/7.0/README.md#docker-container-entrypoint-split) for details.
+* __Default Shared Path (7.0+)__: Setting the default shared path instructs the `dotnet monitor` tool to automatically share all artifacts (dumps, diagnostic ports, shared libraries, etc) with the target applications in the specified path. This setting simplifies configuration so that a setting for each feature that contains sharable information does not need to necessarily be specified.
 
 ## Recommended container limits
 


### PR DESCRIPTION
###### Summary

The changes include:
- Splitting the sample for v6 vs v7 because (1) overriding the command line with just `--no-auth` is not sufficient, (2) there are better settings to use in v7.
- Removal of the second app from the samples so that the `/metrics` route works.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
