### PR TITLE
Make file permissions consistent in archives

### DIFF
--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -36,11 +36,31 @@
              Targets="Publish"
              Properties="$(PackagePublishProjectProperties)"
              RemoveProperties="OutputPath" />
+    <!-- Make executable files readable by all, writable by the user, and executable by all. -->
+    <ItemGroup>
+      <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
+      <_ArchiveExecutableContent Include="$(OutputPath)**\*.dylib" />
+      <_ArchiveExecutableContent Include="$(OutputPath)**\*.so" />
+    </ItemGroup>
+    <Exec Command="chmod 755 %(_ArchiveExecutableContent.Identity)" Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveExecutableContent)' != ''" />
+    <!-- Make non-executable files readable by all and writable by the user. -->
+    <ItemGroup>
+      <_ArchiveNonExecutableContent Remove="@(_ArchiveNonExecutableContent)" />
+      <_ArchiveNonExecutableContent Include="$(OutputPath)**" />
+      <_ArchiveNonExecutableContent Remove="@(_ArchiveExecutableContent)" />
+    </ItemGroup>
+    <Exec Command="chmod 644 %(_ArchiveNonExecutableContent.Identity)" Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveNonExecutableContent)' != ''" />
   </Target>
   <Target Name="PublishSymbolsToDisk">
     <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
              Targets="Publish"
              Properties="$(SymbolsPublishProjectProperties)"
              RemoveProperties="OutputPath" />
+    <!-- Make non-executable files readable by all and writable by the user. -->
+    <ItemGroup>
+      <_SymbolsNonExecutableContent Remove="@(_SymbolsNonExecutableContent)" />
+      <_SymbolsNonExecutableContent Include="$(SymbolsOutputPath)**" />
+    </ItemGroup>
+    <Exec Command="chmod 644 %(_SymbolsNonExecutableContent.Identity)" Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_SymbolsNonExecutableContent)' != ''" />
   </Target>
 </Project>


### PR DESCRIPTION
###### Summary

Make the file permissions of the contents of the archives consistent for tarballs.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2078461&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
