### PR TITLE
Mark archives for shipping

### DIFF
--- a/src/archives/pkgs/dotnet-monitor/dotnet-monitor-archive.proj
+++ b/src/archives/pkgs/dotnet-monitor/dotnet-monitor-archive.proj
@@ -4,6 +4,7 @@
     <ArchiveName>dotnet-monitor</ArchiveName>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
+    <IsShipping>true</IsShipping>
   </PropertyGroup>
   <Import Project="$(RepositoryArchivesDir)dotnet-monitor.props" />
   <PropertyGroup>


### PR DESCRIPTION
###### Summary

With all outstanding work finished for the archives (with the exception of #3506), the archives can now be marked as shipping. This has very little effect on the builds, however it allows the files to be copied to dotnetstage storage account to prepare for shipping.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
