### PR TITLE
Remove unnecessary conditional TFM usage

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/SimpleConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/SimpleConsoleFormatterOptions.cs
@@ -12,13 +12,11 @@ namespace Microsoft.Diagnostics.Monitoring.Options
 {
     internal sealed class SimpleConsoleFormatterOptions
     {
-#if NET5_0_OR_GREATER
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_SimpleConsoleFormatterOptions_ColorBehavior))]
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public LoggerColorBehavior ColorBehavior { get; set; }
-#endif
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/JsonSerializerOptionsFactory.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/JsonSerializerOptionsFactory.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
@@ -12,41 +13,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         {
             JsonSerializerOptions serializerOptions = new()
             {
-#if NET5_0_OR_GREATER
-                DefaultIgnoreCondition = (System.Text.Json.Serialization.JsonIgnoreCondition)ignoreCondition,
-#else
-                IgnoreNullValues = ignoreCondition == JsonIgnoreCondition.WhenWritingNull,
-#endif
+                DefaultIgnoreCondition = ignoreCondition,
             };
             return serializerOptions;
-        }
-
-
-        /// <summary>
-        /// Controls how the System.Text.Json.Serialization.JsonIgnoreAttribute ignores properties
-        /// on serialization and deserialization.
-        /// </summary>
-        /// <remarks>This is a copy of System.Text.Json.Serialization.JsonIgnoreCondition for use older versions of .net.</remarks>
-        public enum JsonIgnoreCondition
-        {
-            //
-            // Summary:
-            //     Property will always be serialized and deserialized, regardless of System.Text.Json.JsonSerializerOptions.IgnoreNullValues
-            //     configuration.
-            Never = 0,
-            //
-            // Summary:
-            //     Property will always be ignored.
-            Always = 1,
-            //
-            // Summary:
-            //     Property will only be ignored if it is null.
-            WhenWritingDefault = 2,
-            //
-            // Summary:
-            //     If the value is null, the property is ignored during serialization. This is applied
-            //     only to reference-type properties and fields.
-            WhenWritingNull = 3
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -20,6 +20,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -476,7 +477,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.True(false, "Unknown algorithm");
                 }
 
-                JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonSerializerOptionsFactory.JsonIgnoreCondition.WhenWritingNull);
+                JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
                 serializerOptions.IgnoreReadOnlyProperties = true;
                 string privateKeyJson = JsonSerializer.Serialize(exportableJwk, serializerOptions);
                 string privateKeyEncoded = Base64UrlEncoder.Encode(privateKeyJson);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             _outputHelper = outputHelper;
         }
 
-#if NET5_0_OR_GREATER
         [Fact]
         public Task StopOnEvent_Succeeds_WithMatchingOpcode()
         {
@@ -185,6 +184,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 return (didSeeStoppingEvent, didSeeRundownEvents);
             });
         }
-#endif // NET5_0_OR_GREATER
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             _outputHelper = outputHelper;
         }
 
-#if NET5_0_OR_GREATER
         private const string NonStartupRuleName = "NonStartupTestRule";
         private const string StartupRuleName = "StartupTestRule";
 
@@ -360,6 +359,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 Assert.Equal(expectedDescription, actualDescription);
             }
         }
-#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             _outputHelper = outputHelper;
         }
 
-#if NET5_0_OR_GREATER
         private const string DefaultRuleName = "FunctionalTestRule";
 
         /// <summary>
@@ -369,7 +368,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         private static bool IsNotNet5OrGreaterOnUnix =>
             DotNetHost.RuntimeVersion.Major < 5 ||
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -126,7 +126,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Validates that a collection rule with a command line filter can be matched to the
         /// target process.
         /// </summary>
-        [ConditionalTheory(nameof(IsNotNet5OrGreaterOnUnix))]
+        /// <remarks>
+        /// The GetProcessInfo command is not providing command line arguments (only the process name)
+        /// for .NET 5+ processes on non-Windows when suspended. See https://github.com/dotnet/dotnet-monitor/issues/885
+        /// </remarks>
+        [ConditionalTheory(typeof(TestConditions), nameof(TestConditions.IsWindows))]
         [InlineData(DiagnosticPortConnectionMode.Listen)]
         public async Task CollectionRule_CommandLineFilterMatchTest(DiagnosticPortConnectionMode mode)
         {
@@ -362,11 +366,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // for the target process before dotnet-monitor shuts down.
             await rulesStoppedTask;
         }
-
-        // The GetProcessInfo command is not providing command line arguments (only the process name)
-        // for .NET 5+ process on non-Windows when suspended. See https://github.com/dotnet/dotnet-monitor/issues/885
-        private static bool IsNotNet5OrGreaterOnUnix =>
-            DotNetHost.RuntimeVersion.Major < 5 ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             _outputHelper = outputHelper;
         }
 
-        [ConditionalTheory(typeof(TestConditions), nameof(TestConditions.IsDumpSupported))]
+        [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, DumpType.Full)]
         [InlineData(DiagnosticPortConnectionMode.Connect, DumpType.Mini)]
         [InlineData(DiagnosticPortConnectionMode.Connect, DumpType.Triage)]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -39,12 +39,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [InlineData(DiagnosticPortConnectionMode.Connect, DumpType.Mini)]
         [InlineData(DiagnosticPortConnectionMode.Connect, DumpType.Triage)]
         [InlineData(DiagnosticPortConnectionMode.Connect, DumpType.WithHeap)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, DumpType.Full)]
         [InlineData(DiagnosticPortConnectionMode.Listen, DumpType.Mini)]
         [InlineData(DiagnosticPortConnectionMode.Listen, DumpType.Triage)]
         [InlineData(DiagnosticPortConnectionMode.Listen, DumpType.WithHeap)]
-#endif
         public Task DumpTest(DiagnosticPortConnectionMode mode, DumpType type)
         {
             return RetryUtilities.RetryAsync(
@@ -55,17 +53,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
         private Task DumpTestCore(DiagnosticPortConnectionMode mode, DumpType type)
         {
-#if !NET6_0_OR_GREATER
-            // Capturing non-full dumps via diagnostic command works inconsistently
-            // on Alpine for .NET 5 and lower (the dump command will return successfully, but)
-            // the dump file will not exist). Only test other dump types on .NET 6+
-            if (DistroInformation.IsAlpineLinux && type != DumpType.Full)
-            {
-                _outputHelper.WriteLine("Skipped on Alpine for .NET 5 and lower.");
-                return Task.CompletedTask;
-            }
-#endif
-
             return ScenarioRunner.SingleTarget(
                 _outputHelper,
                 _httpClientFactory,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         }
 
         // https://github.com/dotnet/dotnet-monitor/issues/1285
-        [ConditionalFact(nameof(IsNotCore31OnOSX))]
+        [Fact]
         public async Task EgressListTest()
         {
             await ScenarioRunner.SingleTarget(
@@ -424,15 +424,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                     await appRunner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
                 });
-        }
-
-        public static bool IsNotCore31OnOSX()
-        {
-#if NET5_0_OR_GREATER
-            return true;
-#else
-            return !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-#endif
         }
 
         private static async Task<HttpResponseMessage> TraceWithDelay(ApiClient client, int processId, bool delay = true)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiStatusCodeException.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiStatusCodeException.cs
@@ -10,19 +10,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
     internal class ApiStatusCodeException : HttpRequestException
     {
         public ApiStatusCodeException(string message, HttpStatusCode statusCode)
-#if NET5_0_OR_GREATER
             : base(message, null, statusCode)
         {
         }
-#else
-            : base(message)
-        {
-            StatusCode = statusCode;
-        }
-#endif
-
-#if !NET5_0_OR_GREATER
-        public HttpStatusCode StatusCode { get; set; }
-#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -36,9 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// </summary>
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen)]
-#endif
         public Task InfoEndpointValidationTest(DiagnosticPortConnectionMode mode)
         {
             return ScenarioRunner.SingleTarget(

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
@@ -43,11 +43,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsAllCategoriesTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(
@@ -89,10 +86,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsDefaultLevelTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(
@@ -121,10 +116,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsDefaultLevelFallbackTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(
@@ -162,10 +155,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsDefaultLevelNoneNotSupportedViaQueryTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ScenarioRunner.SingleTarget(
@@ -198,10 +189,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsDefaultLevelNoneNotSupportedViaBodyTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ScenarioRunner.SingleTarget(
@@ -234,10 +223,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsUseAppFiltersViaQueryTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(
@@ -268,10 +255,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsUseAppFiltersViaBodyTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(
@@ -307,10 +292,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsUseAppFiltersAndFilterSpecsTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(
@@ -351,10 +334,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Connect, LogFormat.NewlineDelimitedJson)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.JsonSequence)]
         [InlineData(DiagnosticPortConnectionMode.Listen, LogFormat.NewlineDelimitedJson)]
-#endif
         public Task LogsWildcardTest(DiagnosticPortConnectionMode mode, LogFormat logFormat)
         {
             return ValidateLogsAsync(

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -13,6 +13,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 {
@@ -185,7 +186,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
             string resultToken = tokenHandler.WriteToken(newToken);
 
-            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonSerializerOptionsFactory.JsonIgnoreCondition.WhenWritingNull);
+            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
             string publicKeyJson = JsonSerializer.Serialize(exportableJwk, serializerOptions);
 
             string publicKeyEncoded = Base64UrlEncoder.Encode(publicKeyJson);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             _outputHelper = outputHelper;
         }
 
-#if NET6_0_OR_GREATER
         private const string DefaultRuleName = "FunctionalTestRule";
         private readonly TimeSpan TraceDuration = Timeout.InfiniteTimeSpan;
         private const string AppUrl = "http://+:0";
@@ -179,6 +178,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             return holder;
         }
-#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -43,9 +43,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// </summary>
         [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen)]
-#endif
         public Task SingleProcessIdentificationTest(DiagnosticPortConnectionMode mode)
         {
             string expectedEnvVarValue = Guid.NewGuid().ToString("D");
@@ -93,9 +91,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// </summary>
         [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
         [InlineData(DiagnosticPortConnectionMode.Connect)]
-#if NET5_0_OR_GREATER
         [InlineData(DiagnosticPortConnectionMode.Listen)]
-#endif
         public async Task MultiProcessIdentificationTest(DiagnosticPortConnectionMode mode)
         {
             DiagnosticPortHelper.Generate(
@@ -162,7 +158,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     int pid = processIdentifier.Pid;
                     Guid uid = processIdentifier.Uid;
                     string name = processIdentifier.Name;
-#if NET5_0_OR_GREATER
+
                     // CHECK 1: Get response for processes using PID, UID, and Name and check for consistency
 
                     List<ProcessInfo> processInfoQueriesCheck1 = new List<ProcessInfo>();
@@ -180,7 +176,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     }
 
                     VerifyProcessInfoEquality(processInfoQueriesCheck1);
-#endif
+
                     // CHECK 2: Get response for requests using PID | PID and UID | PID, UID, and Name and check for consistency
 
                     List<ProcessInfo> processInfoQueriesCheck2 = new List<ProcessInfo>();
@@ -290,7 +286,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Assert.NotNull(info);
             Assert.Equal(identifier.Pid, info.Pid);
 
-#if NET5_0_OR_GREATER
             // Currently, the runtime instance identifier is only provided for .NET 5 and higher
             info = await client.GetProcessWithRetryAsync(_outputHelper, uid: identifier.Uid);
             Assert.NotNull(info);
@@ -302,13 +297,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Assert.NotEmpty(env);
             Assert.True(env.TryGetValue(ExpectedEnvVarName, out string actualEnvVarValue));
             Assert.Equal(expectedEnvVarValue, actualEnvVarValue);
-#else
-            // .NET Core 3.1 and earlier do not support getting the environment block
-            ValidationProblemDetailsException validationProblemDetailsException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(
-                () => client.GetProcessEnvironmentAsync(processId));
-            Assert.Equal(HttpStatusCode.BadRequest, validationProblemDetailsException.StatusCode);
-            Assert.Equal(StatusCodes.Status400BadRequest, validationProblemDetailsException.Details.Status);
-#endif
         }
 
         public static bool IsNotWindowsNetCore31

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Tests that multiple processes are discoverable by dotnet-monitor.
         /// Also tests for correct behavior in response to queries with different/multiple process identifiers.
         /// </summary>
-        [ConditionalTheory(nameof(IsNotWindowsNetCore31))]
+        [Theory]
         [InlineData(DiagnosticPortConnectionMode.Connect)]
         [InlineData(DiagnosticPortConnectionMode.Listen)]
         public async Task MultiProcessIdentificationTest(DiagnosticPortConnectionMode mode)
@@ -297,18 +297,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Assert.NotEmpty(env);
             Assert.True(env.TryGetValue(ExpectedEnvVarName, out string actualEnvVarValue));
             Assert.Equal(expectedEnvVarValue, actualEnvVarValue);
-        }
-
-        public static bool IsNotWindowsNetCore31
-        {
-            get
-            {
-                /// Disabled on Windows .NET Core 3.1; process enumeration frequent hangs when running in connect mode.
-                /// Additional logging shows that some discovered processes on the test machines are not responding on their
-                /// diagnostic pipe and the named pipe implementation is not responding to cancellation.
-                /// See https://github.com/dotnet/diagnostics/issues/2711
-                return !TestConditions.IsWindows || !TestConditions.IsNetCore31;
-            }
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
@@ -206,7 +207,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         {
             using FileStream stream = new(UserSettingsFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
 
-            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonSerializerOptionsFactory.JsonIgnoreCondition.WhenWritingNull);
+            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
             await JsonSerializer.SerializeAsync(stream, options, serializerOptions).ConfigureAwait(false);
 
             _outputHelper.WriteLine("Wrote user settings.");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
     [Collection(DefaultCollectionFixture.Name)]
     public class StacksTests
     {
-#if NET6_0_OR_GREATER
-
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ITestOutputHelper _outputHelper;
         private readonly TemporaryDirectory _tempDirectory;
@@ -466,6 +464,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                             MethodName = ExpectedFunction
                         }
             };
-#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
@@ -2,31 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
     internal static class TestConditions
     {
-        public static bool IsDumpSupported
-        {
-            get
-            {
-                // MacOS supported dumps starting in .NET 5
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && DotNetHost.RuntimeVersion.Major < 5)
-                    return false;
-
-                // MacOS dumps inconsistently segfault the runtime on .NET 5: https://github.com/dotnet/dotnet-monitor/issues/174
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && DotNetHost.RuntimeVersion.Major == 5)
-                    return false;
-
-                return true;
-            }
-        }
-
-        public static bool IsNetCore31 => DotNetHost.BuiltTargetFrameworkMoniker == TargetFrameworkMoniker.NetCoreApp31;
-
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         public static bool IsNotWindows => !IsWindows;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/AzureBlob/AzureBlobEgressProviderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/AzureBlob/AzureBlobEgressProviderTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             _testUploadFileHash = GetFileSHA256(_testUploadFile);
         }
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_UploadsCorrectData(UploadAction uploadAction)
@@ -82,7 +82,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
         }
 
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_QueueMessages(UploadAction uploadAction)
@@ -109,7 +109,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             ValidateQueue(blobs, messages, expectedCount: 1);
         }
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_RestrictiveSasToken(UploadAction uploadAction)
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             Assert.Equal($"{providerOptions.BlobPrefix}/{artifactSettings.Name}", resultingBlob.Name);
         }
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_RestrictiveQueueSasToken(UploadAction uploadAction)
@@ -167,7 +167,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             ValidateQueue(blobs, messages, expectedCount: 1);
         }
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_OnlyRestrictiveSasTokens(UploadAction uploadAction)
@@ -199,7 +199,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             ValidateQueue(blobs, messages, expectedCount: 1);
         }
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs, Skip = "https://github.com/dotnet/dotnet-monitor/issues/2754")]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs, Skip = "https://github.com/dotnet/dotnet-monitor/issues/2754")]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_ThrowsWhen_ContainerDoesNotExistAndUsingRestrictiveSasToken(UploadAction uploadAction)
@@ -221,7 +221,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             await Assert.ThrowsAsync<EgressException>(async () => await EgressAsync(uploadAction, egressProvider, providerOptions, artifactSettings, CancellationToken.None));
         }
 
-        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_DoesNotThrowWhen_QueueDoesNotExistAndUsingRestrictiveQueueSasToken(UploadAction uploadAction)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/AzureBlob/AzureBlobEgressProviderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/AzureBlob/AzureBlobEgressProviderTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             _testUploadFileHash = GetFileSHA256(_testUploadFile);
         }
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_UploadsCorrectData(UploadAction uploadAction)
@@ -82,7 +82,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
         }
 
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_QueueMessages(UploadAction uploadAction)
@@ -109,7 +109,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             ValidateQueue(blobs, messages, expectedCount: 1);
         }
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_RestrictiveSasToken(UploadAction uploadAction)
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             Assert.Equal($"{providerOptions.BlobPrefix}/{artifactSettings.Name}", resultingBlob.Name);
         }
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_RestrictiveQueueSasToken(UploadAction uploadAction)
@@ -167,7 +167,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             ValidateQueue(blobs, messages, expectedCount: 1);
         }
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_Supports_OnlyRestrictiveSasTokens(UploadAction uploadAction)
@@ -199,7 +199,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             ValidateQueue(blobs, messages, expectedCount: 1);
         }
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs, Skip = "https://github.com/dotnet/dotnet-monitor/issues/2754")]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs, Skip = "https://github.com/dotnet/dotnet-monitor/issues/2754")]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_ThrowsWhen_ContainerDoesNotExistAndUsingRestrictiveSasToken(UploadAction uploadAction)
@@ -221,7 +221,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Egress.AzureBlob
             await Assert.ThrowsAsync<EgressException>(async () => await EgressAsync(uploadAction, egressProvider, providerOptions, artifactSettings, CancellationToken.None));
         }
 
-        [ConditionalTheory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
+        [Theory(Timeout = TestTimeouts.EgressUnitTestTimeoutMs)]
         [InlineData(UploadAction.ProvideUploadStream)]
         [InlineData(UploadAction.WriteToProviderStream)]
         public async Task AzureBlobEgress_DoesNotThrowWhen_QueueDoesNotExistAndUsingRestrictiveQueueSasToken(UploadAction uploadAction)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
@@ -15,9 +15,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
         {
             return new CommandLineBuilder(new RootCommand()
             {
-#if NET6_0_OR_GREATER
                 AspNetScenario.Command(),
-#endif
                 AsyncWaitScenario.Command(),
                 ExecuteScenario.Command(),
                 LoggerScenario.Command(),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AspNetScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AspNetScenario.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
 {
-#if NET6_0_OR_GREATER
     internal sealed class AspNetScenario
     {
         public static Command Command()
@@ -66,5 +65,4 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             }
         }
     }
-#endif
 }


### PR DESCRIPTION
###### Summary

Remove any conditional TFM usage that included code for .NET 6 or later or excluded code for .NET 5 or lower since this branch now only builds .NET 6 or later.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
