### PR TITLE
Standardize on two-line license header

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,7 +33,7 @@ indent_size = 2
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = false
 dotnet_diagnostic.IDE0005.severity = warning
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,6 @@ Please use the following file header for new files.
 ```
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 ```
 
 ### PR - CI Process

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AuthenticationOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AuthenticationOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureBlobEgressProviderOptions.Validate.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureBlobEgressProviderOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureBlobEgressProviderOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureBlobEgressProviderOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleFinishedStates.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleFinishedStates.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleMetadata.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleState.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.DataAnnotations;
 

--- a/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortConnectionMode.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortConnectionMode.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptionsExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/EgressOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/EgressOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ExperimentalAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ExperimentalAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.Options/FileSystemEgressProviderOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/FileSystemEgressProviderOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/IEgressProviderCommonOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/IEgressProviderCommonOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Options
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptionsExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Options
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/LogFormat.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/LogFormat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Options
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptionsExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MonitorApiKeyOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MonitorApiKeyOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/S3StorageEgressProviderOptions.Validate.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/S3StorageEgressProviderOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/S3StorageEgressProviderOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/S3StorageEgressProviderOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using System.ComponentModel.DataAnnotations;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ActionContextExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ActionContextExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ArtifactMetadataNames.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ArtifactMetadataNames.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ArtifactOperationExetensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ArtifactOperationExetensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/AssemblyExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/AssemblyExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Reflection;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Auth/AuthConstants.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Auth/AuthConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/CancellationTokenSourceExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/CancellationTokenSourceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/CollectionRulePipelineState.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/CollectionRulePipelineState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/CommandLineHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/CommandLineHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ConfigurationHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ConfigurationHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypeUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypeUtilities.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Net.Http.Headers;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ContentTypes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagControllerExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagControllerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Options;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EgressOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EgressOutputConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EgressValidationAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EgressValidationAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EncodingCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EncodingCache.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EventMonitoringPassthroughStream.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EventMonitoringPassthroughStream.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ExceptionExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ExceptionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/HostRestrictionAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/HostRestrictionAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/HttpContextExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/HttpContextExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IArtifactOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IArtifactOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ICollectionRuleService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ICollectionRuleService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Extensions.Hosting;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IDiagnosticServices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IDumpOperationFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IDumpOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IDumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IDumpService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressOutputConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IExperimentalFlags.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IExperimentalFlags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IInProcessFeatures.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IInProcessFeatures.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ILogsOperationFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ILogsOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IMetricsOperationFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IMetricsOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ITraceOperationFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ITraceOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/KeyValueLogScope.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/KeyValueLogScope.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/KeyValueLogScopeExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/KeyValueLogScopeExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/EventCounterSettingsFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/IMetricsPortsProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/IMetricsPortsProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/IMetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/IMetricsStore.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/JsonCounterLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/JsonCounterLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStoreService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStoreService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/PrometheusDataModel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/PrometheusDataModel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/StreamingCounterLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/StreamingCounterLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CollectionRuleDescription.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CollectionRuleDescription.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CollectionRuleDetailedDescription.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CollectionRuleDetailedDescription.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/DotnetMonitorInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/DotnetMonitorInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/DumpType.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/DumpType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventMetricsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventMetricsConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if !SCHEMAGEN
 using Microsoft.Diagnostics.Monitoring.WebApi.Validation;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/LogsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/LogsConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessIdentifier.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/SpeedScopeStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/SpeedScopeStackResults.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/TraceProfile.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/TraceProfile.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationQueue.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationQueue.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressProcessInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressProcessInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressRequest.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressRequest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressResult.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/HttpResponseEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/HttpResponseEgressOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperationQueue.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperationQueue.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/OperationExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/OperationExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/TooManyRequestsException.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/TooManyRequestsException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OperationTrackerService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OperationTrackerService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessKey.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessKey.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProducesWithProblemDetailsAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProducesWithProblemDetailsAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProfilerChannel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProfilerChannel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/IRequestLimitTracker.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/IRequestLimitTracker.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimitTracker.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimitTracker.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ScopeState.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ScopeState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackData.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackEvents.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackEvents.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/EventStacksPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/EventStacksPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Text;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 using System.IO;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamLeaveOpenWrapper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamLeaveOpenWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/GCDumpUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/GCDumpUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using FastSerialization;
 using Microsoft.Diagnostics.Monitoring.EventPipe;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Stacks;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceEventExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi.Validation;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/IntegerOrHexStringAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/IntegerOrHexStringAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel.DataAnnotations;

--- a/src/MonitorProfiler/ClassFactory.cpp
+++ b/src/MonitorProfiler/ClassFactory.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ClassFactory.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/ClassFactory.h
+++ b/src/MonitorProfiler/ClassFactory.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Communication/CommandServer.cpp
+++ b/src/MonitorProfiler/Communication/CommandServer.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "CommandServer.h"
 #include <thread>

--- a/src/MonitorProfiler/Communication/CommandServer.h
+++ b/src/MonitorProfiler/Communication/CommandServer.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Communication/IpcCommClient.cpp
+++ b/src/MonitorProfiler/Communication/IpcCommClient.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "IpcCommClient.h"
 #include <memory>

--- a/src/MonitorProfiler/Communication/IpcCommClient.h
+++ b/src/MonitorProfiler/Communication/IpcCommClient.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Communication/IpcCommServer.cpp
+++ b/src/MonitorProfiler/Communication/IpcCommServer.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "IpcCommClient.h"
 #include "IpcCommServer.h"

--- a/src/MonitorProfiler/Communication/IpcCommServer.h
+++ b/src/MonitorProfiler/Communication/IpcCommServer.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Communication/Messages.h
+++ b/src/MonitorProfiler/Communication/Messages.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Communication/SocketWrapper.h
+++ b/src/MonitorProfiler/Communication/SocketWrapper.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/DllMain.cpp
+++ b/src/MonitorProfiler/DllMain.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ClassFactory.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/Environment/Environment.h
+++ b/src/MonitorProfiler/Environment/Environment.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "EnvironmentHelper.h"
 #include "../Logging/LogLevelHelper.h"

--- a/src/MonitorProfiler/Environment/EnvironmentHelper.h
+++ b/src/MonitorProfiler/Environment/EnvironmentHelper.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Environment/ProfilerEnvironment.cpp
+++ b/src/MonitorProfiler/Environment/ProfilerEnvironment.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ProfilerEnvironment.h"
 

--- a/src/MonitorProfiler/Environment/ProfilerEnvironment.h
+++ b/src/MonitorProfiler/Environment/ProfilerEnvironment.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/EventProvider/EventTypeMapping.h
+++ b/src/MonitorProfiler/EventProvider/EventTypeMapping.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/EventProvider/ProfilerEvent.h
+++ b/src/MonitorProfiler/EventProvider/ProfilerEvent.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/EventProvider/ProfilerEventProvider.cpp
+++ b/src/MonitorProfiler/EventProvider/ProfilerEventProvider.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ProfilerEventProvider.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/EventProvider/ProfilerEventProvider.h
+++ b/src/MonitorProfiler/EventProvider/ProfilerEventProvider.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/AggregateLogger.cpp
+++ b/src/MonitorProfiler/Logging/AggregateLogger.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "AggregateLogger.h"
 

--- a/src/MonitorProfiler/Logging/AggregateLogger.h
+++ b/src/MonitorProfiler/Logging/AggregateLogger.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/DebugLogger.cpp
+++ b/src/MonitorProfiler/Logging/DebugLogger.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "DebugLogger.h"
 #include "LoggerHelper.h"

--- a/src/MonitorProfiler/Logging/DebugLogger.h
+++ b/src/MonitorProfiler/Logging/DebugLogger.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/LogLevelHelper.h
+++ b/src/MonitorProfiler/Logging/LogLevelHelper.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/Logger.cpp
+++ b/src/MonitorProfiler/Logging/Logger.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "Logger.h"
 #include "LoggerHelper.h"

--- a/src/MonitorProfiler/Logging/Logger.h
+++ b/src/MonitorProfiler/Logging/Logger.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/LoggerHelper.cpp
+++ b/src/MonitorProfiler/Logging/LoggerHelper.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "LoggerHelper.h"
 #include "macros.h"

--- a/src/MonitorProfiler/Logging/LoggerHelper.h
+++ b/src/MonitorProfiler/Logging/LoggerHelper.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/NullLogger.cpp
+++ b/src/MonitorProfiler/Logging/NullLogger.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "NullLogger.h"
 

--- a/src/MonitorProfiler/Logging/NullLogger.h
+++ b/src/MonitorProfiler/Logging/NullLogger.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Logging/StdErrLogger.cpp
+++ b/src/MonitorProfiler/Logging/StdErrLogger.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "StdErrLogger.h"
 #include "LoggerHelper.h"

--- a/src/MonitorProfiler/Logging/StdErrLogger.h
+++ b/src/MonitorProfiler/Logging/StdErrLogger.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include "ExceptionTracker.h"

--- a/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
+++ b/src/MonitorProfiler/MainProfiler/ExceptionTracker.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "MainProfiler.h"
 #include "../Environment/EnvironmentHelper.h"

--- a/src/MonitorProfiler/MainProfiler/MainProfiler.h
+++ b/src/MonitorProfiler/MainProfiler/MainProfiler.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/MainProfiler/ThreadData.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include "ThreadData.h"

--- a/src/MonitorProfiler/MainProfiler/ThreadData.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadData.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #ifdef DOTNETMONITOR_FEATURE_EXCEPTIONS
 #include "ThreadDataManager.h"

--- a/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
+++ b/src/MonitorProfiler/MainProfiler/ThreadDataManager.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/ProfilerBase.cpp
+++ b/src/MonitorProfiler/ProfilerBase.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ProfilerBase.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/ProfilerBase.h
+++ b/src/MonitorProfiler/ProfilerBase.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Stacks/Stack.h
+++ b/src/MonitorProfiler/Stacks/Stack.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Stacks/StackSampler.cpp
+++ b/src/MonitorProfiler/Stacks/StackSampler.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "StackSampler.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/Stacks/StackSampler.h
+++ b/src/MonitorProfiler/Stacks/StackSampler.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Stacks/StacksEventProvider.cpp
+++ b/src/MonitorProfiler/Stacks/StacksEventProvider.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "StacksEventProvider.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/Stacks/StacksEventProvider.h
+++ b/src/MonitorProfiler/Stacks/StacksEventProvider.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/BlockingQueue.h
+++ b/src/MonitorProfiler/Utilities/BlockingQueue.h
@@ -1,6 +1,5 @@
 #// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include <queue>
 #include <mutex>

--- a/src/MonitorProfiler/Utilities/ClrData.h
+++ b/src/MonitorProfiler/Utilities/ClrData.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/NameCache.cpp
+++ b/src/MonitorProfiler/Utilities/NameCache.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "NameCache.h"
 #include "macros.h"

--- a/src/MonitorProfiler/Utilities/NameCache.h
+++ b/src/MonitorProfiler/Utilities/NameCache.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/PairHash.h
+++ b/src/MonitorProfiler/Utilities/PairHash.h
@@ -1,6 +1,5 @@
-// Licensed to the.NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/StringUtilities.h
+++ b/src/MonitorProfiler/Utilities/StringUtilities.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/ThreadNameCache.cpp
+++ b/src/MonitorProfiler/Utilities/ThreadNameCache.cpp
@@ -1,6 +1,5 @@
-// Licensed to the.NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ThreadNameCache.h"
 

--- a/src/MonitorProfiler/Utilities/ThreadNameCache.h
+++ b/src/MonitorProfiler/Utilities/ThreadNameCache.h
@@ -1,6 +1,5 @@
-// Licensed to the.NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/ThreadUtilities.cpp
+++ b/src/MonitorProfiler/Utilities/ThreadUtilities.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "ThreadUtilities.h"
 #if TARGET_UNIX

--- a/src/MonitorProfiler/Utilities/ThreadUtilities.h
+++ b/src/MonitorProfiler/Utilities/ThreadUtilities.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/MonitorProfiler/Utilities/TypeNameUtilities.cpp
+++ b/src/MonitorProfiler/Utilities/TypeNameUtilities.cpp
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #include "TypeNameUtilities.h"
 #include "corhlpr.h"

--- a/src/MonitorProfiler/Utilities/TypeNameUtilities.h
+++ b/src/MonitorProfiler/Utilities/TypeNameUtilities.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/CollectionRuleActions.UnitTests/Egress/Pipe/PipeEgressConfigureOptions.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/Egress/Pipe/PipeEgressConfigureOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 using System.IO.Pipelines;

--- a/src/Tests/CollectionRuleActions.UnitTests/Egress/Pipe/PipeEgressOptions.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/Egress/Pipe/PipeEgressOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO.Pipelines;
 

--- a/src/Tests/CollectionRuleActions.UnitTests/Egress/Pipe/PipeEgressProvider.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/Egress/Pipe/PipeEgressProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.Egress;
 using System;

--- a/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/CollectionRuleActions.UnitTests/TestCollections.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/TestCollections.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace CollectionRuleActions.UnitTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/ExperimentalSchemaProcessor.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/ExperimentalSchemaProcessor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using NJsonSchema.Generation;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleFormatterOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleLoggerFormat.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleLoggerFormat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Options
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleLoggerOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleLoggerOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/JsonConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/JsonConsoleFormatterOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LogLevelOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LogLevelOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LoggingOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LoggingOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/RootOptions.Logging.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/RootOptions.Logging.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/SimpleConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/SimpleConsoleFormatterOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging.Console;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/BadRequestResponseDocumentFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/BadRequestResponseDocumentFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/BadRequestResponseOperationFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/BadRequestResponseOperationFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Controllers;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/RemoveFailureContentTypesOperationFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/RemoveFailureContentTypesOperationFilter.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Diagnostics.Monitoring.WebApi;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/ResponseNames.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/ResponseNames.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/StatusCodeStrings.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/StatusCodeStrings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using System.Globalization;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/TooManyRequestsResponseDocumentFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/TooManyRequestsResponseDocumentFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/TooManyRequestsResponseOperationFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/TooManyRequestsResponseOperationFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/UnauthorizedResponseDocumentFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/UnauthorizedResponseDocumentFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/UnauthorizedResponseOperationFilter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/UnauthorizedResponseOperationFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp.Scenarios;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Scenarios/ExceptionThrowCatchScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Scenarios/ExceptionThrowCatchScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Scenarios/ExceptionThrowCrashScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTestApp/Scenarios/ExceptionThrowCrashScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ExceptionTrackingTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ProfilerInitializationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Profiler.UnitTests/ProfilerInitializationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ActionTestsConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ActionTestsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Reflection;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ConsoleOutputHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ConsoleOutputHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CounterPayload.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CounterPayload.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text.Json.Serialization;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DiagnosticPortHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DiagnosticPortHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DictionaryExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DictionaryExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Text.Json;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DistroInformation.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DistroInformation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DotNetHost.cs.template
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // THIS FILE IS AUTO-GENERATED DURING BUILD.  MODIFICATIONS _WILL_ BE OVERWRITTEN!
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DumpTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DumpTestUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.FileFormats;
 using Microsoft.FileFormats.ELF;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/EnumerableExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/EnumerableExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/EnvironmentInformation.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/EnvironmentInformation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Fixtures/AzuriteFixture.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Fixtures/AzuriteFixture.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 // This file and its classes are derived from:

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/JsonSerializerOptionsFactory.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/JsonSerializerOptionsFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LogEntry.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LogEntry.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LogsTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LogsTestUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/NativeLibraryHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/NativeLibraryHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/PrefixedOutputHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/PrefixedOutputHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Abstractions;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ProfilerHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ProfilerHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/RetryUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/RetryUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunnerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/ConsoleLogEvent.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/ConsoleLogEvent.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Text.Json;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/StreamExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/StreamExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitAttribute.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitDiscoverer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerTraitDiscoverer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TaskTestExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TaskTestExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TemporaryDirectory.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TemporaryDirectory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppLogEventIds.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppLogEventIds.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TraceTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TraceTestUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DiagnosticPortTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DiagnosticPortTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DisposableBox.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DisposableBox.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Fixtures/DefaultCollectionFixture.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Fixtures/DefaultCollectionFixture.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Fixtures/ServiceProviderFixture.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Fixtures/ServiceProviderFixture.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiStatusCodeException.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiStatusCodeException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Net;
 using System.Net.Http;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ContentTypes.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ContentTypes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/OperationResponse.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/OperationResponse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/OperationStatusResponse.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/OperationStatusResponse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using System.Net;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ResponseStreamHolder.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ResponseStreamHolder.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ValidationProblemDetailsException.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ValidationProblemDetailsException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Mvc;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/KestrelTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/KestrelTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LogsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OperationsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OperationsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/RootTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/RootTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.Artifacts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.Artifacts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.CollectionRule.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorGenerateKeyRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunnerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestConditions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.FileProviders.Physical;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.Profiler;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/HostingStartup.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/HostingStartup.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook/StartupHook.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook/StartupHook.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/ActionsServiceCollectionExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/ActionsServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/CallbackAction.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/CallbackAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/PassThroughAction.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/PassThroughAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointInfoSourceCallback.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointInfoSourceCallback.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ExecuteActionTestHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ExecuteActionTestHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Options/CollectionRuleOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestOutputLogger.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestOutputLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/BuiltInTriggerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/BuiltInTriggerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDefaultsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDescriptionPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleDescriptionPipelineTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRuleOptionsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTestsHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRules/Triggers/ManualTrigger.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRules/Triggers/ManualTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRules/Triggers/TriggersServiceCollectionExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRules/Triggers/TriggersServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTestsConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DiagnosticPortTestsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/AzureBlob/AzureBlobEgressProviderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/AzureBlob/AzureBlobEgressProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Azure;
 using Azure.Storage.Blobs;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/S3/InMemoryS3.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/S3/InMemoryS3.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Amazon.S3;
 using Amazon.S3.Model;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/S3/MultiPartUploadStreamTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/S3/MultiPartUploadStreamTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.Egress.S3;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/S3/S3StorageEgressProviderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Egress/S3/S3StorageEgressProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Amazon.S3;
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EndpointInfoSourceTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HostBuilderExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/HostBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Extensions.Configuration;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LimitsTestsConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LimitsTestsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LimitsTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/LimitsTestsHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MockSystemClock.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MockSystemClock.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleDefaultsOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleDefaultsOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.UnitTest.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/CollectionRuleOptionsExtensions.UnitTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Tool.UnitTests.CollectionRules.Triggers;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/S3StorageEgressProviderOptions.UnitTest.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/S3StorageEgressProviderOptions.UnitTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ShowSourcesTestsConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ShowSourcesTestsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestExperimentalFlags.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestExperimentalFlags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestLogger.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestTimeouts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TriggerTestsConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TriggerTestsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TriggerTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TriggerTestsHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/AppCommands.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/AppCommands.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/LoggingExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/LoggingExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Extensions.Logging;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/ScenarioHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AspNetScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AspNetScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AsyncWaitScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/AsyncWaitScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/EnvironmentVariablesScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/EnvironmentVariablesScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExecuteScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExecuteScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/LoggerScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/LoggerScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/SpinWaitScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/SpinWaitScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System.CommandLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics.Tracing;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/TraceEventsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/TraceEventsScenario.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/CommandLineHelperTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/CommandLineHelperTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/DefaultProcessConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/DefaultProcessConfigurationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Operation/EgressOperationStoreTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Operation/EgressOperationStoreTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Moq;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/PrometheusDataModelTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/PrometheusDataModelTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Tools/dotnet-monitor/ActivityExtensions.cs
+++ b/src/Tools/dotnet-monitor/ActivityExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 

--- a/src/Tools/dotnet-monitor/ActivityMetadataNames.cs
+++ b/src/Tools/dotnet-monitor/ActivityMetadataNames.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/AddressListenResults.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/src/Tools/dotnet-monitor/AddressListenResultsStartupFilter.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResultsStartupFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Tools/dotnet-monitor/AddressListenResultsStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResultsStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/src/Tools/dotnet-monitor/Auth/AuthConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/Tools/dotnet-monitor/Auth/AuthenticationStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthenticationStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Tools/dotnet-monitor/Auth/AuthorizedUserRequirement.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthorizedUserRequirement.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authorization;
 

--- a/src/Tools/dotnet-monitor/Auth/GeneratedJwtKey.cs
+++ b/src/Tools/dotnet-monitor/Auth/GeneratedJwtKey.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.IdentityModel.Tokens;

--- a/src/Tools/dotnet-monitor/Auth/IAuthConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/IAuthConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/Auth/JwtAlgorithmChecker.cs
+++ b/src/Tools/dotnet-monitor/Auth/JwtAlgorithmChecker.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.IdentityModel.Tokens;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Tools/dotnet-monitor/Auth/JwtBearerChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Auth/JwtBearerChangeTokenSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyChangeTokenSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Tokens;

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyConfigurationObserver.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/Auth/MonitorApiKeyPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/MonitorApiKeyPostConfigure.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/Auth/RejectAllSecurityValidator.cs
+++ b/src/Tools/dotnet-monitor/Auth/RejectAllSecurityValidator.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.IdentityModel.Tokens;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Security.Claims;
 

--- a/src/Tools/dotnet-monitor/Auth/UserAuthorizationHandler.cs
+++ b/src/Tools/dotnet-monitor/Auth/UserAuthorizationHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRuleMetadataNames.cs
+++ b/src/Tools/dotnet-monitor/CollectionRuleMetadataNames.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectDumpAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectDumpAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectGCDumpAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectGCDumpAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLiveMetricsAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLiveMetricsAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLogsAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLogsAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectStacksAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectStacksAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionFactoryProxy.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionOperations.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ExecuteAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ExecuteAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactoryProxy.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionOperations.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/LoadProfilerAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/LoadProfilerAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleEndpointInfoSourceCallbacks.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleEndpointInfoSourceCallbacks.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleActionDescriptor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleActionDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleBindingHelper.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleBindingHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulePostConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulePostConfigureNamedOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerDescriptor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationChangeTokenSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleActionDescriptor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleActionDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerDescriptor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/TemplatesConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/TemplatesConfigureNamedOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Exceptions/CollectionRuleActionException.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Exceptions/CollectionRuleActionException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 using Microsoft.Diagnostics.Monitoring;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Exceptions/CollectionRuleActionExecutionException.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Exceptions/CollectionRuleActionExecutionException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
 
 using Microsoft.Diagnostics.Monitoring;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/KeyValueLogScopeExtensions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/KeyValueLogScopeExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleActions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleActions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleTriggers.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/KnownCollectionRuleTriggers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsDependencyPropertyAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ActionOptionsDependencyPropertyAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/BaseRecordOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/BaseRecordOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/LoadProfilerOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/LoadProfilerOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/RequiredGuidAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/RequiredGuidAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/TraceEventFilter.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/TraceEventFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ValidateEgressProviderAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ValidateEgressProviderAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionDefaultsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionDefaultsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsInterfaces/IEgressProviderProperties.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsInterfaces/IEgressProviderProperties.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsInterfaces/IRequestCountProperties.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsInterfaces/IRequestCountProperties.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsInterfaces/ISlidingWindowDurationProperties.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsInterfaces/ISlidingWindowDurationProperties.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsDefaultsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsDefaultsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleLimitsOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptionsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerDefaultsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerDefaultsOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/DefaultCollectionRulePostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/DefaultCollectionRulePostConfigureOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/RegularExpressionsAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/RegularExpressionsAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/TemplateOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/TemplateOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/CPUUsageOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/CPUUsageOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/CPUUsageOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/CPUUsageOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.EventCounterShortcuts
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/GCHeapSizeOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/GCHeapSizeOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/GCHeapSizeOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/GCHeapSizeOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.EventCounterShortcuts
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/IEventCounterShortcuts.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/IEventCounterShortcuts.Validate.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/IEventCounterShortcuts.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/IEventCounterShortcuts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/KnownEventCounterConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/KnownEventCounterConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.EventCounterShortcuts
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/ThreadpoolQueueLengthOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/ThreadpoolQueueLengthOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/ThreadpoolQueueLengthOptionsDefaults.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterShortcuts/ThreadpoolQueueLengthOptionsDefaults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.EventCounterShortcuts
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/IAspNetActionPathFilters.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/IAspNetActionPathFilters.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/TriggerOptionsConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/ValidationHelper.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/ValidationHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetRequestCountTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetRequestCountTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetRequestDurationTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetRequestDurationTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetResponseStatusTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/AspNetResponseStatusTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerFactoryProxy.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerOperations.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventCounterTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventPipeTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventPipeTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleStartupTrigger.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleStartupTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
 {

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTrigger.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerFactoryProxy.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerOperations.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/StartupTrigger.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/StartupTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/StartupTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/StartupTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if UNITTEST
 using Microsoft.Diagnostics.Monitoring.TestCommon;

--- a/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using System.Linq;

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob;

--- a/src/Tools/dotnet-monitor/ConfigurationKeys.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationKeys.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Options;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortPostConfigureOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortValidateOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/DirectoryInfoExtensions.cs
+++ b/src/Tools/dotnet-monitor/DirectoryInfoExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Tools/dotnet-monitor/DisposableHelper.cs
+++ b/src/Tools/dotnet-monitor/DisposableHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Tools/dotnet-monitor/Dumps/DumpOperation.cs
+++ b/src/Tools/dotnet-monitor/Dumps/DumpOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Dumps/DumpOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Dumps/DumpOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;

--- a/src/Tools/dotnet-monitor/DynamicNamedOptionsCache.cs
+++ b/src/Tools/dotnet-monitor/DynamicNamedOptionsCache.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressPostConfigureOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressProvider.AutoFlushStream.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressProvider.AutoFlushStream.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Azure;
 using Azure.Identity;

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigurationExtensions.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigurationExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesConfigurationChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesConfigurationChangeTokenSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesConfigurationProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressPropertiesProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationChangeTokenSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigureNamedOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressPropertiesConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressPropertiesConfigurationProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressPropertiesProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressPropertiesProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
 {

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressProviderConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressProviderConfigurationProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/EgressArtifactSettings.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressArtifactSettings.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress

--- a/src/Tools/dotnet-monitor/Egress/EgressException.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/EgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/EgressProviderInternal.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProviderInternal.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/Egress/EgressProviderTypes.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProviderTypes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 {

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/IEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/IEgressProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tools/dotnet-monitor/Egress/IEgressProviderInternal.cs
+++ b/src/Tools/dotnet-monitor/Egress/IEgressProviderInternal.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tools/dotnet-monitor/Egress/S3/IS3Storage.cs
+++ b/src/Tools/dotnet-monitor/Egress/S3/IS3Storage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Amazon.S3.Model;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/S3/MultiPartUploadStream.cs
+++ b/src/Tools/dotnet-monitor/Egress/S3/MultiPartUploadStream.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Amazon.S3.Model;
 using System;
 using System.Buffers;

--- a/src/Tools/dotnet-monitor/Egress/S3/S3Storage.cs
+++ b/src/Tools/dotnet-monitor/Egress/S3/S3Storage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;

--- a/src/Tools/dotnet-monitor/Egress/S3/S3StorageEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/S3/S3StorageEgressProvider.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Amazon.S3;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tools/dotnet-monitor/ElevatedPermissionsStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/ElevatedPermissionsStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System.Runtime.InteropServices;

--- a/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/EndpointInfo/IEndpointInfoSourceCallbacks.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/IEndpointInfoSourceCallbacks.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Threading;

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/Experimental/ExperimentalFlags.cs
+++ b/src/Tools/dotnet-monitor/Experimental/ExperimentalFlags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/Experimental/ExperimentalStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/Experimental/ExperimentalStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderResults.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderResults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationManager.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationManager.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationSource.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Tools/dotnet-monitor/IStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/IStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeatures.cs
+++ b/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeatures.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeaturesPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeaturesPostConfigureOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/Logs/LogsOperation.cs
+++ b/src/Tools/dotnet-monitor/Logs/LogsOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Tools/dotnet-monitor/Logs/LogsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Logs/LogsOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.Options;

--- a/src/Tools/dotnet-monitor/Metrics/MetricsOperation.cs
+++ b/src/Tools/dotnet-monitor/Metrics/MetricsOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Metrics/MetricsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Metrics/MetricsOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/MetricsPortsProvider.cs
+++ b/src/Tools/dotnet-monitor/MetricsPortsProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/src/Tools/dotnet-monitor/OperationTrackerServiceEndpointInfoSourceCallback.cs
+++ b/src/Tools/dotnet-monitor/OperationTrackerServiceEndpointInfoSourceCallback.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;

--- a/src/Tools/dotnet-monitor/OutputFormat.cs
+++ b/src/Tools/dotnet-monitor/OutputFormat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options

--- a/src/Tools/dotnet-monitor/PipelineArtifactOperation.cs
+++ b/src/Tools/dotnet-monitor/PipelineArtifactOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Profiler/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/Profiler/DefaultSharedLibraryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.FileProviders;

--- a/src/Tools/dotnet-monitor/Profiler/INativeFileProviderFactory.cs
+++ b/src/Tools/dotnet-monitor/Profiler/INativeFileProviderFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileProviders;
 

--- a/src/Tools/dotnet-monitor/Profiler/ISharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ISharedLibraryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
 {

--- a/src/Tools/dotnet-monitor/Profiler/NativeLibraryHelper.cs
+++ b/src/Tools/dotnet-monitor/Profiler/NativeLibraryHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Tools/dotnet-monitor/Profiler/ProfilerEndpointInfoSourceCallbacks.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ProfilerEndpointInfoSourceCallbacks.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Threading;

--- a/src/Tools/dotnet-monitor/Profiler/ProfilerIdentifiers.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ProfilerIdentifiers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/Profiler/ProfilerService.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ProfilerService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Profiler/SharedNativeFileProvider.cs
+++ b/src/Tools/dotnet-monitor/Profiler/SharedNativeFileProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.FileProviders.Physical;

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.Commands;
 using System;

--- a/src/Tools/dotnet-monitor/RealSystemClock.cs
+++ b/src/Tools/dotnet-monitor/RealSystemClock.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using System;

--- a/src/Tools/dotnet-monitor/RootOptions.cs
+++ b/src/Tools/dotnet-monitor/RootOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/RuntimeInfo.cs
+++ b/src/Tools/dotnet-monitor/RuntimeInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Tools/dotnet-monitor/StartupLoggingHostedService.cs
+++ b/src/Tools/dotnet-monitor/StartupLoggingHostedService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Hosting;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/StoragePostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/StoragePostConfigureOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Options;

--- a/src/Tools/dotnet-monitor/Survey/ExperienceSurvey.cs
+++ b/src/Tools/dotnet-monitor/Survey/ExperienceSurvey.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 

--- a/src/Tools/dotnet-monitor/Survey/ExperienceSurveyStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/Survey/ExperienceSurveyStartupLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Tools/dotnet-monitor/TaskCompletionSourceExtensions.cs
+++ b/src/Tools/dotnet-monitor/TaskCompletionSourceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-monitor/TaskExtensions.cs
+++ b/src/Tools/dotnet-monitor/TaskExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-monitor/TestAssemblies.cs
+++ b/src/Tools/dotnet-monitor/TestAssemblies.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Hosting;
 using System;

--- a/src/Tools/dotnet-monitor/ToolIdentifiers.cs
+++ b/src/Tools/dotnet-monitor/ToolIdentifiers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon

--- a/src/Tools/dotnet-monitor/Trace/AbstractTraceOperation.cs
+++ b/src/Tools/dotnet-monitor/Trace/AbstractTraceOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Trace/TraceOperation.cs
+++ b/src/Tools/dotnet-monitor/Trace/TraceOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Trace/TraceOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Trace/TraceOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/Tools/dotnet-monitor/Trace/TraceUntilEventOperation.cs
+++ b/src/Tools/dotnet-monitor/Trace/TraceUntilEventOperation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.Monitoring.WebApi;

--- a/src/inc/com.h
+++ b/src/inc/com.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/guids.h
+++ b/src/inc/guids.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/macros.h
+++ b/src/inc/macros.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/pal/ntimage.h
+++ b/src/inc/pal/ntimage.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/pal/pal_error.h
+++ b/src/inc/pal/pal_error.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/pal/safecrt.h
+++ b/src/inc/pal/safecrt.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/pal/safemath.h
+++ b/src/inc/pal/safemath.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/refcount.h
+++ b/src/inc/refcount.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/tostream.h
+++ b/src/inc/tostream.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 

--- a/src/inc/tstring.h
+++ b/src/inc/tstring.h
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #pragma once
 


### PR DESCRIPTION
###### Summary

The main dotnet repositories standardized on a two-line license header (e.g. https://github.com/dotnet/runtime/pull/38793) a few years ago. Update the license header to conform.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
