### PR TITLE
Pull requests only run .NET 8 tests

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -17,14 +17,6 @@ pr:
     - eng/actions
     - '**.md'
 
-schedules:
-- cron: 15 11 * * 6
-  displayName: Weekly Full Test Run
-  branches:
-    include:
-    - main
-  always: true
-
 parameters:
 - name: TestGroup
   displayName: 'Test Group'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,13 +24,9 @@
   </PropertyGroup>
 
   <!-- Filter tests based on specified TestGroup -->
-  <PropertyGroup Condition="'$(TestGroup)' == 'CI'">
-    <!-- Exclude netcoreapp3.1 and net5.0 tests from CI builds -->
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker!=NetCoreApp31&amp;TargetFrameworkMoniker!=Net50"</TestRunnerAdditionalArguments>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TestGroup)' == 'PR'">
-    <!-- Exclude netcoreapp3.1 and net5.0 tests from PR builds -->
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker!=NetCoreApp31&amp;TargetFrameworkMoniker!=Net50"</TestRunnerAdditionalArguments>
+    <!-- Only run tests for .NET 8 -->
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker=Net80"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public sealed class ActionListExecutorTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public sealed class CollectDumpActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public sealed class CollectGCDumpActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public class CollectLiveMetricsActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
@@ -32,6 +32,7 @@ using DisposableHelper = Microsoft.Diagnostics.Monitoring.TestCommon.DisposableH
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public class CollectLogsActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public sealed class CollectTraceActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public class EnvironmentVariableActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
@@ -19,6 +19,7 @@ using DisposableHelper = Microsoft.Diagnostics.Monitoring.TestCommon.DisposableH
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public sealed class ExecuteActionTests
     {

--- a/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace CollectionRuleActions.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(TestCollections.CollectionRuleActions)]
     public sealed class LoadProfilerActionTests
     {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
@@ -18,6 +18,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ExceptionTrackingTests
     {
         private const string IgnoreOutputPrefix = "[ignore]";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ProfilerInitializationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ProfilerInitializationTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ProfilerInitializationTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ActionDependencyAnalyzerTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/BuiltInTriggerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/BuiltInTriggerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.EventCounterShortcuts;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers;
@@ -11,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class BuiltInTriggerTests
     {
         private readonly TimeSpan CustomSlidingWindowDuration = TimeSpan.Parse("00:00:03");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectionRuleDefaultsTests
     {
         private const string DefaultRuleName = nameof(CollectionRuleDefaultsTests);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDescriptionPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDescriptionPipelineTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class CollectionRuleDescriptionPipelineTests
     {
         private readonly TimeSpan DefaultPipelineTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -26,6 +26,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectionRuleOptionsTests
     {
         private const string DefaultRuleName = "TestRule";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class CollectionRulePipelineTests
     {
         private readonly TimeSpan DefaultPipelineTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ConfigurationTests
     {
         private static readonly Dictionary<string, string> AppSettingsContent = new(StringComparer.Ordinal)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTests.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class DiagnosticPortTests
     {
         private ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class EndpointInfoSourceTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class TemplatesTests
     {
         private readonly ITestOutputHelper _outputHelper;


### PR DESCRIPTION
###### Summary

For pull requests, only run .NET 8 tests. For CI builds, run all tests. Remove scheduled build since CI builds will now run all tests.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
