### PR TITLE
[release/6.x] Pull requests only run .NET 6 tests

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -17,14 +17,6 @@ pr:
     - eng/actions
     - '**.md'
 
-schedules:
-- cron: 15 11 * * 6
-  displayName: Weekly Full Test Run
-  branches:
-    include:
-    - main
-  always: true
-
 parameters:
 - name: TestGroup
   displayName: 'Test Group'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,13 +24,9 @@
   </PropertyGroup>
 
   <!-- Filter tests based on specified TestGroup -->
-  <PropertyGroup Condition="'$(TestGroup)' == 'CI'">
-    <!-- Exclude netcoreapp3.1 and net5.0 tests from CI builds -->
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker!=NetCoreApp31&amp;TargetFrameworkMoniker!=Net50"</TestRunnerAdditionalArguments>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TestGroup)' == 'PR'">
-    <!-- Exclude netcoreapp3.1 and net5.0 tests from PR builds -->
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker!=NetCoreApp31&amp;TargetFrameworkMoniker!=Net50"</TestRunnerAdditionalArguments>
+    <!-- Only run tests for .NET 6 -->
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker=Net60"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
@@ -18,6 +18,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.Diagnostics.Monitoring.Profiler.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ExceptionTrackingTests
     {
         private const string IgnoreOutputPrefix = "[ignore]";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Monitoring.Tool.UnitTests.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor;
@@ -22,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ActionDependencyAnalyzerTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionListExecutorTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ActionListExecutorTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/BuiltInTriggerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/BuiltInTriggerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.EventCounterShortcuts;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers;
@@ -11,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class BuiltInTriggerTests
     {
         private readonly TimeSpan CustomSlidingWindowDuration = TimeSpan.Parse("00:00:03");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectDumpActionTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectDumpActionTests
     {
         private const string DefaultRuleName = nameof(CollectDumpActionTests);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectGCDumpActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectGCDumpActionTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectGCDumpActionTests
     {
         private const string DefaultRuleName = "GCDumpTestRule";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLiveMetricsActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLiveMetricsActionTests.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class CollectLiveMetricsActionTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectLogsActionTests.cs
@@ -31,6 +31,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class CollectLogsActionTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectTraceActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectTraceActionTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectTraceActionTests
     {
         private const string DefaultRuleName = "TraceTestRule";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectionRuleDefaultsTests
     {
         private const string DefaultRuleName = nameof(CollectionRuleDefaultsTests);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDescriptionPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDescriptionPipelineTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class CollectionRuleDescriptionPipelineTests
     {
         private readonly TimeSpan DefaultPipelineTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Tools.Monitor;
@@ -25,6 +26,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CollectionRuleOptionsTests
     {
         private const string DefaultRuleName = "TestRule";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class CollectionRulePipelineTests
     {
         private readonly TimeSpan DefaultPipelineTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ConfigurationTests
     {
         private static readonly Dictionary<string, string> AppSettingsContent = new(StringComparer.Ordinal)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
@@ -14,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class DiagnosticPortTests
     {
         private ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class EndpointInfoSourceTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EnvironmentVariableActionTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class EnvironmentVariableActionTests
     {
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExecuteActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExecuteActionTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ExecuteActionTests
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LoadProfilerActionTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class LoadProfilerActionTests
     {
         private const string DefaultRuleName = "ProfilerTestRule";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class TemplatesTests
     {
         private readonly ITestOutputHelper _outputHelper;


### PR DESCRIPTION
###### Summary

Manual backport of #3043 to `release/6.x`. Main difference is that PRs run .NET 6 instead of .NET 8 (which does not exist in the `release/6*` branches.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
