### PR TITLE
Implement strncpy_s when on glibc

### DIFF
--- a/src/MonitorProfiler/Utilities/StringUtilities.h
+++ b/src/MonitorProfiler/Utilities/StringUtilities.h
@@ -59,6 +59,7 @@ class StringUtilities
             /* validation section */
             if (dst == NULL || size == 0)
             {
+                errno = EINVAL;
                 return EINVAL;
             }
 
@@ -72,6 +73,7 @@ class StringUtilities
             if (src == NULL)
             {
                 *dst = 0;
+                errno = EINVAL;
                 return EINVAL;
             }
 
@@ -102,6 +104,7 @@ class StringUtilities
                     return STRUNCATE;
                 }
                 *dst = 0;
+                errno = ERANGE;
                 return ERANGE;
             }
 


### PR DESCRIPTION
###### Summary

Port the PAL's implementation of `strncpy_s` for use on glibc builds of the profiler. The PAL uses a single generic algorithm for all `strncpy_s` variants via heavy macro usage, since we only need the basic case this PR ports over it in a simplified form with minimal extra code. There are the following differences from the PAL's:
- The only functional difference is that in debug builds this ported version will not fill any remaining space in the dst buffer with `0xFE`.
- Expanded/replaced macros.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
