### PR TITLE
Mark dotnet-monitor as executable in archives

### DIFF
--- a/src/archives/pkgs/Directory.Build.props
+++ b/src/archives/pkgs/Directory.Build.props
@@ -8,4 +8,15 @@
     <IsArchivable>true</IsArchivable>
     <CreateSymbolsArchive>true</CreateSymbolsArchive>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <_FileToArchive>
+      <PackagePath>%(RecursiveDir)</PackagePath>
+    </_FileToArchive>
+    <_SymbolFileToArchive>
+      <PackagePath>%(RecursiveDir)</PackagePath>
+    </_SymbolFileToArchive>
+    <FileToArchive>
+      <MarkExecutable>false</MarkExecutable>
+    </FileToArchive>
+  </ItemDefinitionGroup>
 </Project>

--- a/src/archives/pkgs/Directory.Build.targets
+++ b/src/archives/pkgs/Directory.Build.targets
@@ -14,9 +14,6 @@
     </ItemGroup>
     <!-- Update metadata on existing items -->
     <ItemGroup>
-      <_FileToArchive Condition="'%(_FileToArchive.PackagePath)' == ''">
-        <PackagePath>%(RecursiveDir)</PackagePath>
-      </_FileToArchive>
       <_FileToArchive>
         <TargetPath>$(OutputPath)%(PackagePath)%(Filename)%(Extension)</TargetPath>
       </_FileToArchive>
@@ -26,6 +23,7 @@
       <_StagedFile Remove="@(_StagedFile)" />
       <_StagedFile Include="%(_FileToArchive.TargetPath)">
         <SourcePath>@(_FileToArchive->'%(Identity)')</SourcePath>
+        <MarkExecutable>%(_FileToArchive.MarkExecutable)</MarkExecutable>
       </_StagedFile>
     </ItemGroup>
     <Copy SourceFiles="%(SourcePath)" DestinationFiles="@(_StagedFile)" />
@@ -34,6 +32,8 @@
       <_ArchiveExecutableContent Remove="@(_ArchiveExecutableContent)" />
       <_ArchiveExecutableContent Include="@(_StagedFile)"
                                  Condition="'%(Extension)' == '.dylib' or '%(Extension)' == '.so'" />
+      <_ArchiveExecutableContent Include="@(_StagedFile)"
+                                 Condition="'%(MarkExecutable)' == 'true'" />
     </ItemGroup>
     <Exec Command="chmod 755 %(_ArchiveExecutableContent.Identity)"
           Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '@(_ArchiveExecutableContent)' != ''" />
@@ -56,9 +56,6 @@
     </ItemGroup>
     <!-- Update metadata on existing items -->
     <ItemGroup>
-      <_SymbolFileToArchive Condition="'%(_SymbolFileToArchive.PackagePath)' == ''">
-        <PackagePath>%(RecursiveDir)</PackagePath>
-      </_SymbolFileToArchive>
       <_SymbolFileToArchive>
         <TargetPath>$(SymbolsOutputPath)%(PackagePath)%(Filename)%(Extension)</TargetPath>
       </_SymbolFileToArchive>

--- a/src/archives/pkgs/dotnet-monitor/dotnet-monitor-archive.proj
+++ b/src/archives/pkgs/dotnet-monitor/dotnet-monitor-archive.proj
@@ -6,4 +6,15 @@
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
   <Import Project="$(RepositoryArchivesDir)dotnet-monitor.props" />
+  <PropertyGroup>
+    <PublishToDiskDependsOn>$(PublishToDiskDependsOn);UpdateFilesToArchive</PublishToDiskDependsOn>
+  </PropertyGroup>
+  <Target Name="UpdateFilesToArchive">
+    <ItemGroup>
+      <!-- Check extension so as to not mark 'dotnet-monitor.dll' as executable. -->
+      <FileToArchive Condition="'%(Filename)%(Extension)' == 'dotnet-monitor'">
+        <MarkExecutable>true</MarkExecutable>
+      </FileToArchive>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
###### Summary

- Use ItemDefinitionGroup to provide defaults for metadata.
- Mark the `dotnet-monitor` executable so that it is made executable before archiving.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
