### PR TITLE
[release/7.x] Trigger updates to dotnet-docker for release builds

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -29,13 +29,17 @@ parameters:
   - None
   - CI
   - PR
+- name: updateDocker
+  displayName: 'Update dotnet-docker? (Only for release branches)'
+  type: boolean
+  default: false
 
 variables:
 - name: _TeamName
   value: DotNetCore
 - name: _TPNFile
   value: THIRD-PARTY-NOTICES.TXT
-  
+
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   # DotNet-Diagnostics-SDL-Params provides Tsa* variables for SDL checks.
   - group: DotNet-Diagnostics-SDL-Params
@@ -121,3 +125,5 @@ stages:
         - 'PackageArtifacts'
 # This sets up the bits to do a Release.
 - template: /eng/pipelines/stages/preparerelease.yml
+  parameters:
+    updateDocker: ${{ parameters.updateDocker }}

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -42,3 +42,15 @@ jobs:
         /p:DotNetPublishUsingPipelines=true
         /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
       displayName: Pack, Sign, and Publish
+    - task: powershell@2
+      displayName: Generate Build Info
+      inputs:
+        targetType: inline
+        script: |
+            New-Item "$(Build.ArtifactStagingDirectory)/buildInfo" -Type Directory
+            Copy-Item "$(Build.SourcesDirectory)/artifacts/packages/Release/Shipping/dotnet-monitor.*.nupkg.buildversion" "$(Build.ArtifactStagingDirectory)/buildInfo/dotnet-monitor.nupkg.buildversion"
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Build Info
+      inputs:
+        artifactName: 'Build_Info'
+        targetPath: $(Build.ArtifactStagingDirectory)/buildInfo

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
   - job: PrepareReleaseJob
     displayName: Prepare release with Darc
-    pool: 
+    pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCore-Svc-Public
         demands: ImageOverride -equals 1es-windows-2019-open
@@ -49,25 +49,25 @@ stages:
           targetType: filePath
           filePath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
           arguments: >-
-            -BarBuildId "$(BARBuildId)" 
-            -AzdoToken "$(dn-bot-dotnet-all-scopes)" 
-            -MaestroToken "$(MaestroAccessToken)" 
-            -GitHubToken "$(BotAccount-dotnet-bot-repo-PAT)" 
-            -DownloadTargetPath "$(System.ArtifactsDirectory)\ReleaseTarget" 
-            -SasSuffixes "$(dotnetclichecksumsmsrc-dotnet-read-list-sas-token),$(dotnetclimsrc-read-sas-token)" 
+            -BarBuildId "$(BARBuildId)"
+            -AzdoToken "$(dn-bot-dotnet-all-scopes)"
+            -MaestroToken "$(MaestroAccessToken)"
+            -GitHubToken "$(BotAccount-dotnet-bot-repo-PAT)"
+            -DownloadTargetPath "$(System.ArtifactsDirectory)\ReleaseTarget"
+            -SasSuffixes "$(dotnetclichecksumsmsrc-dotnet-read-list-sas-token),$(dotnetclimsrc-read-sas-token)"
             -ReleaseVersion "$(Build.BuildNumber)"
           workingDirectory: '$(Build.Repository.LocalPath)'
       - script: >-
           dotnet.cmd run --project $(Build.Repository.LocalPath)\eng\release\DiagnosticsReleaseTool\DiagnosticsReleaseTool.csproj -c Release
           --
-          prepare-release 
-          --input-drop-path "$(System.ArtifactsDirectory)\ReleaseTarget" 
-          --tool-manifest "$(Build.Repository.LocalPath)\eng\release\tool-list.json" 
-          --staging-directory "$(System.ArtifactsDirectory)\ReleaseStaging" 
-          --release-name "$(Build.BuildNumber)" 
-          --account-name "$(dotnet-diagnostics-storage-accountname)" 
-          --account-key "$(dotnetstage-storage-key)" 
-          --sas-valid-days "$(dotnet-diagnostics-storage-retentiondays)" 
+          prepare-release
+          --input-drop-path "$(System.ArtifactsDirectory)\ReleaseTarget"
+          --tool-manifest "$(Build.Repository.LocalPath)\eng\release\tool-list.json"
+          --staging-directory "$(System.ArtifactsDirectory)\ReleaseStaging"
+          --release-name "$(Build.BuildNumber)"
+          --account-name "$(dotnet-diagnostics-storage-accountname)"
+          --account-key "$(dotnetstage-storage-key)"
+          --sas-valid-days "$(dotnet-diagnostics-storage-retentiondays)"
           -v True
         workingDirectory: '$(Build.Repository.LocalPath)\'
         displayName: 'Manifest generation and asset publishing'
@@ -82,3 +82,9 @@ stages:
           inputs:
             type: 'Build'
             tags: 'MonitorRelease'
+        - ${{ if eq(parameters.updateDocker, true) }}:
+          - task: tagBuildOrRelease@0
+            displayName: 'Tag Build with update-docker'
+            inputs:
+              type: 'Build'
+              tags: 'update-docker'


### PR DESCRIPTION
###### Summary

Manual backport of #3480 to release/7.x. Automatic merge conflict was due to minor/unreleated differences in `preparerelease.yml`.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
