### PR TITLE
[release/6.x] Create platform and TFM specific archives

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup Condition="'$(CreateArchives)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src\archives\dotnet-monitor-archive.proj">
+      <AdditionalProperties>RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+    </ProjectToBuild>
+  </ItemGroup>
+</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,4 +3,16 @@
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
+  <ItemGroup>
+    <!--
+      Tarballs are currently not signed nor are their contents.
+      This entry allows them to be signed automatically when tooling allows for it.
+      -->
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tar.gz" />
+    <!--
+      The zip file itself is not signed but their contents are.
+      The zip is expanded, the contents are signed, and then rezipped.
+      -->
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.zip" />
+  </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,6 +42,7 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- dotnet/arcade references -->
+    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.22601.5</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.22601.5</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22601.5</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -5,6 +5,7 @@
 # Obtain the location of the bash script to figure out where the root of the repo is.
 __RepoRootDir="$(cd "$(dirname "$0")"/..; pwd -P)"
 
+__CreateArchives=0
 __BuildArch=x64
 __BuildType=Debug
 __CMakeArgs=
@@ -91,6 +92,10 @@ handle_arguments() {
             __ShiftArgs=1
             ;;
 
+        archive|-archive)
+            __CreateArchives=1
+            ;;
+
         -warnaserror|-nodereuse)
             __ManagedBuildArgs="$__ManagedBuildArgs $1 $2"
             __ShiftArgs=1
@@ -137,7 +142,7 @@ fi
 
 if [[ "$__ManagedBuild" == 1 ]]; then
     echo "Commencing managed build for $__BuildType in $__RootBinDir/bin"
-    "$__RepoRootDir/eng/common/build.sh" --build --configuration "$__BuildType" $__CommonMSBuildArgs $__ManagedBuildArgs $__UnprocessedBuildArgs
+    "$__RepoRootDir/eng/common/build.sh" --build --configuration "$__BuildType" $__CommonMSBuildArgs $__ManagedBuildArgs $__ArcadeScriptArgs $__UnprocessedBuildArgs
     if [ "$?" != 0 ]; then
         exit 1
     fi
@@ -198,6 +203,28 @@ if [[ "$__NativeBuild" == 1 ]]; then
 fi
 
 #
+# Archive build
+#
+
+if [[ "$__CreateArchives" == 1 ]]; then
+    echo "Commencing archiving for $__BuildType in $__RootBinDir/bin"
+    "$__RepoRootDir/eng/common/build.sh" \
+      --build \
+      --configuration "$__BuildType" \
+      -nobl \
+      /bl:"$__LogsDir"/Archive.binlog \
+      /p:CreateArchives=true \
+      /p:PackageRid=$__DistroRid \
+      $__CommonMSBuildArgs \
+      $__ManagedBuildArgs \
+      $__ArcadeScriptArgs \
+      $__UnprocessedBuildArgs
+    if [ "$?" != 0 ]; then
+        exit 1
+    fi
+fi
+
+#
 # Run xunit tests
 #
 
@@ -228,11 +255,12 @@ if [[ "$__Test" == 1 ]]; then
       "$__RepoRootDir/eng/common/build.sh" \
         --test \
         --configuration "$__BuildType" \
+        /p:BuildArch="$__BuildArch" \
         -nobl \
         /bl:"$__LogsDir"/Test.binlog \
-        /p:BuildArch="$__BuildArch" \
         /p:TestGroup="$__TestGroup" \
         $__CommonMSBuildArgs \
+        $__ArcadeScriptArgs \
         $__UnprocessedBuildArgs
 
       if [ $? != 0 ]; then

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -157,6 +157,7 @@ jobs:
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
+        -archive
         $(_CrossBuildArgs)
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)

--- a/eng/pipelines/jobs/platform-matrix.yml
+++ b/eng/pipelines/jobs/platform-matrix.yml
@@ -31,6 +31,7 @@ jobs:
       publishArtifactsSubPaths:
       - source: 'bin'
       - source: 'obj'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
@@ -42,6 +43,7 @@ jobs:
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
       - source: 'bin/Windows_NT.x86.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -54,6 +56,7 @@ jobs:
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
         - source: 'bin/Windows_NT.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -72,6 +75,7 @@ jobs:
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
       - source: 'bin/Linux.x64.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -84,6 +88,7 @@ jobs:
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
         - source: 'bin/Linux.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -103,6 +108,7 @@ jobs:
       publishArtifactsSubPaths:
       - source: 'bin/Linux.x64.Release'
         target: 'bin/Linux-musl.x64.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -116,6 +122,7 @@ jobs:
         publishArtifactsSubPaths:
         - source: 'bin/Linux.arm64.Release'
           target: 'bin/Linux-musl.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -134,6 +141,7 @@ jobs:
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
       - source: 'bin/OSX.x64.Release'
+      - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
@@ -146,4 +154,5 @@ jobs:
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
         - source: 'bin/OSX.arm64.Release'
+        - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,8 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DebugSymbols>true</DebugSymbols>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+    <DefaultRuntimeIdentifiers>linux-arm64;linux-x64;linux-musl-arm64;linux-musl-x64;win-arm64;win-x64;win-x86;osx-x64</DefaultRuntimeIdentifiers>
+    <DefaultRuntimeIdentifiers Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">$(DefaultRuntimeIdentifiers);osx-arm64</DefaultRuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64;win-arm;osx-x64;linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;linux-arm</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(RuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
-    <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
-    <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
     <ToolCommandName>dotnet-monitor</ToolCommandName>
     <Description>.NET Core Diagnostic Monitoring Tool</Description>
@@ -72,29 +70,84 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Profiler library items for all of the native platforms. -->
+    <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
+      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
+    </MonitorProfilerLibraryFile>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Profiler symbols items for all of the native platforms. -->
+    <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
+      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
+    </MonitorProfilerSymbolsFile>
+  </ItemGroup>
+
   <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherNativeFilesForTfm</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherTfmNativeFilesInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <!-- Don't include profiler files in official builds until productized. -->
-  <Target Name="GatherNativeFilesForTfm" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
-    <ItemGroup>
-      <!-- Create profiler library items for all of the native platforms. -->
-      <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
-        <PackagePath>tools/$(TargetFramework)/any/profiler/%(TargetRid)</PackagePath>
-      </MonitorProfilerLibraryFile>
-    </ItemGroup>
-    <ItemGroup>
-      <!-- Create profiler symbols items for all of the native platforms. -->
-      <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
-        <PackagePath>tools/$(TargetFramework)/any/profiler/%(TargetRid)</PackagePath>
-      </MonitorProfilerSymbolsFile>
-    </ItemGroup>
+  <Target Name="GatherTfmNativeFilesInPackage" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
     <ItemGroup>
       <!-- Pack the profiler library for each platform if it exists. -->
       <TfmSpecificPackageFile Include="@(MonitorProfilerLibraryFile->Exists())" />
       <!-- Pack the profiler symbols for each platform if it exists. -->
       <TfmSpecificPackageFile Include="@(MonitorProfilerSymbolsFile->Exists())" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeNonSymbolFilesToPublish"
+          AfterTargets="ComputeFilesToPublish"
+          Condition="'$(ExcludeNonSymbolFiles)' != 'true' and '$(ContinuousIntegrationBuild)' != 'true'">
+    <ItemGroup>
+      <!-- Include the profiler library for the corresponding platform if it exists. -->
+      <ResolvedFileToPublish Include="@(MonitorProfilerLibraryFile-&gt;Exists())"
+                             Condition="'%(MonitorProfilerLibraryFile.TargetRid)' == '$(RuntimeIdentifier)'">
+        <RelativePath>%(MonitorProfilerLibraryFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeSymbolFilesToPublish"
+          AfterTargets="ComputeFilesToPublish"
+          Condition="'$(ExcludeSymbolFiles)' != 'true' and '$(ContinuousIntegrationBuild)' != 'true'">
+    <ItemGroup>
+      <!-- Include the profiler symbols for the corresponding platform if it exists. -->
+      <ResolvedFileToPublish Include="@(MonitorProfilerSymbolsFile-&gt;Exists())"
+                             Condition="'%(MonitorProfilerSymbolsFile.TargetRid)' == '$(RuntimeIdentifier)'">
+        <RelativePath>%(MonitorProfilerSymbolsFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CalculateSymbolsFilesToPublish">
+    <ItemGroup>
+      <ResolvedSymbolFileToPublish Include="@(ResolvedFileToPublish)"
+                                   Condition="'%(Extension)' == '.dbg' or '%(Extension)' == '.dwarf' or '%(Extension)' == '.pdb'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExcludeNonSymbolFilesFromPublish"
+          AfterTargets="ComputeFilesToPublish"
+          DependsOnTargets="CalculateSymbolsFilesToPublish"
+          Condition="'$(ExcludeNonSymbolFiles)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" />
+      <ResolvedFileToPublish Include="@(ResolvedSymbolFileToPublish)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExcludeSymbolFilesFromPublish"
+          AfterTargets="ComputeFilesToPublish"
+          DependsOnTargets="CalculateSymbolsFilesToPublish"
+          Condition="'$(ExcludeSymbolFiles)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedSymbolFileToPublish)" />
     </ItemGroup>
   </Target>
 

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <ArchiveName>dotnet-monitor</ArchiveName>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
+    <CreateSymbolsArchive>true</CreateSymbolsArchive>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
+  </ItemGroup>
+  <PropertyGroup>
+    <SharedPublishProjectProperties>SelfContained=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);PackAsTool=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);TargetFramework=$(TargetFramework)</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);RuntimeIdentifier=$(RuntimeIdentifier)</SharedPublishProjectProperties>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackagePublishProjectProperties>$(SharedPublishProjectProperties)</PackagePublishProjectProperties>
+    <PackagePublishProjectProperties>$(PackagePublishProjectProperties);PublishDir=$(OutputPath)</PackagePublishProjectProperties>
+    <!-- Remove all files that are symbols files. -->
+    <PackagePublishProjectProperties>$(PackagePublishProjectProperties);ExcludeSymbolFiles=true</PackagePublishProjectProperties>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SymbolsPublishProjectProperties>$(SharedPublishProjectProperties)</SymbolsPublishProjectProperties>
+    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);PublishDir=$(SymbolsOutputPath)</SymbolsPublishProjectProperties>
+    <!-- Remove all files that are not symbol files. -->
+    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);ExcludeNonSymbolFiles=true</SymbolsPublishProjectProperties>
+    <!-- Disable web.config transforms so it doesn't end up in the symbols package. -->
+    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);IsWebConfigTransformDisabled=true</SymbolsPublishProjectProperties>
+  </PropertyGroup>
+  <!-- TODO: TPN is not included due to build ordering (archives are created in build job, TPN created in separate job) -->
+  <Target Name="PublishToDisk">
+    <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
+             Targets="Publish"
+             Properties="$(PackagePublishProjectProperties)"
+             RemoveProperties="OutputPath" />
+  </Target>
+  <Target Name="PublishSymbolsToDisk">
+    <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
+             Targets="Publish"
+             Properties="$(SymbolsPublishProjectProperties)"
+             RemoveProperties="OutputPath" />
+  </Target>
+</Project>


### PR DESCRIPTION
###### Summary

Manual backport of #3204 to `release/6.x`. Notable differences are:
- Changing the archive TFM from `net7.0` to `net6.0`.
- Excluding `osx-arm64` runtime identifier for `netcoreapp3.1`.
- Excluded the profiler assemblies from the archives in official builds as is done for the NuGet packages.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
