### PR TITLE
[release/7.x] Do not trigger CI for cspell changes

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -14,6 +14,7 @@ pr:
     - .github
     - .vscode
     - .gitignore
+    - cspell.json
     - eng/actions
     - '**.md'
 


### PR DESCRIPTION
###### Summary

Manual backport of #3281 to `release/7.x`. Notably only include the changes that ignore `cspell.json` when triggering CI builds. Everything else has already been backported as part of branch syncs.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
