### PR TITLE
Archive in separate job with license and TPN

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -43,95 +43,29 @@ stages:
 - stage: Build
   displayName: Build and Test
   jobs:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    # Generate a TPN for only the dotnet-monitor project
+    - template: /eng/pipelines/jobs/tpn.yml
+
   # Build and test binaries
   - template: /eng/pipelines/jobs/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/jobs/build-test.yml
       includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
       includeDebug: true
-      publishBuildArtifacts: true
       jobParameters:
         testGroup: ${{ parameters.testGroup }}
+
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # Generate a TPN for only the dotnet-monitor project
-    - template: /eng/common/templates/job/job.yml
+    # Build RID (runtime identifier) archives
+    - template: /eng/pipelines/jobs/platform-matrix.yml
       parameters:
-        name: Generate_TPN
-        displayName: Generate TPN
-        disableComponentGovernance: true
-        enableSbom: false
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        steps:
-        # Only restore the dotnet-monitor project so only packages we ship get included in the below CG scan
-        - script: >-
-            $(Build.SourcesDirectory)/restore.cmd -ci -projects $(Build.SourcesDirectory)/src/Tools/dotnet-monitor/dotnet-monitor.csproj
-          displayName: Restore dotnet-monitor tool packages
-            
-        - task: ComponentGovernanceComponentDetection@0
-          displayName: Component Detection (dotnet-monitor tool)
+        jobTemplate: /eng/pipelines/jobs/build-archive.yml
+        includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
 
-        - task: notice@0
-          displayName: Generate TPN file
-          inputs:
-            outputfile: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'
-            outputformat: text
+    # Pack, sign, and publish manifest
+    - template: /eng/pipelines/jobs/pack-sign-publish.yml
 
-        - task: PublishPipelineArtifact@1
-          displayName: Publish TPN
-          inputs:
-            artifactName: 'THIRD-PARTY-NOTICES'
-            targetPath: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'
-
-    # Pack, sign, and publish
-    - template: /eng/common/templates/job/job.yml
-      parameters:
-        name: Pack_Sign
-        displayName: Pack and Sign
-        dependsOn:
-        - Windows_x64_Release
-        - Windows_x86_Release
-        - Windows_arm64_Release
-        - Linux_x64_Release
-        - Linux_arm64_Release
-        - Linux_Musl_x64_Release
-        - Linux_Musl_arm64_Release
-        - MacOS_x64_Release
-        - MacOS_arm64_Release
-        - Generate_TPN
-        pool:
-          name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        enablePublishUsingPipelines: true
-        enableMicrobuild: true
-        artifacts:
-          download:
-            name: Build_Release
-          publish:
-            artifacts:
-              name: Artifacts_Pack_Sign
-            logs:
-              name: Logs_Pack_Sign
-            manifests: true
-        variables:
-        - _BuildConfig: Release
-        - _SignType: real
-        steps:
-        - task: DownloadPipelineArtifact@2
-          displayName: Download TPN
-          inputs:
-            buildType: current
-            artifactName: 'THIRD-PARTY-NOTICES'
-            targetPath: '$(Build.SourcesDirectory)'
-        - script: >-
-            $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
-            /p:TeamName=$(_TeamName)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            /p:DotNetSignType=real
-            /p:DotNetPublishUsingPipelines=true
-            /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
-          displayName: Pack, Sign, and Publish
     # Register with BAR
     - template: /eng/common/templates/job/publish-build-assets.yml
       parameters:
@@ -158,16 +92,17 @@ stages:
       SDLValidationParameters:
         enable: true
         continueOnError: true
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "dotnet-monitor"
-        -TsaCodebaseName "dotnet-monitor"
-        -TsaPublish $True'
+        params: >-
+          -SourceToolsList @("policheck","credscan")
+          -TsaInstanceURL $(_TsaInstanceURL)
+          -TsaProjectName $(_TsaProjectName)
+          -TsaNotificationEmail $(_TsaNotificationEmail)
+          -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+          -TsaBugAreaPath $(_TsaBugAreaPath)
+          -TsaIterationPath $(_TsaIterationPath)
+          -TsaRepositoryName "dotnet-monitor"
+          -TsaCodebaseName "dotnet-monitor"
+          -TsaPublish $True
         artifactNames:
         - 'PackageArtifacts'
 # This sets up the bits to do a Release.

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -1,0 +1,52 @@
+# Builds and tests dotnet-monitor for a specific platform and configuration
+
+parameters:
+  # Operating system group (Windows, Linux, MacOS, etc)
+  osGroup: Windows
+  # Build configuration (Debug, Release)
+  configuration: Release
+  # Build architecture (arm64, x64, x86, etc)
+  architecture: x64
+
+jobs:
+- template: /eng/pipelines/jobs/build.yml
+  parameters:
+    prefix: Archive
+    osGroup: ${{ parameters.osGroup }}
+    configuration: ${{ parameters.configuration }}
+    architecture: ${{ parameters.architecture }}
+    dependsOn:
+    - Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+    - Generate_TPN
+
+    preBuildSteps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Binaries
+      inputs:
+        artifactName: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Third Party Notice
+      inputs:
+        artifactName: 'THIRD-PARTY-NOTICES'
+        targetPath: '$(Build.SourcesDirectory)'
+
+    buildArgs: >-
+      -archive
+      -skipmanaged
+      -skipnative
+      /p:PublishProjectsAfterBuild=true
+      /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
+
+    postBuildSteps:
+    - task: CopyFiles@2
+      displayName: Gather Artifacts (packages)
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifacts
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+        artifactName: Archive_${{ parameters.configuration }}

--- a/eng/pipelines/jobs/build-codeql.yml
+++ b/eng/pipelines/jobs/build-codeql.yml
@@ -1,10 +1,6 @@
 # Builds dotnet-monitor for a specific platform and configuration with CodeQL analysis enabled
 
 parameters:
-  # Job name (required)
-  name: ''
-  # Job display name
-  displayName: ''
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
@@ -21,8 +17,7 @@ parameters:
 jobs:
 - template: /eng/pipelines/jobs/build.yml
   parameters:
-    name: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
+    prefix: CodeQL
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
@@ -30,7 +25,7 @@ jobs:
     disableSbom: true
 
     variables:
-    - Codeql.BuildIdentifier: ${{ parameters.name }}
+    - Codeql.BuildIdentifier: $(JobName)
       # Do not let CodeQL 3000 Extension gate scan frequency
     - Codeql.Cadence: 0
     # Force CodeQL enabled so it may be run on any branch

--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -1,18 +1,14 @@
 # Builds and tests dotnet-monitor for a specific platform and configuration
 
 parameters:
-  # Job name (required)
-  name: ''
-  # Job display name
-  displayName: ''
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
   configuration: Release
   # Build architecture (arm64, x64, x86, etc)
   architecture: x64
-  # Sub paths under 'artifacts' folder from which files are published to artifacts location
-  publishArtifactsSubPaths: []
+  # RID (runtime identifier) of build output
+  targetRid: win-x64
   # Group of tests to be run
   testGroup: Default
   # TFMs for which test results are uploaded
@@ -25,12 +21,11 @@ parameters:
 jobs:
 - template: /eng/pipelines/jobs/build.yml
   parameters:
-    name: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
+    prefix: Build
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
-    publishArtifactsSubPaths: ${{ parameters.publishArtifactsSubPaths }}
+
     variables:
     - ${{ if and(ne(parameters.testGroup, 'None'), ne(parameters.architecture, 'arm64')) }}:
       # If TestGroup == 'Default', choose the test group based on the type of pipeline run
@@ -73,7 +68,46 @@ jobs:
         - script: echo "##vso[task.prependpath]/usr/share/node/bin"
           displayName: Add Azurite to PATH
 
+    buildArgs: '/p:PublishProjectsAfterBuild=true'
+
     postBuildSteps:
+    - ${{ if eq(parameters.configuration, 'Release') }}:
+      - task: CopyFiles@2
+        displayName: Gather Artifacts (bin/dotnet-monitor)
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/dotnet-monitor'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin/dotnet-monitor'
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+          artifactName: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+
+      - ${{ if eq(parameters.targetRid, 'win-x64') }}:
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (bin)
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/bin'
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (obj)
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/obj'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/obj'
+      - ${{ else }}:
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (bin/${{ parameters.targetRid }}.${{ parameters.configuration }})
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+      
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts (Unified)
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/unified'
+          artifactName: Build_${{ parameters.configuration }}
+
     # Execute tests
     - ${{ if and(ne(parameters.testGroup, 'None'), eq(parameters.architecture, 'arm64')) }}:
       - script: echo "Running tests for arm64 binaries is currently not supported."
@@ -100,10 +134,10 @@ jobs:
             testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
             searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
             failTaskOnFailedTests: true
-            testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} ${{ testResultTfm.value }}'
+            testRunTitle: '${{ parameters.configuration }} ${{ parameters.osGroup }} ${{ parameters.architecture }} ${{ testResultTfm.value }}'
             publishRunAttachments: true
             mergeTestResults: true
-            buildConfiguration: ${{ parameters.name }}
+            buildConfiguration: $(JobName)
           continueOnError: true
           condition: succeededOrFailed()
 
@@ -112,7 +146,6 @@ jobs:
           displayName: Publish Test Result Files
           inputs:
             PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-            PublishLocation: Container
-            ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
+            ArtifactName: TestResults_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
           continueOnError: true
           condition: succeededOrFailed()

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -1,10 +1,8 @@
 # Builds dotnet-monitor for a specific platform and configuration
 
 parameters:
-  # Job name (required)
-  name: ''
-  # Job display name
-  displayName: ''
+  # Job prefix (required)
+  prefix: ''
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
@@ -27,12 +25,13 @@ parameters:
   disableComponentGovernance: false
   # Disable SBOM generation
   disableSbom: false
+  buildArgs: ''
 
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    name: ${{ parameters.name }}
-    displayName: ${{ coalesce(parameters.displayName, parameters.name) }}
+    name: ${{ parameters.prefix }}_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+    displayName: ${{ format('{0} {1} {2} {3}', parameters.prefix, parameters.osGroup, parameters.architecture, parameters.configuration) }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableTelemetry: true
     disableComponentGovernance: ${{ or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}
@@ -42,7 +41,7 @@ jobs:
     artifacts:
       publish:
         logs:
-          name: Logs_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
+          name: Logs_$(JobName)
 
     pool:
       # Public Linux Build Pool
@@ -90,6 +89,7 @@ jobs:
       clean: all
 
     variables:
+    - JobName: ${{ parameters.prefix }}_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
@@ -155,9 +155,9 @@ jobs:
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
+        ${{ parameters.buildArgs }}
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
-        -archive
         $(_CrossBuildArgs)
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)
@@ -165,21 +165,6 @@ jobs:
       ${{ if and(eq(parameters.architecture, 'arm64'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
         env:
           ROOTFS_DIR: '/crossrootfs/arm64'
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), gt(length(parameters.publishArtifactsSubPaths), 0)) }}:
-      - ${{ each subPath in parameters.publishArtifactsSubPaths }}:
-        - task: CopyFiles@2
-          displayName: Gather Artifacts (${{ subPath.source }})
-          inputs:
-            SourceFolder: '$(Build.SourcesDirectory)/artifacts/${{ subPath.source }}'
-            Contents: '**'
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/${{ coalesce(subPath.target, subPath.source) }}'
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Artifacts
-        inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-          artifactName: Build_${{ parameters.configuration }}
 
     - ${{ each step in parameters.postBuildSteps }}:
       - ${{ step }}

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -1,0 +1,64 @@
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: Pack_Sign
+    displayName: Pack and Sign
+    dependsOn:
+    - Build_Release_Windows_x64
+    - Build_Release_Windows_x86
+    - Build_Release_Windows_arm64
+    - Build_Release_Linux_x64
+    - Build_Release_Linux_arm64
+    - Build_Release_Linux_Musl_x64
+    - Build_Release_Linux_Musl_arm64
+    - Build_Release_MacOS_x64
+    - Build_Release_MacOS_arm64
+    - Archive_Release_Windows_x64
+    - Archive_Release_Windows_x86
+    - Archive_Release_Windows_arm64
+    - Archive_Release_Linux_x64
+    - Archive_Release_Linux_arm64
+    - Archive_Release_Linux_Musl_x64
+    - Archive_Release_Linux_Musl_arm64
+    - Archive_Release_MacOS_x64
+    - Archive_Release_MacOS_arm64
+    - Generate_TPN
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals 1es-windows-2019
+    enablePublishUsingPipelines: true
+    enableMicrobuild: true
+    artifacts:
+      publish:
+        artifacts:
+          name: Artifacts_Pack_Sign
+        logs:
+          name: Logs_Pack_Sign
+        manifests: true
+    variables:
+    - _BuildConfig: Release
+    - _SignType: real
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Binaries
+      inputs:
+        artifactName: Build_Release
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Archives
+      inputs:
+        artifactName: Archive_Release
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Third Party Notice
+      inputs:
+        artifactName: 'THIRD-PARTY-NOTICES'
+        targetPath: '$(Build.SourcesDirectory)'
+    - script: >-
+        $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
+        /p:TeamName=$(_TeamName)
+        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        /p:DotNetSignType=real
+        /p:DotNetPublishUsingPipelines=true
+        /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
+      displayName: Pack, Sign, and Publish

--- a/eng/pipelines/jobs/platform-matrix.yml
+++ b/eng/pipelines/jobs/platform-matrix.yml
@@ -5,8 +5,6 @@ parameters:
   jobTemplate: ''
   # Extra job template parameters to pass to the job template
   jobParameters: {}
-  # Determines if build artifacts should be uploaded as pipeline artifacts
-  publishBuildArtifacts: false
   # Determines if debug configurations should be included
   includeDebug: false
   # Determines if ARM64 architectures should be included
@@ -16,141 +14,91 @@ jobs:
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Windows_x64_Debug
-      displayName: Windows x64 Debug
       osGroup: Windows
       configuration: Debug
+      targetRid: win-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Windows_x64_Release
-    displayName: Windows x64 Release
     osGroup: Windows
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin'
-      - source: 'obj'
-      - source: 'packages'
+    targetRid: win-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Windows_x86_Release
-    displayName: Windows x86 Release
     osGroup: Windows
     configuration: Release
     architecture: x86
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/win-x86.Release'
-      - source: 'packages'
+    targetRid: win-x86
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Windows_arm64_Release
-      displayName: Windows arm64 Release
       osGroup: Windows
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/win-arm64.Release'
-        - source: 'packages'
+      targetRid: win-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_x64_Debug
-      displayName: Linux x64 Debug
       osGroup: Linux
       configuration: Debug
+      targetRid: linux-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Linux_x64_Release
-    displayName: Linux x64 Release
     osGroup: Linux
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/linux-x64.Release'
-      - source: 'packages'
+    targetRid: linux-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_arm64_Release
-      displayName: Linux arm64 Release
       osGroup: Linux
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/linux-arm64.Release'
-        - source: 'packages'
+      targetRid: linux-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_Musl_x64_Debug
-      displayName: Linux Musl x64 Debug
       osGroup: Linux_Musl
       configuration: Debug
+      targetRid: linux-musl-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Linux_Musl_x64_Release
-    displayName: Linux Musl x64 Release
     osGroup: Linux_Musl
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/linux-musl-x64.Release'
-      - source: 'packages'
+    targetRid: linux-musl-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_Musl_arm64_Release
-      displayName: Linux Musl arm64 Release
       osGroup: Linux_Musl
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/linux-musl-arm64.Release'
-        - source: 'packages'
+      targetRid: linux-musl-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: MacOS_x64_Debug
-      displayName: MacOS x64 Debug
       osGroup: MacOS
       configuration: Debug
+      targetRid: osx-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: MacOS_x64_Release
-    displayName: MacOS x64 Release
     osGroup: MacOS
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/osx-x64.Release'
-      - source: 'packages'
+    targetRid: osx-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: MacOS_arm64_Release
-      displayName: MacOS arm64 Release
       osGroup: MacOS
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/osx-arm64.Release'
-        - source: 'packages'
+      targetRid: osx-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/jobs/tpn.yml
+++ b/eng/pipelines/jobs/tpn.yml
@@ -1,0 +1,30 @@
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: Generate_TPN
+    displayName: Generate TPN
+    disableComponentGovernance: true
+    enableSbom: false
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    # Only restore the dotnet-monitor project so only packages we ship get included in the below CG scan
+    - script: >-
+        $(Build.SourcesDirectory)/restore.cmd -ci -projects $(Build.SourcesDirectory)/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+      displayName: Restore dotnet-monitor tool packages
+        
+    - task: ComponentGovernanceComponentDetection@0
+      displayName: Component Detection (dotnet-monitor tool)
+
+    - task: notice@0
+      displayName: Generate TPN file
+      inputs:
+        outputfile: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'
+        outputformat: text
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish TPN
+      inputs:
+        artifactName: 'THIRD-PARTY-NOTICES'
+        targetPath: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'

--- a/src/archives/Directory.Build.targets
+++ b/src/archives/Directory.Build.targets
@@ -6,7 +6,6 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
   </ItemGroup>
   
-  <!-- TODO: TPN is not included due to build ordering (archives are created in build job, TPN created in separate job) -->
   <Target Name="PublishToDisk"
           DependsOnTargets="$(PublishToDiskDependsOn)">
     <Error Message="The 'ArchiveContentRootPath' property must be set to the path of the root of the files to archive."
@@ -15,19 +14,20 @@
            Condition="!Exists($(ArchiveContentRootPath))" />
     <!-- Collect non-symbol files and copy to staging directory -->
     <ItemGroup>
-      <FileToArchive Remove="@(FileToArchive)" />
-      <FileToArchive Include="$(ArchiveContentRootPath)**" />
+      <_FileToArchive Remove="@(_FileToArchive)" />
+      <_FileToArchive Include="$(ArchiveContentRootPath)**" />
+      <_FileToArchive Include="@(FileToArchive)" />
     </ItemGroup>
     <ItemGroup Condition="'$(CreateSymbolsArchive)' == 'true'">
-      <FileToArchive Remove="$(ArchiveContentRootPath)**\*.dbg" />
-      <FileToArchive Remove="$(ArchiveContentRootPath)**\*.dwarf" />
-      <FileToArchive Remove="$(ArchiveContentRootPath)**\*.pdb" />
+      <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.dbg" />
+      <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.dwarf" />
+      <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.pdb" />
     </ItemGroup>
-    <Copy SourceFiles="@(FileToArchive)" DestinationFiles="$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(_FileToArchive)" DestinationFiles="$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
     <!-- Make executable files readable by all, writable by the user, and executable by all. -->
     <ItemGroup>
       <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
-      <_ArchiveExecutableContent Include="@(FileToArchive)"
+      <_ArchiveExecutableContent Include="@(_FileToArchive)"
                                  Condition="'%(Extension)' == '.dylib' or '%(Extension)' == '.so'" />
     </ItemGroup>
     <Exec Command="chmod 755 %(_ArchiveExecutableContent.Identity)"
@@ -35,7 +35,7 @@
     <!-- Make non-executable files readable by all and writable by the user. -->
     <ItemGroup>
       <_ArchiveNonExecutableContent Remove="@(_ArchiveNonExecutableContent)" />
-      <_ArchiveNonExecutableContent Include="@(FileToArchive)" />
+      <_ArchiveNonExecutableContent Include="@(_FileToArchive)" />
       <_ArchiveNonExecutableContent Remove="@(_ArchiveExecutableContent)" />
     </ItemGroup>
     <Exec Command="chmod 644 %(_ArchiveNonExecutableContent.Identity)"
@@ -46,16 +46,17 @@
           DependsOnTargets="$(PublishSymbolsToDiskDependsOn)">
     <!-- Collect symbol files and copy to staging directory -->
     <ItemGroup>
-      <FileToArchive Remove="@(FileToArchive)" />
-      <FileToArchive Include="$(ArchiveContentRootPath)**\*.dbg" />
-      <FileToArchive Include="$(ArchiveContentRootPath)**\*.dwarf" />
-      <FileToArchive Include="$(ArchiveContentRootPath)**\*.pdb" />
+      <_SymbolFileToArchive Remove="@(_SymbolFileToArchive)" />
+      <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.dbg" />
+      <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.dwarf" />
+      <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.pdb" />
+      <_SymbolFileToArchive Include="@(SymbolFileToArchive)" />
     </ItemGroup>
-    <Copy SourceFiles="@(FileToArchive)" DestinationFiles="$(SymbolsOutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(_SymbolFileToArchive)" DestinationFiles="$(SymbolsOutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
     <!-- Make non-executable files readable by all and writable by the user. -->
     <ItemGroup>
       <_SymbolsNonExecutableContent Remove="@(_SymbolsNonExecutableContent)" />
-      <_SymbolsNonExecutableContent Include="@(FileToArchive)" />
+      <_SymbolsNonExecutableContent Include="@(_SymbolFileToArchive)" />
     </ItemGroup>
     <Exec Command="chmod 644 %(_SymbolsNonExecutableContent.Identity)"
           Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_SymbolsNonExecutableContent)' != ''" />

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -7,6 +7,11 @@
     <CreateSymbolsArchive>true</CreateSymbolsArchive>
     <ArchiveContentRootPath>$(ArtifactsBinDir)dotnet-monitor\$(Configuration)\$(TargetFramework)\$(PackageRid)\publish\</ArchiveContentRootPath>
   </PropertyGroup>
+  <!-- These items are included in addition to those from publishing the dotnet-monitor project. -->
+  <ItemGroup>
+    <FileToArchive Include="$(RepoRoot)LICENSE.TXT" />
+    <FileToArchive Include="$(ThirdPartyNoticesFilePath)" Condition="Exists('$(ThirdPartyNoticesFilePath)')" />
+  </ItemGroup>
   <!-- Import ProjectToPublish items -->
   <Import Project="$(RepositoryEngineeringDir)DotnetMonitorProjectToPublish.props" />
   <!-- Import archive creation from published project -->


### PR DESCRIPTION
###### Summary

- Removed `jobName` and `displayName` parameters from `build.yml` in favor of calculating each using the platform, architecture, configuration, and the new `prefix` parameter.
- Moved publishing artifact information from `platform-matrix.yml` to `build-test.yml`.
- Pass RID information into `build-test.yml` so it can copy native binaries to unified artifact.
- Add `build-archive.yml` job that downloads binaries from `build-test.yml` job, builds the platform specific archive, and uploads it.
- Moved pack, sign, and publish into its own yml file for better separation; updated to download archives from new job.
- Move TPN creation into its own yml file for better separation.

One suggested optimization is to build all of the archives using a single job, however at this time, arcade doesn't support that except in 8.0, so I'm having it build the archives in a one-to-one match with the build jobs for now until I can get the change that supports building zip vs tar.gz backported.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2087073&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
