### PR TITLE
Sign published artifacts before archiving

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -68,6 +68,9 @@ stages:
     dependsOn:
     - Build
     jobs:
+    # Sign binaries before archiving
+    - template: /eng/pipelines/jobs/sign-binaries.yml
+
     # Build RID (runtime identifier) archives
     - template: /eng/pipelines/jobs/platform-matrix.yml
       parameters:

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,7 +4,7 @@
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Swashbuckle.AspNetCore.SwaggerUI.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(SignAllBinaries)' != 'true'">
     <!--
       Tarballs are currently not signed nor are their contents.
       This entry allows them to be signed automatically when tooling allows for it.
@@ -15,5 +15,13 @@
       The zip is expanded, the contents are signed, and then rezipped.
       -->
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.zip" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(SignAllBinaries)' == 'true'">
+    <!--
+      Sign all binaries in the artifacts directory.
+      -->
+    <ItemsToSign Remove="@(ItemsToSign)" />
+    <ItemsToSign Include="$(ArtifactsDir)bin\**\*" />
+    <ItemsToSign Include="$(ArtifactsDir)pub\**\*" />
   </ItemGroup>
 </Project>

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -15,12 +15,14 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
+    dependsOn:
+    - Sign_Binaries
 
     preBuildSteps:
     - task: DownloadPipelineArtifact@2
-      displayName: Download Build
+      displayName: Download Signed Artifacts
       inputs:
-        artifactName: Build_Published_${{ parameters.configuration }}
+        artifactName: Build_Signed_${{ parameters.configuration }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
     - task: DownloadPipelineArtifact@2
       displayName: Download Third Party Notice

--- a/eng/pipelines/jobs/sign-binaries.yml
+++ b/eng/pipelines/jobs/sign-binaries.yml
@@ -1,0 +1,60 @@
+parameters:
+  # Build configuration (Debug, Release)
+  configuration: Release
+
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: Sign_Binaries
+    displayName: Sign Binaries
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals 1es-windows-2019
+    enableMicrobuild: true
+    artifacts:
+      publish:
+        logs:
+          name: Logs_Sign_Binaries
+    variables:
+    - _BuildConfig: ${{ parameters.configuration }}
+    - _SignType: real
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Build
+      inputs:
+        artifactName: Build_Published_${{ parameters.configuration }}
+        targetPath: '$(Build.SourcesDirectory)/artifacts'
+
+    - script: >-
+        $(Build.SourcesDirectory)/restore.cmd
+        -configuration ${{ parameters.configuration }}
+        -verbosity minimal
+        -ci
+        -preparemachine
+        -sign
+        -nobl
+        /bl:'$(Build.SourcesDirectory)\artifacts\log\Release\SignBinaries.binlog'
+        /p:TeamName=$(_TeamName)
+        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        /p:DotNetSignType=real
+        /p:SignAllBinaries=true
+      displayName: Sign
+
+    - task: CopyFiles@2
+      displayName: Gather Artifacts (bin)
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/bin'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin'
+    
+    - task: CopyFiles@2
+      displayName: Gather Artifacts (pub)
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/pub'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/pub'
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifacts
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
+        artifactName: Build_Signed_${{ parameters.configuration }}


### PR DESCRIPTION
###### Summary

The SignTool task only knows how to unpack *.nuget and *.zip files in order to sign their contents. This leaves all of the files *.tar.gz unsigned.

This change adds an additional job after build but before archiving that signs all of the archive content in one pass.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2100455&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
