### PR TITLE
Use branch name as message prefix for dependabot updates

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -10,6 +10,7 @@ updates:
       interval: "daily"
     target-branch: "main"
 #@ for branch in ["main", "release/8.x", "release/7.x", "release/7.0", "release/6.x"]:
+#@ commit_prefix = "[" + branch + "] "
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:
@@ -18,11 +19,15 @@ updates:
     ignore:
       - dependency-name: "Microsoft.Extensions.*"
         update-types: [ "version-update:semver-major" ]
+    commit-message:
+      prefix: #@ commit_prefix
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot/nuget.org"
     schedule:
       interval: "daily"
     target-branch: #@ branch
+    commit-message:
+      prefix: #@ commit_prefix
 #@ for tfm in ["net7.0", "net6.0", "netcoreapp3.1"]:
   - package-ecosystem: "nuget"
     directory: #@ "/eng/dependabot/" + tfm
@@ -32,5 +37,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+    commit-message:
+      prefix: #@ commit_prefix
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,15 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[main] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
     interval: daily
   target-branch: main
+  commit-message:
+    prefix: '[main] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -28,6 +32,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[main] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -37,6 +43,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[main] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -46,6 +54,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[main] '
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -55,11 +65,15 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/8.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
     interval: daily
   target-branch: release/8.x
+  commit-message:
+    prefix: '[release/8.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -69,6 +83,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/8.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -78,6 +94,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/8.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -87,6 +105,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/8.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -96,11 +116,15 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
     interval: daily
   target-branch: release/7.x
+  commit-message:
+    prefix: '[release/7.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -110,6 +134,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -119,6 +145,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -128,6 +156,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -137,11 +167,15 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.0] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
     interval: daily
   target-branch: release/7.0
+  commit-message:
+    prefix: '[release/7.0] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -151,6 +185,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.0] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -160,6 +196,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.0] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -169,6 +207,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/7.0] '
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -178,11 +218,15 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/6.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
     interval: daily
   target-branch: release/6.x
+  commit-message:
+    prefix: '[release/6.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -192,6 +236,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/6.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -201,6 +247,8 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/6.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -210,3 +258,5 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  commit-message:
+    prefix: '[release/6.x] '


### PR DESCRIPTION
###### Summary

Add branch prefix to commit messages for dependabot updates so its easier to discern which branch is being targeted.

Example PR update: https://github.com/jander-msft/dotnet-monitor/pull/66

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
