### PR TITLE
Create platform and TFM specific archives

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup Condition="'$(CreateArchives)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src\archives\dotnet-monitor-archive.proj">
+      <AdditionalProperties>RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+    </ProjectToBuild>
+  </ItemGroup>
+</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,7 +4,15 @@
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
   <ItemGroup>
+    <!--
+      Tarballs are currently not signed nor are their contents.
+      This entry allows them to be signed automatically when tooling allows for it.
+      -->
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tar.gz" />
+    <!--
+      The zip file itself is not signed but their contents are.
+      The zip is expanded, the contents are signed, and then rezipped.
+      -->
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.zip" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,4 +3,8 @@
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
+  <ItemGroup>
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tar.gz" />
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.zip" />
+  </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,6 +56,7 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- dotnet/arcade references -->
+    <MicrosoftDotNetBuildTasksArchivesVersion>7.0.0-beta.22561.2</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetCodeAnalysisVersion>7.0.0-beta.22561.2</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22561.2</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -5,6 +5,7 @@
 # Obtain the location of the bash script to figure out where the root of the repo is.
 __RepoRootDir="$(cd "$(dirname "$0")"/..; pwd -P)"
 
+__CreateArchives=0
 __BuildArch=x64
 __BuildType=Debug
 __CMakeArgs=
@@ -91,6 +92,10 @@ handle_arguments() {
             __ShiftArgs=1
             ;;
 
+        archive|-archive)
+            __CreateArchives=1
+            ;;
+
         -warnaserror|-nodereuse)
             __ManagedBuildArgs="$__ManagedBuildArgs $1 $2"
             __ShiftArgs=1
@@ -137,7 +142,7 @@ fi
 
 if [[ "$__ManagedBuild" == 1 ]]; then
     echo "Commencing managed build for $__BuildType in $__RootBinDir/bin"
-    "$__RepoRootDir/eng/common/build.sh" --build --configuration "$__BuildType" $__CommonMSBuildArgs $__ManagedBuildArgs $__UnprocessedBuildArgs
+    "$__RepoRootDir/eng/common/build.sh" --build --configuration "$__BuildType" $__CommonMSBuildArgs $__ManagedBuildArgs $__ArcadeScriptArgs $__UnprocessedBuildArgs
     if [ "$?" != 0 ]; then
         exit 1
     fi
@@ -198,6 +203,28 @@ if [[ "$__NativeBuild" == 1 ]]; then
 fi
 
 #
+# Archive build
+#
+
+if [[ "$__CreateArchives" == 1 ]]; then
+    echo "Commencing archiving for $__BuildType in $__RootBinDir/bin"
+    "$__RepoRootDir/eng/common/build.sh" \
+      --build \
+      --configuration "$__BuildType" \
+      -nobl \
+      /bl:"$__LogsDir"/Archive.binlog \
+      /p:CreateArchives=true \
+      /p:PackageRid=$__DistroRid \
+      $__CommonMSBuildArgs \
+      $__ManagedBuildArgs \
+      $__ArcadeScriptArgs \
+      $__UnprocessedBuildArgs
+    if [ "$?" != 0 ]; then
+        exit 1
+    fi
+fi
+
+#
 # Run xunit tests
 #
 
@@ -228,11 +255,12 @@ if [[ "$__Test" == 1 ]]; then
       "$__RepoRootDir/eng/common/build.sh" \
         --test \
         --configuration "$__BuildType" \
+        /p:BuildArch="$__BuildArch" \
         -nobl \
         /bl:"$__LogsDir"/Test.binlog \
-        /p:BuildArch="$__BuildArch" \
         /p:TestGroup="$__TestGroup" \
         $__CommonMSBuildArgs \
+        $__ArcadeScriptArgs \
         $__UnprocessedBuildArgs
 
       if [ $? != 0 ]; then

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -157,6 +157,7 @@ jobs:
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
+        -archive
         $(_CrossBuildArgs)
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)

--- a/eng/pipelines/jobs/platform-matrix.yml
+++ b/eng/pipelines/jobs/platform-matrix.yml
@@ -31,6 +31,7 @@ jobs:
       publishArtifactsSubPaths:
       - source: 'bin'
       - source: 'obj'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
@@ -42,6 +43,7 @@ jobs:
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
       - source: 'bin/Windows_NT.x86.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -54,6 +56,7 @@ jobs:
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
         - source: 'bin/Windows_NT.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -72,6 +75,7 @@ jobs:
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
       - source: 'bin/Linux.x64.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -84,6 +88,7 @@ jobs:
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
         - source: 'bin/Linux.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -103,6 +108,7 @@ jobs:
       publishArtifactsSubPaths:
       - source: 'bin/Linux.x64.Release'
         target: 'bin/Linux-musl.x64.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -116,6 +122,7 @@ jobs:
         publishArtifactsSubPaths:
         - source: 'bin/Linux.arm64.Release'
           target: 'bin/Linux-musl.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -134,6 +141,7 @@ jobs:
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
       - source: 'bin/OSX.x64.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -146,4 +154,5 @@ jobs:
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
         - source: 'bin/OSX.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DebugSymbols>true</DebugSymbols>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+    <DefaultRuntimeIdentifiers>linux-arm64;linux-x64;linux-musl-arm64;linux-musl-x64;win-arm64;win-x64;win-x86;osx-arm64;osx-x64</DefaultRuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64;win-arm;osx-x64;linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;linux-arm</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(RuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
-    <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
-    <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
     <ToolCommandName>dotnet-monitor</ToolCommandName>
     <Description>.NET Core Diagnostic Monitoring Tool</Description>
@@ -56,28 +54,83 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Profiler library items for all of the native platforms. -->
+    <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
+      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
+    </MonitorProfilerLibraryFile>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Profiler symbols items for all of the native platforms. -->
+    <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
+      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
+    </MonitorProfilerSymbolsFile>
+  </ItemGroup>
+
   <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherNativeFilesForTfm</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherTfmNativeFilesInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="GatherNativeFilesForTfm">
-    <ItemGroup>
-      <!-- Create profiler library items for all of the native platforms. -->
-      <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
-        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
-      </MonitorProfilerLibraryFile>
-    </ItemGroup>
-    <ItemGroup>
-      <!-- Create profiler symbols items for all of the native platforms. -->
-      <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
-        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
-      </MonitorProfilerSymbolsFile>
-    </ItemGroup>
+  <Target Name="GatherTfmNativeFilesInPackage">
     <ItemGroup>
       <!-- Pack the profiler library for each platform if it exists. -->
       <TfmSpecificPackageFile Include="@(MonitorProfilerLibraryFile-&gt;Exists())" />
       <!-- Pack the profiler symbols for each platform if it exists. -->
       <TfmSpecificPackageFile Include="@(MonitorProfilerSymbolsFile-&gt;Exists())" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeNonSymbolFilesToPublish"
+          AfterTargets="ComputeFilesToPublish"
+          Condition="'$(ExcludeNonSymbolFiles)' != 'true'">
+    <ItemGroup>
+      <!-- Include the profiler library for the corresponding platform if it exists. -->
+      <ResolvedFileToPublish Include="@(MonitorProfilerLibraryFile-&gt;Exists())"
+                             Condition="'%(MonitorProfilerLibraryFile.TargetRid)' == '$(RuntimeIdentifier)'">
+        <RelativePath>%(MonitorProfilerLibraryFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeSymbolFilesToPublish"
+          AfterTargets="ComputeFilesToPublish"
+          Condition="'$(ExcludeSymbolFiles)' != 'true'">
+    <ItemGroup>
+      <!-- Include the profiler symbols for the corresponding platform if it exists. -->
+      <ResolvedFileToPublish Include="@(MonitorProfilerSymbolsFile-&gt;Exists())"
+                             Condition="'%(MonitorProfilerSymbolsFile.TargetRid)' == '$(RuntimeIdentifier)'">
+        <RelativePath>%(MonitorProfilerSymbolsFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CalculateSymbolsFilesToPublish">
+    <ItemGroup>
+      <ResolvedSymbolFileToPublish Include="@(ResolvedFileToPublish)"
+                                   Condition="'%(Extension)' == '.dbg' or '%(Extension)' == '.dwarf' or '%(Extension)' == '.pdb'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExcludeNonSymbolFilesFromPublish"
+          AfterTargets="ComputeFilesToPublish"
+          DependsOnTargets="CalculateSymbolsFilesToPublish"
+          Condition="'$(ExcludeNonSymbolFiles)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" />
+      <ResolvedFileToPublish Include="@(ResolvedSymbolFileToPublish)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExcludeSymbolFilesFromPublish"
+          AfterTargets="ComputeFilesToPublish"
+          DependsOnTargets="CalculateSymbolsFilesToPublish"
+          Condition="'$(ExcludeSymbolFiles)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedSymbolFileToPublish)" />
     </ItemGroup>
   </Target>
 

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <ArchiveName>dotnet-monitor</ArchiveName>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
+    <CreateSymbolsArchive>true</CreateSymbolsArchive>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
+  </ItemGroup>
+  <PropertyGroup>
+    <SharedPublishProjectProperties>SelfContained=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);PackAsTool=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);TargetFramework=$(TargetFramework)</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);RuntimeIdentifier=$(RuntimeIdentifier)</SharedPublishProjectProperties>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackagePublishProjectProperties>$(SharedPublishProjectProperties)</PackagePublishProjectProperties>
+    <PackagePublishProjectProperties>$(PackagePublishProjectProperties);PublishDir=$(OutputPath)</PackagePublishProjectProperties>
+    <!-- Remove all files that are symbols files. -->
+    <PackagePublishProjectProperties>$(PackagePublishProjectProperties);ExcludeSymbolFiles=true</PackagePublishProjectProperties>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SymbolsPublishProjectProperties>$(SharedPublishProjectProperties)</SymbolsPublishProjectProperties>
+    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);PublishDir=$(SymbolsOutputPath)</SymbolsPublishProjectProperties>
+    <!-- Remove all files that are not symbol files. -->
+    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);ExcludeNonSymbolFiles=true</SymbolsPublishProjectProperties>
+    <!-- Disable web.config transforms so it doesn't end up in the symbols package. -->
+    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);IsWebConfigTransformDisabled=true</SymbolsPublishProjectProperties>
+  </PropertyGroup>
+  <!-- TODO: TPN is not included due to build ordering (archives are created in build job, TPN created in separate job) -->
+  <Target Name="PublishToDisk">
+    <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
+             Targets="Publish"
+             Properties="$(PackagePublishProjectProperties)"
+             RemoveProperties="OutputPath" />
+  </Target>
+  <Target Name="PublishSymbolsToDisk">
+    <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
+             Targets="Publish"
+             Properties="$(SymbolsPublishProjectProperties)"
+             RemoveProperties="OutputPath" />
+  </Target>
+</Project>


### PR DESCRIPTION
###### Summary

These changes add the ability to produce archives (zip for Windows, gzip-compressed tarballs for non-Windows) as part of build. The pipelines have been updated to produce and sign these archives but not to publish them (they will only be available as build artifacts until all of the outstanding issues are resolved).

- Add `-archive` switch to build scripts to optionally produce archives after building the managed and native components.
- The archive is built for the current platform, current build architecture, and latest target framework (namely .NET 7).
- The archives are produced from the `dotnet-monitor-archive.proj` file using Arcade's `Microsoft.DotNet.Build.Tasks.Archives` build task
  - It builds the `dotnet-monitor.csproj` project as a framework dependent, RID-specific (e.g. `win-x64`) output excluding the apphost file (e.g. `dotnet-monitor.exe`)
  - It produces a product archive with just the product binaries and related files it in (no symbol files) and a separate symbols archive that only contains symbol files (no libraries, assemblies, etc).
- The archive includes the profiler assembly only for the corresponding platform and build architecture e.g. Windows x64 archive only contains the `win-x64` profiler.

Example archive name: `dotnet-monitor-7.1.0-rtm.23052.1-win-x64.zip`
Example internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2077707&view=results

Outstanding issues to be fixed in future PRs:
- ~~The package version should be `7.1.0` instead of `7.1.0-rtm.23052.1`.~~ Because the archives are marked as non-shipping, they do not get final version numbers.
- ~~The package versioning on non-Windows platforms is not respecting the `-ci` flag when building, so it produces versions with a `-dev` label e.g. `7.1.0-dev.23052.1`~~ Fixed: The `-ci` flag is captured in the ` $__ArcadeScriptArgs` variable, which has been added back to the `build.sh` script.
- The files inside the tarballs have inconsistent permissions.
- The third-party notice (TPN) file is not included in the archives due to build ordering.
- Addition of a LICENSE.txt file with the MIT license in it.
- Consider including the profiler for other platforms that are emulatable e.g. Windows x64 archive should contain `win-x64` and `win-x86` profilers, Windows ARM64 archive should contain `win-arm64`, `win-x64`, and `win-x86` profilers, etc.

The intent is to backport this to `6.x` an `main` with minor adjustments (the TFM) so that way there is a consistent acquisition experience across all in-support versions.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
