### PR TITLE
Include apphost in archives

### DIFF
--- a/eng/PublishProjects.targets
+++ b/eng/PublishProjects.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <SharedPublishProjectProperties>SelfContained=false</SharedPublishProjectProperties>
-    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=false</SharedPublishProjectProperties>
+    <SharedPublishProjectProperties>$(SharedPublishProjectProperties);UseAppHost=true</SharedPublishProjectProperties>
     <SharedPublishProjectProperties>$(SharedPublishProjectProperties);PackAsTool=false</SharedPublishProjectProperties>
   </PropertyGroup>
 


### PR DESCRIPTION
###### Summary

Include the apphost (e.g. `dotnet-monitor.exe` or `dotnet-monitor`) in the archives in order to preserve the existing behavior of the Dockerfiles (which invoke the apphost). This adds about ~1% to the contents of the archive.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
