### PR TITLE
Skip flaky test CancelOperation_Supports_StoppingState

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Operation/EgressOperationStoreTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Operation/EgressOperationStoreTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.Operation
             Assert.Equal(Models.OperationState.Stopping, store.GetOperationStatus(operationId).Status);
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky")]
         public async Task CancelOperation_Supports_StoppingState()
         {
             // Arrange


### PR DESCRIPTION
###### Summary

`CancelOperation_Supports_StoppingState` appears to be flaky, skip it for now.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
