### PR TITLE
Avoid duplicate entries from backports when generating release notes

### DIFF
--- a/.github/actions/generate-release-notes/index.js
+++ b/.github/actions/generate-release-notes/index.js
@@ -114,7 +114,7 @@ async function getPrsToMention(octokit, branch, repoOwner, repoName, minMergeDat
         }))?.data;
 
         let originNumber = pr.originNumber ?? pr.number;
-        if (commitHashesInRelease.has(fqPr.merge_commit_sha) && !mentionedUrls.has(originNumber)) {
+        if (commitHashesInRelease.has(fqPr.merge_commit_sha) && !mentionedOriginNumbers.has(originNumber)) {
             console.log(`Including: #${fqPr.number} -- origin:#${originNumber}`);
             mentionedOriginNumbers.add(originNumber);
             prs.push(pr);


### PR DESCRIPTION
###### Summary

With these changes, the following changelog is made for `release/8.x`:

```markdown
- Mark archives for shipping ([#3507](https://github.com/dotnet/dotnet-monitor/pull/3507))
- Add support for System.Diagnostics.Metrics ([#3479](https://github.com/dotnet/dotnet-monitor/pull/3479))
- Add Swagger UI to dotnet-monitor as the default endpoint. This will provide documentation of endpoints, and also the ability to use them. ([#3241](https://github.com/dotnet/dotnet-monitor/pull/3241))
- Add support for thread names stack artifacts. ([#2941](https://github.com/dotnet/dotnet-monitor/pull/2941))
- Add Metadata Support For Metrics ([#2939](https://github.com/dotnet/dotnet-monitor/pull/2939))
- Add Tags for API Requests ([#2919](https://github.com/dotnet/dotnet-monitor/pull/2919))
- Add support for gracefully stopping a requested trace on demand while also collecting rundown, via [Stop Operation](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/api/operations-stop.md). All artifact requests are now also recorded under the [Operations API](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/api/operations.md), regardless of if they have an egress provider specified. ([#2828](https://github.com/dotnet/dotnet-monitor/pull/2828))
- Handle exceptions when determining additional information about discovered processes. ([#2806](https://github.com/dotnet/dotnet-monitor/pull/2806))
- 🔬 Add support for [speedscope](https://speedscope.app) format when capturing stacks. ([#2795](https://github.com/dotnet/dotnet-monitor/pull/2795))
- Fixed an issue where AspNet* collection rules could stop functioning after collecting a trace with the Http profile. The fix was made in [dotnet/diagnostics#3425](https://github.com/dotnet/diagnostics/pull/3425). ([#2764](https://github.com/dotnet/dotnet-monitor/pull/2764))
- Change the default Garbage Collector mode to Workstation, except when running inside one of the official `dotnet monitor` docker images with more than 1 logical CPU core available. Learn more [here](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/configuration.md#garbage-collector-mode). ([#2729](https://github.com/dotnet/dotnet-monitor/pull/2729))
- Add the option to specify a `StoppingEvent` on the `CollectTrace` action. The trace will be stopped once either the duration is reached or the specified event occurs. ([#2557](https://github.com/dotnet/dotnet-monitor/pull/2557))
- Add support of egress provider to deliver data to a S3 storage ([#2016](https://github.com/dotnet/dotnet-monitor/pull/2016))

```

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
