### PR TITLE
Use CI agent's temp dir for tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TemporaryDirectory.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TemporaryDirectory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             string tempDir = Path.Combine(topLevelTempDir, Path.GetRandomFileName());
             Assert.False(Directory.Exists(tempDir));
 
-            _directoryInfo = Directory.CreateDirectory(Path.Combine(topLevelTempDir, Path.GetRandomFileName()));
+            _directoryInfo = Directory.CreateDirectory(tempDir);
             _outputHelper.WriteLine("Created temporary directory '{0}'", FullName);
         }
 


### PR DESCRIPTION
###### Summary

When running tests in AzDo, use the agent's temporary directory to prevent using an already-existing temp directory which can impact tests.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
