### PR TITLE
[release/6.x] Unified latest target framework spec and publish directory

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,10 +1,11 @@
 <Project>
+  <Import Project="$(MSBuildThisFileDirectory)Common.props" />
   <ItemGroup Condition="'$(CreateArchives)' == 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\archives\pkgs\dotnet-monitor\dotnet-monitor-archive.proj">
-      <AdditionalProperties>TargetFramework=net6.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(LatestTargetFramework);RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
     </ProjectToBuild>
     <ProjectToBuild Include="$(RepoRoot)src\archives\symbols\dotnet-monitor\dotnet-monitor-symbols.proj">
-      <AdditionalProperties>TargetFramework=net6.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(LatestTargetFramework);RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
     </ProjectToBuild>
   </ItemGroup>
 </Project>

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- These properties are shared among the Arcade build infrastructure as well as individual project build. -->
+  <PropertyGroup>
+    <LatestTargetFramework>net6.0</LatestTargetFramework>
+  </PropertyGroup>
+</Project>

--- a/eng/DotnetMonitorProjectToPublish.props
+++ b/eng/DotnetMonitorProjectToPublish.props
@@ -1,7 +1,12 @@
 <Project>
+  <PropertyGroup>
+    <DotnetMonitorPublishTargetFramework>$(LatestTargetFramework)</DotnetMonitorPublishTargetFramework>
+    <DotnetMonitorPublishTargetFramework Condition="'$(TargetFramework)' != ''">$(TargetFramework)</DotnetMonitorPublishTargetFramework>
+    <DotnetMonitorPublishPath>$(ArtifactsDir)pub\dotnet-monitor\$(Configuration)\$(DotnetMonitorPublishTargetFramework)\$(PackageRid)\</DotnetMonitorPublishPath>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectToPublish Include="$(RepoRoot)src\Tools\dotnet-monitor\dotnet-monitor.csproj">
-      <AdditionalProperties>TargetFramework=net6.0;RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DotnetMonitorPublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(DotnetMonitorPublishPath)</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,9 +19,10 @@
   <PropertyGroup Label="Testing">
     <XUnitCoreSettingsFile>$(MSBuildThisFileDirectory)xunit.runner.json</XUnitCoreSettingsFile>
   </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)Common.props" />
   <PropertyGroup Label="TargetFrameworks">
     <!-- The TFMs of the dotnet-monitor tool.  -->
-    <ToolTargetFrameworks>netcoreapp3.1;net6.0</ToolTargetFrameworks>
+    <ToolTargetFrameworks>netcoreapp3.1;$(LatestTargetFramework)</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
     <TestTargetFrameworks>$(ToolTargetFrameworks)</TestTargetFrameworks>
   </PropertyGroup>

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -18,14 +18,9 @@ jobs:
 
     preBuildSteps:
     - task: DownloadPipelineArtifact@2
-      displayName: Download Managed
+      displayName: Download Build
       inputs:
-        artifactName: Build_Managed_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-        targetPath: '$(Build.SourcesDirectory)/artifacts'
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Native
-      inputs:
-        artifactName: Build_Native_${{ parameters.configuration }}
+        artifactName: Build_Published_${{ parameters.configuration }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
     - task: DownloadPipelineArtifact@2
       displayName: Download Third Party Notice

--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -75,28 +75,22 @@ jobs:
     postBuildSteps:
     - ${{ if and(eq(parameters.publishArtifacts, 'true'), eq(parameters.configuration, 'Release')) }}:
       - task: CopyFiles@2
-        displayName: Gather Artifacts (bin/dotnet-monitor)
+        displayName: Gather Artifacts (pub)
         inputs:
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/dotnet-monitor'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin/dotnet-monitor'
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Artifacts (Managed)
-        inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-          artifactName: Build_Managed_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/pub'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/pub'
       
       - task: CopyFiles@2
         displayName: Gather Artifacts (bin/${{ parameters.targetRid }}.${{ parameters.configuration }})
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/native/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin/${{ parameters.targetRid }}.${{ parameters.configuration }}'
 
       - task: PublishBuildArtifacts@1
-        displayName: Publish Artifacts (Native)
+        displayName: Publish Artifacts (Published)
         inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)/native'
-          artifactName: Build_Native_${{ parameters.configuration }}
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+          artifactName: Build_Published_${{ parameters.configuration }}
 
       - ${{ if eq(parameters.targetRid, 'win-x64') }}:
         - task: CopyFiles@2

--- a/src/archives/PublishedProjectArchive.targets
+++ b/src/archives/PublishedProjectArchive.targets
@@ -14,6 +14,10 @@
 
   <Target Name="CollectPublishedFilesToArchive"
           DependsOnTargets="PublishProjectsBeforeArchive">
+    <Error Text="The 'ArchiveContentRootPath' property must be set to the path of the root of the files to archive."
+           Condition="'$(ArchiveContentRootPath)' == ''" />
+    <Error Text="The archive content root path '$(ArchiveContentRootPath)' does not exist."
+           Condition="!Exists($(ArchiveContentRootPath))" />
     <ItemGroup>
       <FileToArchive Include="$(ArchiveContentRootPath)**" />
     </ItemGroup>

--- a/src/archives/dotnet-monitor.props
+++ b/src/archives/dotnet-monitor.props
@@ -1,6 +1,8 @@
 <Project>
+  <!-- Import ProjectToPublish items -->
+  <Import Project="$(RepositoryEngineeringDir)DotnetMonitorProjectToPublish.props" />
   <PropertyGroup>
-    <ArchiveContentRootPath>$(ArtifactsBinDir)dotnet-monitor\$(Configuration)\$(TargetFramework)\$(PackageRid)\publish\</ArchiveContentRootPath>
+    <ArchiveContentRootPath>$(DotnetMonitorPublishPath)</ArchiveContentRootPath>
   </PropertyGroup>
   <!-- These items are included in addition to those from publishing the dotnet-monitor project. -->
   <ItemGroup>
@@ -37,8 +39,6 @@
     </SymbolFileToArchive>
     <!-- Do not include symbols for the extra native assemblies since they have their own symbols package. -->
   </ItemGroup>
-  <!-- Import ProjectToPublish items -->
-  <Import Project="$(RepositoryEngineeringDir)DotnetMonitorProjectToPublish.props" />
   <!-- Import archive creation from published project -->
   <Import Project="$(MSBuildThisFileDirectory)PublishedProjectArchive.targets" />
 </Project>

--- a/src/archives/pkgs/Directory.Build.targets
+++ b/src/archives/pkgs/Directory.Build.targets
@@ -7,10 +7,6 @@
   
   <Target Name="PublishToDisk"
           DependsOnTargets="$(PublishToDiskDependsOn)">
-    <Error Message="The 'ArchiveContentRootPath' property must be set to the path of the root of the files to archive."
-           Condition="'$(ArchiveContentRootPath)' == ''" />
-    <Error Message="The archive content root path '$(ArchiveContentRootPath)' does not exist."
-           Condition="!Exists($(ArchiveContentRootPath))" />
     <!-- Collect non-symbol files and copy to staging directory -->
     <ItemGroup>
       <_FileToArchive Remove="@(_FileToArchive)" />


### PR DESCRIPTION
###### Summary

Manual backport of #3462 to `release/6.x`; adjusted the LatestTargetFramework usage to `net6.0` and replaced `net6.0` with the property.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
