### PR TITLE
Verify Dependabot updates are harvested in ClearlyDefined

### DIFF
--- a/.github/workflows/verify-dependabot-clearly-defined.yml
+++ b/.github/workflows/verify-dependabot-clearly-defined.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           set -e
           blockPr=""
-          while IFS=%'\t' read -r dependency; do
+          while read -r dependency; do
             url="https://api.clearlydefined.io/definitions/nuget/nuget/-/$dependency"
             echo "Checking $dependency at $url"
             license=$(curl -sX GET "$url" -H "accept: */*" | jq -r '.licensed.declared')


### PR DESCRIPTION
###### Summary

This PR adds a new PR gate to Dependabot PRs. It will verify NuGet package updates are harvested in ClearlyDefined. If not, it will automatically submit a harvesting request to their service and block the PR if it contains a 3rd party dependency.

**NOTE**: Before this PR is merged in, `dependabot/fetch-metadata` needs to be added to the allowed actions list


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
