### PR TITLE
Use NuGetPackageRoot instead of NUGET_PACKAGES

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -74,9 +74,9 @@
       These assets are Windows-specific native libraries and are not used in the trace event usage
       by dotnet-monitor. Removing them saves about 20 MBs from the unpacked dotnet-monitor installation.
       -->
-    <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\*\build\native\**" />
+    <None Remove="$(NuGetPackageRoot)Microsoft.Diagnostics.Tracing.TraceEvent\*\build\native\**" />
     <!-- These are the same items above but using relative paths that haven't been resolved into absolute paths. -->
-    <None Remove="$(NUGET_PACKAGES)Microsoft.Diagnostics.Tracing.TraceEvent\buildTransitive\..\build\native\**" />
+    <None Remove="$(NuGetPackageRoot)Microsoft.Diagnostics.Tracing.TraceEvent\buildTransitive\..\build\native\**" />
   </ItemGroup>
 
   <Target Name="CalculateProjectRuntimeConfigTestFilePath">


### PR DESCRIPTION
###### Summary

Using NUGET_PACKAGES property for looking up paths of NuGet package files works on Windows but not on non-Windows due to extra slashes. This causes the removal of the extra trace event library files to not work on non-Windows platforms. Use NuGetPackageRoot instead which is correctly normalized.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2096170&view=results

I'll only complete this PR if the referenced build produces the correct removal.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
