### PR TITLE
Move pack, sign, publish to separate stage

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -54,6 +54,7 @@ stages:
       includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
       includeDebug: true
       jobParameters:
+        publishArtifacts: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
         testGroup: ${{ parameters.testGroup }}
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -62,7 +63,13 @@ stages:
       parameters:
         jobTemplate: /eng/pipelines/jobs/build-archive.yml
         includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
-
+# This stage creates NuGet packages and generates the BAR manifests
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - stage: PackSignPublish
+    displayName: Pack, Sign, and Generate Manifests
+    dependsOn:
+    - Build
+    jobs:
     # Pack, sign, and publish manifest
     - template: /eng/pipelines/jobs/pack-sign-publish.yml
 
@@ -77,12 +84,13 @@ stages:
           name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals 1es-windows-2019
 # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       # This is to enable SDL runs part of Post-Build Validation Stage.
       # as well as NuGet, SourceLink, and signing validation.
       # The variables get imported from group dotnet-diagnostics-sdl-params
+      validateDependsOn:
+      - PackSignPublish
       publishingInfraVersion: 3
       enableSourceLinkValidation: true
       enableSigningValidation: true

--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -9,6 +9,8 @@ parameters:
   architecture: x64
   # RID (runtime identifier) of build output
   targetRid: win-x64
+  # Enable/disable of publishing build output
+  publishArtifacts: false
   # Group of tests to be run
   testGroup: Default
   # TFMs for which test results are uploaded
@@ -71,7 +73,7 @@ jobs:
     buildArgs: '/p:PublishProjectsAfterBuild=true'
 
     postBuildSteps:
-    - ${{ if eq(parameters.configuration, 'Release') }}:
+    - ${{ if and(eq(parameters.publishArtifacts, 'true'), eq(parameters.configuration, 'Release')) }}:
       - task: CopyFiles@2
         displayName: Gather Artifacts (bin/dotnet-monitor)
         inputs:

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -3,26 +3,6 @@ jobs:
   parameters:
     name: Pack_Sign
     displayName: Pack and Sign
-    dependsOn:
-    - Build_Release_Windows_x64
-    - Build_Release_Windows_x86
-    - Build_Release_Windows_arm64
-    - Build_Release_Linux_x64
-    - Build_Release_Linux_arm64
-    - Build_Release_Linux_Musl_x64
-    - Build_Release_Linux_Musl_arm64
-    - Build_Release_MacOS_x64
-    - Build_Release_MacOS_arm64
-    - Archive_Release_Windows_x64
-    - Archive_Release_Windows_x86
-    - Archive_Release_Windows_arm64
-    - Archive_Release_Linux_x64
-    - Archive_Release_Linux_arm64
-    - Archive_Release_Linux_Musl_x64
-    - Archive_Release_Linux_Musl_arm64
-    - Archive_Release_MacOS_x64
-    - Archive_Release_MacOS_arm64
-    - Generate_TPN
     pool:
       name: NetCore1ESPool-Svc-Internal
       demands: ImageOverride -equals 1es-windows-2019


### PR DESCRIPTION
###### Summary

As suggested in #3294, move pack, sign, publish, and manifest generation to a separate stage.

Also exclude publishing of artifacts for the public project and PR builds.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2088032&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
