### PR TITLE
Exceptions event source and exception identifier cache

### DIFF
--- a/dotnet-monitor.sln
+++ b/dotnet-monitor.sln
@@ -50,9 +50,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CollectionRuleActions.UnitTests", "src\Tests\CollectionRuleActions.UnitTests\CollectionRuleActions.UnitTests.csproj", "{2FD0A2A3-D7DA-4458-9084-E195102B9D5B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.StartupHook", "src\Microsoft.Diagnostics.Monitoring.StartupHook\Microsoft.Diagnostics.Monitoring.StartupHook.csproj", "{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.StartupHook", "src\Microsoft.Diagnostics.Monitoring.StartupHook\Microsoft.Diagnostics.Monitoring.StartupHook.csproj", "{72EC615C-E1BE-4D27-A0FC-C0FEE483D3D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests\Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj", "{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests", "src\Tests\Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests\Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj", "{E7EA323B-0CFE-4D42-9844-4C322A3BC54A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
         {
             // Prevent rethrows from being evaluated; only care about origination of exceptions.
             builder.Add(next => new FilterRepeatExceptionPipelineStep(next).Invoke);
+            builder.Add(next => new ExceptionEventsPipelineStep(next).Invoke);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionEvents.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionEvents.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
+{
+    internal static class ExceptionEvents
+    {
+        public static class ExceptionPayloads
+        {
+            public const int ExceptionId = 0;
+            public const int ExceptionMessage = 1;
+        }
+
+        public static class ExceptionIdPayloads
+        {
+            public const int ExceptionId = 0;
+            public const int ExceptionClassId = 1;
+            public const int ThrowingMethodId = 2;
+            public const int ILOffset = 3;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -1,0 +1,215 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
+{
+    [EventSource(Name = SourceName)]
+    internal sealed class ExceptionsEventSource : EventSource
+    {
+        public const int ExceptionIdEventId = 1;
+        public const int ExceptionEventId = 2;
+        public const int ClassDescriptionEventId = 3;
+        public const int FunctionDescriptionEventId = 4;
+        public const int ModuleDescriptionEventId = 5;
+        public const int TokenDescriptionEventId = 6;
+
+        public const string SourceName = "Microsoft.Diagnostics.Monitoring.Exceptions";
+
+        [Event(ExceptionIdEventId)]
+        public void WriteExceptionId(
+            ulong ExceptionId,
+            ulong ExceptionClassId,
+            ulong ThrowingMethodId,
+            int ILOffset)
+        {
+            Span<EventData> data = stackalloc EventData[4];
+
+            SetValue(ref data[ExceptionEvents.ExceptionIdPayloads.ExceptionId], ExceptionId);
+            SetValue(ref data[ExceptionEvents.ExceptionIdPayloads.ExceptionClassId], ExceptionClassId);
+            SetValue(ref data[ExceptionEvents.ExceptionIdPayloads.ThrowingMethodId], ThrowingMethodId);
+            SetValue(ref data[ExceptionEvents.ExceptionIdPayloads.ILOffset], ILOffset);
+
+            WriteEventCore(ExceptionIdEventId, data);
+        }
+
+        [Event(ExceptionEventId)]
+        public void WriteException(
+            ulong ExceptionId,
+            string? ExceptionMessage)
+        {
+            Span<EventData> data = stackalloc EventData[2];
+            using PinnedData namePinned = PinnedData.Create(ExceptionMessage);
+
+            SetValue(ref data[ExceptionEvents.ExceptionPayloads.ExceptionId], ExceptionId);
+            SetValue(ref data[ExceptionEvents.ExceptionPayloads.ExceptionMessage], namePinned);
+
+            WriteEventCore(ExceptionEventId, data);
+        }
+
+        [Event(ClassDescriptionEventId)]
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance method required for event source manifest generation.")]
+        private unsafe void WriteClassDescription(
+            ulong ClassId,
+            ulong ModuleId,
+            uint Token,
+            uint Flags,
+            byte* TypeArgs)
+        {
+        }
+
+        [NonEvent]
+        public void WriteClassDescription(
+            ulong ClassId,
+            ulong ModuleId,
+            uint Token,
+            uint Flags,
+            ulong[] TypeArgs)
+        {
+            Span<EventData> data = stackalloc EventData[5];
+            using PinnedData typeArgsPinned = PinnedData.Create(TypeArgs);
+
+            SetValue(ref data[NameIdentificationEvents.ClassDescPayloads.ClassId], ClassId);
+            SetValue(ref data[NameIdentificationEvents.ClassDescPayloads.ModuleId], ModuleId);
+            SetValue(ref data[NameIdentificationEvents.ClassDescPayloads.Token], Token);
+            SetValue(ref data[NameIdentificationEvents.ClassDescPayloads.Flags], Flags);
+            SetValue(ref data[NameIdentificationEvents.ClassDescPayloads.TypeArgs], typeArgsPinned);
+
+            WriteEventCore(ClassDescriptionEventId, data);
+        }
+
+        [Event(FunctionDescriptionEventId)]
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance method required for event source manifest generation.")]
+        private unsafe void WriteFunctionDescription(
+            ulong FunctionId,
+            ulong ClassId,
+            uint ClassToken,
+            ulong ModuleId,
+            string Name,
+            byte* TypeArgs)
+        {
+        }
+
+
+        [NonEvent]
+        public void WriteFunctionDescription(
+            ulong FunctionId,
+            ulong ClassId,
+            uint ClassToken,
+            ulong ModuleId,
+            string Name,
+            ulong[] TypeArgs)
+        {
+            Span<EventData> data = stackalloc EventData[6];
+            using PinnedData namePinned = PinnedData.Create(Name);
+            using PinnedData typeArgsPinned = PinnedData.Create(TypeArgs);
+
+            SetValue(ref data[NameIdentificationEvents.FunctionDescPayloads.FunctionId], FunctionId);
+            SetValue(ref data[NameIdentificationEvents.FunctionDescPayloads.ClassId], ClassId);
+            SetValue(ref data[NameIdentificationEvents.FunctionDescPayloads.ClassToken], ClassToken);
+            SetValue(ref data[NameIdentificationEvents.FunctionDescPayloads.ModuleId], ModuleId);
+            SetValue(ref data[NameIdentificationEvents.FunctionDescPayloads.Name], namePinned);
+            SetValue(ref data[NameIdentificationEvents.FunctionDescPayloads.TypeArgs], typeArgsPinned);
+
+            WriteEventCore(FunctionDescriptionEventId, data);
+        }
+
+        [Event(ModuleDescriptionEventId)]
+        public void WriteModuleDescription(
+            ulong ModuleId,
+            string Name)
+        {
+            Span<EventData> data = stackalloc EventData[2];
+            using PinnedData namePinned = PinnedData.Create(Name);
+
+            SetValue(ref data[NameIdentificationEvents.ModuleDescPayloads.ModuleId], ModuleId);
+            SetValue(ref data[NameIdentificationEvents.ModuleDescPayloads.Name], namePinned);
+
+            WriteEventCore(ModuleDescriptionEventId, data);
+        }
+
+        [Event(TokenDescriptionEventId)]
+        public void WriteTokenDescription(
+            ulong ModuleId,
+            uint Token,
+            uint OuterToken,
+            string Name)
+        {
+            Span<EventData> data = stackalloc EventData[4];
+            using PinnedData namePinned = PinnedData.Create(Name);
+
+            SetValue(ref data[NameIdentificationEvents.TokenDescPayloads.ModuleId], ModuleId);
+            SetValue(ref data[NameIdentificationEvents.TokenDescPayloads.Token], Token);
+            SetValue(ref data[NameIdentificationEvents.TokenDescPayloads.OuterToken], OuterToken);
+            SetValue(ref data[NameIdentificationEvents.TokenDescPayloads.Name], namePinned);
+
+            WriteEventCore(TokenDescriptionEventId, data);
+        }
+
+        [NonEvent]
+        private unsafe void WriteEventCore(int eventId, Span<EventData> data)
+        {
+            fixed (EventData* dataPtr = data)
+            {
+                WriteEventCore(eventId, data.Length, dataPtr);
+            }
+        }
+
+        [NonEvent]
+        private static unsafe void SetValue<T>(ref EventData data, in T value) where T : unmanaged
+        {
+            data.DataPointer = (nint)Unsafe.AsPointer(ref Unsafe.AsRef(value));
+            data.Size = sizeof(T);
+        }
+
+        [NonEvent]
+        private static void SetValue(ref EventData data, in PinnedData value)
+        {
+            data.DataPointer = value.Address;
+            data.Size = value.Size;
+        }
+
+        private ref struct PinnedData
+        {
+            private readonly GCHandle _handle;
+
+            private PinnedData(scoped in object? value, int Size)
+            {
+                _handle = GCHandle.Alloc(value, GCHandleType.Pinned);
+
+                this.Size = Size;
+            }
+
+            public static PinnedData Create(in string? value)
+            {
+                if (null == value)
+                {
+                    return new PinnedData(null, 0);
+                }
+                return new PinnedData(value, sizeof(char) * (value.Length + 1));
+            }
+
+            public static PinnedData Create<T>(in T[] value) where T : unmanaged
+            {
+                return new PinnedData(value, Unsafe.SizeOf<T>() * value.Length);
+            }
+
+            public void Dispose()
+            {
+                if (_handle.IsAllocated)
+                {
+                    _handle.Free();
+                }
+            }
+
+            public IntPtr Address => _handle.AddrOfPinnedObject();
+
+            public int Size { get; }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             data.Size = value.Size;
         }
 
-        private ref struct PinnedData
+        private struct PinnedData : IDisposable
         {
             private readonly GCHandle _handle;
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSourceIdentifierCacheCallback.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSourceIdentifierCacheCallback.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
+{
+    internal sealed class ExceptionsEventSourceIdentifierCacheCallback :
+        ExceptionIdentifierCacheCallback
+    {
+        private readonly ExceptionsEventSource _source;
+
+        public ExceptionsEventSourceIdentifierCacheCallback(ExceptionsEventSource source)
+        {
+            _source = source;
+        }
+
+        public override void OnClassData(ulong classId, ClassData data)
+        {
+            _source.WriteClassDescription(
+                classId,
+                data.ModuleId,
+                data.Token,
+                (uint)data.Flags,
+                data.TypeArgs);
+        }
+
+        public override void OnExceptionIdentifier(ulong registrationId, ExceptionIdentifierData data)
+        {
+            _source.WriteExceptionId(
+                registrationId,
+                data.ExceptionClassId,
+                data.ThrowingMethodId,
+                data.ILOffset);
+        }
+
+        public override void OnFunctionData(ulong functionId, FunctionData data)
+        {
+            _source.WriteFunctionDescription(
+                functionId,
+                data.ParentClass,
+                data.ParentToken,
+                data.ModuleId,
+                data.Name,
+                data.TypeArgs);
+        }
+
+        public override void OnModuleData(ulong moduleId, ModuleData data)
+        {
+            _source.WriteModuleDescription(
+                moduleId,
+                data.Name);
+        }
+
+        public override void OnTokenData(ulong moduleId, uint typeToken, TokenData data)
+        {
+            _source.WriteTokenDescription(
+                moduleId,
+                typeToken,
+                data.OuterToken,
+                data.Name);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifier.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 
-namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
     /// <summary>
     /// Class representing a type of exception thrown from the specific location

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
@@ -1,0 +1,271 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    /// <summary>
+    /// Class that caches naming information for provided metadata
+    /// and invokes callbacks for new instances of the metadata.
+    /// </summary>
+    internal sealed class ExceptionIdentifierCache
+    {
+        // List of callbacks to invoke for newly provided metadata.
+        private readonly IEnumerable<ExceptionIdentifierCacheCallback> _callbacks;
+
+        // Mapping of ExceptionIdentifier to a unique ID; ExceptionIdentifier itself does not have a way
+        // of uniquely identifying itself using a primitive type.
+        private readonly ConcurrentDictionary<ExceptionIdentifier, ulong> _exceptionIds = new();
+
+        // Mapping of Module to a unique ID; Module itself does not have a way
+        // of uniquely identifying itself using a primitive type.
+        private readonly ConcurrentDictionary<Module, ulong> _moduleIds = new();
+
+        // Name cache for all provided metadata
+        private readonly NameCache _nameCache = new();
+
+        private ulong _nextRegistrationId = 1;
+        private ulong _nextModuleId = 1;
+
+        public ExceptionIdentifierCache(IEnumerable<ExceptionIdentifierCacheCallback> callbacks)
+        {
+            ArgumentNullException.ThrowIfNull(callbacks);
+
+            _callbacks = callbacks;
+        }
+
+        /// <summary>
+        /// Gets the identifier of the <see cref="ExceptionIdentifier"/> and
+        /// caches its data if it has not been encountered yet.
+        /// </summary>
+        /// <returns>
+        /// An identifier that uniquely identifies the <see cref="ExceptionIdentifier"/> in this cache.
+        /// </returns>
+        public ulong GetOrAdd(ExceptionIdentifier exceptionId)
+        {
+            if (_exceptionIds.TryGetValue(exceptionId, out ulong registrationId))
+                return registrationId;
+
+            registrationId = Interlocked.Increment(ref _nextRegistrationId);
+
+            ulong actualRegistrationId = _exceptionIds.GetOrAdd(exceptionId, registrationId);
+
+            if (registrationId == actualRegistrationId)
+            {
+                ExceptionIdentifierData data = new()
+                {
+                    ExceptionClassId = GetOrAdd(exceptionId.ExceptionType),
+                    ThrowingMethodId = AddOrDefault(exceptionId.ThrowingMethod),
+                    ILOffset = exceptionId.ILOffset
+                };
+
+                InvokeExceptionIdentifierCallbacks(registrationId, data);
+            }
+
+            return actualRegistrationId;
+        }
+
+        /// <summary>
+        /// Gets the identifier of the <see cref="MethodBase"/> instance and
+        /// caches its data if it has not been encountered yet.
+        /// </summary>
+        /// <returns>
+        /// An identifier that uniquely identifies the <see cref="MethodBase"/> in this cache.
+        /// </returns>
+        public ulong GetOrAdd(MethodBase method)
+        {
+            ulong methodId = GetId(method);
+            if (!_nameCache.FunctionData.ContainsKey(methodId))
+            {
+                FunctionData data = new(
+                    method.Name,
+                    AddOrDefault(method.DeclaringType),
+                    Convert.ToUInt32(method.MetadataToken),
+                    GetOrAdd(method.Module),
+                    GetOrAdd(method.GetGenericArguments())
+                    );
+
+                if (_nameCache.FunctionData.TryAdd(methodId, data))
+                {
+                    InvokeFunctionDataCallbacks(methodId, data);
+                }
+            }
+            return methodId;
+        }
+
+
+        /// <summary>
+        /// Gets the identifier of the <see cref="Module"/> instance and
+        /// caches its data if it has not been encountered yet.
+        /// </summary>
+        /// <returns>
+        /// An identifier that uniquely identifies the <see cref="Module"/> in this cache.
+        /// </returns>
+        public ulong GetOrAdd(Module module)
+        {
+            ulong moduleId = GetId(module);
+            if (!_nameCache.ModuleData.ContainsKey(moduleId))
+            {
+                ModuleData data = new(module.Name);
+
+                if (_nameCache.ModuleData.TryAdd(moduleId, data))
+                {
+                    InvokeModuleDataCallbacks(moduleId, data);
+                }
+            }
+            return moduleId;
+        }
+
+        /// <summary>
+        /// Gets the identifier of the <see cref="Type"/> instance and
+        /// caches its data if it has not been encountered yet.
+        /// </summary>
+        /// <returns>
+        /// An identifier that uniquely identifies the <see cref="Type"/> in this cache.
+        /// </returns>
+        public ulong GetOrAdd(Type type)
+        {
+            ulong originalId = GetId(type);
+            ulong classId = originalId;
+            while (!_nameCache.ClassData.ContainsKey(classId))
+            {
+                ulong moduleId = GetOrAdd(type.Module);
+                uint typeToken = Convert.ToUInt32(type.MetadataToken);
+                ClassData classData = new(
+                    typeToken,
+                    moduleId,
+                    ClassFlags.None,
+                    GetOrAdd(type.GetGenericArguments()));
+
+                if (!_nameCache.ClassData.TryAdd(classId, classData))
+                    break;
+
+                InvokeClassDataCallbacks(classId, classData);
+
+                ModuleScopedToken key = new(moduleId, typeToken);
+                if (!_nameCache.TokenData.ContainsKey(key))
+                {
+                    uint parentToken = 0;
+                    if (null != type.DeclaringType)
+                    {
+                        parentToken = Convert.ToUInt32(type.DeclaringType.MetadataToken);
+                    }
+
+                    TokenData tokenData = new(
+                        null == type.DeclaringType ? type.FullName ?? type.Name : type.Name,
+                        parentToken);
+
+                    if (!_nameCache.TokenData.TryAdd(key, tokenData))
+                        break;
+
+                    InvokeTokenDataCallbacks(moduleId, typeToken, tokenData);
+                }
+
+                if (null == type.DeclaringType)
+                {
+                    break;
+                }
+                else
+                {
+                    type = type.DeclaringType;
+                    classId = GetId(type);
+                }
+            }
+            return originalId;
+        }
+
+        private ulong[] GetOrAdd(Type[] types)
+        {
+            ulong[] classIds;
+            if (types.Length > 0)
+            {
+                classIds = new ulong[types.Length];
+                for (int i = 0; i < types.Length; i++)
+                {
+                    classIds[i] = GetOrAdd(types[i]);
+                }
+            }
+            else
+            {
+                classIds = Array.Empty<ulong>();
+            }
+            return classIds;
+        }
+
+        private ulong AddOrDefault(MethodBase? method)
+        {
+            if (null == method)
+                return default;
+
+            return GetOrAdd(method);
+        }
+
+        private ulong AddOrDefault(Type? type)
+        {
+            if (null == type)
+                return default;
+
+            return GetOrAdd(type);
+        }
+
+        private static ulong GetId(MethodBase method)
+        {
+            return Convert.ToUInt64(method.MethodHandle.Value.ToInt64());
+        }
+
+        private ulong GetId(Module module)
+        {
+            return _moduleIds.GetOrAdd(module, _ => _nextModuleId++);
+        }
+
+        private static ulong GetId(Type type)
+        {
+            return Convert.ToUInt64(type.TypeHandle.Value.ToInt64());
+        }
+
+        private void InvokeExceptionIdentifierCallbacks(ulong registrationId, ExceptionIdentifierData data)
+        {
+            foreach (ExceptionIdentifierCacheCallback callback in _callbacks)
+            {
+                callback.OnExceptionIdentifier(registrationId, data);
+            }
+        }
+
+        private void InvokeClassDataCallbacks(ulong classId, ClassData data)
+        {
+            foreach (ExceptionIdentifierCacheCallback callback in _callbacks)
+            {
+                callback.OnClassData(classId, data);
+            }
+        }
+
+        private void InvokeFunctionDataCallbacks(ulong functionId, FunctionData data)
+        {
+            foreach (ExceptionIdentifierCacheCallback callback in _callbacks)
+            {
+                callback.OnFunctionData(functionId, data);
+            }
+        }
+
+        private void InvokeModuleDataCallbacks(ulong moduleId, ModuleData data)
+        {
+            foreach (ExceptionIdentifierCacheCallback callback in _callbacks)
+            {
+                callback.OnModuleData(moduleId, data);
+            }
+        }
+
+        private void InvokeTokenDataCallbacks(ulong moduleId, uint typeToken, TokenData data)
+        {
+            foreach (ExceptionIdentifierCacheCallback callback in _callbacks)
+            {
+                callback.OnTokenData(moduleId, typeToken, data);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCacheCallback.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCacheCallback.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    internal abstract class ExceptionIdentifierCacheCallback
+    {
+        public virtual void OnExceptionIdentifier(
+            ulong registrationId,
+            ExceptionIdentifierData data)
+        {
+        }
+
+        public virtual void OnClassData(
+            ulong classId,
+            ClassData data)
+        {
+        }
+
+        public virtual void OnFunctionData(
+            ulong functionId,
+            FunctionData data)
+        {
+        }
+
+        public virtual void OnModuleData(
+            ulong moduleId,
+            ModuleData data)
+        {
+        }
+
+        public virtual void OnTokenData(
+            ulong moduleId,
+            uint typeToken,
+            TokenData data)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierData.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierData.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    internal sealed class ExceptionIdentifierData
+    {
+        public ulong ExceptionClassId { get; set; }
+        public ulong ThrowingMethodId { get; set; }
+        public int ILOffset { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing;
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    internal sealed class ExceptionEventsPipelineStep
+    {
+        private readonly ExceptionsEventSource _eventSource = new();
+        private readonly ExceptionIdentifierCache _identifierCache;
+        private readonly ExceptionPipelineDelegate _next;
+
+        public ExceptionEventsPipelineStep(ExceptionPipelineDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(next);
+
+            List<ExceptionIdentifierCacheCallback> callbacks = new(1)
+            {
+                new ExceptionsEventSourceIdentifierCacheCallback(_eventSource)
+            };
+
+            _identifierCache = new ExceptionIdentifierCache(callbacks);
+            _next = next;
+        }
+
+        public void Invoke(Exception exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            _identifierCache.GetOrAdd(new ExceptionIdentifier(exception));
+
+            _next(exception);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Microsoft.Diagnostics.Monitoring.StartupHook.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Microsoft.Diagnostics.Monitoring.StartupHook.csproj
@@ -6,9 +6,12 @@
     <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);STARTUPHOOK</DefineConstants>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.Diagnostics.Monitoring.WebApi\Stacks\NameCache.cs" Link="NameCache.cs" />
+    <Compile Include="..\Microsoft.Diagnostics.Monitoring.WebApi\Stacks\NameIdentificationEvents.cs" Link="Exceptions\Eventing\NameIdentificationEvents.cs" />
     <Compile Include="..\Tools\dotnet-monitor\DisposableHelper.cs" Link="DisposableHelper.cs" />
   </ItemGroup>
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackData.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackData.cs
@@ -16,67 +16,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
         public NameCache NameCache { get; } = new NameCache();
     }
 
-    internal sealed class NameCache
-    {
-        public Dictionary<ulong, ClassData> ClassData { get; } = new();
-        public Dictionary<ulong, FunctionData> FunctionData { get; } = new();
-        public Dictionary<ulong, ModuleData> ModuleData { get; } = new();
-        public Dictionary<(ulong moduleId, ulong typeDef), TokenData> TokenData { get; } = new();
-    }
-
-    internal enum ClassFlags : uint
-    {
-        None = 0,
-        Array,
-        Composite,
-        IncompleteData,
-        Error = 0xff
-    }
-
-    internal sealed class ClassData
-    {
-        public ulong[] TypeArgs { get; set; }
-
-        // We do not store the name of the class directly. The name can be retrieved from the TokenData.
-        public uint Token { get; set; }
-
-        public ulong ModuleId { get; set; }
-
-        public ClassFlags Flags { get; set; }
-    }
-
-    internal sealed class TokenData
-    {
-        public uint OuterToken { get; set; }
-
-        public string Name { get; set; }
-    }
-
-    internal sealed class FunctionData
-    {
-        public string Name { get; set; }
-
-        /// <summary>
-        /// ClassID of the containing class for this function. Note it's possible that the ClassID could not be retrieved by the profiler.
-        /// In this case, only the token will be available.
-        /// </summary>
-        public ulong ParentClass { get; set; }
-
-        /// <summary>
-        /// If the ClassID could not be retrieved, the token can be used to get the name.
-        /// </summary>
-        public uint ParentToken { get; set; }
-
-        public ulong[] TypeArgs { get; set; }
-
-        public ulong ModuleId { get; set; }
-    }
-
-    internal sealed class ModuleData
-    {
-        public string Name { get; set; }
-    }
-
     internal sealed class CallStackFrame
     {
         public ulong FunctionId { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackEvents.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackEvents.cs
@@ -24,38 +24,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             public const int IpOffsets = 3;
         }
 
-        public static class FunctionDescPayloads
-        {
-            public const int FunctionId = 0;
-            public const int ClassId = 1;
-            public const int ClassToken = 2;
-            public const int ModuleId = 3;
-            public const int Name = 4;
-            public const int TypeArgs = 5;
-        }
-
-        public static class ClassDescPayloads
-        {
-            public const int ClassId = 0;
-            public const int ModuleId = 1;
-            public const int Token = 2;
-            public const int Flags = 3;
-            public const int TypeArgs = 4;
-        }
-
-        public static class ModuleDescPayloads
-        {
-            public const int ModuleId = 0;
-            public const int Name = 1;
-        }
-        public static class TokenDescPayloads
-        {
-            public const int ModuleId = 0;
-            public const int Token = 1;
-            public const int OuterToken = 2;
-            public const int Name = 3;
-        }
-
         public static class EndPayloads
         {
             public const int Unused = 0;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/EventStacksPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/EventStacksPipeline.cs
@@ -91,52 +91,48 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             }
             else if (action.ID == CallStackEvents.FunctionDesc)
             {
-                ulong id = action.GetPayload<ulong>(CallStackEvents.FunctionDescPayloads.FunctionId);
-                var functionData = new FunctionData
-                {
-                    Name = action.GetPayload<string>(CallStackEvents.FunctionDescPayloads.Name),
-                    ParentClass = action.GetPayload<ulong>(CallStackEvents.FunctionDescPayloads.ClassId),
-                    ParentToken = action.GetPayload<uint>(CallStackEvents.FunctionDescPayloads.ClassToken),
-                    ModuleId = action.GetPayload<ulong>(CallStackEvents.FunctionDescPayloads.ModuleId),
-                    TypeArgs = action.GetPayload<ulong[]>(CallStackEvents.FunctionDescPayloads.TypeArgs) ?? Array.Empty<ulong>()
-                };
+                ulong id = action.GetPayload<ulong>(NameIdentificationEvents.FunctionDescPayloads.FunctionId);
+                var functionData = new FunctionData(
+                    action.GetPayload<string>(NameIdentificationEvents.FunctionDescPayloads.Name),
+                    action.GetPayload<ulong>(NameIdentificationEvents.FunctionDescPayloads.ClassId),
+                    action.GetPayload<uint>(NameIdentificationEvents.FunctionDescPayloads.ClassToken),
+                    action.GetPayload<ulong>(NameIdentificationEvents.FunctionDescPayloads.ModuleId),
+                    action.GetPayload<ulong[]>(NameIdentificationEvents.FunctionDescPayloads.TypeArgs) ?? Array.Empty<ulong>()
+                    );
 
-                _result.NameCache.FunctionData.Add(id, functionData);
+                _result.NameCache.FunctionData.TryAdd(id, functionData);
             }
             else if (action.ID == CallStackEvents.ClassDesc)
             {
-                ulong id = action.GetPayload<ulong>(CallStackEvents.ClassDescPayloads.ClassId);
-                var classData = new ClassData
-                {
-                    ModuleId = action.GetPayload<ulong>(CallStackEvents.ClassDescPayloads.ModuleId),
-                    Token = action.GetPayload<uint>(CallStackEvents.ClassDescPayloads.Token),
-                    Flags = (ClassFlags)action.GetPayload<uint>(CallStackEvents.ClassDescPayloads.Flags),
-                    TypeArgs = action.GetPayload<ulong[]>(CallStackEvents.ClassDescPayloads.TypeArgs) ?? Array.Empty<ulong>()
-                };
+                ulong id = action.GetPayload<ulong>(NameIdentificationEvents.ClassDescPayloads.ClassId);
+                var classData = new ClassData(
+                    action.GetPayload<uint>(NameIdentificationEvents.ClassDescPayloads.Token),
+                    action.GetPayload<ulong>(NameIdentificationEvents.ClassDescPayloads.ModuleId),
+                    (ClassFlags)action.GetPayload<uint>(NameIdentificationEvents.ClassDescPayloads.Flags),
+                    action.GetPayload<ulong[]>(NameIdentificationEvents.ClassDescPayloads.TypeArgs) ?? Array.Empty<ulong>()
+                    );
 
-                _result.NameCache.ClassData.Add(id, classData);
+                _result.NameCache.ClassData.TryAdd(id, classData);
             }
             else if (action.ID == CallStackEvents.ModuleDesc)
             {
-                ulong id = action.GetPayload<ulong>(CallStackEvents.ModuleDescPayloads.ModuleId);
-                var moduleData = new ModuleData
-                {
-                    Name = action.GetPayload<string>(CallStackEvents.ModuleDescPayloads.Name)
-                };
+                ulong id = action.GetPayload<ulong>(NameIdentificationEvents.ModuleDescPayloads.ModuleId);
+                var moduleData = new ModuleData(
+                    action.GetPayload<string>(NameIdentificationEvents.ModuleDescPayloads.Name)
+                    );
 
-                _result.NameCache.ModuleData.Add(id, moduleData);
+                _result.NameCache.ModuleData.TryAdd(id, moduleData);
             }
             else if (action.ID == CallStackEvents.TokenDesc)
             {
-                ulong modId = action.GetPayload<ulong>(CallStackEvents.TokenDescPayloads.ModuleId);
-                ulong token = action.GetPayload<uint>(CallStackEvents.TokenDescPayloads.Token);
-                var tokenData = new TokenData()
-                {
-                    Name = action.GetPayload<string>(CallStackEvents.TokenDescPayloads.Name),
-                    OuterToken = action.GetPayload<uint>(CallStackEvents.TokenDescPayloads.OuterToken)
-                };
+                ulong modId = action.GetPayload<ulong>(NameIdentificationEvents.TokenDescPayloads.ModuleId);
+                uint token = action.GetPayload<uint>(NameIdentificationEvents.TokenDescPayloads.Token);
+                var tokenData = new TokenData(
+                    action.GetPayload<string>(NameIdentificationEvents.TokenDescPayloads.Name),
+                    action.GetPayload<uint>(NameIdentificationEvents.TokenDescPayloads.OuterToken)
+                    );
 
-                _result.NameCache.TokenData.Add((modId, token), tokenData);
+                _result.NameCache.TokenData.TryAdd(new ModuleScopedToken(modId, token), tokenData);
             }
             else if (action.ID == CallStackEvents.End)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
@@ -31,11 +31,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                 {
                     Models.CallStackFrame frameModel = new Models.CallStackFrame()
                     {
-                        ClassName = UnknownClass,
+                        ClassName = NameFormatter.UnknownClass,
                         MethodName = UnknownFunction,
                         //TODO Bring this back once we have a useful offset value
                         //Offset = frame.Offset,
-                        ModuleName = UnknownModule
+                        ModuleName = NameFormatter.UnknownModule
                     };
                     if (frame.FunctionId == 0)
                     {
@@ -45,18 +45,18 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                     }
                     else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData functionData))
                     {
-                        frameModel.ModuleName = GetModuleName(cache, functionData.ModuleId);
+                        frameModel.ModuleName = NameFormatter.GetModuleName(cache, functionData.ModuleId);
                         frameModel.MethodName = functionData.Name;
 
                         builder.Clear();
-                        BuildClassName(builder, cache, functionData);
+                        NameFormatter.BuildClassName(builder, cache, functionData);
                         frameModel.ClassName = builder.ToString();
 
                         if (functionData.TypeArgs.Length > 0)
                         {
                             builder.Clear();
                             builder.Append(functionData.Name);
-                            BuildGenericParameters(builder, cache, functionData.TypeArgs);
+                            NameFormatter.BuildGenericParameters(builder, cache, functionData.TypeArgs);
                             frameModel.MethodName = builder.ToString();
                         }
                     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameCache.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+#if STARTUPHOOK
+namespace Microsoft.Diagnostics.Monitoring.StartupHook
+#else
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
+#endif
+{
+    internal sealed class NameCache
+    {
+        public ConcurrentDictionary<ulong, ClassData> ClassData { get; } = new();
+        public ConcurrentDictionary<ulong, FunctionData> FunctionData { get; } = new();
+        public ConcurrentDictionary<ulong, ModuleData> ModuleData { get; } = new();
+        public ConcurrentDictionary<ModuleScopedToken, TokenData> TokenData { get; } = new();
+    }
+
+    internal enum ClassFlags : uint
+    {
+        None = 0,
+        Array,
+        Composite,
+        IncompleteData,
+        Error = 0xff
+    }
+
+    /// <param name="Token">The metadata token of the class.</param>
+    /// <param name="ModuleId">The identifier of the module that contains the class.</param>
+    /// <param name="Flags">The flags for the class.</param>
+    /// <param name="TypeArgs">The class identifiers of the generic type arguments of the class.</param>
+    /// <remarks>
+    /// The name of the class can be retrieved from the corresponding <see cref="TokenData"/>.
+    /// </remarks>
+    internal sealed record class ClassData(uint Token, ulong ModuleId, ClassFlags Flags, ulong[] TypeArgs);
+
+    /// <param name="Name">The name of the token.</param>
+    /// <param name="OuterToken">The metadata token of the parent container.</param>
+    [DebuggerDisplay("{Name}")]
+    internal sealed record class TokenData(string Name, uint OuterToken);
+
+    /// <param name="Name">The name of the function.</param>
+    /// <param name="ParentClass">The parent class identifier of the function.</param>
+    /// <param name="ParentToken">The parent metadata token of the function.</param>
+    /// <param name="ModuleId">The identifier of the module that contains the function.</param>
+    /// <param name="TypeArgs">The class identifiers of the generic type arguments of the function.</param>
+    /// <remarks>
+    /// If <paramref name="ParentClass"/> is 0, then use <paramref name="ParentToken"/>.
+    /// </remarks>
+    [DebuggerDisplay("{Name}")]
+    internal sealed record class FunctionData(string Name, ulong ParentClass, uint ParentToken, ulong ModuleId, ulong[] TypeArgs);
+
+    /// <param name="Name">The name of the module.</param>
+    [DebuggerDisplay("{Name}")]
+    internal sealed record class ModuleData(string Name);
+
+    internal sealed record class ModuleScopedToken(ulong ModuleId, uint Token);
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameFormatter.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+
+#if STARTUPHOOK
+namespace Microsoft.Diagnostics.Monitoring.StartupHook
+#else
+#nullable enable
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
+#endif
+{
+    internal sealed class NameFormatter
+    {
+        public const string UnknownModule = "UnknownModule";
+        public const string UnknownClass = "UnknownClass";
+
+        private const string ArrayType = "_ArrayType_";
+        private const string CompositeType = "_CompositeType_";
+
+        private const char NestedSeparator = '+';
+        private const char GenericStart = '[';
+        private const char GenericSeparator = ',';
+        private const char GenericEnd = ']';
+
+        public static void BuildClassName(StringBuilder builder, NameCache cache, FunctionData functionData)
+        {
+            if (functionData.ParentClass != 0)
+            {
+                BuildClassName(builder, cache, functionData.ParentClass);
+            }
+            else
+            {
+                BuildClassName(builder, cache, functionData.ModuleId, functionData.ParentToken);
+            }
+        }
+
+        public static void BuildClassName(StringBuilder builder, NameCache cache, ulong classId)
+        {
+            string className = UnknownClass;
+            if (cache.ClassData.TryGetValue(classId, out ClassData? classData))
+            {
+                if (classData.Flags != ClassFlags.None)
+                {
+                    switch (classData.Flags)
+                    {
+                        case ClassFlags.Array:
+                            className = ArrayType;
+                            break;
+                        case ClassFlags.Composite:
+                            className = CompositeType;
+                            break;
+                        default:
+                            //All other cases default to UnknownClass
+                            break;
+                    }
+
+                    builder.Append(className);
+                }
+                else
+                {
+                    BuildClassName(builder, cache, classData.ModuleId, classData.Token);
+                }
+                BuildGenericParameters(builder, cache, classData.TypeArgs);
+            }
+            else
+            {
+                builder.Append(className);
+            }
+        }
+
+        private static void BuildClassName(StringBuilder builder, NameCache cache, ulong moduleId, uint token)
+        {
+            var classNames = new Stack<string>();
+
+            uint currentToken = token;
+            while (currentToken != 0 && cache.TokenData.TryGetValue(new ModuleScopedToken(moduleId, currentToken), out TokenData? tokenData))
+            {
+                classNames.Push(tokenData.Name);
+                currentToken = tokenData.OuterToken;
+            }
+
+            if (classNames.Count == 0)
+            {
+                builder.Append(UnknownClass);
+            }
+
+            while (classNames.Count > 0)
+            {
+                string className = classNames.Pop();
+                builder.Append(className);
+                if (classNames.Count > 0)
+                {
+                    builder.Append(NestedSeparator);
+                }
+            }
+        }
+
+        public static void BuildGenericParameters(StringBuilder builder, NameCache cache, ulong[] parameters)
+        {
+            for (int i = 0; i < parameters?.Length; i++)
+            {
+                if (i == 0)
+                {
+                    builder.Append(GenericStart);
+                }
+                BuildClassName(builder, cache, parameters[i]);
+                if (i < parameters.Length - 1)
+                {
+                    builder.Append(GenericSeparator);
+                }
+                else if (i == parameters.Length - 1)
+                {
+                    builder.Append(GenericEnd);
+                }
+            }
+        }
+
+        public static string GetModuleName(NameCache cache, ulong moduleId)
+        {
+            string moduleName = UnknownModule;
+            if (cache.ModuleData.TryGetValue(moduleId, out ModuleData? moduleData))
+            {
+                moduleName = moduleData.Name;
+            }
+            return moduleName;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameIdentificationEvents.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameIdentificationEvents.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if STARTUPHOOK
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
+#else
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
+#endif
+{
+    internal static class NameIdentificationEvents
+    {
+        public static class FunctionDescPayloads
+        {
+            public const int FunctionId = 0;
+            public const int ClassId = 1;
+            public const int ClassToken = 2;
+            public const int ModuleId = 3;
+            public const int Name = 4;
+            public const int TypeArgs = 5;
+        }
+
+        public static class ClassDescPayloads
+        {
+            public const int ClassId = 0;
+            public const int ModuleId = 1;
+            public const int Token = 2;
+            public const int Flags = 3;
+            public const int TypeArgs = 4;
+        }
+
+        public static class ModuleDescPayloads
+        {
+            public const int ModuleId = 0;
+            public const int Name = 1;
+        }
+
+        public static class TokenDescPayloads
+        {
+            public const int ModuleId = 0;
+            public const int Token = 1;
+            public const int OuterToken = 2;
+            public const int Name = 3;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
@@ -4,7 +4,6 @@
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -50,7 +49,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                 Frames = new List<Models.SharedFrame>()
                 {
                     new Models.SharedFrame{ Name = NativeFrame },
-                    new Models.SharedFrame{ Name = UnknownClass }
+                    new Models.SharedFrame{ Name = NameFormatter.UnknownClass }
                 }
             };
 
@@ -85,12 +84,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                             // but Speedscope uses the name.
 
                             builder.Clear();
-                            builder.Append(GetModuleName(cache, functionData.ModuleId));
+                            builder.Append(NameFormatter.GetModuleName(cache, functionData.ModuleId));
                             builder.Append(ModuleSeparator);
-                            BuildClassName(builder, cache, functionData);
+                            NameFormatter.BuildClassName(builder, cache, functionData);
                             builder.Append(ClassSeparator);
                             builder.Append(functionData.Name);
-                            BuildGenericParameters(builder, cache, functionData.TypeArgs);
+                            NameFormatter.BuildGenericParameters(builder, cache, functionData.TypeArgs);
 
                             speedscopeResult.Shared.Frames.Add(new SharedFrame { Name = builder.ToString() });
                             mapping = speedscopeResult.Shared.Frames.Count - 1;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,18 +10,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 {
     internal abstract class StacksFormatter
     {
-        protected const string UnknownModule = "UnknownModule";
-        protected const string UnknownClass = "UnknownClass";
         protected const string UnknownFunction = "UnknownFunction";
 
-        protected const string ArrayType = "_ArrayType_";
-        protected const string CompositeType = "_CompositeType_";
         protected const string NativeFrame = "[NativeFrame]";
-
-        protected const char NestedSeparator = '+';
-        protected const char GenericStart = '[';
-        protected const char GenericSeparator = ',';
-        protected const char GenericEnd = ']';
 
         protected const char ModuleSeparator = '!';
         protected const char ClassSeparator = '.';
@@ -48,109 +37,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                 return string.Concat(fullThreadName, Separator, threadName);
             }
             return fullThreadName;
-        }
-
-        protected static string GetModuleName(NameCache cache, ulong moduleId)
-        {
-            string moduleName = UnknownModule;
-            if (cache.ModuleData.TryGetValue(moduleId, out ModuleData moduleData))
-            {
-                moduleName = moduleData.Name;
-            }
-            return moduleName;
-        }
-
-        protected void BuildClassName(StringBuilder builder, NameCache cache, FunctionData functionData)
-        {
-            if (functionData.ParentClass != 0)
-            {
-                BuildClassName(builder, cache, functionData.ParentClass);
-            }
-            else
-            {
-                BuildClassName(builder, cache, functionData.ModuleId, functionData.ParentToken);
-            }
-        }
-
-        private void BuildClassName(StringBuilder builder, NameCache cache, ulong classId)
-        {
-            string className = UnknownClass;
-            if (cache.ClassData.TryGetValue(classId, out ClassData classData))
-            {
-                if (classData.Flags != ClassFlags.None)
-                {
-                    switch (classData.Flags)
-                    {
-                        case ClassFlags.Array:
-                            className = ArrayType;
-                            break;
-                        case ClassFlags.Composite:
-                            className = CompositeType;
-                            break;
-                        default:
-                            //All other cases default to UnknownClass
-                            break;
-                    }
-
-                    builder.Append(className);
-                }
-                else
-                {
-                    BuildClassName(builder, cache, classData.ModuleId, classData.Token);
-                }
-                BuildGenericParameters(builder, cache, classData.TypeArgs);
-            }
-            else
-            {
-                builder.Append(className);
-            }
-        }
-
-        private static void BuildClassName(StringBuilder builder, NameCache cache, ulong moduleId, uint token)
-        {
-            var classNames = new Stack<string>();
-
-            uint currentToken = token;
-            while (currentToken != 0 && cache.TokenData.TryGetValue((moduleId, currentToken), out TokenData tokenData))
-            {
-                classNames.Push(tokenData.Name);
-                currentToken = tokenData.OuterToken;
-            }
-
-            if (classNames.Count == 0)
-            {
-                builder.Append(UnknownClass);
-            }
-
-            while (classNames.Count > 0)
-            {
-                string className = classNames.Pop();
-                builder.Append(className);
-                if (classNames.Count > 0)
-                {
-                    builder.Append(NestedSeparator);
-                }
-            }
-        }
-
-        protected void BuildGenericParameters(StringBuilder builder, NameCache cache, ulong[] parameters)
-        {
-            for (int i = 0; i < parameters?.Length; i++)
-            {
-                if (i == 0)
-                {
-                    builder.Append(GenericStart);
-                }
-                BuildClassName(builder, cache, parameters[i]);
-                if (i < parameters.Length - 1)
-                {
-                    builder.Append(GenericSeparator);
-                }
-                else if (i == parameters.Length - 1)
-                {
-                    builder.Append(GenericEnd);
-                }
-            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                 builder.Append(functionData.Name);
                 NameFormatter.BuildGenericParameters(builder, cache, functionData.TypeArgs);
             }
-            else 
+            else
             {
                 builder.Append(UnknownFunction);
             }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -39,7 +38,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             await writer.FlushAsync();
         }
 
-        private void BuildFrame(StringBuilder builder, NameCache cache, CallStackFrame frame)
+        private static void BuildFrame(StringBuilder builder, NameCache cache, CallStackFrame frame)
         {
             if (frame.FunctionId == 0)
             {
@@ -47,14 +46,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             }
             else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData functionData))
             {
-                builder.Append(GetModuleName(cache, functionData.ModuleId));
+                builder.Append(NameFormatter.GetModuleName(cache, functionData.ModuleId));
                 builder.Append(ModuleSeparator);
-                BuildClassName(builder, cache, functionData);
+                NameFormatter.BuildClassName(builder, cache, functionData);
                 builder.Append(ClassSeparator);
                 builder.Append(functionData.Name);
-                BuildGenericParameters(builder, cache, functionData.TypeArgs);
+                NameFormatter.BuildGenericParameters(builder, cache, functionData.TypeArgs);
             }
-            else
+            else 
             {
                 builder.Append(UnknownFunction);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
+{
+    internal sealed class ExceptionsEventListener : EventListener
+    {
+        public const string NullValue = "{null}";
+
+        public readonly NameCache NameCache = new();
+        private readonly Thread _thisThread = Thread.CurrentThread;
+
+        public List<ExceptionInstance> Exceptions { get; } = new();
+
+        public Dictionary<ulong, ExceptionIdentifierData> ExceptionIdentifiers { get; } = new();
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (_thisThread == Thread.CurrentThread)
+            {
+                ArgumentNullException.ThrowIfNull(eventData.Payload);
+
+                switch (eventData.EventId)
+                {
+                    case ExceptionsEventSource.ExceptionEventId:
+                        Exceptions.Add(
+                            new ExceptionInstance()
+                            {
+                                ExceptionId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionPayloads.ExceptionId]),
+                                ExceptionMessage = ToString(eventData.Payload[ExceptionEvents.ExceptionPayloads.ExceptionMessage])
+                            });
+                        break;
+                    case ExceptionsEventSource.ExceptionIdEventId:
+                        ExceptionIdentifiers.Add(
+                            ToUInt64(eventData.Payload[ExceptionEvents.ExceptionIdPayloads.ExceptionId]),
+                            new ExceptionIdentifierData()
+                            {
+                                ExceptionClassId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionIdPayloads.ExceptionClassId]),
+                                ThrowingMethodId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionIdPayloads.ThrowingMethodId]),
+                                ILOffset = ToInt32(eventData.Payload[ExceptionEvents.ExceptionIdPayloads.ILOffset])
+                            });
+                        break;
+                    case ExceptionsEventSource.ClassDescriptionEventId:
+                        NameCache.ClassData.TryAdd(
+                            ToUInt64(eventData.Payload[NameIdentificationEvents.ClassDescPayloads.ClassId]),
+                            new ClassData(
+                                ToUInt32(eventData.Payload[NameIdentificationEvents.ClassDescPayloads.Token]),
+                                ToUInt64(eventData.Payload[NameIdentificationEvents.ClassDescPayloads.ModuleId]),
+                                (ClassFlags)ToUInt32(eventData.Payload[NameIdentificationEvents.ClassDescPayloads.Flags]),
+                                ToArray<ulong>(eventData.Payload[NameIdentificationEvents.ClassDescPayloads.TypeArgs])));
+                        break;
+                    case ExceptionsEventSource.FunctionDescriptionEventId:
+                        NameCache.FunctionData.TryAdd(
+                            ToUInt64(eventData.Payload[NameIdentificationEvents.FunctionDescPayloads.FunctionId]),
+                            new FunctionData(
+                                ToString(eventData.Payload[NameIdentificationEvents.FunctionDescPayloads.Name]),
+                                ToUInt64(eventData.Payload[NameIdentificationEvents.FunctionDescPayloads.ClassId]),
+                                ToUInt32(eventData.Payload[NameIdentificationEvents.FunctionDescPayloads.ClassToken]),
+                                ToUInt64(eventData.Payload[NameIdentificationEvents.FunctionDescPayloads.ModuleId]),
+                                ToArray<ulong>(eventData.Payload[NameIdentificationEvents.FunctionDescPayloads.TypeArgs])));
+                        break;
+                    case ExceptionsEventSource.ModuleDescriptionEventId:
+                        NameCache.ModuleData.TryAdd(
+                            ToUInt64(eventData.Payload[NameIdentificationEvents.ModuleDescPayloads.ModuleId]),
+                            new ModuleData(
+                                ToString(eventData.Payload[NameIdentificationEvents.ModuleDescPayloads.Name])));
+                        break;
+                    case ExceptionsEventSource.TokenDescriptionEventId:
+                        NameCache.TokenData.TryAdd(
+                            new ModuleScopedToken(
+                                ToUInt64(eventData.Payload[NameIdentificationEvents.TokenDescPayloads.ModuleId]),
+                                ToUInt32(eventData.Payload[NameIdentificationEvents.TokenDescPayloads.Token])
+                                ),
+                            new TokenData(
+                                ToString(eventData.Payload[NameIdentificationEvents.TokenDescPayloads.Name]),
+                                ToUInt32(eventData.Payload[NameIdentificationEvents.TokenDescPayloads.OuterToken])));
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        private static int ToInt32(object? value)
+        {
+            return ToType<int>(value);
+        }
+
+        private static uint ToUInt32(object? value)
+        {
+            return ToType<uint>(value);
+        }
+
+        private static ulong ToUInt64(object? value)
+        {
+            return ToType<ulong>(value);
+        }
+
+        private static unsafe T[] ToArray<T>(object? value) where T : unmanaged
+        {
+            if (value is not byte[] byteArray)
+                throw new InvalidCastException();
+
+            if (byteArray.Length == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            T[] destinationArray = new T[byteArray.Length / sizeof(T)];
+            fixed (byte* byteArrayPtr = byteArray)
+            fixed (T* destinationArrayPtr = destinationArray)
+            {
+                Unsafe.CopyBlockUnaligned(destinationArrayPtr, byteArrayPtr, (uint)byteArray.Length);
+            }
+            return destinationArray;
+        }
+
+        private static string ToString(object? value)
+        {
+            if (value is null)
+            {
+                return NullValue;
+            }
+            return ToType<string>(value);
+        }
+
+        private static T ToType<T>(object? value)
+        {
+            if (value is T typedValue)
+            {
+                return typedValue;
+            }
+            throw new InvalidCastException();
+        }
+    }
+
+    internal sealed class ExceptionInstance
+    {
+        public ulong ExceptionId { get; set; }
+
+        public string? ExceptionMessage { get; set; }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification;
+using System.Diagnostics.Tracing;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
+{
+    public sealed class ExceptionsEventSourceTests
+    {
+        private const string InvalidOperationExceptionMessage = "Operation is not valid due to the current state of the object.";
+        private const string ObjectDisposedExceptionMessage = "Cannot access a disposed object.";
+        private const string OperationCancelledExceptionMessage = "The operation was canceled.";
+
+        [Theory]
+        [InlineData(0, 3, 14, int.MaxValue)]
+        [InlineData(1, 0, ulong.MaxValue, 19)]
+        [InlineData(7, ulong.MaxValue, 0, 17)]
+        [InlineData(ulong.MaxValue, 29, 41, 0)]
+        public void ExceptionsEventSource_WriteExceptionId_Event(ulong id, ulong classId, ulong methodId, int ilOffset)
+        {
+            using ExceptionsEventSource source = new();
+
+            using ExceptionsEventListener listener = new();
+            listener.EnableEvents(source, EventLevel.Informational);
+
+            source.WriteExceptionId(id, classId, methodId, ilOffset);
+
+            (ulong exceptionId, ExceptionIdentifierData data) = Assert.Single(listener.ExceptionIdentifiers);
+            Assert.Equal(id, exceptionId);
+            Assert.Equal(classId, data.ExceptionClassId);
+            Assert.Equal(methodId, data.ThrowingMethodId);
+            Assert.Equal(ilOffset, data.ILOffset);
+        }
+
+        [Fact]
+        public void ExceptionsEventSource_WriteExceptionId_LevelTooHigh()
+        {
+            using ExceptionsEventSource source = new();
+
+            using ExceptionsEventListener listener = new();
+            listener.EnableEvents(source, EventLevel.Warning);
+
+            source.WriteExceptionId(1, 2, 3, 4);
+
+            Assert.Empty(listener.ExceptionIdentifiers);
+        }
+
+        [Fact]
+        public void ExceptionsEventSource_WriteExceptionId_NotEnabled()
+        {
+            using ExceptionsEventSource source = new();
+
+            using ExceptionsEventListener listener = new();
+
+            source.WriteExceptionId(4, 3, 2, 1);
+
+            Assert.Empty(listener.ExceptionIdentifiers);
+        }
+
+        [Theory]
+        [InlineData(0, null)]
+        [InlineData(1, "")]
+        [InlineData(7, InvalidOperationExceptionMessage)]
+        [InlineData(ulong.MaxValue - 1, OperationCancelledExceptionMessage)]
+        [InlineData(ulong.MaxValue, ObjectDisposedExceptionMessage)]
+        public void ExceptionsEventSource_WriteException_Event(ulong id, string message)
+        {
+            using ExceptionsEventSource source = new();
+
+            using ExceptionsEventListener listener = new();
+            listener.EnableEvents(source, EventLevel.Informational);
+
+            source.WriteException(id, message);
+
+            ExceptionInstance instance = Assert.Single(listener.Exceptions);
+            Assert.Equal(id, instance.ExceptionId);
+            Assert.Equal(CoalesceNull(message), instance.ExceptionMessage);
+        }
+
+        [Fact]
+        public void ExceptionsEventSource_WriteException_LevelTooHigh()
+        {
+            using ExceptionsEventSource source = new();
+
+            using ExceptionsEventListener listener = new();
+            listener.EnableEvents(source, EventLevel.Warning);
+
+            source.WriteException(7, ObjectDisposedExceptionMessage);
+
+            Assert.Empty(listener.Exceptions);
+        }
+
+        [Fact]
+        public void ExceptionsEventSource_WriteException_NotEnabled()
+        {
+            using ExceptionsEventSource source = new();
+
+            using ExceptionsEventListener listener = new();
+
+            source.WriteException(9, OperationCancelledExceptionMessage);
+
+            Assert.Empty(listener.Exceptions);
+        }
+
+        private static string CoalesceNull(string? value)
+        {
+            return value ?? ExceptionsEventListener.NullValue;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionIdentifierCacheTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionIdentifierCacheTests.cs
@@ -1,0 +1,192 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    public sealed class ExceptionIdentifierCacheTests
+    {
+        private const ulong InvalidId = 0;
+        private const uint InvalidToken = 0;
+
+        private static readonly string ThisModuleName =
+            Assembly.GetExecutingAssembly().ManifestModule.Name;
+
+        [Fact]
+        public void ExceptionIdentifierCache_CallbacksNotRequired()
+        {
+            Exception ex = new Exception();
+            ExceptionIdentifier exceptionId = new(ex);
+
+            List<ExceptionIdentifierCacheCallback> callbacks = new();
+            ExceptionIdentifierCache cache = new(callbacks);
+            ulong registrationId = cache.GetOrAdd(exceptionId);
+
+            Assert.NotEqual(InvalidId, registrationId);
+        }
+
+        [Fact]
+        public void ExceptionIdentifierCache_NotThrownException()
+        {
+            Exception ex = new Exception();
+            ExceptionIdentifier exceptionId = new(ex);
+
+            TestExceptionIdentifierCacheCallback callback = new();
+
+            List<ExceptionIdentifierCacheCallback> callbacks = new()
+            {
+                callback
+            };
+            ExceptionIdentifierCache cache = new(callbacks);
+            ulong registrationId = cache.GetOrAdd(exceptionId);
+            Assert.NotEqual(InvalidId, registrationId);
+
+            // Validate exception type in cache
+            (ulong classId, ClassData classData) = Assert.Single(callback.NameCache.ClassData);
+            Assert.NotEqual(InvalidId, classId);
+            Assert.NotNull(classData);
+            Assert.Equal(ClassFlags.None, classData.Flags);
+            Assert.NotEqual(InvalidId, classData.ModuleId);
+            Assert.NotEqual(InvalidToken, classData.Token);
+            Assert.NotNull(classData.TypeArgs);
+            Assert.Empty(classData.TypeArgs);
+
+            // Validate no function data (since exception was not thrown)
+            Assert.Empty(callback.NameCache.FunctionData);
+
+            // Validate exception type module in cache
+            (ulong moduleId, ModuleData moduleData) = Assert.Single(callback.NameCache.ModuleData);
+            Assert.Equal(classData.ModuleId, moduleId);
+            Assert.NotNull(moduleData);
+            Assert.NotNull(moduleData.Name);
+            Assert.Equal(ex.GetType().Module.Name, moduleData.Name);
+
+            // Validate exception type token in cache
+            (ModuleScopedToken scopedToken, TokenData data) = Assert.Single(callback.NameCache.TokenData);
+            Assert.Equal(moduleId, scopedToken.ModuleId);
+            Assert.Equal(classData.Token, scopedToken.Token);
+            Assert.Equal(ex.GetType().FullName, data.Name);
+            Assert.Equal(InvalidId, data.OuterToken);
+
+            // Validate exception ID registration
+            (ulong registrationIdFromCallback, ExceptionIdentifierData exceptionIdData) = Assert.Single(callback.ExceptionIdentifierData);
+            Assert.Equal(registrationId, registrationIdFromCallback);
+            Assert.NotNull(exceptionIdData);
+            Assert.Equal(classId, exceptionIdData.ExceptionClassId);
+            Assert.Equal(InvalidId, exceptionIdData.ThrowingMethodId);
+        }
+
+        [Fact]
+        public void ExceptionIdentifierCache_ThrownException()
+        {
+            Exception ex = new ExceptionWithGenericArgs<int>();
+            ExceptionIdentifier exceptionId;
+            try
+            {
+                throw ex;
+            }
+            catch (Exception caught)
+            {
+                exceptionId = new(caught);
+            }
+
+            TestExceptionIdentifierCacheCallback callback = new();
+
+            List<ExceptionIdentifierCacheCallback> callbacks = new()
+            {
+                callback
+            };
+            ExceptionIdentifierCache cache = new(callbacks);
+            ulong registrationId = cache.GetOrAdd(exceptionId);
+            Assert.NotEqual(InvalidId, registrationId);
+
+            // Validate cache counts
+            Assert.Equal(3, callback.NameCache.ClassData.Count);
+            Assert.Single(callback.NameCache.FunctionData);
+            Assert.Equal(2, callback.NameCache.ModuleData.Count);
+            Assert.Equal(3, callback.NameCache.TokenData.Count);
+
+            // Validate exception ID registration
+            (ulong registrationIdFromCallback, ExceptionIdentifierData exceptionIdData) = Assert.Single(callback.ExceptionIdentifierData);
+            Assert.Equal(registrationId, registrationIdFromCallback);
+            Assert.NotNull(exceptionIdData);
+
+            // Validate exception type in cache
+            Assert.NotEqual(InvalidId, exceptionIdData.ExceptionClassId);
+            Assert.True(callback.NameCache.ClassData.TryGetValue(exceptionIdData.ExceptionClassId, out ClassData? exceptionClassData));
+            Assert.NotNull(exceptionClassData);
+
+            // Validate exception type module in cache
+            Assert.NotEqual(InvalidId, exceptionClassData.ModuleId);
+            Assert.True(callback.NameCache.ModuleData.TryGetValue(exceptionClassData.ModuleId, out ModuleData? exceptionClassModuleData));
+            Assert.NotNull(exceptionClassModuleData);
+            Assert.Equal(ex.GetType().Module.Name, exceptionClassModuleData.Name);
+
+            // Validate exception type token in cache
+            Assert.NotEqual(InvalidId, exceptionClassData.Token);
+            uint parentClassToken = ValidateTokenAndGetOuterToken(
+                callback.NameCache,
+                exceptionClassData.ModuleId,
+                exceptionClassData.Token,
+                ex.GetType());
+
+            // Validate exception type parent token in cache
+            Assert.NotEqual(InvalidId, parentClassToken);
+            parentClassToken = ValidateTokenAndGetOuterToken(
+                callback.NameCache,
+                exceptionClassData.ModuleId,
+                parentClassToken,
+                ex.GetType().DeclaringType!);
+            Assert.Equal(InvalidId, parentClassToken);
+
+            // Validate exception type generic argument in cache
+            ulong genericArgClassId = Assert.Single(exceptionClassData.TypeArgs);
+            Assert.True(callback.NameCache.ClassData.TryGetValue(genericArgClassId, out ClassData? genericArgClassData));
+            Assert.NotNull(genericArgClassData);
+
+            // Validate exception type generic argument token in cache
+            Assert.NotEqual(InvalidId, genericArgClassData.Token);
+            parentClassToken = ValidateTokenAndGetOuterToken(
+                callback.NameCache,
+                genericArgClassData.ModuleId,
+                genericArgClassData.Token,
+                typeof(int));
+            Assert.Equal(InvalidId, parentClassToken);
+
+            // Validate throwing method in cache
+            Assert.NotEqual(InvalidId, exceptionIdData.ThrowingMethodId);
+            Assert.True(callback.NameCache.FunctionData.TryGetValue(exceptionIdData.ThrowingMethodId, out FunctionData? throwingMethodData));
+            Assert.NotNull(throwingMethodData);
+
+            // Validate throwing method module in cache
+            Assert.NotEqual(InvalidId, throwingMethodData.ModuleId);
+            Assert.True(callback.NameCache.ModuleData.TryGetValue(throwingMethodData.ModuleId, out ModuleData? throwingMethodModuleData));
+            Assert.NotNull(throwingMethodModuleData);
+            Assert.Equal(ThisModuleName, throwingMethodModuleData.Name);
+
+            // Validate throwing method remaining properties
+            Assert.Equal(nameof(ExceptionIdentifierCache_ThrownException), throwingMethodData.Name);
+            Assert.NotEqual(InvalidId, throwingMethodData.ParentClass);
+            Assert.NotEqual(InvalidToken, throwingMethodData.ParentToken);
+            Assert.Empty(throwingMethodData.TypeArgs);
+        }
+
+        private static uint ValidateTokenAndGetOuterToken(NameCache cache, ulong moduleId, uint token, Type expectedType)
+        {
+            Assert.True(cache.TokenData.TryGetValue(new ModuleScopedToken(moduleId, token), out TokenData? tokenData));
+            Assert.NotNull(tokenData);
+            string? expectedTypeName = null == expectedType.DeclaringType ?
+                expectedType.FullName : expectedType.Name;
+            Assert.Equal(expectedTypeName, tokenData.Name);
+            return tokenData.OuterToken;
+        }
+
+        private sealed class ExceptionWithGenericArgs<T> : Exception
+        {
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionIdentifierTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionIdentifierTests.cs
@@ -6,13 +6,13 @@ using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
-namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
     [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
     public sealed class ExceptionIdentifierTests
     {
         [Fact]
-        public void ExceptionIdentifier_UnthrownException()
+        public void ExceptionIdentifier_NotThrownException()
         {
             Exception ex = new();
             ExceptionIdentifier id = new(ex);
@@ -39,6 +39,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             ExceptionIdentifier id2 = ThrowAndCreate();
 
             Assert.Equal(id1, id2);
+            Assert.True(id1 == id2);
         }
 
         [Fact]
@@ -60,6 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair(differentTypes: true);
 
             Assert.NotEqual(id1, id2);
+            Assert.True(id1 != id2);
         }
 
         [Fact]
@@ -80,6 +82,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair(differentMethods: true);
 
             Assert.NotEqual(id1, id2);
+            Assert.True(id1 != id2);
         }
 
         [Fact]
@@ -99,6 +102,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair();
 
             Assert.NotEqual(id1, id2);
+            Assert.True(id1 != id2);
         }
 
         [Fact]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/TestExceptionIdentifierCacheCallback.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/TestExceptionIdentifierCacheCallback.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    internal sealed class TestExceptionIdentifierCacheCallback :
+        ExceptionIdentifierCacheCallback
+    {
+        public readonly NameCache NameCache = new();
+
+        public readonly Dictionary<ulong, ExceptionIdentifierData> ExceptionIdentifierData = new();
+
+        public override void OnClassData(ulong classId, ClassData data)
+        {
+            Assert.True(NameCache.ClassData.TryAdd(classId, data));
+        }
+
+        public override void OnExceptionIdentifier(ulong registrationId, ExceptionIdentifierData data)
+        {
+            Assert.True(ExceptionIdentifierData.TryAdd(registrationId, data));
+        }
+
+        public override void OnFunctionData(ulong functionId, FunctionData data)
+        {
+            Assert.True(NameCache.FunctionData.TryAdd(functionId, data));
+        }
+
+        public override void OnModuleData(ulong moduleId, ModuleData data)
+        {
+            Assert.True(NameCache.ModuleData.TryAdd(moduleId, data));
+        }
+
+        public override void OnTokenData(ulong moduleId, uint typeToken, TokenData data)
+        {
+            Assert.True(NameCache.TokenData.TryAdd(new ModuleScopedToken(moduleId, typeToken), data));
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj
@@ -4,7 +4,13 @@
     <RootNamespace>Microsoft.Diagnostics.Monitoring.StartupHook</RootNamespace>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);STARTUPHOOK</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Stacks\NameFormatter.cs" Link="NameFormatter.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.StartupHook\Microsoft.Diagnostics.Monitoring.StartupHook.csproj" />


### PR DESCRIPTION
###### Summary

- Add event source for producing exception information so that external process (e.g. dotnet-monitor) can get exception information that is grouped and identified by the `ExceptionIdentifier` class.
- Add exception identifier cache that invokes callbacks when new exception identification information is added to it. This allows filtering of repeated exceptions so that the event source doesn't have to repeat the same exception, method, type, and module information.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
