### PR TITLE
[release/7.x] Fix typos in resx files

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
             catch (UnauthorizedAccessException)
             {
-                throw new InvalidOperationException(Strings.ErrorMessage_ProcessEnumeratuinFailed);
+                throw new InvalidOperationException(Strings.ErrorMessage_ProcessEnumerationFailed);
             }
 
             if (processFilterConfig != null)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -180,9 +180,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         /// <summary>
         ///   Looks up a localized string similar to Unable to enumerate processes..
         /// </summary>
-        internal static string ErrorMessage_ProcessEnumeratuinFailed {
+        internal static string ErrorMessage_ProcessEnumerationFailed {
             get {
-                return ResourceManager.GetString("ErrorMessage_ProcessEnumeratuinFailed", resourceCulture);
+                return ResourceManager.GetString("ErrorMessage_ProcessEnumerationFailed", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -163,7 +163,7 @@
   <data name="ErrorMessage_OperationNotRunning" xml:space="preserve">
     <value>Operation is not running.</value>
   </data>
-  <data name="ErrorMessage_ProcessEnumeratuinFailed" xml:space="preserve">
+  <data name="ErrorMessage_ProcessEnumerationFailed" xml:space="preserve">
     <value>Unable to enumerate processes.</value>
     <comment>Gets a string similar to "Unable to enumerate processes.".</comment>
   </data>

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -234,9 +234,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         /// <summary>
         ///   Looks up a localized string similar to The {0} field value length must be an even number..
         /// </summary>
-        internal static string ErrorMessage_FieldOddLengh {
+        internal static string ErrorMessage_FieldOddLength {
             get {
-                return ResourceManager.GetString("ErrorMessage_FieldOddLengh", resourceCulture);
+                return ResourceManager.GetString("ErrorMessage_FieldOddLength", resourceCulture);
             }
         }
         
@@ -871,7 +871,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attemping to delete diagnostic port file at &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Attempting to delete diagnostic port file at &apos;{0}&apos;..
         /// </summary>
         internal static string LogFormatString_DiagnosticPortDeleteAttempt {
             get {
@@ -1114,7 +1114,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid result refrence &apos;{actionToken}&apos;..
+        ///   Looks up a localized string similar to Invalid result reference &apos;{actionToken}&apos;..
         /// </summary>
         internal static string LogFormatString_InvalidActionResultReference {
             get {
@@ -1168,7 +1168,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The configuration field {fieldName} contains private key information. The private key information is not required for dotnet-monitor to verify a token signature and it is strongly recomended to only provide the public key..
+        ///   Looks up a localized string similar to The configuration field {fieldName} contains private key information. The private key information is not required for dotnet-monitor to verify a token signature and it is strongly recommended to only provide the public key..
         /// </summary>
         internal static string LogFormatString_NotifyPrivateKey {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -206,7 +206,7 @@
 1 Format Parameter:
 0. fieldName: The name of the field that failed validation</comment>
   </data>
-  <data name="ErrorMessage_FieldOddLengh" xml:space="preserve">
+  <data name="ErrorMessage_FieldOddLength" xml:space="preserve">
     <value>The {0} field value length must be an even number.</value>
     <comment>Gets the format string for rejecting a field because it must have an even numbered length.
 1 Format Parameter:
@@ -518,7 +518,7 @@
     <value>Diagnostic port file at '{0}' was either deleted or moved while it was still being used.</value>
   </data>
   <data name="LogFormatString_DiagnosticPortDeleteAttempt" xml:space="preserve">
-    <value>Attemping to delete diagnostic port file at '{0}'.</value>
+    <value>Attempting to delete diagnostic port file at '{0}'.</value>
   </data>
   <data name="LogFormatString_DiagnosticPortDeleteFailed" xml:space="preserve">
     <value>Failed to delete diagnostic port file at '{0}'.</value>
@@ -625,7 +625,7 @@
   <data name="LogFormatString_GetEnvironmentVariable" xml:space="preserve">
     <value>Getting the environment variable {variableName} from process {processId}.</value>
     <comment>Gets the format string that is printed in the 55:GetEnvironmentVariable event.
-2 Format parameterts:
+2 Format Parameters:
 1. variableName: The name of the environment variable being read
 2. processId: The id of the process to which the variable is being read</comment>
   </data>
@@ -641,7 +641,7 @@
     <value>Invalid action reference '{actionReference}'.</value>
   </data>
   <data name="LogFormatString_InvalidActionResultReference" xml:space="preserve">
-    <value>Invalid result refrence '{actionToken}'.</value>
+    <value>Invalid result reference '{actionToken}'.</value>
   </data>
   <data name="LogFormatString_InvalidMetadata" xml:space="preserve">
     <value>Invalid metadata; custom metadata keys must be valid C# identifiers.</value>
@@ -653,7 +653,7 @@
   <data name="LogFormatString_LoadingProfiler" xml:space="preserve">
     <value>Loading the profiler with CLSID {clsid} from {path} into process {processId}.</value>
     <comment>Gets the format string that is printed in the 53:LoadingProfiler event.
-3 Format parameterts:
+3 Format Parameters:
 1. profilerGuid: The id in guid form of the cor profiler in question
 2. path: The file path to the profiler being loaded relative to target process
 3. processId: The id of the process to which the profiler is being loaded</comment>
@@ -673,7 +673,7 @@
 0 Format Parameters</comment>
   </data>
   <data name="LogFormatString_NotifyPrivateKey" xml:space="preserve">
-    <value>The configuration field {fieldName} contains private key information. The private key information is not required for dotnet-monitor to verify a token signature and it is strongly recomended to only provide the public key.</value>
+    <value>The configuration field {fieldName} contains private key information. The private key information is not required for dotnet-monitor to verify a token signature and it is strongly recommended to only provide the public key.</value>
   </data>
   <data name="LogFormatString_OptionsValidationFailure" xml:space="preserve">
     <value>{failure}</value>
@@ -710,7 +710,7 @@
   <data name="LogFormatString_SetEnvironmentVariable" xml:space="preserve">
     <value>Setting the environment variable {variableName} in process {processId}.</value>
     <comment>Gets the format string that is printed in the 54:SetEnvironmentVariable event.
-2 Format parameterts:
+2 Format Parameters:
 1. variableName: The name of the environment variable being set
 2. processId: The id of the process to which the variable is being set</comment>
   </data>


### PR DESCRIPTION
###### Summary

Manual backport of #3309 to release/7.x. Manual backporting due to the `.vscode/*` and `cspell.json` files in the original PR being taken care of by branch syncs.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
