### PR TITLE
Remove unused TraceEvent Windows-only dependencies two ways.

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -75,6 +75,8 @@
       by dotnet-monitor. Removing them saves about 20 MBs from the unpacked dotnet-monitor installation.
       -->
     <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\*\build\native\**" />
+    <!-- These are the same items above but using relative paths that haven't been resolved into absolute paths. -->
+    <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\buildTransitive\..\build\native\**" />
   </ItemGroup>
 
   <Target Name="CalculateProjectRuntimeConfigTestFilePath">


### PR DESCRIPTION
###### Summary

The unused Windows-only TraceEvent native dependencies are being included in the published output of dotnet-monitor. This is happening because publish is not resolving the paths in absolute terms. To fix this, add another removal entry that matches the relative paths used by TraceEvent to prevent them being included during publish.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
