### PR TITLE
Add boilerplate configuration sources when debugging with Codespaces/VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.sln.docstates
 .vs/
 *.VC.db
+.vscode/innerloop/
 
 # Build results
 [Aa]rtifacts/

--- a/.vscode/innerloop/config/.env
+++ b/.vscode/innerloop/config/.env
@@ -1,0 +1,1 @@
+Example_Environment_Variable=1

--- a/.vscode/innerloop/config/settings.json
+++ b/.vscode/innerloop/config/settings.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../../documentation/schema.json",
+    "CollectionRuleDefaults": {
+        "Actions": {
+            "Egress": "artifacts"
+        }
+    },
+    "Egress": {
+        "FileSystem": {
+            "artifacts": {
+                "DirectoryPath": "./artifacts",
+                "IntermediateDirectoryPath": "./intermediateArtifacts"
+            }
+        }
+    }
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,9 @@
             "request": "launch",
             "preLaunchTask": "Build (Debug)",
             "program": "${workspaceFolder}/artifacts/bin/dotnet-monitor/Debug/net7.0/dotnet-monitor.dll",
-            "args": "${input:args}",
+            "args": "${input:args} --configuration-file-path \"${workspaceFolder}/.vscode/innerloop/config/settings.json\"",
+            "envFile": "${workspaceFolder}/.vscode/innerloop/config/.env",
+            "cwd": "${workspaceFolder}/.vscode/innerloop",
             "stopAtEntry": false,
             "justMyCode": false
         },
@@ -24,7 +26,9 @@
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceFolder}/artifacts/bin/dotnet-monitor/Debug/net7.0/dotnet-monitor.dll",
-            "args": "${input:args}",
+            "args": "${input:args} --configuration-file-path \"${workspaceFolder}/.vscode/innerloop/config/settings.json\"",
+            "envFile": "${workspaceFolder}/.vscode/innerloop/config/.env",
+            "cwd": "${workspaceFolder}/.vscode/innerloop",
             "stopAtEntry": false,
             "justMyCode": false
         },


### PR DESCRIPTION
###### Summary

Add a boilerplate `dotnet-monitor` configuration that is used when launching/debugging `dotnet-monitor` in Codespaces/VSCode (this is a minimal version of the setup I have been using). 
- `.vscode/innerloop/config/*` holds environment variables and configuration that is applied to a launched `dotnet-monitor` instance.
- `.vscode/innerloop/{artifacts,intermediateArtifacts}` are used to store artifacts and are ignored by git.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
