### PR TITLE
Fix docker tag opt-out variable and usage

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -47,9 +47,6 @@ variables:
   value: DotNetCore
 - name: _TPNFile
   value: THIRD-PARTY-NOTICES.TXT
-# Scheduled builds of main branch will be marked for update by dotnet-docker if this is true
-- name: NightlyUpdateDockerFromMain
-  value: true
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   # DotNet-Diagnostics-SDL-Params provides Tsa* variables for SDL checks.
@@ -141,7 +138,8 @@ stages:
 - template: /eng/pipelines/stages/preparerelease.yml
   parameters:
     ${{ if eq(parameters.updateDocker, 'true') }}:
-      updateDocker: true
+      updateDockerCondition: true
     ${{ else }}:
       # If scheduled build from main and nightly update from main enabled
-      updateDocker: ${{ and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['NightlyUpdateDockerFromMain'], 'true')) }}
+      updateDockerCondition: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['NightlyUpdateDockerFromMain'], 'true'))
+

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -1,7 +1,6 @@
 parameters:
-- name: updateDocker
-  displayName: 'Update dotnet-docker? (Only for release branches)'
-  type: boolean
+- name: updateDockerCondition
+  type: string
   default: false
 
 stages:
@@ -88,9 +87,10 @@ stages:
           inputs:
             type: 'Build'
             tags: 'MonitorRelease'
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.updateDocker, true)) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: tagBuildOrRelease@0
         displayName: 'Tag Build with update-docker'
+        condition: ${{ parameters.updateDockerCondition }}
         inputs:
           type: 'Build'
           tags: 'update-docker'


### PR DESCRIPTION
###### Summary

There were two issues regarding the `NightlyUpdateDockerFromMain` pipeline variable:
- Looking up the variable with template syntax (e.g. `${{ varaibles['NightlyUpdateDockerFromMain'] }}`) only takes that value at template compile time and doesn't consider the value at queue time. Thus the pipeline variable defined on the AzDO pipeline was ignored. I had to move to using runtime evaluation, hence the change to using it within a condition on the tagging task rather than using templating to exclude the task.
- Having the `NightlyUpdateDockerFromMain` variable declared in both the yaml pipeline and AzDO pipeline ignored the value from the AzDO pipeline. Even though the job would state that the value of the variable is what was set at queue time, the runtime evaluation of the variable would still be whatever it was set to in yaml. To fix this, remove the variable from the yaml pipeline.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
