### PR TITLE
Add test run option to release notes workflow

### DIFF
--- a/.github/actions/open-pr/action.yml
+++ b/.github/actions/open-pr/action.yml
@@ -25,6 +25,9 @@ inputs:
   auth_token:
     description: 'The token used to authenticate to GitHub.'
     required: true
+  draft:
+    description: 'Open as a draft PR.'
+    required: false
 
 runs:
   using: "composite"
@@ -53,7 +56,16 @@ runs:
         git commit -m "${{ inputs.commit_message }}"
         git push --force --set-upstream origin "HEAD:$pr_branch_name"
 
-        gh pr create --repo "${{ github.repository }}" --base "$current_branch_name" -t "${{ inputs.title }}" -b  "${{ inputs.body }}" -l "${{ inputs.labels }}"
+        extraArgs=""
+        if [[ ! -z "${{ inputs.labels }}" ]]; then
+          extraArgs="${extraArgs} --label \"${{ inputs.labels }}\""
+        fi
+
+        if [[ "${{ inputs.draft }}" == "true" ]]; then
+          extraArgs="${extraArgs} --draft"
+        fi
+
+        gh pr create --repo "${{ github.repository }}" --base "$current_branch_name" -t "${{ inputs.title }}" -b "${{ inputs.body }}" $extraArgs
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.auth_token }}

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -1,8 +1,13 @@
 name: 'Generate release notes'
-run-name: '[${{ github.ref_name }}] Generate release notes'
+run-name: '[${{ github.ref_name }}] Generate release notes (test: ${{ inputs.test_run }})'
 
 on:
   workflow_dispatch:
+    inputs:
+      test_run:
+        description: 'Test run?'
+        required: true
+        type: boolean
 
 permissions:
   contents: write
@@ -33,16 +38,20 @@ jobs:
           release_version_label=$(perl -ne '/<PreReleaseVersionLabel>([^<]*)/ && print $1' $versionFile)
           major_minor_version=${release_version%.*}
 
-          version_url="https://aka.ms/dotnet/diagnostics/monitor${major_minor_version}/release/dotnet-monitor.nupkg.version"
-          qualified_release_version=$(curl -sL $version_url)
-          # Check if the aka.ms url existed
-          if [[ "$qualified_release_version" =~ "<html" || -z "$qualified_release_version" ]]; then
-            echo "Could not determine qualified release version, $version_url did not contain the expected information"
-            exit 1
-          fi
+          if [[ "${{ inputs.test_run }}" == "true" ]]; then
+            qualified_release_version="test-$release_version"
+          else
+            version_url="https://aka.ms/dotnet/diagnostics/monitor${major_minor_version}/release/dotnet-monitor.nupkg.version"
+            qualified_release_version=$(curl -sL $version_url)
+            # Check if the aka.ms url existed
+            if [[ "$qualified_release_version" =~ "<html" || -z "$qualified_release_version" ]]; then
+              echo "Could not determine qualified release version, $version_url did not contain the expected information"
+              exit 1
+            fi
 
-          # trim the return carriage
-          qualified_release_version=$(echo $qualified_release_version | tr -d '\r')
+            # trim the return carriage
+            qualified_release_version=$(echo $qualified_release_version | tr -d '\r')
+          fi
 
           friendly_release_name=""
 
@@ -72,11 +81,25 @@ jobs:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           branch_name: ${{ github.ref_name }}
 
+      - name: Open PR (test run)
+        if: ${{ inputs.test_run }}
+        uses: ./.github/actions/open-pr
+        with:
+          draft: true
+          files_to_commit: ${{ env.release_note_path }}
+          title: "[test] Add ${{ env.qualified_release_version }} release notes"
+          commit_message: generate release notes
+          body: This is a test PR. Add ${{ env.qualified_release_version }} release notes. This PR was auto generated and will not be automatically merged in.
+          branch_name: releaseNotes/test/${{ env.qualified_release_version }}
+          fail_if_files_unchanged: true
+          auth_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Open PR
+        if: ${{ !inputs.test_run }}
         uses: ./.github/actions/open-pr
         with:
           files_to_commit: ${{ env.release_note_path }}
-          title: Add ${{ env.qualified_release_version }} release notes
+          title: "Add ${{ env.qualified_release_version }} release notes"
           commit_message: generate release notes
           body: Add ${{ env.qualified_release_version }} release notes. This PR was auto generated and will not be automatically merged in.
           branch_name: releaseNotes/${{ env.qualified_release_version }}


### PR DESCRIPTION
###### Summary

Add a new run option for the generate release notes workflow. Setting this will skip checking for a matching release build and open a draft PR instead of a regular one.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
