### PR TITLE
Initial in-proc exception detection and handling pipeline.

### DIFF
--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -50,6 +50,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CollectionRuleActions.UnitTests", "src\Tests\CollectionRuleActions.UnitTests\CollectionRuleActions.UnitTests.csproj", "{2FD0A2A3-D7DA-4458-9084-E195102B9D5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.StartupHook", "src\Microsoft.Diagnostics.Monitoring.StartupHook\Microsoft.Diagnostics.Monitoring.StartupHook.csproj", "{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests\Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj", "{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -128,6 +132,14 @@ Global
 		{2FD0A2A3-D7DA-4458-9084-E195102B9D5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FD0A2A3-D7DA-4458-9084-E195102B9D5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FD0A2A3-D7DA-4458-9084-E195102B9D5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -153,6 +165,8 @@ Global
 		{9BEB8058-7EE4-4EE2-B83D-592E85236E78} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{E438C0E0-0301-4A8F-9153-BFE4839F213E} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 		{2FD0A2A3-D7DA-4458-9084-E195102B9D5B} = {C7568468-1C79-4944-8136-18812A7F9EA7}
+		{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2} = {19FAB78C-3351-4911-8F0C-8C6056401740}
+		{E7EA323B-0CFE-4D42-9844-4C322A3BC54A} = {C7568468-1C79-4944-8136-18812A7F9EA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline;
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    internal sealed class CurrentAppDomainExceptionProcessor
+    {
+        private readonly ExceptionPipeline _pipeline;
+        private readonly CurrentAppDomainExceptionSource _source;
+
+        public CurrentAppDomainExceptionProcessor()
+        {
+            _source = new();
+            _pipeline = new(_source, ConfigurePipeline);
+        }
+
+        public void Start()
+        {
+            _pipeline.Start();
+        }
+
+        private static void ConfigurePipeline(ExceptionPipelineBuilder builder)
+        {
+            // Prevent rethrows from being evaluated; only care about origination of exceptions.
+            builder.Add(next => new FilterRepeatExceptionPipelineStep(next).Invoke);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionSource.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    /// <summary>
+    /// Produces first chance exceptions from the current app domain.
+    /// </summary>
+    internal sealed class CurrentAppDomainExceptionSource :
+        IExceptionSource,
+        IDisposable
+    {
+        private long _disposedState;
+        private ThreadLocal<bool> _handlingException = new();
+
+        public event EventHandler<Exception>? ExceptionThrown;
+
+        public CurrentAppDomainExceptionSource()
+        {
+            AppDomain.CurrentDomain.FirstChanceException += CurrentDomain_FirstChanceException;
+        }
+
+        private void CurrentDomain_FirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
+        {
+            if (_handlingException.Value)
+            {
+                // Exception handling is already in progress on this thread. The current exception is likely
+                // due to the handling code and should be ignored. It will be logged (if not handled) at the
+                // root call of the first chance exception handler.
+                return;
+            }
+
+            // Prevent exeptions from unwinding into user code.
+            try
+            {
+                _handlingException.Value = true;
+
+                ExceptionThrown?.Invoke(sender, e.Exception);
+            }
+            catch
+            {
+                // TODO: Log failure
+            }
+            finally
+            {
+                _handlingException.Value = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (0 != Interlocked.CompareExchange(ref _disposedState, 1, 0))
+                return;
+
+            AppDomain.CurrentDomain.FirstChanceException -= CurrentDomain_FirstChanceException;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
@@ -6,13 +6,18 @@ using System;
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
     /// <summary>
-    /// Interface representing a source of thrown exceptions.
+    /// Represents a source of thrown exceptions.
     /// </summary>
-    internal interface IExceptionSource
+    internal abstract class ExceptionSourceBase
     {
+        protected void RaiseExceptionThrown(Exception ex)
+        {
+            ExceptionThrown?.Invoke(this, ex);
+        }
+
         /// <summary>
         /// Event that is raised each time an exception is thrown.
         /// </summary>
-        event EventHandler<Exception>? ExceptionThrown;
+        public event EventHandler<Exception>? ExceptionThrown;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/IExceptionSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/IExceptionSource.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    /// <summary>
+    /// Interface representing a source of thrown exceptions.
+    /// </summary>
+    internal interface IExceptionSource
+    {
+        /// <summary>
+        /// Event that is raised each time an exception is thrown.
+        /// </summary>
+        event EventHandler<Exception>? ExceptionThrown;
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
+{
+    internal sealed class ExceptionPipeline :
+        IDisposable
+    {
+        private readonly ExceptionPipelineDelegate _exceptionHandler;
+        private readonly IExceptionSource _exceptionSource;
+
+        private long _disposedState;
+
+        public ExceptionPipeline(IExceptionSource exceptionSource, Action<ExceptionPipelineBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(exceptionSource);
+            ArgumentNullException.ThrowIfNull(configure);
+
+            _exceptionSource = exceptionSource;
+
+            ExceptionPipelineBuilder builder = new();
+            configure(builder);
+            _exceptionHandler = builder.Build();
+        }
+
+        public void Start()
+        {
+            _exceptionSource.ExceptionThrown += ExceptionSource_ExceptionThrown;
+        }
+
+        private void ExceptionSource_ExceptionThrown(object? sender, Exception e)
+        {
+            _exceptionHandler.Invoke(e);
+        }
+
+        public void Dispose()
+        {
+            if (0 != Interlocked.CompareExchange(ref _disposedState, 1, 0))
+                return;
+
+            _exceptionSource.ExceptionThrown -= ExceptionSource_ExceptionThrown;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
             // DESIGN: While async patterns are typically favored over synchronous patterns,
             // this is intentionally synchronous. Use cases for making this asynchronous typically
             // involve I/O operations, however those can be dispatched to other threads if necessary
-            // (e.g. EventSource provides events but diagnostic pipe events are queue and asynchronously emitted).
+            // (e.g. EventSource provides events but diagnostic pipe events are queued and asynchronously emitted).
             // Synchronous execution is required for scenarios where the exception needs to be held
             // at the site of where it is thrown before allowing it to unwind (e.g. capturing a dump of the exception).
             _exceptionHandler.Invoke(e);

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineBuilder.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineBuilder.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 
         public ExceptionPipelineDelegate Build()
         {
+            // DESIGN: Chaining delegates together could natively be done using multicast delegates,
+            // however that would eliminate the ability for one pipeline step to short-circuit the
+            // execution of the remaining steps, thus allowing exception filtering. Alternate designs
+            // that allow for this would still require to not use multicast delegates or would need
+            // to throw specialized exceptions.
             ExceptionPipelineDelegate next = Empty;
             for (int index = _steps.Count - 1; index >= 0; index--)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineBuilder.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineBuilder.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
+{
+    /// <summary>
+    /// Builds a single exception pipeline handler from individual exception pipeline steps.
+    /// </summary>
+    internal sealed class ExceptionPipelineBuilder
+    {
+        private static readonly ExceptionPipelineDelegate Empty = _ => { };
+
+        private List<Func<ExceptionPipelineDelegate, ExceptionPipelineDelegate>> _steps = new();
+
+        public ExceptionPipelineBuilder Add(Func<ExceptionPipelineDelegate, ExceptionPipelineDelegate> step)
+        {
+            ArgumentNullException.ThrowIfNull(step);
+
+            _steps.Add(step);
+            return this;
+        }
+
+        public ExceptionPipelineDelegate Build()
+        {
+            ExceptionPipelineDelegate next = Empty;
+            for (int index = _steps.Count - 1; index >= 0; index--)
+            {
+                next = _steps[index].Invoke(next);
+            }
+            return next;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineDelegate.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineDelegate.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
+{
+    /// <summary>
+    /// Delegate representing an exception handler in the exception processing pipeline.
+    /// </summary>
+    internal delegate void ExceptionPipelineDelegate(Exception exception);
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStep.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    /// <summary>
+    /// An exception pipeline step that will only allow an exception to be
+    /// processed further if it was not observed previously.
+    /// </summary>
+    internal sealed class FilterRepeatExceptionPipelineStep
+    {
+        // This is not static so that instances of this action can be used
+        // in multiple pipelines that may process the same exception.
+        private readonly object _firstOccurrenceKey = new();
+        private readonly ExceptionPipelineDelegate _next;
+
+        public FilterRepeatExceptionPipelineStep(ExceptionPipelineDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(next);
+
+            _next = next;
+        }
+
+        public void Invoke(Exception exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            if (IsFirstObservance(exception))
+            {
+                MarkObservance(exception);
+
+                _next(exception);
+            }
+        }
+
+        private bool IsFirstObservance(Exception ex)
+        {
+            return !ex.Data.Contains(_firstOccurrenceKey);
+        }
+
+        private void MarkObservance(Exception ex)
+        {
+            ex.Data.Add(_firstOccurrenceKey, null);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Microsoft.Diagnostics.Monitoring.StartupHook.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Microsoft.Diagnostics.Monitoring.StartupHook.csproj
@@ -5,10 +5,15 @@
     <IsShippingAssembly>true</IsShippingAssembly>
     <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);STARTUPHOOK</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests"/>
+    <Compile Include="..\Tools\dotnet-monitor\DisposableHelper.cs" Link="DisposableHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests" />
   </ItemGroup>
   
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Microsoft.Diagnostics.Monitoring.StartupHook.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Microsoft.Diagnostics.Monitoring.StartupHook.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsShippingAssembly>true</IsShippingAssembly>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests"/>
+  </ItemGroup>
+  
+</Project>

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/StartupHook.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/StartupHook.cs
@@ -9,6 +9,13 @@ internal sealed class StartupHook
 
     public static void Initialize()
     {
-        s_exceptionProcessor.Start();
+        try
+        {
+            s_exceptionProcessor.Start();
+        }
+        catch
+        {
+            // TODO: Log failure
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/StartupHook.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/StartupHook.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions;
+
+internal sealed class StartupHook
+{
+    private static CurrentAppDomainExceptionProcessor s_exceptionProcessor = new();
+
+    public static void Initialize()
+    {
+        s_exceptionProcessor.Start();
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    public sealed class CurrentAppDomainExceptionSourceTests
+    {
+        private readonly Thread _thisThread = Thread.CurrentThread;
+
+        private EventHandler<Exception> CreateHandler(List<Exception> reportedExceptions)
+        {
+            return (sender, exception) =>
+            {
+                if (Thread.CurrentThread == _thisThread)
+                {
+                    reportedExceptions.Add(exception);
+                }
+            };
+        }
+
+        [Fact]
+        public void CurrentAppDomainExceptionSource_ReportsExceptionInsideLifetime()
+        {
+            List<Exception> reportedExceptions = new();
+
+            Exception thrownException = new();
+            using (CurrentAppDomainExceptionSource source = new())
+            {
+                source.ExceptionThrown += CreateHandler(reportedExceptions);
+                try
+                {
+                    throw thrownException;
+                }
+                catch
+                {
+                }
+            }
+
+            Exception singleException = Assert.Single(reportedExceptions);
+            Assert.Equal(thrownException, singleException);
+        }
+
+        [Fact]
+        public void CurrentAppDomainExceptionSource_NoExceptionsOutsideLifetime()
+        {
+            List<Exception> reportedExceptions = new();
+
+            using (CurrentAppDomainExceptionSource source = new())
+            {
+                source.ExceptionThrown += CreateHandler(reportedExceptions);
+            }
+
+            try
+            {
+                throw new Exception();
+            }
+            catch
+            {
+            }
+
+            Assert.Empty(reportedExceptions);
+        }
+
+        [Fact]
+        public void CurrentAppDomainExceptionSource_ReentrancyPrevented()
+        {
+            bool handled = false;
+            EventHandler<Exception> handler = (sender, exception) =>
+            {
+                if (Thread.CurrentThread == _thisThread)
+                {
+                    Assert.False(handled, "Exception handling reentrancy prevention failed.");
+                    handled = true;
+
+                    throw new InvalidOperationException();
+                }
+            };
+
+            Exception thrownException = new ();
+            using (CurrentAppDomainExceptionSource source = new())
+            {
+                source.ExceptionThrown += handler;
+                try
+                {
+                    throw thrownException;
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
                 }
             };
 
-            Exception thrownException = new ();
+            Exception thrownException = new();
             using (CurrentAppDomainExceptionSource source = new())
             {
                 source.ExceptionThrown += handler;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    internal sealed class MockExceptionSource :
+        IExceptionSource,
+        IDisposable
+    {
+        public event EventHandler<Exception>? ExceptionThrown;
+
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+
+        public void ProvideException(Exception exception)
+        {
+            ExceptionThrown?.Invoke(this, exception);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
@@ -6,11 +6,9 @@ using System;
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
     internal sealed class MockExceptionSource :
-        IExceptionSource,
+        ExceptionSourceBase,
         IDisposable
     {
-        public event EventHandler<Exception>? ExceptionThrown;
-
         public bool IsDisposed { get; private set; }
 
         public void Dispose()
@@ -20,7 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 
         public void ProvideException(Exception exception)
         {
-            ExceptionThrown?.Invoke(this, exception);
+            RaiseExceptionThrown(exception);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineBuilderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineBuilderTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    public sealed class ExceptionPipelineBuilderTests
+    {
+        [Fact]
+        public void ExceptionPipelineBuilder_NoSteps()
+        {
+            ExceptionPipelineDelegate handler = new ExceptionPipelineBuilder()
+                .Build();
+
+            Assert.NotNull(handler);
+
+            handler.Invoke(new Exception());
+        }
+
+        [Fact]
+        public void ExceptionPipelineBuilder_StepExecutionOrder()
+        {
+            const int Step1Id = 5;
+            const int Step2Id = 8;
+            const int Step3Id = 2;
+
+            List<int> stepOrder = new List<int>();
+
+            ExceptionPipelineDelegate handler = new ExceptionPipelineBuilder()
+                .Add(AppendIntegerPipelineStep.CreateBuilderStep(stepOrder, Step1Id))
+                .Add(AppendIntegerPipelineStep.CreateBuilderStep(stepOrder, Step2Id))
+                .Add(AppendIntegerPipelineStep.CreateBuilderStep(stepOrder, Step3Id))
+                .Build();
+
+            Assert.NotNull(handler);
+
+            Assert.Empty(stepOrder);
+
+            handler.Invoke(new Exception());
+
+            Assert.Equal(new int[] { Step1Id, Step2Id, Step3Id }, stepOrder);
+        }
+
+        [Fact]
+        public void ExceptionPipelineBuilder_StepShortCircuit()
+        {
+            const int Step1Id = 5;
+            const int Step2Id = 8;
+            const int Step3Id = 2;
+
+            List<int> stepOrder = new List<int>();
+
+            ExceptionPipelineDelegate handler = new ExceptionPipelineBuilder()
+                .Add(AppendIntegerPipelineStep.CreateBuilderStep(stepOrder, Step1Id))
+                .Add(AppendIntegerPipelineStep.CreateBuilderStep(stepOrder, Step2Id, shortCircuit: true))
+                .Add(AppendIntegerPipelineStep.CreateBuilderStep(stepOrder, Step3Id))
+                .Build();
+
+            Assert.NotNull(handler);
+
+            Assert.Empty(stepOrder);
+
+            handler.Invoke(new Exception());
+
+            Assert.Equal(new int[] { Step1Id, Step2Id }, stepOrder);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineTests.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    public sealed class ExceptionPipelineTests
+    {
+        private static readonly Action<ExceptionPipelineBuilder> EmptyConfigure = _ => { };
+
+
+        [Fact]
+        public void ExceptionPipeline_NoSteps()
+        {
+            using MockExceptionSource source = new();
+            using ExceptionPipeline pipeline = new(source, EmptyConfigure);
+
+            pipeline.Start();
+
+            source.ProvideException(new Exception());
+        }
+
+        [Fact]
+        public void ExceptionPipeline_NotStarted()
+        {
+            List<int> steps = new();
+
+            using MockExceptionSource source = new();
+            using ExceptionPipeline pipeline = new(
+                source,
+                builder => builder.Add(AppendIntegerPipelineStep.CreateBuilderStep(steps, 3)));
+
+            source.ProvideException(new Exception());
+
+            Assert.Empty(steps);
+        }
+
+        [Fact]
+        public void ExceptionPipeline_SingleException()
+        {
+            const int ExpectedId = 3;
+
+            List<int> steps = new(1);
+
+            using MockExceptionSource source = new();
+            using ExceptionPipeline pipeline = new(
+                source,
+                builder => builder.Add(AppendIntegerPipelineStep.CreateBuilderStep(steps, ExpectedId)));
+
+            pipeline.Start();
+
+            source.ProvideException(new Exception());
+
+            int id = Assert.Single(steps);
+            Assert.Equal(ExpectedId, id);
+        }
+
+        [Fact]
+        public void ExceptionPipeline_RepeatedException()
+        {
+            const int ExpectedId = 5;
+            const int ExpectedCount = 7;
+
+            List<int> steps = new(ExpectedCount);
+
+            using MockExceptionSource source = new();
+            using ExceptionPipeline pipeline = new(
+                source,
+                builder => builder.Add(AppendIntegerPipelineStep.CreateBuilderStep(steps, ExpectedId)));
+
+            pipeline.Start();
+
+            // Simulates same exception rethrown several times
+            Exception exception = new();
+            for (int i = 0; i < ExpectedCount; i++)
+            {
+                source.ProvideException(exception);
+            }
+
+            Assert.Equal(ExpectedCount, steps.Count);
+            Assert.All(steps, id => Assert.Equal(ExpectedId, id));
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/AppendIntegerPipelineStep.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/AppendIntegerPipelineStep.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    internal sealed class AppendIntegerPipelineStep
+    {
+        private readonly int _id;
+        private readonly List<int> _list;
+        private readonly ExceptionPipelineDelegate _next;
+        private readonly bool _shortCircuit;
+
+        public AppendIntegerPipelineStep(ExceptionPipelineDelegate next, List<int> list, int id, bool shortCircuit)
+        {
+            _id = id;
+            _list = list;
+            _next = next;
+            _shortCircuit = shortCircuit;
+        }
+
+        public void Invoke(Exception ex)
+        {
+            _list.Add(_id);
+            if (!_shortCircuit)
+            {
+                _next.Invoke(ex);
+            }
+        }
+
+        public static Func<ExceptionPipelineDelegate, ExceptionPipelineDelegate> CreateBuilderStep(List<int> list, int id, bool shortCircuit = false)
+        {
+            return next => new AppendIntegerPipelineStep(next, list, id, shortCircuit).Invoke;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStepTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStepTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    public sealed class FilterRepeatExceptionPipelineStepTests
+    {
+        private readonly List<Exception> _reportedExceptions = new();
+        private readonly ExceptionPipelineDelegate _finalHandler;
+
+        public FilterRepeatExceptionPipelineStepTests()
+        {
+            _finalHandler = _reportedExceptions.Add;
+        }
+
+        [Fact]
+        public void FilterRepeatExceptionPipelineStep_AllowFirstOccurrences()
+        {
+            FilterRepeatExceptionPipelineStep action = new(_finalHandler);
+
+            Exception firstException = new();
+            action.Invoke(firstException);
+
+            Exception secondException = new();
+            action.Invoke(secondException);
+
+            IEnumerable<Exception> allExceptions = new List<Exception>()
+            {
+                firstException,
+                secondException
+            };
+
+            Assert.Equal(allExceptions, _reportedExceptions);
+        }
+
+        [Fact]
+        public void FilterRepeatExceptionPipelineStep_FilterSubsequentOccurrences()
+        {
+            FilterRepeatExceptionPipelineStep action = new(_finalHandler);
+
+            Exception firstException = new();
+            action.Invoke(firstException);
+            action.Invoke(firstException);
+            action.Invoke(firstException);
+
+            Exception secondException = new();
+            action.Invoke(secondException);
+            action.Invoke(secondException);
+
+            IEnumerable<Exception> allExceptions = new List<Exception>()
+            {
+                firstException,
+                secondException
+            };
+
+            Assert.Equal(allExceptions, _reportedExceptions);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Diagnostics.Monitoring.StartupHook</RootNamespace>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.StartupHook\Microsoft.Diagnostics.Monitoring.StartupHook.csproj" />
+    <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tools/dotnet-monitor/DisposableHelper.cs
+++ b/src/Tools/dotnet-monitor/DisposableHelper.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 
 #if UNITTEST
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
+#elif STARTUPHOOK
+namespace Microsoft.Diagnostics.Monitoring.StartupHook
 #else
 namespace Microsoft.Diagnostics.Tools.Monitor
 #endif


### PR DESCRIPTION
###### Summary

These changes provide an initial implementation of detecting first chance exceptions in target applications using a startup hook and providing a pipeline for processing the exception instances.

Overview of changes:
- First chance exceptions are monitored when the startup hook code is initialized.
- When an exception is detected, it is handled by a pipeline. This pipeline allows discrete steps to be taken in the specified order  to observe the provided exception. These steps an implementation specific: the only one currently registered is one that prevents rethrown exceptions from being considered. The current pipeline step list will be extended in the future as more of exception handling and reporting is fleshed out.
- The startup hook assembly is only built for .NET 6 but should be loadable for .NET 6+. This can be changed if differing functionality is needed for different runtimes.
- Unit tests for most classes that run on all test target runtimes.


Note that these changes do not impact the product in any way at this time (they are not built into the tool nor are they loaded into any target process).

Interesting classes:
- `CurrentAppDomainExceptionSource`: listens for first chance exceptions in the current app domain and reports them via an event. Handling reentrancy is prevented when the handling code happens to throw an exception (and is hopefully caught).
- `ExceptionPipeline`: executes a list of specified steps in order each time an exception is provided by the exception source.
- `ExceptionPipelineBuilder`: aggregates a list of specified steps into a single handler.
- `FilterRepeatExceptionPipelineStep`: pipeline step that filters out exception instances that were already processed by the pipeline; this is used to allow the first occurrence of thrown exceptions and prevents evaluating rethrows.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
