### PR TITLE
Allow non-shipping assets in manifest generation

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,7 +14,7 @@
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
   <Target Name="GenerateNuGetPackageProjectFiles"
           AfterTargets="Pack"
-          Condition="'$(IsPackable)' == 'true' and '$(IsShipping)' == 'true'">
+          Condition="'$(IsPackable)' == 'true'">
     <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.projectpath"
                       Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
@@ -22,7 +22,7 @@
   </Target>
   <Target Name="GenerateArchivePackageProjectFiles"
           AfterTargets="_CreateArchive"
-          Condition="'$(IsArchivable)' == 'true' and '$(IsShipping)' == 'true'">
+          Condition="'$(IsArchivable)' == 'true'">
     <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
     <WriteLinesToFile File="$(_DestinationFileName).projectpath"
                       Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
@@ -38,7 +38,7 @@
   </Target>
   <Target Name="GenerateSymbolsArchivePackageProjectFiles"
           AfterTargets="_CreateSymbolsArchive"
-          Condition="'$(IsArchivable)' == 'true' and '$(CreateSymbolsArchive)' == 'true' and '$(IsShipping)' == 'true'">
+          Condition="'$(IsArchivable)' == 'true' and '$(CreateSymbolsArchive)' == 'true'">
     <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
     <WriteLinesToFile File="$(_DestinationFileName).projectpath"
                       Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"


### PR DESCRIPTION
###### Summary

Allow non-shipping assets to participate in asset manifest generation. The effect of this change is that these non-shipping assets are published to the `dotnetbuilds` blob storage account, however they are not available when acquiring the drop during the release staging job (because the `--non-shipping` flag is not used, which is correct) so there shouldn't be any issue with accidentally releasing non-shipping artifacts.

This change allows us to more easily acquire and verify the non-shipping assets without releasing them.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2088444&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
