### PR TITLE
[release/7.x] Allow pivoting on released vs development versions of diagnostics libraries

### DIFF
--- a/documentation/release-process.md
+++ b/documentation/release-process.md
@@ -76,7 +76,7 @@ After the release has been completed, this pipeline variable should be changed t
 ### Updating dependencies
 
 If necessary, update dependencies in the release branch.
->**Note**: This is no longer needed for the diagnostics packages. They are kept up-to-date by dependabot.
+>**Note**: This is typically not needed for the diagnostics packages. They are kept up-to-date by dependabot if `UseMicrosoftDiagnosticsMonitoringShippedVersion` in [../eng/Versions.props](../eng/Versions.props) is set to `true`. It might be set to `false` if feature development requiring unreleased diagnostics libraries was merged into the branch. Official releases should use the released diagnostics libraries per agreed upon policy.
 
 1. For new branches only, you need to setup a subscription using darc: `darc add-subscription --channel ".NET Core Tooling Release" --source-repo https://github.com/dotnet/diagnostics --target-repo https://github.com/dotnet/dotnet-monitor --target-branch release/8.x --update-frequency None --standard-automerge`
 1. Use `darc get-subscriptions --target-repo monitor` to see existing subscriptions.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,8 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="5.0.328102">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="6.0.0-preview.22609.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>ab657cc109f93e48d52f6b12cd7f136bb2d0b311</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="5.0.328102">
-      <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>ab657cc109f93e48d52f6b12cd7f136bb2d0b311</Sha>
+      <Sha>5002b6c90d80f205fad75674f159dee74d4ff19a</Sha>
     </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22568.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,10 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>5002b6c90d80f205fad75674f159dee74d4ff19a</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="6.0.0-preview.22609.1">
+      <Uri>https://github.com/dotnet/diagnostics</Uri>
+      <Sha>5002b6c90d80f205fad75674f159dee74d4ff19a</Sha>
+    </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22568.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>350a618ab44932c568ae2392d7a571281baed59a</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,9 @@
       - 'release': sets the blob group release name to 'release'. Can be used for prereleases and full releases.
     -->
     <BlobGroupBuildQuality>release</BlobGroupBuildQuality>
+    <!--
+      This should be set to true for official releases.
+    -->
     <UseMicrosoftDiagnosticsMonitoringShippedVersion>false</UseMicrosoftDiagnosticsMonitoringShippedVersion>
   </PropertyGroup>
 
@@ -64,6 +67,7 @@
     <SystemCommandLineVersion>2.0.0-beta4.22568.1</SystemCommandLineVersion>
     <!-- dotnet/diagnostics references -->
     <MicrosoftDiagnosticsMonitoringVersion>6.0.0-preview.22609.1</MicrosoftDiagnosticsMonitoringVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeVersion>6.0.0-preview.22609.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/roslyn-analyzers -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22559.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- dotnet/runtime references -->
@@ -100,8 +104,12 @@
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet7)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiateVersionNet7)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <MicrosoftDiagnosticsMonitoringLibrariesVersion Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibrariesVersion>
-    <MicrosoftDiagnosticsMonitoringLibrariesVersion Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' != 'true'">$(MicrosoftDiagnosticsMonitoringVersion)</MicrosoftDiagnosticsMonitoringLibrariesVersion>
+  <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">
+    <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringEventPipeLibraryVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' != 'true'">
+    <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeLibraryVersion>$(MicrosoftDiagnosticsMonitoringEventPipeVersion)</MicrosoftDiagnosticsMonitoringEventPipeLibraryVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
       - 'release': sets the blob group release name to 'release'. Can be used for prereleases and full releases.
     -->
     <BlobGroupBuildQuality>release</BlobGroupBuildQuality>
+    <UseMicrosoftDiagnosticsMonitoringShippedVersion>false</UseMicrosoftDiagnosticsMonitoringShippedVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Testing">
@@ -61,6 +62,8 @@
     <VSRedistCommonAspNetCoreSharedFrameworkx6470Version>7.0.0-rtm.22513.7</VSRedistCommonAspNetCoreSharedFrameworkx6470Version>
     <!-- dotnet/command-line-api references -->
     <SystemCommandLineVersion>2.0.0-beta4.22568.1</SystemCommandLineVersion>
+    <!-- dotnet/diagnostics references -->
+    <MicrosoftDiagnosticsMonitoringVersion>6.0.0-preview.22609.1</MicrosoftDiagnosticsMonitoringVersion>
     <!-- dotnet/roslyn-analyzers -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22559.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- dotnet/runtime references -->
@@ -96,5 +99,9 @@
   <PropertyGroup Label=".NET 7 Dependent" Condition=" '$(TargetFramework)' == 'net7.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreAuthenticationJwtBearerVersionNet7)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiateVersionNet7)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MicrosoftDiagnosticsMonitoringLibrariesVersion Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibrariesVersion>
+    <MicrosoftDiagnosticsMonitoringLibrariesVersion Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' != 'true'">$(MicrosoftDiagnosticsMonitoringVersion)</MicrosoftDiagnosticsMonitoringLibrariesVersion>
   </PropertyGroup>
 </Project>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -34,7 +34,7 @@
         the dotnet-tools feed, but it contains additional (often newer) versions that don't correspond to
         the publicly shipped related packages.
       - dotnet-dump, and select other packages from dotnet/diagnostics, share the same version tag as the
-        Microsoft.Diagnostics.Monitoring.* packages so we can use them to manage MicrosoftDiagnosticsMonitoringLibrariesVersion.
+        Microsoft.Diagnostics.Monitoring.* packages so we can use them to manage MicrosoftDiagnosticsMonitoring*LibraryVersion.
       - This is part of a shim project for dependabot and will never actually be built or restored, so we
         can add a package reference to the dotnet-dump tool.
     -->

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -27,18 +27,18 @@
     <!-- Release-branch specific reference -->
     <!-- dotnet/diagnostics references -->
     <!--
-      Keep MicrosoftDiagnosticsMonitoringVersion in-sync with the latest publicly shipped version of dotnet-dump:
+      Keep MicrosoftDiagnosticsMonitoringShippedVersion in-sync with the latest publicly shipped version of dotnet-dump:
       - In release branches we want to only use versions of Microsoft.Diagnostics.Monitoring.* packages that
         were built together with other packages from dotnet/diagnostics that have publicly shipped on nuget.org.
       - Microsoft.Diagnostics.Monitoring.* packages are not shipped via nuget.org, and instead are available via
         the dotnet-tools feed, but it contains additional (often newer) versions that don't correspond to
         the publicly shipped related packages.
       - dotnet-dump, and select other packages from dotnet/diagnostics, share the same version tag as the
-        Microsoft.Diagnostics.Monitoring.* packages so we can use them to manage MicrosoftDiagnosticsMonitoringVersion.
+        Microsoft.Diagnostics.Monitoring.* packages so we can use them to manage MicrosoftDiagnosticsMonitoringLibrariesVersion.
       - This is part of a shim project for dependabot and will never actually be built or restored, so we
         can add a package reference to the dotnet-dump tool.
     -->
-    <PackageReference Include="dotnet-dump" Version="$(MicrosoftDiagnosticsMonitoringVersion)" />
+    <PackageReference Include="dotnet-dump" Version="$(MicrosoftDiagnosticsMonitoringShippedVersion)" />
 
   </ItemGroup>
 </Project>

--- a/eng/dependabot/Versions.props
+++ b/eng/dependabot/Versions.props
@@ -23,7 +23,7 @@
 
     <!-- Release-branch specific reference -->
     <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringVersion>6.0.351802</MicrosoftDiagnosticsMonitoringVersion>
+    <MicrosoftDiagnosticsMonitoringShippedVersion>6.0.351802</MicrosoftDiagnosticsMonitoringShippedVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">
-    <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringLibrariesVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' != ''">

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">
-    <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringLibrariesVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Monitoring.EventPipe" Version="$(MicrosoftDiagnosticsMonitoringEventPipeLibraryVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' != ''">

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">
-    <PackageReference Include="Microsoft.Diagnostics.Monitoring" Version="$(MicrosoftDiagnosticsMonitoringLibrariesVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Monitoring" Version="$(MicrosoftDiagnosticsMonitoringLibraryVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' != ''">

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">
-    <PackageReference Include="Microsoft.Diagnostics.Monitoring" Version="$(MicrosoftDiagnosticsMonitoringVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Monitoring" Version="$(MicrosoftDiagnosticsMonitoringLibrariesVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' != ''">


### PR DESCRIPTION
###### Summary

This change allows easy pivoting of the diagnostic library versions between public releases and development versions. Change `UseMicrosoftDiagnosticsMonitoringShippedVersion` to `true` in order to use the publicly shipped version or `false` to use the development version.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
