### PR TITLE
Filter which PRs to consider for dependabot PR gate

### DIFF
--- a/.github/workflows/verify-dependabot-clearly-defined.yml
+++ b/.github/workflows/verify-dependabot-clearly-defined.yml
@@ -1,5 +1,7 @@
 name: Dependabot Verify ClearlyDefined
-on: pull_request
+on:
+  pull_request:
+    paths: ['eng/dependabot/**']
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
###### Summary

The existing mechanism of skipping the Dependabot PR gate depending on the PR author results in a 'skipped' PR gate for non-applicable PRs. This is breaking the Maestro auto-merge. Update the PR gate to only be considered if the PR affects dependabot-managed files

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
