### PR TITLE
Merge release/7.x to main

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,11 +1,11 @@
 ﻿{
   "configurations": [
     {
-      "name": "Windows_NT.arm64.Debug",
+      "name": "win-arm64.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.arm64.Debug\\crossgen",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.arm64.Debug",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-arm64.Debug\\crossgen",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-arm64.Debug",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -29,11 +29,11 @@
       ]
     },
     {
-      "name": "Windows_NT.arm64.Release",
+      "name": "win-arm64.Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.arm64.Release\\crossgen",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.arm64.Release",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-arm64.Release\\crossgen",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-arm64.Release",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -57,12 +57,12 @@
       ]
     },
     {
-      "name": "Windows_NT.x64.Debug",
+      "name": "win-x64.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64" ],
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x64.Debug",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x64.Debug",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x64.Debug",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x64.Debug",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -80,11 +80,11 @@
       ]
     },
     {
-      "name": "Windows_NT.x64.Release",
+      "name": "win-x64.Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x64.Release",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x64.Release",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x64.Release",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x64.Release",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -103,11 +103,11 @@
       ]
     },
     {
-      "name": "Windows_NT.x86.Debug",
+      "name": "win-x86.Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x86.Debug",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x86.Debug",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x86.Debug",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x86.Debug",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
@@ -131,11 +131,11 @@
       ]
     },
     {
-      "name": "Windows_NT.x86.Release",
+      "name": "win-x86.Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}\\artifacts\\obj\\Windows_NT.x86.Release",
-      "installRoot": "${projectDir}\\artifacts\\bin\\Windows_NT.x86.Release",
+      "buildRoot": "${projectDir}\\artifacts\\obj\\win-x86.Release",
+      "installRoot": "${projectDir}\\artifacts\\bin\\win-x86.Release",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",

--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -44,95 +44,36 @@ stages:
 - stage: Build
   displayName: Build and Test
   jobs:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    # Generate a TPN for only the dotnet-monitor project
+    - template: /eng/pipelines/jobs/tpn.yml
+
   # Build and test binaries
   - template: /eng/pipelines/jobs/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/jobs/build-test.yml
       includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
       includeDebug: true
-      publishBuildArtifacts: true
       jobParameters:
+        publishArtifacts: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
         testGroup: ${{ parameters.testGroup }}
+
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # Generate a TPN for only the dotnet-monitor project
-    - template: /eng/common/templates/job/job.yml
+    # Build RID (runtime identifier) archives
+    - template: /eng/pipelines/jobs/platform-matrix.yml
       parameters:
-        name: Generate_TPN
-        displayName: Generate TPN
-        disableComponentGovernance: true
-        enableSbom: false
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        steps:
-        # Only restore the dotnet-monitor project so only packages we ship get included in the below CG scan
-        - script: >-
-            $(Build.SourcesDirectory)/restore.cmd -ci -projects $(Build.SourcesDirectory)/src/Tools/dotnet-monitor/dotnet-monitor.csproj
-          displayName: Restore dotnet-monitor tool packages
-            
-        - task: ComponentGovernanceComponentDetection@0
-          displayName: Component Detection (dotnet-monitor tool)
+        jobTemplate: /eng/pipelines/jobs/build-archive.yml
+        includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
+# This stage creates NuGet packages and generates the BAR manifests
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - stage: PackSignPublish
+    displayName: Pack, Sign, and Generate Manifests
+    dependsOn:
+    - Build
+    jobs:
+    # Pack, sign, and publish manifest
+    - template: /eng/pipelines/jobs/pack-sign-publish.yml
 
-        - task: notice@0
-          displayName: Generate TPN file
-          inputs:
-            outputfile: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'
-            outputformat: text
-
-        - task: PublishPipelineArtifact@1
-          displayName: Publish TPN
-          inputs:
-            artifactName: 'THIRD-PARTY-NOTICES'
-            targetPath: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'
-
-    # Pack, sign, and publish
-    - template: /eng/common/templates/job/job.yml
-      parameters:
-        name: Pack_Sign
-        displayName: Pack and Sign
-        dependsOn:
-        - Windows_x64_Release
-        - Windows_x86_Release
-        - Windows_arm64_Release
-        - Linux_x64_Release
-        - Linux_arm64_Release
-        - Linux_Musl_x64_Release
-        - Linux_Musl_arm64_Release
-        - MacOS_x64_Release
-        - MacOS_arm64_Release
-        - Generate_TPN
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        enablePublishUsingPipelines: true
-        enableMicrobuild: true
-        artifacts:
-          download:
-            name: Build_Release
-          publish:
-            artifacts:
-              name: Artifacts_Pack_Sign
-            logs:
-              name: Logs_Pack_Sign
-            manifests: true
-        variables:
-        - _BuildConfig: Release
-        - _SignType: real
-        steps:
-        - task: DownloadPipelineArtifact@2
-          displayName: Download TPN
-          inputs:
-            buildType: current
-            artifactName: 'THIRD-PARTY-NOTICES'
-            targetPath: '$(Build.SourcesDirectory)'
-        - script: >-
-            $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
-            /p:TeamName=$(_TeamName)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            /p:DotNetSignType=real
-            /p:DotNetPublishUsingPipelines=true
-            /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
-          displayName: Pack, Sign, and Publish
     # Register with BAR
     - template: /eng/common/templates/job/publish-build-assets.yml
       parameters:
@@ -144,12 +85,13 @@ stages:
           name: NetCore1ESPool-Internal
           demands: ImageOverride -equals 1es-windows-2019
 # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       # This is to enable SDL runs part of Post-Build Validation Stage.
       # as well as NuGet, SourceLink, and signing validation.
       # The variables get imported from group dotnet-diagnostics-sdl-params
+      validateDependsOn:
+      - PackSignPublish
       publishingInfraVersion: 3
       enableSourceLinkValidation: true
       enableSigningValidation: true
@@ -159,16 +101,17 @@ stages:
       SDLValidationParameters:
         enable: true
         continueOnError: true
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "dotnet-monitor"
-        -TsaCodebaseName "dotnet-monitor"
-        -TsaPublish $True'
+        params: >-
+          -SourceToolsList @("policheck","credscan")
+          -TsaInstanceURL $(_TsaInstanceURL)
+          -TsaProjectName $(_TsaProjectName)
+          -TsaNotificationEmail $(_TsaNotificationEmail)
+          -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+          -TsaBugAreaPath $(_TsaBugAreaPath)
+          -TsaIterationPath $(_TsaIterationPath)
+          -TsaRepositoryName "dotnet-monitor"
+          -TsaCodebaseName "dotnet-monitor"
+          -TsaPublish $True
         artifactNames:
         - 'PackageArtifacts'
 # This sets up the bits to do a Release.

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Import ProjectToPublish items; all projects that would participate in publishing should be listed here. -->
+  <Import Project="$(MSBuildThisFileDirectory)DotnetMonitorProjectToPublish.props" />
+
+  <!-- Only publish projects after build if opt-in -->
+  <Target Name="PublishProjectsAfterBuild"
+          AfterTargets="Build"
+          Condition="'$(PublishProjectsAfterBuild)' == 'true' and '$(CreateArchives)' != 'true'">
+    <CallTarget Targets="PublishProjects" />
+  </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)PublishProjects.targets" />
+</Project>

--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -110,10 +110,10 @@ echo %NUGET_PACKAGES%
 
 :: Set the remaining variables based upon the determined build configuration
 set "__RootBinDir=%__ProjectDir%\artifacts"
-set "__BinDir=%__RootBinDir%\bin\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__BinDir=%__RootBinDir%\bin\win-%__BuildArch%.%__BuildType%"
 set "__LogDir=%__RootBinDir%\log\%__BuildType%"
 set "__ArtifactsIntermediatesDir=%__RootBinDir%\obj"
-set "__IntermediatesDir=%__ArtifactsIntermediatesDir%\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__IntermediatesDir=%__ArtifactsIntermediatesDir%\win-%__BuildArch%.%__BuildType%"
 set "__PackagesBinDir=%__RootBinDir%\packages\%__BuildType%\Shipping"
 
 set "__CrossComponentBinDir=%__BinDir%"
@@ -154,13 +154,6 @@ REM ===
 REM =========================================================================================
 
 @if defined _echo @echo on
-
-:: Parse the optdata package versions out of msbuild so that we can pass them on to CMake
-set __DotNetCli=%__ProjectDir%\.dotnet\dotnet.exe
-if not exist "%__DotNetCli%" (
-    echo %__MsgPrefix%Assertion failed: dotnet cli not found at path "%__DotNetCli%"
-    goto ExitWithError
-)
 
 REM =========================================================================================
 REM ===
@@ -214,7 +207,7 @@ if /i %__BuildCrossArch% EQU 1 (
 
     set __BuildLog="%__LogDir%\Cross.Build.binlog"
 
-    :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
+    :: MSBuild.exe is the only one that has the C++ targets. "dotnet msbuild" fails because VCTargetsPath isn't defined.
     msbuild.exe %__CrossCompIntermediatesDir%\install.vcxproj /bl:!__BuildLog! %__CommonBuildArgs%
 
     if not !ERRORLEVEL! == 0 (
@@ -287,7 +280,7 @@ if %__Build% EQU 1 (
     )
     set __BuildLog="%__LogDir%\Native.Build.binlog"
 
-    :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
+    :: MSBuild.exe is the only one that has the C++ targets. "dotnet msbuild" fails because VCTargetsPath isn't defined.
     msbuild.exe %__IntermediatesDir%\install.vcxproj /bl:!__BuildLog! %__CommonBuildArgs%
 
     if not !ERRORLEVEL! == 0 (

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup Condition="'$(CreateArchives)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src\archives\dotnet-monitor-archive.proj">
+      <AdditionalProperties>TargetFramework=net8.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+    </ProjectToBuild>
+  </ItemGroup>
+</Project>

--- a/eng/DotnetMonitorProjectToPublish.props
+++ b/eng/DotnetMonitorProjectToPublish.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <ProjectToPublish Include="$(RepoRoot)src\Tools\dotnet-monitor\dotnet-monitor.csproj">
+      <AdditionalProperties>TargetFramework=net8.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+    </ProjectToPublish>
+  </ItemGroup>
+</Project>

--- a/eng/PublishProjects.targets
+++ b/eng/PublishProjects.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <SharedPublishProjectProperties>SelfContained=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);PackAsTool=false</SharedPublishProjectProperties>
+  </PropertyGroup>
+
+  <Target Name="PublishProjects">
+    <MSBuild Projects="@(ProjectToPublish)"
+             Properties="$(SharedPublishProjectProperties)"
+             RemoveProperties="OutputPath"
+             Targets="Publish" />
+  </Target>
+
+</Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -13,7 +13,11 @@
 
   <ItemGroup>
     <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.tar.gz" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.zip" IsShipping="true" />
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.tar.gz" IsShipping="false" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.zip" IsShipping="false" />
   </ItemGroup>
 
   <Target Name="CalculateBlobGroupAndBuildVersion">
@@ -99,25 +103,42 @@
 
     <!-- Read in project file name -->
     <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectpath">
-      <Output TaskParameter="Lines" PropertyName="_ProjectPath"/>
+      <Output TaskParameter="Lines" PropertyName="_RelativeProjectPath"/>
+    </ReadLinesFromFile>
+    
+    <!-- Read in project props -->
+    <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectprops"
+                       Condition="Exists('%(PackageToPublish.FullPath).projectprops')">
+      <Output TaskParameter="Lines" PropertyName="_ProjectProps"/>
     </ReadLinesFromFile>
 
     <!-- Get package name from project as if its version was set to the build version -->
-    <MSBuild Projects="$(_ProjectPath)"
+    <ItemGroup>
+      <GetPackageFileNameProps Remove="@(GetPackageFileNameProps)" />
+      <GetPackageFileNameProps Include="Version=$(_BuildVersion)" />
+      <GetPackageFileNameProps Include="$(_ProjectProps)" />
+    </ItemGroup>
+    <MSBuild Projects="$(RepoRoot)$(_RelativeProjectPath)"
              Targets="GetPackageFileName"
-             Properties="Version=$(_BuildVersion)">
+             Properties="@(GetPackageFileNameProps)">
       <Output ItemName="_PackageWithBuildVersionFileName" TaskParameter="TargetOutputs" />
     </MSBuild>
 
     <!-- Get package version from project -->
-    <MSBuild Projects="$(_ProjectPath)"
-             Targets="GetPackageVersion">
+    <ItemGroup>
+      <GetPackageVersionProps Remove="@(GetPackageVersionProps)" />
+      <GetPackageVersionProps Include="$(_ProjectProps)" />
+    </ItemGroup>
+    <MSBuild Projects="$(RepoRoot)$(_RelativeProjectPath)"
+             Targets="GetPackageVersion"
+             Properties="@(GetPackageVersionProps)">
       <Output ItemName="_PackageVersion" TaskParameter="TargetOutputs" />
     </MSBuild>
 
     <!-- Package artifact file paths -->
     <PropertyGroup>
-      <!-- Example file name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg -->
+      <!-- Example nupkg file name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg -->
+      <!-- Example archive file name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip -->
       <_PackageWithBuildVersionFileName>@(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFileName>
       <_PackageWithBuildVersionFilePath>%(PackageToPublish.RootDir)%(PackageToPublish.Directory)$(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFilePath>
       <_ChecksumFilePath>%(PackageToPublish.FullPath).sha512</_ChecksumFilePath>
@@ -127,7 +148,8 @@
 
     <!--
       A file that contains the version of the package.
-      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
+      Example nupkg name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
+      Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.version
       -->
     <WriteLinesToFile File="$(_PackageVersionFilePath)"
                       Lines="@(_PackageVersion)"
@@ -136,7 +158,8 @@
     <!--
       A file that contains the build version of the package. The name of this file contains the build
       version in order to avoid collisions when uploaded to blob storage.
-      Example name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
+      Example nupkg name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
+      Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.buildversion
       -->
     <WriteLinesToFile File="$(_BuildVersionFilePath)"
                       Lines="$(_BuildVersion)"
@@ -148,8 +171,8 @@
     </ItemGroup>
     <ItemGroup>
       <_PackageArtifactData Include="@(_CommonArtifactData)" />
-      <!-- Set Category to OTHER so that packages are also published to blob storage. -->
-      <_PackageArtifactData Include="Category=OTHER" />
+      <!-- Set Category to OTHER so that nupkgs are also published to blob storage. -->
+      <_PackageArtifactData Include="Category=OTHER" Condition="'%(PackageToPublish.Extension)' == 'nupkg'" />
     </ItemGroup>
 
     <!-- Capture items that need to be published under the blob group. -->

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,4 +5,16 @@
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
+  <ItemGroup>
+    <!--
+      Tarballs are currently not signed nor are their contents.
+      This entry allows them to be signed automatically when tooling allows for it.
+      -->
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.tar.gz" />
+    <!--
+      The zip file itself is not signed but their contents are.
+      The zip is expanded, the contents are signed, and then rezipped.
+      -->
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.zip" />
+  </ItemGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,6 +26,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>12b42d0d77948889890ef2f35af8c46438d3f2d2</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.BuildTasks.Archives" Version="8.0.0-beta.23062.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>12b42d0d77948889890ef2f35af8c46438d3f2d2</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="8.0.0-beta.23062.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>12b42d0d77948889890ef2f35af8c46438d3f2d2</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,6 +56,7 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- dotnet/arcade references -->
+    <MicrosoftDotNetBuildTasksArchivesVersion>8.0.0-beta.23062.3</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetCodeAnalysisVersion>8.0.0-beta.23062.3</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.23062.3</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -1,0 +1,52 @@
+# Builds and tests dotnet-monitor for a specific platform and configuration
+
+parameters:
+  # Operating system group (Windows, Linux, MacOS, etc)
+  osGroup: Windows
+  # Build configuration (Debug, Release)
+  configuration: Release
+  # Build architecture (arm64, x64, x86, etc)
+  architecture: x64
+
+jobs:
+- template: /eng/pipelines/jobs/build.yml
+  parameters:
+    prefix: Archive
+    osGroup: ${{ parameters.osGroup }}
+    configuration: ${{ parameters.configuration }}
+    architecture: ${{ parameters.architecture }}
+    dependsOn:
+    - Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+    - Generate_TPN
+
+    preBuildSteps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Binaries
+      inputs:
+        artifactName: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Third Party Notice
+      inputs:
+        artifactName: 'THIRD-PARTY-NOTICES'
+        targetPath: '$(Build.SourcesDirectory)'
+
+    buildArgs: >-
+      -archive
+      -skipmanaged
+      -skipnative
+      /p:PublishProjectsAfterBuild=true
+      /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
+
+    postBuildSteps:
+    - task: CopyFiles@2
+      displayName: Gather Artifacts (packages)
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifacts
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+        artifactName: Archive_${{ parameters.configuration }}

--- a/eng/pipelines/jobs/build-codeql.yml
+++ b/eng/pipelines/jobs/build-codeql.yml
@@ -1,10 +1,6 @@
 # Builds dotnet-monitor for a specific platform and configuration with CodeQL analysis enabled
 
 parameters:
-  # Job name (required)
-  name: ''
-  # Job display name
-  displayName: ''
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
@@ -21,8 +17,7 @@ parameters:
 jobs:
 - template: /eng/pipelines/jobs/build.yml
   parameters:
-    name: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
+    prefix: CodeQL
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
@@ -30,7 +25,7 @@ jobs:
     disableSbom: true
 
     variables:
-    - Codeql.BuildIdentifier: ${{ parameters.name }}
+    - Codeql.BuildIdentifier: $(JobName)
       # Do not let CodeQL 3000 Extension gate scan frequency
     - Codeql.Cadence: 0
     # Force CodeQL enabled so it may be run on any branch

--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -1,18 +1,16 @@
 # Builds and tests dotnet-monitor for a specific platform and configuration
 
 parameters:
-  # Job name (required)
-  name: ''
-  # Job display name
-  displayName: ''
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
   configuration: Release
   # Build architecture (arm64, x64, x86, etc)
   architecture: x64
-  # Sub paths under 'artifacts' folder from which files are published to artifacts location
-  publishArtifactsSubPaths: []
+  # RID (runtime identifier) of build output
+  targetRid: win-x64
+  # Enable/disable of publishing build output
+  publishArtifacts: false
   # Group of tests to be run
   testGroup: Default
   # TFMs for which test results are uploaded
@@ -27,12 +25,11 @@ parameters:
 jobs:
 - template: /eng/pipelines/jobs/build.yml
   parameters:
-    name: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
+    prefix: Build
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
-    publishArtifactsSubPaths: ${{ parameters.publishArtifactsSubPaths }}
+
     variables:
     - ${{ if and(ne(parameters.testGroup, 'None'), ne(parameters.architecture, 'arm64')) }}:
       # If TestGroup == 'Default', choose the test group based on the type of pipeline run
@@ -75,7 +72,46 @@ jobs:
         - script: echo "##vso[task.prependpath]/usr/share/node/bin"
           displayName: Add Azurite to PATH
 
+    buildArgs: '/p:PublishProjectsAfterBuild=true'
+
     postBuildSteps:
+    - ${{ if and(eq(parameters.publishArtifacts, 'true'), eq(parameters.configuration, 'Release')) }}:
+      - task: CopyFiles@2
+        displayName: Gather Artifacts (bin/dotnet-monitor)
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/dotnet-monitor'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin/dotnet-monitor'
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+          artifactName: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+
+      - ${{ if eq(parameters.targetRid, 'win-x64') }}:
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (bin)
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/bin'
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (obj)
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/obj'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/obj'
+      - ${{ else }}:
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (bin/${{ parameters.targetRid }}.${{ parameters.configuration }})
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+      
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts (Unified)
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/unified'
+          artifactName: Build_${{ parameters.configuration }}
+
     # Execute tests
     - ${{ if and(ne(parameters.testGroup, 'None'), eq(parameters.architecture, 'arm64')) }}:
       - script: echo "Running tests for arm64 binaries is currently not supported."
@@ -102,10 +138,10 @@ jobs:
             testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
             searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
             failTaskOnFailedTests: true
-            testRunTitle: '${{ coalesce(parameters.displayName, parameters.name) }} ${{ testResultTfm.value }}'
+            testRunTitle: '${{ parameters.configuration }} ${{ parameters.osGroup }} ${{ parameters.architecture }} ${{ testResultTfm.value }}'
             publishRunAttachments: true
             mergeTestResults: true
-            buildConfiguration: ${{ parameters.name }}
+            buildConfiguration: $(JobName)
           continueOnError: true
           condition: succeededOrFailed()
 
@@ -114,7 +150,6 @@ jobs:
           displayName: Publish Test Result Files
           inputs:
             PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-            PublishLocation: Container
-            ArtifactName: TestResults_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
+            ArtifactName: TestResults_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
           continueOnError: true
           condition: succeededOrFailed()

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -1,10 +1,8 @@
 # Builds dotnet-monitor for a specific platform and configuration
 
 parameters:
-  # Job name (required)
-  name: ''
-  # Job display name
-  displayName: ''
+  # Job prefix (required)
+  prefix: ''
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
@@ -27,22 +25,23 @@ parameters:
   disableComponentGovernance: false
   # Disable SBOM generation
   disableSbom: false
+  buildArgs: ''
 
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    name: ${{ parameters.name }}
-    displayName: ${{ coalesce(parameters.displayName, parameters.name) }}
+    name: ${{ parameters.prefix }}_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+    displayName: ${{ format('{0} {1} {2} {3}', parameters.prefix, parameters.osGroup, parameters.architecture, parameters.configuration) }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableTelemetry: true
-    disableComponentGovernance: ${{ or(parameters.disableComponentGovernance, eq(parameters.osGroup, 'Linux_Musl')) }}
+    disableComponentGovernance: ${{ or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}
     ${{ if eq(parameters.disableSbom, 'true') }}:
       enableSbom: false
     helixRepo: dotnet/dotnet-monitor
     artifacts:
       publish:
         logs:
-          name: Logs_${{ parameters.osGroup }}_${{ parameters.architecture }}_${{ parameters.configuration }}
+          name: Logs_$(JobName)
 
     pool:
       # Public Linux Build Pool
@@ -90,6 +89,7 @@ jobs:
       clean: all
 
     variables:
+    - JobName: ${{ parameters.prefix }}_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
@@ -100,7 +100,7 @@ jobs:
       - ${{ variable }}
 
     # Component Governance does not work on Musl
-    - ${{ if or(parameters.disableComponentGovernance, eq(parameters.osGroup, 'Linux_Musl')) }}:
+    - ${{ if or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}:
       - skipComponentGovernanceDetection: true
     
     # Cross build for arm64 non-Windows builds
@@ -155,6 +155,7 @@ jobs:
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
+        ${{ parameters.buildArgs }}
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
         $(_CrossBuildArgs)
@@ -164,21 +165,6 @@ jobs:
       ${{ if and(eq(parameters.architecture, 'arm64'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
         env:
           ROOTFS_DIR: '/crossrootfs/arm64'
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), gt(length(parameters.publishArtifactsSubPaths), 0)) }}:
-      - ${{ each subPath in parameters.publishArtifactsSubPaths }}:
-        - task: CopyFiles@2
-          displayName: Gather Artifacts (${{ subPath.source }})
-          inputs:
-            SourceFolder: '$(Build.SourcesDirectory)/artifacts/${{ subPath.source }}'
-            Contents: '**'
-            TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/${{ coalesce(subPath.target, subPath.source) }}'
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Artifacts
-        inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-          artifactName: Build_${{ parameters.configuration }}
 
     - ${{ each step in parameters.postBuildSteps }}:
       - ${{ step }}

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -1,0 +1,44 @@
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: Pack_Sign
+    displayName: Pack and Sign
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals 1es-windows-2019
+    enablePublishUsingPipelines: true
+    enableMicrobuild: true
+    artifacts:
+      publish:
+        artifacts:
+          name: Artifacts_Pack_Sign
+        logs:
+          name: Logs_Pack_Sign
+        manifests: true
+    variables:
+    - _BuildConfig: Release
+    - _SignType: real
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Binaries
+      inputs:
+        artifactName: Build_Release
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Archives
+      inputs:
+        artifactName: Archive_Release
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Third Party Notice
+      inputs:
+        artifactName: 'THIRD-PARTY-NOTICES'
+        targetPath: '$(Build.SourcesDirectory)'
+    - script: >-
+        $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
+        /p:TeamName=$(_TeamName)
+        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        /p:DotNetSignType=real
+        /p:DotNetPublishUsingPipelines=true
+        /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
+      displayName: Pack, Sign, and Publish

--- a/eng/pipelines/jobs/platform-matrix.yml
+++ b/eng/pipelines/jobs/platform-matrix.yml
@@ -5,8 +5,6 @@ parameters:
   jobTemplate: ''
   # Extra job template parameters to pass to the job template
   jobParameters: {}
-  # Determines if build artifacts should be uploaded as pipeline artifacts
-  publishBuildArtifacts: false
   # Determines if debug configurations should be included
   includeDebug: false
   # Determines if ARM64 architectures should be included
@@ -16,134 +14,91 @@ jobs:
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Windows_x64_Debug
-      displayName: Windows x64 Debug
       osGroup: Windows
       configuration: Debug
+      targetRid: win-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Windows_x64_Release
-    displayName: Windows x64 Release
     osGroup: Windows
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin'
-      - source: 'obj'
+    targetRid: win-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Windows_x86_Release
-    displayName: Windows x86 Release
     osGroup: Windows
     configuration: Release
     architecture: x86
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/Windows_NT.x86.Release'
+    targetRid: win-x86
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Windows_arm64_Release
-      displayName: Windows arm64 Release
       osGroup: Windows
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/Windows_NT.arm64.Release'
+      targetRid: win-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_x64_Debug
-      displayName: Linux x64 Debug
       osGroup: Linux
       configuration: Debug
+      targetRid: linux-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Linux_x64_Release
-    displayName: Linux x64 Release
     osGroup: Linux
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/Linux.x64.Release'
+    targetRid: linux-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_arm64_Release
-      displayName: Linux arm64 Release
       osGroup: Linux
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/Linux.arm64.Release'
+      targetRid: linux-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_Musl_x64_Debug
-      displayName: Linux Musl x64 Debug
       osGroup: Linux_Musl
       configuration: Debug
+      targetRid: linux-musl-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: Linux_Musl_x64_Release
-    displayName: Linux Musl x64 Release
     osGroup: Linux_Musl
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/Linux.x64.Release'
-        target: 'bin/Linux-musl.x64.Release'
+    targetRid: linux-musl-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: Linux_Musl_arm64_Release
-      displayName: Linux Musl arm64 Release
       osGroup: Linux_Musl
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/Linux.arm64.Release'
-          target: 'bin/Linux-musl.arm64.Release'
+      targetRid: linux-musl-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeDebug, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: MacOS_x64_Debug
-      displayName: MacOS x64 Debug
       osGroup: MacOS
       configuration: Debug
+      targetRid: osx-x64
       ${{ insert }}: ${{ parameters.jobParameters }}
 - template: ${{ parameters.jobTemplate }}
   parameters:
-    name: MacOS_x64_Release
-    displayName: MacOS x64 Release
     osGroup: MacOS
     configuration: Release
-    ${{ if parameters.publishBuildArtifacts }}:
-      publishArtifactsSubPaths:
-      - source: 'bin/OSX.x64.Release'
+    targetRid: osx-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
-      name: MacOS_arm64_Release
-      displayName: MacOS arm64 Release
       osGroup: MacOS
       configuration: Release
       architecture: arm64
-      ${{ if parameters.publishBuildArtifacts }}:
-        publishArtifactsSubPaths:
-        - source: 'bin/OSX.arm64.Release'
+      targetRid: osx-arm64
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/jobs/tpn.yml
+++ b/eng/pipelines/jobs/tpn.yml
@@ -1,0 +1,30 @@
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: Generate_TPN
+    displayName: Generate TPN
+    disableComponentGovernance: true
+    enableSbom: false
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    # Only restore the dotnet-monitor project so only packages we ship get included in the below CG scan
+    - script: >-
+        $(Build.SourcesDirectory)/restore.cmd -ci -projects $(Build.SourcesDirectory)/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+      displayName: Restore dotnet-monitor tool packages
+        
+    - task: ComponentGovernanceComponentDetection@0
+      displayName: Component Detection (dotnet-monitor tool)
+
+    - task: notice@0
+      displayName: Generate TPN file
+      inputs:
+        outputfile: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'
+        outputformat: text
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish TPN
+      inputs:
+        artifactName: 'THIRD-PARTY-NOTICES'
+        targetPath: '$(Build.ArtifactStagingDirectory)/$(_TPNFile)'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,11 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DebugSymbols>true</DebugSymbols>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+    <!-- Executables for these runtime identifiers do not require notarization. -->
+    <SignOnlyRuntimeIdentifiers>linux-arm64;linux-x64;linux-musl-arm64;linux-musl-x64;win-arm64;win-x64;win-x86</SignOnlyRuntimeIdentifiers>
+    <!-- OSX requires executables to be notarized; separate these out from the others so they can be excluded when producing executable shims -->
+    <SignAndNotarizeRuntimeIdentifiers>osx-arm64;osx-x64</SignAndNotarizeRuntimeIdentifiers>
+    <DefaultRuntimeIdentifiers>$(SignOnlyRuntimeIdentifiers);$(SignAndNotarizeRuntimeIdentifiers)</DefaultRuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -12,11 +12,45 @@
   </ItemGroup>
 
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
-  <Target Name="GeneratePackageProjectPathFile"
+  <Target Name="GenerateNuGetPackageProjectFiles"
           AfterTargets="Pack"
           Condition="'$(IsPackable)' == 'true' and '$(IsShipping)' == 'true'">
+    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.projectpath"
-                      Lines="$(MSBuildProjectFullPath)"
+                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+                      Overwrite="true" />
+  </Target>
+  <Target Name="GenerateArchivePackageProjectFiles"
+          AfterTargets="_CreateArchive"
+          Condition="'$(IsArchivable)' == 'true' and '$(IsShipping)' == 'true'">
+    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectpath"
+                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+                      Overwrite="true" />
+    <ItemGroup>
+      <PackageProjectProps Remove="@(PackageProjectProps)" />
+      <PackageProjectProps Include="RuntimeIdentifier=$(RuntimeIdentifier)" />
+    </ItemGroup>
+    <!-- Write a props file so that the above project is invoked during publish with the specified properties. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectprops"
+                      Lines="@(PackageProjectProps)"
+                      Overwrite="true" />
+  </Target>
+  <Target Name="GenerateSymbolsArchivePackageProjectFiles"
+          AfterTargets="_CreateSymbolsArchive"
+          Condition="'$(IsArchivable)' == 'true' and '$(CreateSymbolsArchive)' == 'true' and '$(IsShipping)' == 'true'">
+    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectpath"
+                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+                      Overwrite="true" />
+    <ItemGroup>
+      <PackageProjectProps Remove="@(PackageProjectProps)" />
+      <PackageProjectProps Include="RuntimeIdentifier=$(RuntimeIdentifier)" />
+      <PackageProjectProps Include="IsSymbolsArchive=true" />
+    </ItemGroup>
+    <!-- Write a props file so that the above project is invoked during publish with the specified properties. -->
+    <WriteLinesToFile File="$(_DestinationFileName).projectprops"
+                      Lines="@(PackageProjectProps)"
                       Overwrite="true" />
   </Target>
 
@@ -24,7 +58,15 @@
           Returns="$(PackageVersion)" />
 
   <Target Name="GetPackageFileName"
-          Returns="$(PackageId).$(PackageVersion).nupkg" />
+          Returns="@(PackageFileName)">
+    <ItemGroup>
+      <PackageFileName Include="$(PackageId).$(PackageVersion).nupkg" Condition="'$(IsPackable)' == 'true'" />
+      <!-- The archive targets use Version instead of PackageVersion; do the same to be consistent. -->
+      <PackageFileName Include="$(ArchiveName)-$(Version)-$(RuntimeIdentifier).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' != 'true' " />
+      <!-- Symbols archive names reverse the order of the version and runtime identifier compared to the product archive. -->
+      <PackageFileName Include="$(ArchiveName)-symbols-$(RuntimeIdentifier)-$(Version).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' == 'true' " />
+    </ItemGroup>
+  </Target>
 
   <!-- Remove native libraries from transitive dependencies -->
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/NativeLibraryHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/NativeLibraryHelper.cs
@@ -17,28 +17,44 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             "Release";
 #endif
 
+        private const string OSReleasePath = "/etc/os-release";
+
         public static string GetSharedLibraryPath(Architecture architecture, string rootName)
         {
             string artifactsBinPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", ".."));
             return Path.Combine(artifactsBinPath, GetNativeBinDirectoryName(architecture), GetSharedLibraryName(rootName));
         }
 
-        private static string GetNativeBinDirectoryName(Architecture architecture)
+        public static string GetTargetRuntimeIdentifier(Architecture? architecture)
         {
-            string architectureString = GetArchitectureFolderName(architecture);
+            string architectureString = GetArchitectureFolderName(architecture ?? RuntimeInformation.OSArchitecture);
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return $"Windows_NT.{architectureString}.{ConfigurationName}";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return $"Linux.{architectureString}.{ConfigurationName}";
+                return FormattableString.Invariant($"win-{architectureString}");
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return $"OSX.{architectureString}.{ConfigurationName}";
+                return FormattableString.Invariant($"osx-{architectureString}");
             }
-            throw new PlatformNotSupportedException();
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (File.Exists(OSReleasePath) && File.ReadAllText(OSReleasePath).Contains("Alpine", StringComparison.OrdinalIgnoreCase))
+                {
+                    return FormattableString.Invariant($"linux-musl-{architectureString}");
+                }
+                else
+                {
+                    return FormattableString.Invariant($"linux-{architectureString}");
+                }
+            }
+
+            throw new PlatformNotSupportedException("Unable to determine OS platform.");
+        }
+
+        private static string GetNativeBinDirectoryName(Architecture architecture)
+        {
+            return $"{GetTargetRuntimeIdentifier(architecture)}.{ConfigurationName}";
         }
 
         private static string GetSharedLibraryName(string rootName)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ProfilerHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/ProfilerHelper.cs
@@ -25,37 +25,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static string GetPath(Architecture architecture) =>
             NativeLibraryHelper.GetSharedLibraryPath(architecture, ProfilerIdentifiers.LibraryRootFileName);
 
-        private const string OSReleasePath = "/etc/os-release";
-
-        public static string GetTargetRuntimeIdentifier(Architecture? architecture)
-        {
-            string architectureString = (architecture ?? RuntimeInformation.OSArchitecture)
-                .ToString("G")
-                .ToLowerInvariant();
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return FormattableString.Invariant($"win-{architectureString}");
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return FormattableString.Invariant($"osx-{architectureString}");
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                if (File.Exists(OSReleasePath) && File.ReadAllText(OSReleasePath).Contains("Alpine", StringComparison.OrdinalIgnoreCase))
-                {
-                    return FormattableString.Invariant($"linux-musl-{architectureString}");
-                }
-                else
-                {
-                    return FormattableString.Invariant($"linux-{architectureString}");
-                }
-            }
-
-            throw new PlatformNotSupportedException("Unable to determine OS platform.");
-        }
-
         public static IEnumerable<object[]> GetArchitecture()
         {
             // There isn't a good way to check which architecture to use when running unit tests.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             {
                 _adapter.Environment.Add(
                     ToolIdentifiers.EnvironmentVariables.RuntimeIdentifier,
-                    ProfilerHelper.GetTargetRuntimeIdentifier(Architecture));
+                    NativeLibraryHelper.GetTargetRuntimeIdentifier(Architecture));
             }
             if (ProfilerLogLevel != null)
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
@@ -28,31 +28,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
         /// </summary>
         public static IFileProvider Create(string runtimeIdentifier, string sharedLibraryPath)
         {
-            int index = runtimeIdentifier.LastIndexOf('-');
-            if (index < 0)
-            {
-                throw new ArgumentException();
-            }
-            string osPlatform = runtimeIdentifier.Substring(0, index);
-            string architecture = runtimeIdentifier.Substring(index + 1);
-
-            string nativePlatformFolderPrefix = null;
-            switch (osPlatform)
-            {
-                case "linux":
-                case "linux-musl":
-                    nativePlatformFolderPrefix = "Linux";
-                    break;
-                case "osx":
-                    nativePlatformFolderPrefix = "OSX";
-                    break;
-                case "win":
-                    nativePlatformFolderPrefix = "Windows_NT";
-                    break;
-                default:
-                    throw new PlatformNotSupportedException();
-            }
-
             string configurationName =
 #if DEBUG
             "Debug";
@@ -60,7 +35,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
             "Release";
 #endif
 
-            string nativeOutputPath = Path.Combine(sharedLibraryPath, $"{nativePlatformFolderPrefix}.{architecture}.{configurationName}");
+            string nativeOutputPath = Path.Combine(sharedLibraryPath, $"{runtimeIdentifier}.{configurationName}");
 
             return new BuildOutputNativeFileProvider(nativeOutputPath);
         }

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -3,23 +3,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64;win-arm;osx-x64;linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;linux-arm</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(SignOnlyRuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux.arm64.$(Configuration)" TargetRid="linux-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux.x64.$(Configuration)" TargetRid="linux-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux-musl.arm64.$(Configuration)" TargetRid="linux-musl-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Linux-musl.x64.$(Configuration)" TargetRid="linux-musl-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)OSX.arm64.$(Configuration)" TargetRid="osx-arm64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)OSX.x64.$(Configuration)" TargetRid="osx-x64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Windows_NT.arm64.$(Configuration)" TargetRid="win-arm64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Windows_NT.x64.$(Configuration)" TargetRid="win-x64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)Windows_NT.x86.$(Configuration)" TargetRid="win-x86" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-arm64.$(Configuration)" TargetRid="linux-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-x64.$(Configuration)" TargetRid="linux-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-arm64.$(Configuration)" TargetRid="linux-musl-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-x64.$(Configuration)" TargetRid="linux-musl-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-arm64.$(Configuration)" TargetRid="osx-arm64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-x64.$(Configuration)" TargetRid="osx-x64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-arm64.$(Configuration)" TargetRid="win-arm64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x64.$(Configuration)" TargetRid="win-x64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x86.$(Configuration)" TargetRid="win-x86" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsPackable)' == 'true' and '$(ThirdPartyNoticesFilePath)' != ''">

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
-    <RuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</RuntimeIdentifiers>
-    <PackAsToolShimRuntimeIdentifiers>linux-x64;linux-musl-x64;win-x64</PackAsToolShimRuntimeIdentifiers>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
     <ToolCommandName>dotnet-monitor</ToolCommandName>
     <Description>.NET Core Diagnostic Monitoring Tool</Description>
@@ -58,28 +56,49 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Profiler library items for all of the native platforms. -->
+    <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
+      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
+    </MonitorProfilerLibraryFile>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Profiler symbols items for all of the native platforms. -->
+    <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
+      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
+    </MonitorProfilerSymbolsFile>
+  </ItemGroup>
+
   <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherNativeFilesForTfm</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherTfmNativeFilesInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="GatherNativeFilesForTfm">
-    <ItemGroup>
-      <!-- Create profiler library items for all of the native platforms. -->
-      <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
-        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
-      </MonitorProfilerLibraryFile>
-    </ItemGroup>
-    <ItemGroup>
-      <!-- Create profiler symbols items for all of the native platforms. -->
-      <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
-        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
-      </MonitorProfilerSymbolsFile>
-    </ItemGroup>
+  <Target Name="GatherTfmNativeFilesInPackage">
     <ItemGroup>
       <!-- Pack the profiler library for each platform if it exists. -->
       <TfmSpecificPackageFile Include="@(MonitorProfilerLibraryFile-&gt;Exists())" />
       <!-- Pack the profiler symbols for each platform if it exists. -->
       <TfmSpecificPackageFile Include="@(MonitorProfilerSymbolsFile-&gt;Exists())" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeProfilerFilesToPublish"
+          AfterTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <!-- Include the profiler library for the corresponding platform if it exists. -->
+      <ResolvedFileToPublish Include="@(MonitorProfilerLibraryFile-&gt;Exists())"
+                             Condition="'%(MonitorProfilerLibraryFile.TargetRid)' == '$(RuntimeIdentifier)'">
+        <RelativePath>%(MonitorProfilerLibraryFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+      <!-- Include the profiler symbols for the corresponding platform if it exists. -->
+      <ResolvedFileToPublish Include="@(MonitorProfilerSymbolsFile-&gt;Exists())"
+                             Condition="'%(MonitorProfilerSymbolsFile.TargetRid)' == '$(RuntimeIdentifier)'">
+        <RelativePath>%(MonitorProfilerSymbolsFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
     </ItemGroup>
   </Target>
 

--- a/src/archives/Directory.Build.props
+++ b/src/archives/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+  <PropertyGroup>
+    <ArchiveFormat Condition="$(RuntimeIdentifier.Contains(win))">zip</ArchiveFormat>
+    <ArchiveFormat Condition="!$(RuntimeIdentifier.Contains(win))">tar.gz</ArchiveFormat>
+  </PropertyGroup>
+</Project>

--- a/src/archives/Directory.Build.targets
+++ b/src/archives/Directory.Build.targets
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
+  </ItemGroup>
+  
+  <Target Name="PublishToDisk"
+          DependsOnTargets="$(PublishToDiskDependsOn)">
+    <Error Message="The 'ArchiveContentRootPath' property must be set to the path of the root of the files to archive."
+           Condition="'$(ArchiveContentRootPath)' == ''" />
+    <Error Message="The archive content root path '$(ArchiveContentRootPath)' does not exist."
+           Condition="!Exists($(ArchiveContentRootPath))" />
+    <!-- Collect non-symbol files and copy to staging directory -->
+    <ItemGroup>
+      <_FileToArchive Remove="@(_FileToArchive)" />
+      <_FileToArchive Include="$(ArchiveContentRootPath)**" />
+      <_FileToArchive Include="@(FileToArchive)" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(CreateSymbolsArchive)' == 'true'">
+      <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.dbg" />
+      <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.dwarf" />
+      <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_FileToArchive)" DestinationFiles="$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Make executable files readable by all, writable by the user, and executable by all. -->
+    <ItemGroup>
+      <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
+      <_ArchiveExecutableContent Include="@(_FileToArchive)"
+                                 Condition="'%(Extension)' == '.dylib' or '%(Extension)' == '.so'" />
+    </ItemGroup>
+    <Exec Command="chmod 755 %(_ArchiveExecutableContent.Identity)"
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveExecutableContent)' != ''" />
+    <!-- Make non-executable files readable by all and writable by the user. -->
+    <ItemGroup>
+      <_ArchiveNonExecutableContent Remove="@(_ArchiveNonExecutableContent)" />
+      <_ArchiveNonExecutableContent Include="@(_FileToArchive)" />
+      <_ArchiveNonExecutableContent Remove="@(_ArchiveExecutableContent)" />
+    </ItemGroup>
+    <Exec Command="chmod 644 %(_ArchiveNonExecutableContent.Identity)"
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveNonExecutableContent)' != ''" />
+  </Target>
+
+  <Target Name="PublishSymbolsToDisk"
+          DependsOnTargets="$(PublishSymbolsToDiskDependsOn)">
+    <!-- Collect symbol files and copy to staging directory -->
+    <ItemGroup>
+      <_SymbolFileToArchive Remove="@(_SymbolFileToArchive)" />
+      <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.dbg" />
+      <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.dwarf" />
+      <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.pdb" />
+      <_SymbolFileToArchive Include="@(SymbolFileToArchive)" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_SymbolFileToArchive)" DestinationFiles="$(SymbolsOutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Make non-executable files readable by all and writable by the user. -->
+    <ItemGroup>
+      <_SymbolsNonExecutableContent Remove="@(_SymbolsNonExecutableContent)" />
+      <_SymbolsNonExecutableContent Include="@(_SymbolFileToArchive)" />
+    </ItemGroup>
+    <Exec Command="chmod 644 %(_SymbolsNonExecutableContent.Identity)"
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_SymbolsNonExecutableContent)' != ''" />
+  </Target>
+</Project>

--- a/src/archives/PublishedProjectArchive.targets
+++ b/src/archives/PublishedProjectArchive.targets
@@ -1,0 +1,14 @@
+<Project>
+  <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />
+
+  <PropertyGroup>
+    <PublishToDiskDependsOn>PublishProjectsBeforeArchive</PublishToDiskDependsOn>
+    <PublishSymbolsToDiskDependsOn>PublishProjectsBeforeArchive</PublishSymbolsToDiskDependsOn>
+  </PropertyGroup>
+
+  <!-- Publish projects if they were not published after build -->
+  <Target Name="PublishProjectsBeforeArchive"
+          Condition="'$(PublishProjectsAfterBuild)' != 'true'">
+    <CallTarget Targets="PublishProjects" />
+  </Target>
+</Project>

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <ArchiveName>dotnet-monitor</ArchiveName>
+    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
+    <IsShipping>false</IsShipping>
+    <IsArchivable>true</IsArchivable>
+    <CreateSymbolsArchive>true</CreateSymbolsArchive>
+    <ArchiveContentRootPath>$(ArtifactsBinDir)dotnet-monitor\$(Configuration)\$(TargetFramework)\$(PackageRid)\publish\</ArchiveContentRootPath>
+  </PropertyGroup>
+  <!-- These items are included in addition to those from publishing the dotnet-monitor project. -->
+  <ItemGroup>
+    <FileToArchive Include="$(RepoRoot)LICENSE.TXT" />
+    <FileToArchive Include="$(ThirdPartyNoticesFilePath)" Condition="Exists('$(ThirdPartyNoticesFilePath)')" />
+  </ItemGroup>
+  <!-- Import ProjectToPublish items -->
+  <Import Project="$(RepositoryEngineeringDir)DotnetMonitorProjectToPublish.props" />
+  <!-- Import archive creation from published project -->
+  <Import Project="$(MSBuildThisFileDirectory)PublishedProjectArchive.targets" />
+</Project>


### PR DESCRIPTION
###### Summary

Merge from `release/7.x` to `main` to bring in latest changes for archive production. Minor adjustments were made to change `net7.0` to `net8.0` in the archive projects/props/targets.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
