### PR TITLE
Allow bundling of cross-platform native libraries

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -57,7 +57,12 @@ stages:
         publishArtifacts: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
         testGroup: ${{ parameters.testGroup }}
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - stage: Archive
+    displayName: Archive
+    dependsOn:
+    - Build
+    jobs:
     # Build RID (runtime identifier) archives
     - template: /eng/pipelines/jobs/platform-matrix.yml
       parameters:
@@ -68,7 +73,7 @@ stages:
   - stage: PackSignPublish
     displayName: Pack, Sign, and Generate Manifests
     dependsOn:
-    - Build
+    - Archive
     jobs:
     # Pack, sign, and publish manifest
     - template: /eng/pipelines/jobs/pack-sign-publish.yml

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -15,15 +15,17 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
-    dependsOn:
-    - Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-    - Generate_TPN
 
     preBuildSteps:
     - task: DownloadPipelineArtifact@2
-      displayName: Download Binaries
+      displayName: Download Managed
       inputs:
-        artifactName: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+        artifactName: Build_Managed_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Native
+      inputs:
+        artifactName: Build_Native_${{ parameters.configuration }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
     - task: DownloadPipelineArtifact@2
       displayName: Download Third Party Notice
@@ -46,7 +48,7 @@ jobs:
         TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
 
     - task: PublishBuildArtifacts@1
-      displayName: Publish Artifacts
+      displayName: Publish Artifacts (Unified)
       inputs:
         pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-        artifactName: Archive_${{ parameters.configuration }}
+        artifactName: Archive_Unified_${{ parameters.configuration }}

--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -81,10 +81,22 @@ jobs:
           TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin/dotnet-monitor'
 
       - task: PublishBuildArtifacts@1
-        displayName: Publish Artifacts
+        displayName: Publish Artifacts (Managed)
         inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-          artifactName: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+          artifactName: Build_Managed_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+      
+      - task: CopyFiles@2
+        displayName: Gather Artifacts (bin/${{ parameters.targetRid }}.${{ parameters.configuration }})
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/native/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts (Native)
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/native'
+          artifactName: Build_Native_${{ parameters.configuration }}
 
       - ${{ if eq(parameters.targetRid, 'win-x64') }}:
         - task: CopyFiles@2
@@ -108,7 +120,7 @@ jobs:
         displayName: Publish Artifacts (Unified)
         inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)/unified'
-          artifactName: Build_${{ parameters.configuration }}
+          artifactName: Build_Unified_${{ parameters.configuration }}
 
     # Execute tests
     - ${{ if and(ne(parameters.testGroup, 'None'), eq(parameters.architecture, 'arm64')) }}:

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -22,12 +22,12 @@ jobs:
     - task: DownloadPipelineArtifact@2
       displayName: Download Binaries
       inputs:
-        artifactName: Build_Release
+        artifactName: Build_Unified_Release
         targetPath: '$(Build.SourcesDirectory)/artifacts'
     - task: DownloadPipelineArtifact@2
       displayName: Download Archives
       inputs:
-        artifactName: Archive_Release
+        artifactName: Archive_Unified_Release
         targetPath: '$(Build.SourcesDirectory)/artifacts'
     - task: DownloadPipelineArtifact@2
       displayName: Download Third Party Notice

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,5 +38,28 @@
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-arm64.$(Configuration)" TargetRid="linux-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-x64.$(Configuration)" TargetRid="linux-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-arm64.$(Configuration)" TargetRid="linux-musl-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-x64.$(Configuration)" TargetRid="linux-musl-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-arm64.$(Configuration)" TargetRid="osx-arm64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-x64.$(Configuration)" TargetRid="osx-x64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-arm64.$(Configuration)" TargetRid="win-arm64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x64.$(Configuration)" TargetRid="win-x64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x86.$(Configuration)" TargetRid="win-x86" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Profiler library items for all of the native platforms. -->
+    <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Profiler symbols items for all of the native platforms. -->
+    <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')" />
+  </ItemGroup>
+
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
+  <Import Project="$(RepositoryEngineeringDir)native\naming.props" />
 </Project>

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -11,17 +11,6 @@
     <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(SignOnlyRuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
-  <ItemGroup>
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-arm64.$(Configuration)" TargetRid="linux-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-x64.$(Configuration)" TargetRid="linux-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-arm64.$(Configuration)" TargetRid="linux-musl-arm64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)linux-musl-x64.$(Configuration)" TargetRid="linux-musl-x64" LibraryPrefix="lib" LibraryExtension=".so" SymbolsExtension=".so.dbg" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-arm64.$(Configuration)" TargetRid="osx-arm64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)osx-x64.$(Configuration)" TargetRid="osx-x64" LibraryPrefix="lib" LibraryExtension=".dylib" SymbolsExtension=".dylib.dwarf" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-arm64.$(Configuration)" TargetRid="win-arm64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x64.$(Configuration)" TargetRid="win-x64" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-    <NativeArtifactDirectories Include="$(ArtifactsBinDir)win-x86.$(Configuration)" TargetRid="win-x86" LibraryPrefix="" LibraryExtension=".dll" SymbolsExtension=".pdb" />
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(IsPackable)' == 'true' and '$(ThirdPartyNoticesFilePath)' != ''">
     <None Include="$(ThirdPartyNoticesFilePath)" Pack="true" PackagePath="notices" Visible="false" />

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -54,49 +54,24 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Profiler library items for all of the native platforms. -->
-    <MonitorProfilerLibraryFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(LibraryExtension)')">
-      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
-      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
-    </MonitorProfilerLibraryFile>
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Profiler symbols items for all of the native platforms. -->
-    <MonitorProfilerSymbolsFile Include="@(NativeArtifactDirectories->'%(Identity)\%(LibraryPrefix)MonitorProfiler%(SymbolsExtension)')">
-      <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
-      <PublishSubPath>shared/%(TargetRid)/native</PublishSubPath>
-    </MonitorProfilerSymbolsFile>
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GatherTfmNativeFilesInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <Target Name="GatherTfmNativeFilesInPackage">
     <ItemGroup>
-      <!-- Pack the profiler library for each platform if it exists. -->
-      <TfmSpecificPackageFile Include="@(MonitorProfilerLibraryFile-&gt;Exists())" />
-      <!-- Pack the profiler symbols for each platform if it exists. -->
-      <TfmSpecificPackageFile Include="@(MonitorProfilerSymbolsFile-&gt;Exists())" />
+      <!-- Pack the profiler library for each platform. -->
+      <AdditionalPackageFile Include="@(MonitorProfilerLibraryFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
+      <!-- Pack the profiler symbols for each platform. -->
+      <AdditionalPackageFile Include="@(MonitorProfilerSymbolsFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
     </ItemGroup>
-  </Target>
-
-  <Target Name="IncludeProfilerFilesToPublish"
-          AfterTargets="ComputeFilesToPublish">
     <ItemGroup>
-      <!-- Include the profiler library for the corresponding platform if it exists. -->
-      <ResolvedFileToPublish Include="@(MonitorProfilerLibraryFile-&gt;Exists())"
-                             Condition="'%(MonitorProfilerLibraryFile.TargetRid)' == '$(RuntimeIdentifier)'">
-        <RelativePath>%(MonitorProfilerLibraryFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFileToPublish>
-      <!-- Include the profiler symbols for the corresponding platform if it exists. -->
-      <ResolvedFileToPublish Include="@(MonitorProfilerSymbolsFile-&gt;Exists())"
-                             Condition="'%(MonitorProfilerSymbolsFile.TargetRid)' == '$(RuntimeIdentifier)'">
-        <RelativePath>%(MonitorProfilerSymbolsFile.PublishSubPath)\%(Filename)%(Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFileToPublish>
+      <!-- Pack the file if it exists. -->
+      <TfmSpecificPackageFile Include="@(AdditionalPackageFile->Exists())" />
     </ItemGroup>
   </Target>
 

--- a/src/archives/Directory.Build.targets
+++ b/src/archives/Directory.Build.targets
@@ -23,7 +23,12 @@
       <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.dwarf" />
       <_FileToArchive Remove="$(ArchiveContentRootPath)**\*.pdb" />
     </ItemGroup>
-    <Copy SourceFiles="@(_FileToArchive)" DestinationFiles="$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <ItemGroup>
+      <_FileToArchive Condition="'%(_FileToArchive.PackagePath)' == ''">
+        <PackagePath>%(RecursiveDir)</PackagePath>
+      </_FileToArchive>
+    </ItemGroup>
+    <Copy SourceFiles="@(_FileToArchive)" DestinationFiles="$(OutputPath)%(PackagePath)%(Filename)%(Extension)" />
     <!-- Make executable files readable by all, writable by the user, and executable by all. -->
     <ItemGroup>
       <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
@@ -52,7 +57,12 @@
       <_SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.pdb" />
       <_SymbolFileToArchive Include="@(SymbolFileToArchive)" />
     </ItemGroup>
-    <Copy SourceFiles="@(_SymbolFileToArchive)" DestinationFiles="$(SymbolsOutputPath)%(RecursiveDir)%(Filename)%(Extension)" />
+    <ItemGroup>
+      <_SymbolFileToArchive Condition="'%(_SymbolFileToArchive.PackagePath)' == ''">
+        <PackagePath>%(RecursiveDir)</PackagePath>
+      </_SymbolFileToArchive>
+    </ItemGroup>
+    <Copy SourceFiles="@(_SymbolFileToArchive)" DestinationFiles="$(SymbolsOutputPath)%(PackagePath)%(Filename)%(Extension)" />
     <!-- Make non-executable files readable by all and writable by the user. -->
     <ItemGroup>
       <_SymbolsNonExecutableContent Remove="@(_SymbolsNonExecutableContent)" />

--- a/src/archives/dotnet-monitor-archive.proj
+++ b/src/archives/dotnet-monitor-archive.proj
@@ -12,6 +12,33 @@
   <ItemGroup>
     <FileToArchive Include="$(RepoRoot)LICENSE.TXT" />
     <FileToArchive Include="$(ThirdPartyNoticesFilePath)" Condition="Exists('$(ThirdPartyNoticesFilePath)')" />
+    <!-- Include the profiler for the current platform. -->
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </FileToArchive>
+    <!-- For linux, include both musl and glib variants; thus include the profiler for the other variant. -->
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-arm64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-musl-arm64'">
+      <PackagePath>shared\linux-arm64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-x64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'">
+      <PackagePath>shared\linux-x64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-musl-arm64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+      <PackagePath>shared\linux-musl-arm64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-musl-x64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+      <PackagePath>shared\linux-musl-x64\native\</PackagePath>
+    </FileToArchive>
+  </ItemGroup>
+  <ItemGroup>
+    <SymbolFileToArchive Include="@(MonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </SymbolFileToArchive>
+    <!-- Do not include symbols for the extra native assemblies since they have their own symbols package. -->
   </ItemGroup>
   <!-- Import ProjectToPublish items -->
   <Import Project="$(RepositoryEngineeringDir)DotnetMonitorProjectToPublish.props" />


### PR DESCRIPTION
###### Summary

- Stop including profiler files during RID publishing.
- Move profiler inclusion to archive build.
- Include both musl and glib based profilers in each other's archives.
- Move archive build to separate stage since they depend on all build jobs to finish and publish artifacts into a unified artifact.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2091950&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
