### PR TITLE
[release/6.x] Do not pack shims for OSX

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,8 +9,12 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DebugSymbols>true</DebugSymbols>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <DefaultRuntimeIdentifiers>linux-arm64;linux-x64;linux-musl-arm64;linux-musl-x64;win-arm64;win-x64;win-x86;osx-x64</DefaultRuntimeIdentifiers>
-    <DefaultRuntimeIdentifiers Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">$(DefaultRuntimeIdentifiers);osx-arm64</DefaultRuntimeIdentifiers>
+    <!-- Executables for these runtime identifiers do not require notarization. -->
+    <SignOnlyRuntimeIdentifiers>linux-arm64;linux-x64;linux-musl-arm64;linux-musl-x64;win-arm64;win-x64;win-x86</SignOnlyRuntimeIdentifiers>
+    <!-- OSX requires executables to be notarized; separate these out from the others so they can be excluded when producing executable shims -->
+    <SignAndNotarizeRuntimeIdentifiers>osx-x64</SignAndNotarizeRuntimeIdentifiers>
+    <SignAndNotarizeRuntimeIdentifiers Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">$(SignAndNotarizeRuntimeIdentifiers);osx-arm64</SignAndNotarizeRuntimeIdentifiers>
+    <DefaultRuntimeIdentifiers>$(SignOnlyRuntimeIdentifiers);$(SignAndNotarizeRuntimeIdentifiers)</DefaultRuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(RuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(SignOnlyRuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
###### Summary

Manual backport of #3211 to `release/6.x`; only difference is that I have to exclude `osx-arm64` for `netcoreapp3.1`.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
