### PR TITLE
Swagger generation updates and minimize shipping dependencies

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "dotnet-monitor",
-    "version": "v1.0"
+    "version": "1.0"
   },
   "paths": {
     "/processes": {
@@ -1894,17 +1894,17 @@
       }
     },
     "securitySchemes": {
-      "bearerAuth": {
+      "ApiKeyAuth": {
         "type": "apiKey",
-        "description": "JWT Authorization header using the Bearer scheme. Put only the JWT Token in the textbox when prompted using Swagger UI.",
-        "name": "JWT Authentication",
+        "description": "JWT Authorization header using the bearer token authentication. Put the Authorization header value (\"Bearer\" prefix and the JWT value) in the textbox when prompted.",
+        "name": "Authorization",
         "in": "header"
       }
     }
   },
   "security": [
     {
-      "bearerAuth": [ ]
+      "ApiKeyAuth": [ ]
     }
   ]
 }

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,6 +4,7 @@
     <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Swashbuckle.AspNetCore.SwaggerUI.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
   <ItemGroup>
     <!--

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -21,7 +21,7 @@
     <!-- Third-party references -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreSwaggerGenVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
 
     <!-- Release-branch specific reference -->

--- a/eng/dependabot/Versions.props
+++ b/eng/dependabot/Versions.props
@@ -18,7 +18,7 @@
     <!-- Third-party references -->
     <NewtonsoftJsonVersion>13.0.2</NewtonsoftJsonVersion>
     <NJsonSchemaVersion>10.8.0</NJsonSchemaVersion>
-    <SwashbuckleAspNetCoreSwaggerGenVersion>6.5.0</SwashbuckleAspNetCoreSwaggerGenVersion>
+    <SwashbuckleAspNetCoreVersion>6.5.0</SwashbuckleAspNetCoreVersion>
     <AwsSdkS3Version>3.5.8.1</AwsSdkS3Version>
 
     <!--

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreSwaggerGenVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -1,10 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Diagnostics.Monitoring.WebApi.Controllers;
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Swashbuckle.AspNetCore.Swagger;
@@ -16,6 +18,8 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
 {
     internal sealed class Program
     {
+        private const string ApiKeySecurityDefinitionName = "ApiKeyAuth";
+
         private static readonly OpenApiSchema ProcessKey_Int32Schema =
             new OpenApiSchema() { Type = "integer", Format = "int32", Description = "The ID of the process." };
         private static readonly OpenApiSchema ProcessKey_GuidSchema =
@@ -54,6 +58,27 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
                 {
                     services.AddSwaggerGen(options =>
                     {
+                        options.AddSecurityDefinition(ApiKeySecurityDefinitionName, new OpenApiSecurityScheme
+                        {
+                            Name = HeaderNames.Authorization,
+                            Type = SecuritySchemeType.ApiKey,
+                            Scheme = JwtBearerDefaults.AuthenticationScheme,
+                            BearerFormat = "JWT",
+                            In = ParameterLocation.Header,
+                            Description = Strings.HelpDescription_SecurityDefinitionDescription_ApiKey
+                        });
+
+                        options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                        {
+                            {
+                                new OpenApiSecurityScheme
+                                {
+                                    Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = ApiKeySecurityDefinitionName }
+                                },
+                                Array.Empty<string>()
+                            }
+                        });
+
                         options.DocumentFilter<BadRequestResponseDocumentFilter>();
                         options.DocumentFilter<UnauthorizedResponseDocumentFilter>();
                         options.DocumentFilter<TooManyRequestsResponseDocumentFilter>();

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -13,8 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
-using System;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Text.Json.Serialization;
@@ -45,37 +42,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.AddControllers(options =>
             {
                 options.Filters.Add(typeof(EgressValidationUnhandledExceptionFilter));
-            });
-
-            //Swagger API explorer
-            services.AddEndpointsApiExplorer();
-            services.AddSwaggerGen(sg =>
-            {
-                sg.SwaggerDoc("v1", new OpenApiInfo
-                {
-                    Version = "v1.0",
-                    Title = "dotnet-monitor"
-                });
-
-                sg.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
-                {
-                    Name = "JWT Authentication",
-                    Type = SecuritySchemeType.ApiKey,
-                    Scheme = JwtBearerDefaults.AuthenticationScheme,
-                    BearerFormat = "JWT",
-                    In = ParameterLocation.Header,
-                    Description = Strings.HelpDescription_JWT_Header
-                });
-                sg.AddSecurityRequirement(new OpenApiSecurityRequirement
-                {
-                    {
-                        new OpenApiSecurityScheme
-                        {
-                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "bearerAuth" }
-                        },
-                        Array.Empty<string>()
-                    }
-                });
             });
 
             services.Configure<ApiBehaviorOptions>(options =>

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -538,15 +538,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JWT Authorization header using the Bearer scheme. Put only the JWT Token in the textbox when prompted using Swagger UI..
-        /// </summary>
-        internal static string HelpDescription_JWT_Header {
-            get {
-                return ResourceManager.GetString("HelpDescription_JWT_Header", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The fully qualified path and filename of the json configuration file you&apos;d like to add to the list of configuration sources..
         /// </summary>
         internal static string HelpDescription_OptionConfigurationFilePath {
@@ -642,6 +633,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string HelpDescription_OutputFormat {
             get {
                 return ResourceManager.GetString("HelpDescription_OutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JWT Authorization header using bearer token authentication. Put the Authorization header value (&quot;Bearer&quot; prefix and the JWT value) in the textbox when prompted..
+        /// </summary>
+        internal static string HelpDescription_SecurityDefinitionDescription_ApiKey {
+            get {
+                return ResourceManager.GetString("HelpDescription_SecurityDefinitionDescription_ApiKey", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -376,10 +376,6 @@
     <value>Shows configuration, as if dotnet-monitor collect was executed with these parameters.</value>
     <comment>Gets the string to display in help that explains what the 'show' command does.</comment>
   </data>
-  <data name="HelpDescription_JWT_Header" xml:space="preserve">
-    <value>JWT Authorization header using the Bearer scheme. Put only the JWT Token in the textbox when prompted using Swagger UI.</value>
-    <comment>Gets a string used in the generated OpenAPI doc for the auth scheme</comment>
-  </data>
   <data name="HelpDescription_OptionConfigurationFilePath" xml:space="preserve">
     <value>The fully qualified path and filename of the json configuration file you'd like to add to the list of configuration sources.</value>
     <comment>Gets the string to display in help that explains what the '--configuration-file-path' option does.</comment>
@@ -423,6 +419,10 @@
   <data name="HelpDescription_OutputFormat" xml:space="preserve">
     <value>The output format of the API Key configuration.</value>
     <comment>Gets the string to display in help that explains what the '--output' option does.</comment>
+  </data>
+  <data name="HelpDescription_SecurityDefinitionDescription_ApiKey" xml:space="preserve">
+    <value>JWT Authorization header using bearer token authentication. Put the Authorization header value ("Bearer" prefix and the JWT value) in the textbox when prompted.</value>
+    <comment>Gets a string used in the generated OpenAPI doc for the auth scheme</comment>
   </data>
   <data name="LogFormatString_ActionSettingsTokenizationNotSupported" xml:space="preserve">
     <value>Collection rule action options '{settingsType}' must implement ICloneable to support property tokenization.</value>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(MicrosoftIdentityModelTokensVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCoreSwaggerGenVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="$(SwashbuckleAspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">


### PR DESCRIPTION
###### Summary

- Move the OpenApi security description to the OpenApiGen project
- Update the description to identify that this is the API Key authentication via bearer token and that the whole authorization header value must be used.
- Minimize the dependencies shipped in the tool by just using the UI package.
- Add 3rd party signing entry for shipped assemblies.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
