### PR TITLE
Add exceptions experimental feature flag

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IExperimentalFlags.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IExperimentalFlags.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     internal interface IExperimentalFlags
     {
         bool IsCallStacksEnabled { get; }
+
+        bool IsExceptionsEnabled { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IInProcessFeatures.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IInProcessFeatures.cs
@@ -6,5 +6,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     public interface IInProcessFeatures
     {
         bool IsCallStacksEnabled { get; }
+
+        bool IsExceptionsEnabled { get; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestExperimentalFlags.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TestExperimentalFlags.cs
@@ -6,5 +6,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
     internal sealed class TestExperimentalFlags : Microsoft.Diagnostics.Monitoring.WebApi.IExperimentalFlags
     {
         public bool IsCallStacksEnabled { get; set; }
+
+        public bool IsExceptionsEnabled { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/Experimental/ExperimentalFlags.cs
+++ b/src/Tools/dotnet-monitor/Experimental/ExperimentalFlags.cs
@@ -17,12 +17,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         // Feature flags
         public const string Feature_CallStacks = ExperimentalPrefix + nameof(Feature_CallStacks);
+        public const string Feature_Exceptions = ExperimentalPrefix + nameof(Feature_Exceptions);
 
         // Behaviors
         private const string EnabledTrueValue = "True";
         private const string EnabledOneValue = "1";
 
         private readonly Lazy<bool> _isCallStacksEnabledLazy = new Lazy<bool>(() => IsFeatureEnabled(Feature_CallStacks));
+
+        private readonly Lazy<bool> _isExceptionsEnabledLazy = new Lazy<bool>(() => IsFeatureEnabled(Feature_Exceptions));
 
         private static bool IsFeatureEnabled(string environmentVariable)
         {
@@ -33,5 +36,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         }
 
         public bool IsCallStacksEnabled => _isCallStacksEnabledLazy.Value;
+
+        public bool IsExceptionsEnabled => _isExceptionsEnabledLazy.Value;
     }
 }

--- a/src/Tools/dotnet-monitor/Experimental/ExperimentalStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/Experimental/ExperimentalStartupLogger.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             {
                 _logger.ExperimentalFeatureEnabled(Strings.FeatureName_CallStacks);
             }
+            if (_experimentalFlags.IsExceptionsEnabled)
+            {
+                _logger.ExperimentalFeatureEnabled(Strings.FeatureName_Exceptions);
+            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeatures.cs
+++ b/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeatures.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         }
 
         public bool IsCallStacksEnabled => _options.GetEnabled() && _experimentalFlags.IsCallStacksEnabled;
+
+        public bool IsExceptionsEnabled => _options.GetEnabled() && _experimentalFlags.IsExceptionsEnabled;
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -493,6 +493,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exceptions.
+        /// </summary>
+        internal static string FeatureName_Exceptions {
+            get {
+                return ResourceManager.GetString("FeatureName_Exceptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Monitor logs and metrics in a .NET application send the results to a chosen destination..
         /// </summary>
         internal static string HelpDescription_CommandCollect {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -354,6 +354,9 @@
   <data name="FeatureName_CallStacks" xml:space="preserve">
     <value>Call Stacks</value>
   </data>
+  <data name="FeatureName_Exceptions" xml:space="preserve">
+    <value>Exceptions</value>
+  </data>
   <data name="HelpDescription_CommandCollect" xml:space="preserve">
     <value>Monitor logs and metrics in a .NET application send the results to a chosen destination.</value>
     <comment>Gets the string to display in help that explains what the 'collect' command does.</comment>


### PR DESCRIPTION
###### Summary

Add an experimental feature flag for the exceptions feature. Note that the feature itself is not implemented yet; this should be added before any exception feature code is added to dotnet-monitor.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
