### PR TITLE
Fix Component Governance

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -35,7 +35,7 @@ jobs:
     displayName: ${{ coalesce(parameters.displayName, parameters.name) }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableTelemetry: true
-    disableComponentGovernance: ${{ or(parameters.disableComponentGovernance, eq(parameters.osGroup, 'Linux_Musl')) }}
+    disableComponentGovernance: ${{ or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}
     ${{ if eq(parameters.disableSbom, 'true') }}:
       enableSbom: false
     helixRepo: dotnet/dotnet-monitor
@@ -100,7 +100,7 @@ jobs:
       - ${{ variable }}
 
     # Component Governance does not work on Musl
-    - ${{ if or(parameters.disableComponentGovernance, eq(parameters.osGroup, 'Linux_Musl')) }}:
+    - ${{ if or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}:
       - skipComponentGovernanceDetection: true
     
     # Cross build for arm64 non-Windows builds


### PR DESCRIPTION
###### Summary

#3112 regressed the component governance coverage by not evaluating the `disableComponentGovernance` template parameter correctly which caused it to always be disabled. This change fixes the regression.

Build demonstrating that its fixed: https://dev.azure.com/dnceng/internal/_build/results?buildId=2079307&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
