### PR TITLE
Run OpenApi tests for all TFMs

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class OpenApiGeneratorTests
     {
         private static readonly TimeSpan GenerationTimeout = TimeSpan.FromSeconds(30);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
###### Summary

Currently, the OpenApi tests are not running during PR because PR only executes tests with for the `net8.0` TFM. These tests currently don't specify any TFM that they run on. Add the attribute to specify for which TFM the tests run. Additionally, update the TFM list of the project to all testable TFMs so it works for future TFM changes. This will cause the tests to be run for each TFM, but they are fairly fast and should not add noticeable test time.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
