### PR TITLE
Tag build for dotnet-docker update if enable nightly update from main

### DIFF
--- a/documentation/release-process.md
+++ b/documentation/release-process.md
@@ -5,6 +5,7 @@
 
 ## Prepare the release branch
 
+1. Update the [internal pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=954) variables to prevent consumption of nightly builds into dotnet-docker. Set `NightlyUpdateDockerFromMain` variable to `false` on the pipeline itself, not just on a new build.
 1. Merge from the `main` branch to the appropriate release branch (e.g. `release/5.0`). Note that for patch releases, fixes should be made directly to the appropriate release branch and we do not merge from the `main` branch. Note that it is acceptable to use a release/major.x branch. Alternatively, you can create a new release branch for the minor version. See [additional branch steps](#additional-steps-when-creating-a-new-release-branch) below.
 1. Review and merge in any outstanding dependabot PRs for the release branch.
 1. Run the [Update release version](https://github.com/dotnet/dotnet-monitor/actions/workflows/update-release-version.yml) workflow, setting `Use workflow from` to the release branch and correctly setting the `Release type` and `Release version` options. (*NOTE:* Release version should include only major.minor.patch, without any extra labels). Review and merge in the PR created by this workflow.
@@ -104,6 +105,7 @@ The release image is `mcr.microsoft.com/dotnet/monitor`. The tag list is https:/
 
 ## After the Release
 
+1. Change the `NightlyUpdateDockerFromMain` variable to `true` in the [internal pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=954) to begin the consumption of nightly builds into dotnet-docker.
 1. Update [releases.md](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/releases.md) with the latest version.
 1. When necessary, update this document if its instructions were unclear or incorrect.
 1. When releasing a new minor version, include an announcement that the previous version will soon be out of support. For example, https://github.com/dotnet/dotnet-monitor/discussions/1871

--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -18,6 +18,14 @@ pr:
     - eng/actions
     - '**.md'
 
+schedules:
+# Schedule before docker update pipeline
+- cron: "0 3 * * Mon-Fri"
+  displayName: M-F Scheduled Build
+  branches:
+    include:
+    - main
+
 parameters:
 - name: testGroup
   displayName: 'Test Group'
@@ -39,6 +47,9 @@ variables:
   value: DotNetCore
 - name: _TPNFile
   value: THIRD-PARTY-NOTICES.TXT
+# Scheduled builds of main branch will be marked for update by dotnet-docker if this is true
+- name: NightlyUpdateDockerFromMain
+  value: true
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   # DotNet-Diagnostics-SDL-Params provides Tsa* variables for SDL checks.
@@ -129,4 +140,8 @@ stages:
 # This sets up the bits to do a Release.
 - template: /eng/pipelines/stages/preparerelease.yml
   parameters:
-    updateDocker: ${{ parameters.updateDocker }}
+    ${{ if eq(parameters.updateDocker, 'true') }}:
+      updateDocker: true
+    ${{ else }}:
+      # If scheduled build from main and nightly update from main enabled
+      updateDocker: ${{ and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['NightlyUpdateDockerFromMain'], 'true')) }}

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -88,9 +88,9 @@ stages:
           inputs:
             type: 'Build'
             tags: 'MonitorRelease'
-        - ${{ if eq(parameters.updateDocker, true) }}:
-          - task: tagBuildOrRelease@0
-            displayName: 'Tag Build with update-docker'
-            inputs:
-              type: 'Build'
-              tags: 'update-docker'
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.updateDocker, true)) }}:
+      - task: tagBuildOrRelease@0
+        displayName: 'Tag Build with update-docker'
+        inputs:
+          type: 'Build'
+          tags: 'update-docker'


### PR DESCRIPTION
###### Summary

Tag builds from `main` with `docker-update` if variable enables it. This allows us to more easily opt into and out of producing dotnet-docker updates of nightly builds from the main branch.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
