### PR TITLE
[release/6.x] Use RID folders instead of osGroup/architecture folders

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,11 +1,11 @@
 ﻿{
   "configurations": [
     {
-      "name": "Windows_NT.arm64.Debug",
+      "name": "win-arm64.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.arm64.Debug\\crossgen",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.arm64.Debug",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-arm64.Debug\\crossgen",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-arm64.Debug",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -29,11 +29,11 @@
       ]
     },
     {
-      "name": "Windows_NT.arm64.Release",
+      "name": "win-arm64.Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.arm64.Release\\crossgen",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.arm64.Release",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-arm64.Release\\crossgen",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-arm64.Release",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -57,12 +57,12 @@
       ]
     },
     {
-      "name": "Windows_NT.x64.Debug",
+      "name": "win-x64.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64" ],
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x64.Debug",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x64.Debug",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x64.Debug",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x64.Debug",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -80,11 +80,11 @@
       ]
     },
     {
-      "name": "Windows_NT.x64.Release",
+      "name": "win-x64.Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x64.Release",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x64.Release",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x64.Release",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x64.Release",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -103,11 +103,11 @@
       ]
     },
     {
-      "name": "Windows_NT.x86.Debug",
+      "name": "win-x86.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x86.Debug",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x86.Debug",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x86.Debug",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x86.Debug",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -131,11 +131,11 @@
       ]
     },
     {
-      "name": "Windows_NT.x86.Release",
+      "name": "win-x86.Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x86.Release",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x86.Release",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x86.Release",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x86.Release",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",

--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -110,10 +110,10 @@ echo %NUGET_PACKAGES%
 
 :: Set the remaining variables based upon the determined build configuration
 set "__RootBinDir=%__ProjectDir%\artifacts"
-set "__BinDir=%__RootBinDir%\bin\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__BinDir=%__RootBinDir%\bin\win-%__BuildArch%.%__BuildType%"
 set "__LogDir=%__RootBinDir%\log\%__BuildType%"
 set "__ArtifactsIntermediatesDir=%__RootBinDir%\obj"
-set "__IntermediatesDir=%__ArtifactsIntermediatesDir%\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__IntermediatesDir=%__ArtifactsIntermediatesDir%\win-%__BuildArch%.%__BuildType%"
 set "__PackagesBinDir=%__RootBinDir%\packages\%__BuildType%\Shipping"
 
 set "__CrossComponentBinDir=%__BinDir%"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -110,26 +110,7 @@ handle_arguments() {
 source "$__RepoRootDir"/eng/native/build-commons.sh
 
 __LogsDir="$__RootBinDir/log/$__BuildType"
-__ConfigTriplet="$__TargetOS.$__BuildArch.$__BuildType"
-__BinDir="$__RootBinDir/bin/$__ConfigTriplet"
 __ArtifactsIntermediatesDir="$__RootBinDir/obj"
-__IntermediatesDir="$__ArtifactsIntermediatesDir/$__ConfigTriplet"
-
-# Specify path to be set for CMAKE_INSTALL_PREFIX.
-# This is where all built libraries will copied to.
-__CMakeBinDir="$__BinDir"
-export __CMakeBinDir
-
-mkdir -p "$__IntermediatesDir"
-mkdir -p "$__LogsDir"
-mkdir -p "$__CMakeBinDir"
-
-__ExtraCmakeArgs="$__ExtraCmakeArgs -DCLR_MANAGED_BINARY_DIR=$__RootBinDir/bin -DCLR_BUILD_TYPE=$__BuildType"
-
-# Specify path to be set for CMAKE_INSTALL_PREFIX.
-# This is where all built native libraries will copied to.
-export __CMakeBinDir="$__BinDir"
-
 
 if [[ "$__BuildArch" == "armel" ]]; then
     # Armel cross build is Tizen specific and does not support Portable RID build
@@ -155,6 +136,24 @@ fi
 initTargetDistroRid
 
 echo "RID: $__DistroRid"
+
+__BinDir="$__RootBinDir/bin/$__DistroRid.$__BuildType"
+__IntermediatesDir="$__ArtifactsIntermediatesDir/$__DistroRid.$__BuildType"
+
+# Specify path to be set for CMAKE_INSTALL_PREFIX.
+# This is where all built libraries will copied to.
+__CMakeBinDir="$__BinDir"
+export __CMakeBinDir
+
+mkdir -p "$__IntermediatesDir"
+mkdir -p "$__LogsDir"
+mkdir -p "$__CMakeBinDir"
+
+__ExtraCmakeArgs="$__ExtraCmakeArgs -DCLR_MANAGED_BINARY_DIR=$__RootBinDir/bin -DCLR_BUILD_TYPE=$__BuildType"
+
+# Specify path to be set for CMAKE_INSTALL_PREFIX.
+# This is where all built native libraries will copied to.
+export __CMakeBinDir="$__BinDir"
 
 #
 # Setup LLDB paths for native build

--- a/eng/pipelines/jobs/platform-matrix.yml
+++ b/eng/pipelines/jobs/platform-matrix.yml
@@ -42,7 +42,7 @@ jobs:
     architecture: x86
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
-      - source: 'bin/Windows_NT.x86.Release'
+      - source: 'bin/win-x86.Release'
       - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
@@ -55,7 +55,7 @@ jobs:
       architecture: arm64
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
-        - source: 'bin/Windows_NT.arm64.Release'
+        - source: 'bin/win-arm64.Release'
         - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
@@ -74,7 +74,7 @@ jobs:
     configuration: Release
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
-      - source: 'bin/Linux.x64.Release'
+      - source: 'bin/linux-x64.Release'
       - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
@@ -87,7 +87,7 @@ jobs:
       architecture: arm64
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
-        - source: 'bin/Linux.arm64.Release'
+        - source: 'bin/linux-arm64.Release'
         - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
@@ -106,8 +106,7 @@ jobs:
     configuration: Release
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
-      - source: 'bin/Linux.x64.Release'
-        target: 'bin/Linux-musl.x64.Release'
+      - source: 'bin/linux-musl-x64.Release'
       - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
@@ -120,8 +119,7 @@ jobs:
       architecture: arm64
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
-        - source: 'bin/Linux.arm64.Release'
-          target: 'bin/Linux-musl.arm64.Release'
+        - source: 'bin/linux-musl-arm64.Release'
         - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
@@ -140,7 +138,7 @@ jobs:
     configuration: Release
     ${{ if parameters.publishBuildArtifacts }}:
       publishArtifactsSubPaths:
-      - source: 'bin/OSX.x64.Release'
+      - source: 'bin/osx-x64.Release'
       - source: 'packages'
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
@@ -153,6 +151,6 @@ jobs:
       architecture: arm64
       ${{ if parameters.publishBuildArtifacts }}:
         publishArtifactsSubPaths:
-        - source: 'bin/OSX.arm64.Release'
+        - source: 'bin/osx-arm64.Release'
         - source: 'packages'
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/NativeLibraryHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/NativeLibraryHelper.cs
@@ -17,28 +17,44 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             "Release";
 #endif
 
+        private const string OSReleasePath = "/etc/os-release";
+
         public static string GetSharedLibraryPath(Architecture architecture, string rootName)
         {
             string artifactsBinPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", ".."));
             return Path.Combine(artifactsBinPath, GetNativeBinDirectoryName(architecture), GetSharedLibraryName(rootName));
         }
 
-        private static string GetNativeBinDirectoryName(Architecture architecture)
+        public static string GetTargetRuntimeIdentifier(Architecture? architecture)
         {
-            string architectureString = GetArchitectureFolderName(architecture);
+            string architectureString = GetArchitectureFolderName(architecture ?? RuntimeInformation.OSArchitecture);
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return $"Windows_NT.{architectureString}.{ConfigurationName}";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return $"Linux.{architectureString}.{ConfigurationName}";
+                return FormattableString.Invariant($"win-{architectureString}");
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return $"OSX.{architectureString}.{ConfigurationName}";
+                return FormattableString.Invariant($"osx-{architectureString}");
             }
-            throw new PlatformNotSupportedException();
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (File.Exists(OSReleasePath) && File.ReadAllText(OSReleasePath).Contains("Alpine", StringComparison.OrdinalIgnoreCase))
+                {
+                    return FormattableString.Invariant($"linux-musl-{architectureString}");
+                }
+                else
+                {
+                    return FormattableString.Invariant($"linux-{architectureString}");
+                }
+            }
+
+            throw new PlatformNotSupportedException("Unable to determine OS platform.");
+        }
+
+        private static string GetNativeBinDirectoryName(Architecture architecture)
+        {
+            return $"{GetTargetRuntimeIdentifier(architecture)}.{ConfigurationName}";
         }
 
         private static string GetSharedLibraryName(string rootName)

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -12,15 +12,15 @@
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux.arm64.$(Configuration)" TargetRid="linux-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux.x64.$(Configuration)" TargetRid="linux-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux-musl.arm64.$(Configuration)" TargetRid="linux-musl-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux-musl.x64.$(Configuration)" TargetRid="linux-musl-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)OSX.arm64.$(Configuration)" TargetRid="osx-arm64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)OSX.x64.$(Configuration)" TargetRid="osx-x64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Windows_NT.arm64.$(Configuration)" TargetRid="win-arm64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Windows_NT.x64.$(Configuration)" TargetRid="win-x64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Windows_NT.x86.$(Configuration)" TargetRid="win-x86" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-arm64.$(Configuration)" TargetRid="linux-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-x64.$(Configuration)" TargetRid="linux-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-arm64.$(Configuration)" TargetRid="linux-musl-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-x64.$(Configuration)" TargetRid="linux-musl-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-arm64.$(Configuration)" TargetRid="osx-arm64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-x64.$(Configuration)" TargetRid="osx-x64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-arm64.$(Configuration)" TargetRid="win-arm64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x64.$(Configuration)" TargetRid="win-x64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x86.$(Configuration)" TargetRid="win-x86" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsPackable)' == 'true' and '$(ThirdPartyNoticesFilePath)' != ''">


### PR DESCRIPTION
###### Summary

Manual backport of #3224 to `release/6.x`; merge conflicts were on files that don't exist.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
