### PR TITLE
Split build and test yaml into separate templates

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -47,14 +47,14 @@ stages:
   displayName: Build and Test
   jobs:
   # Build and test binaries
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Windows_x64_Debug
       displayName: Windows x64 Debug
       osGroup: Windows
       configuration: Debug
       testGroup: ${{ parameters.TestGroup }}
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Windows_x64_Release
       displayName: Windows x64 Release
@@ -64,7 +64,7 @@ stages:
       - source: 'bin'
       - source: 'obj'
       testGroup: ${{ parameters.TestGroup }}
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Windows_x86_Release
       displayName: Windows x86 Release
@@ -75,7 +75,7 @@ stages:
       - source: 'bin/Windows_NT.x86.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - template: /eng/build.yml
+    - template: /eng/build-test.yml
       parameters:
         name: Windows_arm64_Release
         displayName: Windows arm64 Release
@@ -85,14 +85,14 @@ stages:
         publishArtifactsSubPaths:
         - source: 'bin/Windows_NT.arm64.Release'
         testGroup: None
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Linux_x64_Debug
       displayName: Linux x64 Debug
       osGroup: Linux
       configuration: Debug
       testGroup: ${{ parameters.TestGroup }}
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Linux_x64_Release
       displayName: Linux x64 Release
@@ -102,7 +102,7 @@ stages:
       - source: 'bin/Linux.x64.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - template: /eng/build.yml
+    - template: /eng/build-test.yml
       parameters:
         name: Linux_arm64_Release
         displayName: Linux arm64 Release
@@ -112,14 +112,14 @@ stages:
         publishArtifactsSubPaths:
         - source: 'bin/Linux.arm64.Release'
         testGroup: None
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Linux_Musl_x64_Debug
       displayName: Linux Musl x64 Debug
       osGroup: Linux_Musl
       configuration: Debug
       testGroup: ${{ parameters.TestGroup }}
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: Linux_Musl_x64_Release
       displayName: Linux Musl x64 Release
@@ -130,7 +130,7 @@ stages:
         target: 'bin/Linux-musl.x64.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - template: /eng/build.yml
+    - template: /eng/build-test.yml
       parameters:
         name: Linux_Musl_arm64_Release
         displayName: Linux Musl arm64 Release
@@ -141,14 +141,14 @@ stages:
         - source: 'bin/Linux.arm64.Release'
           target: 'bin/Linux-musl.arm64.Release'
         testGroup: None
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: MacOS_x64_Debug
       displayName: MacOS x64 Debug
       osGroup: MacOS
       configuration: Debug
       testGroup: ${{ parameters.TestGroup }}
-  - template: /eng/build.yml
+  - template: /eng/build-test.yml
     parameters:
       name: MacOS_x64_Release
       displayName: MacOS x64 Release
@@ -158,7 +158,7 @@ stages:
       - source: 'bin/OSX.x64.Release'
       testGroup: ${{ parameters.TestGroup }}
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - template: /eng/build.yml
+    - template: /eng/build-test.yml
       parameters:
         name: MacOS_arm64_Release
         displayName: MacOS arm64 Release

--- a/eng/build-test.yml
+++ b/eng/build-test.yml
@@ -1,0 +1,111 @@
+parameters:
+  # Job name
+  name: ''
+  displayName: ''
+  osGroup: Windows
+  configuration: Release
+  architecture: x64
+  # Sub paths under 'artifacts' folder from which files are published to artifacts location
+  publishArtifactsSubPaths: []
+  # Group of tests to be run
+  testGroup: Default
+  # TFMs for which test results are uploaded
+  testResultTfms:
+  - key: net6.0
+    value: .NET 6
+  - key: net7.0
+    value: .NET 7
+  - key: net8.0
+    value: .NET 8
+
+jobs:
+- template: build.yml
+  parameters:
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    osGroup: ${{ parameters.osGroup }}
+    configuration: ${{ parameters.configuration }}
+    architecture: ${{ parameters.architecture }}
+    publishArtifactsSubPaths: ${{ parameters.publishArtifactsSubPaths }}
+    variables:
+    - ${{ if ne(parameters.testGroup, 'None') }}:
+      # If TestGroup == 'Default', choose the test group based on the type of pipeline run
+      - ${{ if eq(parameters.testGroup, 'Default') }}:
+        - ${{ if in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI') }}:
+          - _TestGroup: 'CI'
+        - ${{ elseif eq(variables['Build.Reason'], 'PullRequest') }}:
+          - _TestGroup: 'PR'
+        - ${{ else }}:
+          - _TestGroup: 'All'
+      - ${{ else }}:
+        - _TestGroup: '${{ parameters.testGroup }}'
+
+    preBuildSteps:
+    - ${{ if ne(parameters.testGroup, 'None') }}:
+      - ${{ if ne(parameters.osGroup, 'Windows') }}:
+        - task: NodeTool@0
+          displayName: Install Node.js
+          inputs:
+            # Version requirements:
+            # - Azurite requires 8.x or higher.
+            # - The alpine containers have their own build of Node.js of 10.x but without supplemental tooling like npm.
+            # Since the alpine containers already have a Node.js build, match it's major version for a compatible version
+            # of npm across all build environments.
+            versionSpec: '10.x'
+
+        - task: Npm@1
+          displayName: Install Azurite
+          inputs:
+            command: custom
+            customCommand: install -g azurite
+
+      # When using the Alpine build containers, the above npm install will install to the system's
+      # node directory instead of the agent's copy.
+      # The container doesn't have the node bin directory included in PATH by default, so global npm tool installations
+      # are not discoverable by the test infrastructure.
+      #
+      # Add the azurite installation location to PATH to workaround this.
+      - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
+        - script: echo "##vso[task.prependpath]/usr/share/node/bin"
+          displayName: Add Azurite to PATH
+
+    postBuildSteps:
+    # Execute tests
+    - ${{ if ne(parameters.testGroup, 'None') }}:
+      - script: >-
+          $(Build.SourcesDirectory)/eng/citest$(scriptExt)
+          -configuration ${{ parameters.configuration }}
+          -architecture ${{ parameters.architecture }}
+          -test
+          -testgroup $(_TestGroup)
+          -skipmanaged
+          -skipnative
+          /m:1
+        displayName: Test
+        timeoutInMinutes: 60
+
+      # Publish test results to Azure Pipelines
+      - ${{ each testResultTfm in parameters.testResultTfms }}:
+        - task: PublishTestResults@2
+          displayName: Publish Test Results (${{ testResultTfm.value }})
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+            failTaskOnFailedTests: true
+            testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} ${{ testResultTfm.value }}'
+            publishRunAttachments: true
+            mergeTestResults: true
+            buildConfiguration: ${{ parameters.name }}
+          continueOnError: true
+          condition: succeededOrFailed()
+
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Test Result Files
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            PublishLocation: Container
+            ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
+          continueOnError: true
+          condition: succeededOrFailed()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -6,23 +6,17 @@ parameters:
   configuration: Release
   architecture: x64
   # Additional variables
-  variables: {}
+  variables: []
+  # Additional prebuild steps
+  preBuildSteps: []
+  # Additional postbuild steps
+  postBuildSteps: []
   # Optional: Job timeout
   timeoutInMinutes: 180
   # Depends on 
   dependsOn: ''
   # Sub paths under 'artifacts' folder from which files are published to artifacts location
   publishArtifactsSubPaths: []
-  # Group of tests to be run
-  testGroup: Default
-  # TFMs for which test results are uploaded
-  testResultTfms:
-  - key: net6.0
-    value: .NET 6
-  - key: net7.0
-    value: .NET 7
-  - key: net8.0
-    value: .NET 8
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -85,15 +79,14 @@ jobs:
       clean: all
 
     variables:
-    - ${{ insert }}: ${{ parameters.variables }}
     - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
     - _CrossBuildArgs: ''
-    - _TestArgs: ''
-    - _TestGroup: ''
     - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
+    - ${{ each variable in parameters.variables }}:
+      - ${{ variable }}
 
     # Component Governance does not work on Musl
     - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
@@ -102,21 +95,6 @@ jobs:
     # Cross build for arm64 non-Windows builds
     - ${{ if and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows')) }}:
       - _CrossBuildArgs: '-cross'
-
-    - ${{ if ne(parameters.testGroup, 'None') }}:
-      # If TestGroup == 'Default', choose the test group based on the type of pipeline run
-      - ${{ if eq(parameters.testGroup, 'Default') }}:
-        - ${{ if in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI') }}:
-          - _TestGroup: 'CI'
-        - ${{ elseif eq(variables['Build.Reason'], 'PullRequest') }}:
-          - _TestGroup: 'PR'
-        - ${{ else }}:
-          - _TestGroup: 'All'
-      - ${{ else }}:
-          - _TestGroup: '${{ parameters.testGroup }}'
-
-    - ${{ if ne(parameters.testGroup, 'None') }}:
-        - _TestArgs: '-test -testgroup $(_TestGroup) -skipmanaged -skipnative /m:1'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-MSRC-Storage
@@ -161,30 +139,8 @@ jobs:
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-    - ${{ if ne(parameters.osGroup, 'Windows') }}:
-      - task: NodeTool@0
-        displayName: Install Node.js
-        inputs:
-          # Version requirements:
-          # - Azurite requires 8.x or higher.
-          # - The alpine containers have their own build of Node.js of 10.x but without supplemental tooling like npm.
-          # Since the alpine containers already have a Node.js build, match it's major version for a compatible version
-          # of npm across all build environments.
-          versionSpec: '10.x'
-      - task: Npm@1
-        displayName: Install Azurite
-        inputs:
-          command: custom
-          customCommand: install -g azurite
-    # When using the Alpine build containers, the above npm install will install to the system's
-    # node directory instead of the agent's copy.
-    # The container doesn't have the node bin directory included in PATH by default, so global npm tool installations
-    # are not discoverable by the test infrastructure.
-    #
-    # Add the azurite installation location to PATH to workaround this.
-    - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
-      - script: echo "##vso[task.prependpath]/usr/share/node/bin"
-        displayName: Add Azurite to PATH
+    - ${{ each step in parameters.preBuildSteps }}:
+      - ${{ step }}
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
@@ -213,38 +169,5 @@ jobs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
           artifactName: Build_${{ parameters.configuration }}
 
-    - ${{ if ne(parameters.testGroup, 'None') }}:
-      - script: >-
-          $(Build.SourcesDirectory)/eng/citest$(scriptExt)
-          -configuration ${{ parameters.configuration }}
-          -architecture ${{ parameters.architecture }}
-          $(_TestArgs)
-        displayName: Test
-        timeoutInMinutes: 60
-
-    # Publish test results to Azure Pipelines
-    - ${{ if ne(parameters.testGroup, 'None') }}:
-      - ${{ each testResultTfm in parameters.testResultTfms }}:
-        - task: PublishTestResults@2
-          displayName: Publish Test Results (${{ testResultTfm.value }})
-          inputs:
-            testResultsFormat: VSTest
-            testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-            failTaskOnFailedTests: true
-            testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} ${{ testResultTfm.value }}'
-            publishRunAttachments: true
-            mergeTestResults: true
-            buildConfiguration: ${{ parameters.name }}
-          continueOnError: true
-          condition: succeededOrFailed()
-
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Test Result Files
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-            PublishLocation: Container
-            ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
-          continueOnError: true
-          condition: succeededOrFailed()
+    - ${{ each step in parameters.postBuildSteps }}:
+      - ${{ step }}

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -24,7 +24,6 @@ jobs:
     name: ${{ parameters.name }}
     displayName: ${{ coalesce(parameters.displayName, parameters.name) }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-    enableMicrobuild: true
     enableTelemetry: true
     disableComponentGovernance: ${{ eq(parameters.osGroup, 'Linux_Musl') }}
     helixRepo: dotnet/dotnet-monitor


### PR DESCRIPTION
###### Summary

Split the test phase into a separate yaml template to allow the build phase to be reused in other pipelines.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
