### PR TITLE
Add net8.0 TFM to product and tests

### DIFF
--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -2,7 +2,8 @@ name: 'C# linting'
 on:
   pull_request:
     paths: ['src/**.cs']
-    branches: ['main', 'release/6.x', 'release/7.*']
+    # Disable on 'main' as dotnet-format does not work for .NET 8
+    branches: ['release/6.x', 'release/7.*']
 
 permissions:
   pull-requests: read

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,13 +23,13 @@
   <PropertyGroup Label="TargetFrameworks">
     <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
     <ExcludeLatestTargetFramework>false</ExcludeLatestTargetFramework>
-    <!-- <ExcludeLatestTargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework> -->
+    <ExcludeLatestTargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework>
     <!-- The TFMs of the dotnet-monitor tool.  -->
     <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
-    <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);net7.0</ToolTargetFrameworks>
+    <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);net8.0</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
-    <TestTargetFrameworks>net6.0</TestTargetFrameworks>
-    <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);net7.0</TestTargetFrameworks>
+    <TestTargetFrameworks>net6.0;net7.0</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);net8.0</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
     <SchemaTargetFramework>net6.0</SchemaTargetFramework>
     <!-- Defines for including the next .NET version -->
@@ -76,6 +76,8 @@
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftNETCoreApp70Version)</MicrosoftAspNetCoreApp70Version>
+    <MicrosoftNETCoreApp80Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp80Version>
+    <MicrosoftAspNetCoreApp80Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp80Version>
   </PropertyGroup>
   <PropertyGroup Label="Dev Workflow">
     <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow
@@ -88,8 +90,8 @@
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
   </PropertyGroup>
-  <PropertyGroup Label=".NET 7 Dependent" Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp70Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp70Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+  <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -95,7 +95,15 @@
         <Version>$(MicrosoftAspNetCoreApp70Version)</Version>
       </_TestRuntimeFramework>
     </ItemGroup>
-        <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+      <_TestRuntimeFramework Include="@(RuntimeFramework)" Condition=" '%(Identity)' == 'Microsoft.NETCore.App' ">
+        <Version>$(MicrosoftNETCoreApp80Version)</Version>
+      </_TestRuntimeFramework>
+      <_TestRuntimeFramework Include="@(RuntimeFramework)" Condition=" '%(Identity)' == 'Microsoft.AspNetCore.App' ">
+        <Version>$(MicrosoftAspNetCoreApp80Version)</Version>
+      </_TestRuntimeFramework>
+    </ItemGroup>
+    <ItemGroup>
       <_TestRuntimeFramework Include="@(RuntimeFramework)" Condition=" '%(Identity)' != 'Microsoft.NETCore.App' and '%(Identity)' != 'Microsoft.AspNetCore.App' " />
     </ItemGroup>
     <GenerateRuntimeConfigurationFiles AssetsFilePath="$(ProjectAssetsFile)"

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -80,6 +80,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 return TargetFrameworkMoniker.Net60;
 #elif NET7_0
                 return TargetFrameworkMoniker.Net70;
+#elif NET8_0
+                return TargetFrameworkMoniker.Net70;
 #endif
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 #elif NET7_0
                 return TargetFrameworkMoniker.Net70;
 #elif NET8_0
-                return TargetFrameworkMoniker.Net70;
+                return TargetFrameworkMoniker.Net80;
 #endif
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -15,10 +15,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly string NetCore50VersionString = "$MicrosoftNetCoreApp50Version$";
         public static readonly string NetCore60VersionString = "$MicrosoftNetCoreApp60Version$";
         public static readonly string NetCore70VersionString = "$MicrosoftNetCoreApp70Version$";
+        public static readonly string NetCore80VersionString = "$MicrosoftNetCoreApp80Version$";
 
         public static readonly string AspNetCore31VersionString = "$MicrosoftAspNetCoreApp31Version$";
         public static readonly string AspNetCore50VersionString = "$MicrosoftAspNetCoreApp50Version$";
         public static readonly string AspNetCore60VersionString = "$MicrosoftAspNetCoreApp60Version$";
         public static readonly string AspNetCore70VersionString = "$MicrosoftAspNetCoreApp70Version$";
+        public static readonly string AspNetCore80VersionString = "$MicrosoftAspNetCoreApp80Version$";
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -12,10 +12,12 @@
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftNETCoreApp50Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net7.0'">$(MicrosoftNETCoreApp70Version)</NetCoreAppVersion>
+    <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net8.0'">$(MicrosoftNETCoreApp80Version)</NetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftAspNetCoreApp31Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftAspNetCoreApp50Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftAspNetCoreApp60Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net7.0'">$(MicrosoftAspNetCoreApp70Version)</AspNetCoreAppVersion>
+    <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net8.0'">$(MicrosoftAspNetCoreApp80Version)</AspNetCoreAppVersion>
   </PropertyGroup>
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
@@ -27,10 +29,12 @@
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp50Version$', '$(MicrosoftNETCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp60Version$', '$(MicrosoftNETCoreApp60Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp70Version$', '$(MicrosoftNETCoreApp70Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp80Version$', '$(MicrosoftNETCoreApp80Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp31Version$', '$(MicrosoftAspNetCoreApp31Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp50Version$', '$(MicrosoftAspNetCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp60Version$', '$(MicrosoftAspNetCoreApp60Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp70Version$', '$(MicrosoftAspNetCoreApp70Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp80Version$', '$(MicrosoftAspNetCoreApp80Version)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         NetCoreApp31,
         Net50,
         Net60,
-        Net70
+        Net70,
+        Net80
     }
 
     public static class TargetFrameworkMonikerExtensions
@@ -37,6 +38,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return DotNetHost.AspNetCore60VersionString;
                 case TargetFrameworkMoniker.Net70:
                     return DotNetHost.AspNetCore70VersionString;
+                case TargetFrameworkMoniker.Net80:
+                    return DotNetHost.AspNetCore80VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -55,6 +58,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return DotNetHost.NetCore60VersionString;
                 case TargetFrameworkMoniker.Net70:
                     return DotNetHost.NetCore70VersionString;
+                case TargetFrameworkMoniker.Net80:
+                    return DotNetHost.NetCore80VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -83,6 +88,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return "net6.0";
                 case TargetFrameworkMoniker.Net70:
                     return "net7.0";
+                case TargetFrameworkMoniker.Net80:
+                    return "net8.0";
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -104,7 +111,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         }
 
         public const TargetFrameworkMoniker CurrentTargetFrameworkMoniker =
-#if NET7_0
+#if NET8_0
+            TargetFrameworkMoniker.Net80;
+#elif NET7_0
             TargetFrameworkMoniker.Net70;
 #elif NET6_0
             TargetFrameworkMoniker.Net60;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
 
 #if NET7_0_OR_GREATER
-                    Version currentAspNetVersion = TargetFrameworkMoniker.Current.GetAspNetCoreFrameworkVersion();
+                    Version currentAspNetVersion = TargetFrameworkMoniker.Net80.GetAspNetCoreFrameworkVersion();
 #else
                     Version currentAspNetVersion = TargetFrameworkMoniker.Net60.GetAspNetCoreFrameworkVersion();
 #endif

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
 #if NET7_0_OR_GREATER
-                TargetFrameworkMoniker.Net70
+                TargetFrameworkMoniker.Net80
 #else
                 TargetFrameworkMoniker.Net60
 #endif
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
                 Assembly.GetExecutingAssembly(),
                 TestStartupHookAssemblyName,
 #if NET7_0_OR_GREATER
-                TargetFrameworkMoniker.Net70
+                TargetFrameworkMoniker.Net80
 #else
                 TargetFrameworkMoniker.Net60
 #endif

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
@@ -25,15 +25,17 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static TargetFrameworkMoniker[] tfmsToTest = new TargetFrameworkMoniker[]
         {
             TargetFrameworkMoniker.Net60,
+            TargetFrameworkMoniker.Net70,
 #if INCLUDE_NEXT_DOTNET
-            TargetFrameworkMoniker.Net70
+            TargetFrameworkMoniker.Net80
 #endif
         };
         public static TargetFrameworkMoniker[] tfms6PlusToTest = new TargetFrameworkMoniker[]
         {
             TargetFrameworkMoniker.Net60,
+            TargetFrameworkMoniker.Net70,
 #if INCLUDE_NEXT_DOTNET
-            TargetFrameworkMoniker.Net70
+            TargetFrameworkMoniker.Net80
 #endif
         };
 
@@ -72,7 +74,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 // Capturing non-full dumps via diagnostic command works inconsistently
                 // on Alpine for .NET 5 and lower (the dump command will return successfully, but)
                 // the dump file will not exist). Only test other dump types on .NET 6+
-                if (!DistroInformation.IsAlpineLinux || tfm == TargetFrameworkMoniker.Net60)
+                if (!DistroInformation.IsAlpineLinux
+                    || tfm == TargetFrameworkMoniker.Net60
+                    || tfm == TargetFrameworkMoniker.Net70
+                    || tfm == TargetFrameworkMoniker.Net80)
                 {
                     yield return new object[] { tfm, DumpType.WithHeap };
                     yield return new object[] { tfm, DumpType.Triage };

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -375,8 +375,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public static IEnumerable<object[]> GetTfmsSupportingPortListener()
         {
             yield return new object[] { TargetFrameworkMoniker.Net60 };
-#if INCLUDE_NEXT_DOTNET
             yield return new object[] { TargetFrameworkMoniker.Net70 };
+#if INCLUDE_NEXT_DOTNET
+            yield return new object[] { TargetFrameworkMoniker.Net80 };
 #endif
         }
     }


### PR DESCRIPTION
###### Summary

- Update dotnet-monitor to build net6.0 and net8.0 TFMs
- Add net8.0 TFM to tests
- Prevent building of net8.0 assets in Visual Studio

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
