### PR TITLE
Use pool provider variables

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -43,6 +43,7 @@ parameters:
   default: false
 
 variables:
+- template: /eng/common/templates/variables/pool-providers.yml
 - name: _TeamName
   value: DotNetCore
 - name: _TPNFile
@@ -102,7 +103,7 @@ stages:
         - Pack_Sign
         publishUsingPipelines: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2019
 # These are the stages that perform validation of several SDL requirements and publish the bits required to the designated feed.
   - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/pipelines/dotnet-monitor-codeql.yml
+++ b/eng/pipelines/dotnet-monitor-codeql.yml
@@ -1,4 +1,5 @@
 variables:
+- template: /eng/common/templates/variables/pool-providers.yml
 - name: _TeamName
   value: DotNetCore
     

--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -10,6 +10,7 @@ parameters:
   default: true
 
 variables:
+- template: /eng/common/templates/variables/pool-providers.yml
 - name: _TeamName
   value: DotNetCore
   readonly: true
@@ -30,7 +31,7 @@ stages:
 - stage: Validation
 
   pool:
-    name: NetCore1ESPool-Internal
+    name: $(DncEngInternalBuildPool)
     demands: ImageOverride -equals 1es-windows-2019
 
   jobs:
@@ -94,7 +95,7 @@ stages:
   - Validation
 
   pool:
-    name: NetCore1ESPool-Internal
+    name: $(DncEngInternalBuildPool)
     demands: ImageOverride -equals 1es-windows-2019
 
   jobs:

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -47,12 +47,12 @@ jobs:
       # Public Linux Build Pool
       ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
       # Build OSX Pool
@@ -62,11 +62,11 @@ jobs:
       # Public Windows Build Pool
       ${{ if eq(parameters.osGroup, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64.open
 
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:

--- a/eng/pipelines/jobs/sign-binaries.yml
+++ b/eng/pipelines/jobs/sign-binaries.yml
@@ -8,7 +8,7 @@ jobs:
     name: Sign_Binaries
     displayName: Sign Binaries
     pool:
-      name: NetCore1ESPool-Internal
+      name: $(DncEngInternalBuildPool)
       demands: ImageOverride -equals 1es-windows-2019
     enableMicrobuild: true
     artifacts:

--- a/eng/pipelines/jobs/tpn.yml
+++ b/eng/pipelines/jobs/tpn.yml
@@ -6,7 +6,7 @@ jobs:
     disableComponentGovernance: true
     enableSbom: false
     pool:
-      name: NetCore1ESPool-Internal
+      name: $(DncEngInternalBuildPool)
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     # Only restore the dotnet-monitor project so only packages we ship get included in the below CG scan

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -14,10 +14,10 @@ stages:
     displayName: Prepare release with Darc
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore-Public
+        name: $(DncEngPublicBuildPool)
         demands: ImageOverride -equals 1es-windows-2019-open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Internal
+        name: $(DncEngInternalBuildPool)
         demands: ImageOverride -equals 1es-windows-2019
     variables:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:


### PR DESCRIPTION
###### Summary

Use pool provider variables from Arcade; this allows us to not have to update the pool names when merging between branches and forking branches.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
