### PR TITLE
Enable checksum and publishing of archives

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -13,7 +13,11 @@
 
   <ItemGroup>
     <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.tar.gz" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.zip" IsShipping="true" />
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.tar.gz" IsShipping="false" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.zip" IsShipping="false" />
   </ItemGroup>
 
   <Target Name="CalculateBlobGroupAndBuildVersion">
@@ -99,25 +103,42 @@
 
     <!-- Read in project file name -->
     <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectpath">
-      <Output TaskParameter="Lines" PropertyName="_ProjectPath"/>
+      <Output TaskParameter="Lines" PropertyName="_RelativeProjectPath"/>
+    </ReadLinesFromFile>
+    
+    <!-- Read in project props -->
+    <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectprops"
+                       Condition="Exists('%(PackageToPublish.FullPath).projectprops')">
+      <Output TaskParameter="Lines" PropertyName="_ProjectProps"/>
     </ReadLinesFromFile>
 
     <!-- Get package name from project as if its version was set to the build version -->
-    <MSBuild Projects="$(_ProjectPath)"
+    <ItemGroup>
+      <GetPackageFileNameProps Remove="@(GetPackageFileNameProps)" />
+      <GetPackageFileNameProps Include="Version=$(_BuildVersion)" />
+      <GetPackageFileNameProps Include="$(_ProjectProps)" />
+    </ItemGroup>
+    <MSBuild Projects="$(RepoRoot)$(_RelativeProjectPath)"
              Targets="GetPackageFileName"
-             Properties="Version=$(_BuildVersion)">
+             Properties="@(GetPackageFileNameProps)">
       <Output ItemName="_PackageWithBuildVersionFileName" TaskParameter="TargetOutputs" />
     </MSBuild>
 
     <!-- Get package version from project -->
-    <MSBuild Projects="$(_ProjectPath)"
-             Targets="GetPackageVersion">
+    <ItemGroup>
+      <GetPackageVersionProps Remove="@(GetPackageVersionProps)" />
+      <GetPackageVersionProps Include="$(_ProjectProps)" />
+    </ItemGroup>
+    <MSBuild Projects="$(RepoRoot)$(_RelativeProjectPath)"
+             Targets="GetPackageVersion"
+             Properties="@(GetPackageVersionProps)">
       <Output ItemName="_PackageVersion" TaskParameter="TargetOutputs" />
     </MSBuild>
 
     <!-- Package artifact file paths -->
     <PropertyGroup>
-      <!-- Example file name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg -->
+      <!-- Example nupkg file name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg -->
+      <!-- Example archive file name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip -->
       <_PackageWithBuildVersionFileName>@(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFileName>
       <_PackageWithBuildVersionFilePath>%(PackageToPublish.RootDir)%(PackageToPublish.Directory)$(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFilePath>
       <_ChecksumFilePath>%(PackageToPublish.FullPath).sha512</_ChecksumFilePath>
@@ -127,7 +148,8 @@
 
     <!--
       A file that contains the version of the package.
-      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
+      Example nupkg name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
+      Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.version
       -->
     <WriteLinesToFile File="$(_PackageVersionFilePath)"
                       Lines="@(_PackageVersion)"
@@ -136,7 +158,8 @@
     <!--
       A file that contains the build version of the package. The name of this file contains the build
       version in order to avoid collisions when uploaded to blob storage.
-      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
+      Example nupkg name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
+      Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.buildversion
       -->
     <WriteLinesToFile File="$(_BuildVersionFilePath)"
                       Lines="$(_BuildVersion)"
@@ -148,8 +171,8 @@
     </ItemGroup>
     <ItemGroup>
       <_PackageArtifactData Include="@(_CommonArtifactData)" />
-      <!-- Set Category to OTHER so that packages are also published to blob storage. -->
-      <_PackageArtifactData Include="Category=OTHER" />
+      <!-- Set Category to OTHER so that nupkgs are also published to blob storage. -->
+      <_PackageArtifactData Include="Category=OTHER" Condition="'%(PackageToPublish.Extension)' == 'nupkg'" />
     </ItemGroup>
 
     <!-- Capture items that need to be published under the blob group. -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -12,11 +12,45 @@
   </ItemGroup>
 
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
-  <Target Name="GeneratePackageProjectPathFile"
+  <Target Name="GenerateNuGetPackageProjectFiles"
           AfterTargets="Pack"
           Condition="'$(IsPackable)' == 'true' and '$(IsShipping)' == 'true'">
+    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.projectpath"
-                      Lines="$(MSBuildProjectFullPath)"
+                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+                      Overwrite="true" />
+  </Target>
+  <Target Name="GenerateArchivePackageProjectFiles"
+          AfterTargets="_CreateArchive"
+          Condition="'$(IsArchivable)' == 'true' and '$(IsShipping)' == 'true'">
+    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectpath"
+                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+                      Overwrite="true" />
+    <ItemGroup>
+      <PackageProjectProps Remove="@(PackageProjectProps)" />
+      <PackageProjectProps Include="RuntimeIdentifier=$(RuntimeIdentifier)" />
+    </ItemGroup>
+    <!-- Write a props file so that the above project is invoked during publish with the specified properties. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectprops"
+                      Lines="@(PackageProjectProps)"
+                      Overwrite="true" />
+  </Target>
+  <Target Name="GenerateSymbolsArchivePackageProjectFiles"
+          AfterTargets="_CreateSymbolsArchive"
+          Condition="'$(IsArchivable)' == 'true' and '$(CreateSymbolsArchive)' == 'true' and '$(IsShipping)' == 'true'">
+    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectpath"
+                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+                      Overwrite="true" />
+    <ItemGroup>
+      <PackageProjectProps Remove="@(PackageProjectProps)" />
+      <PackageProjectProps Include="RuntimeIdentifier=$(RuntimeIdentifier)" />
+      <PackageProjectProps Include="IsSymbolsArchive=true" />
+    </ItemGroup>
+    <!-- Write a props file so that the above project is invoked during publish with the specified properties. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectprops"
+                      Lines="@(PackageProjectProps)"
                       Overwrite="true" />
   </Target>
 
@@ -24,7 +58,15 @@
           Returns="$(PackageVersion)" />
 
   <Target Name="GetPackageFileName"
-          Returns="$(PackageId).$(PackageVersion).nupkg" />
+          Returns="@(PackageFileName)">
+    <ItemGroup>
+      <PackageFileName Include="$(PackageId).$(PackageVersion).nupkg" Condition="'$(IsPackable)' == 'true'" />
+      <!-- The archive targets use Version instead of PackageVersion; do the same to be consistent. -->
+      <PackageFileName Include="$(ArchiveName)-$(Version)-$(RuntimeIdentifier).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' != 'true' " />
+      <!-- Symbols archive names reverse the order of the version and runtime identifier compared to the product archive. -->
+      <PackageFileName Include="$(ArchiveName)-symbols-$(RuntimeIdentifier)-$(Version).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' == 'true' " />
+    </ItemGroup>
+  </Target>
 
   <!-- Remove native libraries from transitive dependencies -->
   <ItemGroup>

--- a/src/archives/Directory.Build.props
+++ b/src/archives/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+  <PropertyGroup>
+    <ArchiveFormat Condition="$(RuntimeIdentifier.Contains(win))">zip</ArchiveFormat>
+    <ArchiveFormat Condition="!$(RuntimeIdentifier.Contains(win))">tar.gz</ArchiveFormat>
+  </PropertyGroup>
+</Project>

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
     <IsShipping>false</IsShipping>
+    <IsArchivable>true</IsArchivable>
     <CreateSymbolsArchive>true</CreateSymbolsArchive>
     <ArchiveContentRootPath>$(ArtifactsBinDir)dotnet-monitor\$(Configuration)\$(TargetFramework)\$(PackageRid)\publish\</ArchiveContentRootPath>
   </PropertyGroup>


### PR DESCRIPTION
###### Summary

The following changes allow archive packages to participate in the publishing process (inclusion in the BAR manifest so that they are published to dotnetbuilds feed during Maestro promotion).

Overview of changes:
- Update `src/Directory.Build.targets` to produce projectpath and projectprops (these are new in this PR to support specifying per-project properties when the project is invoked during publish) files for both product archives and symbols archives.
- Update `src/Directory.Build.targets` to report correct archive name from `GetPackageFileName` target, which is invoked during publish.
- Update `eng/Publishing.props` include archive file types, to use the projectprops file for each package file (if it exists), and to only apply `Category=OTHER` to nupkg files (this categorization forces publishing to blob feeds instead of NuGet feeds; all other 'binary layout' types are published to blob feeds automatically).

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2086815&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
