### PR TITLE
Fix c# linting on main

### DIFF
--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     paths: ['src/**.cs']
     # Disable on 'main' as dotnet-format does not work for .NET 8
-    branches: ['release/6.x', 'release/7.*']
+    branches: ['main', 'release/6.x', 'release/7.*']
 
 permissions:
   pull-requests: read
@@ -30,21 +30,14 @@ jobs:
           echo "Files to validate: '${changed_source_files}'"
           echo "updated_files=$(echo ${changed_source_files})" >> $GITHUB_ENV
 
-      - name: Get dotnet version
-        run: echo 'dotnet_version='$(jq -r '.tools.dotnet' global.json) >> $GITHUB_ENV
+      - name: Run dotnet restore
+        run: ./dotnet.sh restore
 
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v3.0.3
-        with:
-          dotnet-version: ${{ env.dotnet_version }}
-          include-prerelease: true
+      - name: Run dotnet format (whitespace)
+        run: ./dotnet.sh format whitespace --no-restore --include ${{ env.updated_files }}
 
-      # Workaround for a bug in the dotnet-format build shipped in .NET 7.0 Preview 5. Ref: https://github.com/dotnet/core/blob/main/release-notes/7.0/known-issues.md#unhandled-exception-in-dotnet-format-app-in-net-70-preview-5
-      - name: Setup dotnet format
-        run: dotnet tool install -g dotnet-format --version "7.*" --configfile ./NuGet.config
-
-      - name: Run dotnet format
-        run: dotnet-format --include ${{ env.updated_files }}
+      - name: Run dotnet format (style)
+        run: ./dotnet.sh format style --no-restore --include ${{ env.updated_files }}
 
       - name: Generate artifacts
         run: |

--- a/src/Tools/dotnet-monitor/ConfigurationKeys.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationKeys.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ConfigurationKeys
     {
-        public const string Authentication = nameof(RootOptions.Authentication);
+             public const string Authentication = nameof(RootOptions.Authentication);
 
         public const string CollectionRules = nameof(CollectionRules);
 

--- a/src/Tools/dotnet-monitor/ConfigurationKeys.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationKeys.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ConfigurationKeys
     {
-             public const string Authentication = nameof(RootOptions.Authentication);
+        public const string Authentication = nameof(RootOptions.Authentication);
 
         public const string CollectionRules = nameof(CollectionRules);
 


### PR DESCRIPTION
###### Summary

This PR fixes and re-enables linting on PRs that target main.  Of note, skip the analyzer phase of formatting as there appears to be an issue where `dotnet format` is trying to load an analyzer that isn't available locally (`Microsoft.CodeAnalysis.ExternalAccess.AspNetCore`).  This can be re-enabled later once properly triaged and fixed.

Also apply some minor cleanups to the workflow, simplifying it.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
