### PR TITLE
Allow archiving without building product

### DIFF
--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Import ProjectToPublish items; all projects that would participate in publishing should be listed here. -->
+  <Import Project="$(MSBuildThisFileDirectory)DotnetMonitorProjectToPublish.props" />
+
+  <!-- Only publish projects after build if opt-in -->
+  <Target Name="PublishProjectsAfterBuild"
+          AfterTargets="Build"
+          Condition="'$(PublishProjectsAfterBuild)' == 'true' and '$(CreateArchives)' != 'true'">
+    <CallTarget Targets="PublishProjects" />
+  </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)PublishProjects.targets" />
+</Project>

--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -155,13 +155,6 @@ REM ============================================================================
 
 @if defined _echo @echo on
 
-:: Parse the optdata package versions out of msbuild so that we can pass them on to CMake
-set __DotNetCli=%__ProjectDir%\.dotnet\dotnet.exe
-if not exist "%__DotNetCli%" (
-    echo %__MsgPrefix%Assertion failed: dotnet cli not found at path "%__DotNetCli%"
-    goto ExitWithError
-)
-
 REM =========================================================================================
 REM ===
 REM === Build Cross-Architecture Native Components (if applicable)
@@ -214,7 +207,7 @@ if /i %__BuildCrossArch% EQU 1 (
 
     set __BuildLog="%__LogDir%\Cross.Build.binlog"
 
-    :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
+    :: MSBuild.exe is the only one that has the C++ targets. "dotnet msbuild" fails because VCTargetsPath isn't defined.
     msbuild.exe %__CrossCompIntermediatesDir%\install.vcxproj /bl:!__BuildLog! %__CommonBuildArgs%
 
     if not !ERRORLEVEL! == 0 (
@@ -287,7 +280,7 @@ if %__Build% EQU 1 (
     )
     set __BuildLog="%__LogDir%\Native.Build.binlog"
 
-    :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
+    :: MSBuild.exe is the only one that has the C++ targets. "dotnet msbuild" fails because VCTargetsPath isn't defined.
     msbuild.exe %__IntermediatesDir%\install.vcxproj /bl:!__BuildLog! %__CommonBuildArgs%
 
     if not !ERRORLEVEL! == 0 (

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup Condition="'$(CreateArchives)' == 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\archives\dotnet-monitor-archive.proj">
-      <AdditionalProperties>RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=net7.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
     </ProjectToBuild>
   </ItemGroup>
 </Project>

--- a/eng/DotnetMonitorProjectToPublish.props
+++ b/eng/DotnetMonitorProjectToPublish.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <ProjectToPublish Include="$(RepoRoot)src\Tools\dotnet-monitor\dotnet-monitor.csproj">
+      <AdditionalProperties>TargetFramework=net7.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+    </ProjectToPublish>
+  </ItemGroup>
+</Project>

--- a/eng/PublishProjects.targets
+++ b/eng/PublishProjects.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <SharedPublishProjectProperties>SelfContained=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);PackAsTool=false</SharedPublishProjectProperties>
+  </PropertyGroup>
+
+  <Target Name="PublishProjects">
+    <MSBuild Projects="@(ProjectToPublish)"
+             Properties="$(SharedPublishProjectProperties)"
+             RemoveProperties="OutputPath"
+             Targets="Publish" />
+  </Target>
+
+</Project>

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -118,18 +118,6 @@ if [[ "$__BuildArch" == "armel" ]]; then
 fi
 
 #
-# Managed build
-#
-
-if [[ "$__ManagedBuild" == 1 ]]; then
-    echo "Commencing managed build for $__BuildType in $__RootBinDir/bin"
-    "$__RepoRootDir/eng/common/build.sh" --build --configuration "$__BuildType" $__CommonMSBuildArgs $__ManagedBuildArgs $__ArcadeScriptArgs $__UnprocessedBuildArgs
-    if [ "$?" != 0 ]; then
-        exit 1
-    fi
-fi
-
-#
 # Initialize the target distro name
 #
 
@@ -139,6 +127,7 @@ echo "RID: $__DistroRid"
 
 __BinDir="$__RootBinDir/bin/$__DistroRid.$__BuildType"
 __IntermediatesDir="$__ArtifactsIntermediatesDir/$__DistroRid.$__BuildType"
+__CommonMSBuildArgs="/p:PackageRid=$__DistroRid"
 
 # Specify path to be set for CMAKE_INSTALL_PREFIX.
 # This is where all built libraries will copied to.
@@ -202,6 +191,18 @@ if [[ "$__NativeBuild" == 1 ]]; then
 fi
 
 #
+# Managed build
+#
+
+if [[ "$__ManagedBuild" == 1 ]]; then
+    echo "Commencing managed build for $__BuildType in $__RootBinDir/bin"
+    "$__RepoRootDir/eng/common/build.sh" --build --configuration "$__BuildType" $__CommonMSBuildArgs $__ManagedBuildArgs $__ArcadeScriptArgs $__UnprocessedBuildArgs
+    if [ "$?" != 0 ]; then
+        exit 1
+    fi
+fi
+
+#
 # Archive build
 #
 
@@ -213,7 +214,6 @@ if [[ "$__CreateArchives" == 1 ]]; then
       -nobl \
       /bl:"$__LogsDir"/Archive.binlog \
       /p:CreateArchives=true \
-      /p:PackageRid=$__DistroRid \
       $__CommonMSBuildArgs \
       $__ManagedBuildArgs \
       $__ArcadeScriptArgs \

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -82,9 +82,8 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="IncludeNonSymbolFilesToPublish"
-          AfterTargets="ComputeFilesToPublish"
-          Condition="'$(ExcludeNonSymbolFiles)' != 'true'">
+  <Target Name="IncludeProfilerFilesToPublish"
+          AfterTargets="ComputeFilesToPublish">
     <ItemGroup>
       <!-- Include the profiler library for the corresponding platform if it exists. -->
       <ResolvedFileToPublish Include="@(MonitorProfilerLibraryFile-&gt;Exists())"
@@ -92,45 +91,12 @@
         <RelativePath>%(MonitorProfilerLibraryFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="IncludeSymbolFilesToPublish"
-          AfterTargets="ComputeFilesToPublish"
-          Condition="'$(ExcludeSymbolFiles)' != 'true'">
-    <ItemGroup>
       <!-- Include the profiler symbols for the corresponding platform if it exists. -->
       <ResolvedFileToPublish Include="@(MonitorProfilerSymbolsFile-&gt;Exists())"
                              Condition="'%(MonitorProfilerSymbolsFile.TargetRid)' == '$(RuntimeIdentifier)'">
         <RelativePath>%(MonitorProfilerSymbolsFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CalculateSymbolsFilesToPublish">
-    <ItemGroup>
-      <ResolvedSymbolFileToPublish Include="@(ResolvedFileToPublish)"
-                                   Condition="'%(Extension)' == '.dbg' or '%(Extension)' == '.dwarf' or '%(Extension)' == '.pdb'" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="ExcludeNonSymbolFilesFromPublish"
-          AfterTargets="ComputeFilesToPublish"
-          DependsOnTargets="CalculateSymbolsFilesToPublish"
-          Condition="'$(ExcludeNonSymbolFiles)' == 'true'">
-    <ItemGroup>
-      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" />
-      <ResolvedFileToPublish Include="@(ResolvedSymbolFileToPublish)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="ExcludeSymbolFilesFromPublish"
-          AfterTargets="ComputeFilesToPublish"
-          DependsOnTargets="CalculateSymbolsFilesToPublish"
-          Condition="'$(ExcludeSymbolFiles)' == 'true'">
-    <ItemGroup>
-      <ResolvedFileToPublish Remove="@(ResolvedSymbolFileToPublish)" />
     </ItemGroup>
   </Target>
 

--- a/src/archives/Directory.Build.targets
+++ b/src/archives/Directory.Build.targets
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
+  </ItemGroup>
+  
+  <!-- TODO: TPN is not included due to build ordering (archives are created in build job, TPN created in separate job) -->
+  <Target Name="PublishToDisk"
+          DependsOnTargets="$(PublishToDiskDependsOn)">
+    <Error Message="The 'ArchiveContentRootPath' property must be set to the path of the root of the files to archive."
+           Condition="'$(ArchiveContentRootPath)' == ''" />
+    <Error Message="The archive content root path '$(ArchiveContentRootPath)' does not exist."
+           Condition="!Exists($(ArchiveContentRootPath))" />
+    <!-- Collect non-symbol files and copy to staging directory -->
+    <ItemGroup>
+      <FileToArchive Remove="@(FileToArchive)" />
+      <FileToArchive Include="$(ArchiveContentRootPath)**" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(CreateSymbolsArchive)' == 'true'">
+      <FileToArchive Remove="$(ArchiveContentRootPath)**\*.dbg" />
+      <FileToArchive Remove="$(ArchiveContentRootPath)**\*.dwarf" />
+      <FileToArchive Remove="$(ArchiveContentRootPath)**\*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(FileToArchive)" DestinationFiles="$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Make executable files readable by all, writable by the user, and executable by all. -->
+    <ItemGroup>
+      <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
+      <_ArchiveExecutableContent Include="@(FileToArchive)"
+                                 Condition="'%(Extension)' == '.dylib' or '%(Extension)' == '.so'" />
+    </ItemGroup>
+    <Exec Command="chmod 755 %(_ArchiveExecutableContent.Identity)"
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveExecutableContent)' != ''" />
+    <!-- Make non-executable files readable by all and writable by the user. -->
+    <ItemGroup>
+      <_ArchiveNonExecutableContent Remove="@(_ArchiveNonExecutableContent)" />
+      <_ArchiveNonExecutableContent Include="@(FileToArchive)" />
+      <_ArchiveNonExecutableContent Remove="@(_ArchiveExecutableContent)" />
+    </ItemGroup>
+    <Exec Command="chmod 644 %(_ArchiveNonExecutableContent.Identity)"
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveNonExecutableContent)' != ''" />
+  </Target>
+
+  <Target Name="PublishSymbolsToDisk"
+          DependsOnTargets="$(PublishSymbolsToDiskDependsOn)">
+    <!-- Collect symbol files and copy to staging directory -->
+    <ItemGroup>
+      <FileToArchive Remove="@(FileToArchive)" />
+      <FileToArchive Include="$(ArchiveContentRootPath)**\*.dbg" />
+      <FileToArchive Include="$(ArchiveContentRootPath)**\*.dwarf" />
+      <FileToArchive Include="$(ArchiveContentRootPath)**\*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(FileToArchive)" DestinationFiles="$(SymbolsOutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Make non-executable files readable by all and writable by the user. -->
+    <ItemGroup>
+      <_SymbolsNonExecutableContent Remove="@(_SymbolsNonExecutableContent)" />
+      <_SymbolsNonExecutableContent Include="@(FileToArchive)" />
+    </ItemGroup>
+    <Exec Command="chmod 644 %(_SymbolsNonExecutableContent.Identity)"
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_SymbolsNonExecutableContent)' != ''" />
+  </Target>
+</Project>

--- a/src/archives/PublishedProjectArchive.targets
+++ b/src/archives/PublishedProjectArchive.targets
@@ -1,0 +1,14 @@
+<Project>
+  <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />
+
+  <PropertyGroup>
+    <PublishToDiskDependsOn>PublishProjectsBeforeArchive</PublishToDiskDependsOn>
+    <PublishSymbolsToDiskDependsOn>PublishProjectsBeforeArchive</PublishSymbolsToDiskDependsOn>
+  </PropertyGroup>
+
+  <!-- Publish projects if they were not published after build -->
+  <Target Name="PublishProjectsBeforeArchive"
+          Condition="'$(PublishProjectsAfterBuild)' != 'true'">
+    <CallTarget Targets="PublishProjects" />
+  </Target>
+</Project>

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -1,66 +1,14 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <ArchiveName>dotnet-monitor</ArchiveName>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
-    <CreateSymbolsArchive>true</CreateSymbolsArchive>
     <IsShipping>false</IsShipping>
+    <CreateSymbolsArchive>true</CreateSymbolsArchive>
+    <ArchiveContentRootPath>$(ArtifactsBinDir)dotnet-monitor\$(Configuration)\$(TargetFramework)\$(PackageRid)\publish\</ArchiveContentRootPath>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
-  </ItemGroup>
-  <PropertyGroup>
-    <SharedPublishProjectProperties>SelfContained=false</SharedPublishProjectProperties>
-    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=false</SharedPublishProjectProperties>
-    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);PackAsTool=false</SharedPublishProjectProperties>
-    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);TargetFramework=$(TargetFramework)</SharedPublishProjectProperties>
-    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);RuntimeIdentifier=$(RuntimeIdentifier)</SharedPublishProjectProperties>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PackagePublishProjectProperties>$(SharedPublishProjectProperties)</PackagePublishProjectProperties>
-    <PackagePublishProjectProperties>$(PackagePublishProjectProperties);PublishDir=$(OutputPath)</PackagePublishProjectProperties>
-    <!-- Remove all files that are symbols files. -->
-    <PackagePublishProjectProperties>$(PackagePublishProjectProperties);ExcludeSymbolFiles=true</PackagePublishProjectProperties>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SymbolsPublishProjectProperties>$(SharedPublishProjectProperties)</SymbolsPublishProjectProperties>
-    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);PublishDir=$(SymbolsOutputPath)</SymbolsPublishProjectProperties>
-    <!-- Remove all files that are not symbol files. -->
-    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);ExcludeNonSymbolFiles=true</SymbolsPublishProjectProperties>
-    <!-- Disable web.config transforms so it doesn't end up in the symbols package. -->
-    <SymbolsPublishProjectProperties>$(SymbolsPublishProjectProperties);IsWebConfigTransformDisabled=true</SymbolsPublishProjectProperties>
-  </PropertyGroup>
-  <!-- TODO: TPN is not included due to build ordering (archives are created in build job, TPN created in separate job) -->
-  <Target Name="PublishToDisk">
-    <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
-             Targets="Publish"
-             Properties="$(PackagePublishProjectProperties)"
-             RemoveProperties="OutputPath" />
-    <!-- Make executable files readable by all, writable by the user, and executable by all. -->
-    <ItemGroup>
-      <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
-      <_ArchiveExecutableContent Include="$(OutputPath)**\*.dylib" />
-      <_ArchiveExecutableContent Include="$(OutputPath)**\*.so" />
-    </ItemGroup>
-    <Exec Command="chmod 755 %(_ArchiveExecutableContent.Identity)" Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveExecutableContent)' != ''" />
-    <!-- Make non-executable files readable by all and writable by the user. -->
-    <ItemGroup>
-      <_ArchiveNonExecutableContent Remove="@(_ArchiveNonExecutableContent)" />
-      <_ArchiveNonExecutableContent Include="$(OutputPath)**" />
-      <_ArchiveNonExecutableContent Remove="@(_ArchiveExecutableContent)" />
-    </ItemGroup>
-    <Exec Command="chmod 644 %(_ArchiveNonExecutableContent.Identity)" Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveNonExecutableContent)' != ''" />
-  </Target>
-  <Target Name="PublishSymbolsToDisk">
-    <MSBuild Projects="$(RepoRoot)\src\Tools\dotnet-monitor\dotnet-monitor.csproj"
-             Targets="Publish"
-             Properties="$(SymbolsPublishProjectProperties)"
-             RemoveProperties="OutputPath" />
-    <!-- Make non-executable files readable by all and writable by the user. -->
-    <ItemGroup>
-      <_SymbolsNonExecutableContent Remove="@(_SymbolsNonExecutableContent)" />
-      <_SymbolsNonExecutableContent Include="$(SymbolsOutputPath)**" />
-    </ItemGroup>
-    <Exec Command="chmod 644 %(_SymbolsNonExecutableContent.Identity)" Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_SymbolsNonExecutableContent)' != ''" />
-  </Target>
+  <!-- Import ProjectToPublish items -->
+  <Import Project="$(RepositoryEngineeringDir)DotnetMonitorProjectToPublish.props" />
+  <!-- Import archive creation from published project -->
+  <Import Project="$(MSBuildThisFileDirectory)PublishedProjectArchive.targets" />
 </Project>


### PR DESCRIPTION
###### Summary

The following changes were made to take a step in the direction of splitting packaging from binary build in the official builds:
- Move native build in front of managed build to allow for native build, managed build, and pack to be done with one build script invocation.
- Add ability to publish dotnet-monitor project for the current RID after build completes (opt-in using `/p:PublishProjectsAfterBuild=true`) __XOR__ when archiving (publish is done by default, opt-out using `/p:PublishProjectsAfterBuild=true`)

###### Details

With the need to include the third-party notice (TPN) file in the archives (not done in this PR), the build needs to be refactored such that binaries are built in parallel with the TPN generation followed by archive and NuGet packaging. Currently, archiving effectively rebuilds the entire product, which is a waste of time for builds and what's tested is not the binaries that are shipped.

These changes allow for the binaries to be built and published, preserved in the build artifacts, and packaged as-is at a later point in the build. This is accomplished by adding a publishing step in `AfterSolutionBuild.targets` that publishes dotnet-monitor for the latest TPM (in this case, `net7.0`) and the current architecture; this behavior is enabled by setting `PublishProjectsAfterBuild=true`. The archive generation process has been updated to copy the subset of applicable binaries from the publish output directory instead of invoking a build/publish itself; it skips the publish step if `PublishProjectsAfterBuild=true` (since they've already been published); it does the build/publish by-default to enable local builds to easily generate archives locally.

The build and archive separation was verified by:
1. `Build.cmd -ci /p:PublishProjectsAfterBuild=true`
2. Validate dotnet-monitor was published correctly
3. Delete all directories (e.g. `.dotnet`, `.packages`, `artifacts`, etc) except for `artifacts\bin` and `artifacts\obj`.
4. `Build.cmd -ci -skipmanaged -skipnative -archive /p:PublishProjectsAfterBuild=true`
5. Validate only archives were produced and no rebuild or publishing occured

Note that this separation has not be implemented in the build pipelines in the PR, as that itself would be a significant change and can be done separately.

Normal local development workflows (build, test) should not be impacted by this change.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
