### PR TITLE
Fix support for nested backport in release notes

### DIFF
--- a/.github/actions/generate-release-notes/index.js
+++ b/.github/actions/generate-release-notes/index.js
@@ -204,7 +204,7 @@ async function resolveBackportPrToReleaseNotePr(octokit, pr, repoOwner, repoName
     for (const label of originPr.labels)
     {
         if (label.name === UpdateReleaseNotesLabel) {
-            console.log(`--> Mentioning in release notes`)
+            console.log(`--> Potentially mentioning in release notes`)
             return originPr;
         }
 


### PR DESCRIPTION
###### Summary

Fix support for PRs which are a backport of a backport during release notes generation.

See https://github.com/dotnet/dotnet-monitor/actions/runs/4000434158 for the failure.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
