### PR TITLE
Update Alpine build image to 3.14

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -79,8 +79,7 @@ jobs:
       ${{ if eq(parameters.architecture, 'arm64') }}:
         container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
       ${{ else }}:
-        # CMake + Clang is broken on Alpine 3.14 prereqs image
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
 
     ${{ if ne(parameters.dependsOn, '') }}:
       dependsOn: ${{ parameters.dependsOn }}


### PR DESCRIPTION
###### Summary

Alpine 3.13 was EOL in November 2022; move to 3.14

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
