### PR TITLE
Fix artifact publish metadata for NuGet packages

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -172,7 +172,7 @@
     <ItemGroup>
       <_PackageArtifactData Include="@(_CommonArtifactData)" />
       <!-- Set Category to OTHER so that nupkgs are also published to blob storage. -->
-      <_PackageArtifactData Include="Category=OTHER" Condition="'%(PackageToPublish.Extension)' == 'nupkg'" />
+      <_PackageArtifactData Include="Category=OTHER" Condition="'%(PackageToPublish.Extension)' == '.nupkg'" />
     </ItemGroup>
 
     <!-- Capture items that need to be published under the blob group. -->


### PR DESCRIPTION
###### Summary

Fixes an issue where the `Category=OTHER` metadata is not applied to nupkg files, which causes them to only be published to NuGet package feeds; the "other" categorization allows the packages to also be published to blob storage feeds.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
