### PR TITLE
[release/6.x] Use CI agent's temp dir for tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TemporaryDirectory.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TemporaryDirectory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
@@ -16,9 +17,18 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         {
             _outputHelper = outputhelper;
 
-            _directoryInfo = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
-            _directoryInfo.Create();
+            // AGENT_TEMPDIRECTORY is an AzureDevops variable which is set to a path
+            // that is cleaned up after every job.
+            string topLevelTempDir = Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY");
+            if (string.IsNullOrEmpty(topLevelTempDir))
+            {
+                topLevelTempDir = Path.GetTempPath();
+            }
 
+            string tempDir = Path.Combine(topLevelTempDir, Path.GetRandomFileName());
+            Assert.False(Directory.Exists(tempDir));
+
+            _directoryInfo = Directory.CreateDirectory(tempDir);
             _outputHelper.WriteLine("Created temporary directory '{0}'", FullName);
         }
 


### PR DESCRIPTION
###### Summary

Manual backport #3431 to release/6.x. release/6.x used a guid for the random folder name, change this to be consistent with the other branches.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
