### PR TITLE
Fix release notes entry regex

### DIFF
--- a/.github/actions/generate-release-notes/index.js
+++ b/.github/actions/generate-release-notes/index.js
@@ -149,7 +149,7 @@ async function generateChangelog(octokit, branch, repoOwner, repoName, minMergeD
             entry += ` ${significantLabels[index].moniker}`;
         }
 
-        const changelogRegex=/^###### Release Notes Entry\s*(?<releaseNotesEntry>.*)/m
+        const changelogRegex=/^###### Release Notes Entry\s+(?<releaseNotesEntry>.*)/m
         const userDefinedChangelogEntry = pr.body?.match(changelogRegex)?.groups?.releaseNotesEntry?.trim();
         if (userDefinedChangelogEntry !== undefined && userDefinedChangelogEntry.length !== 0) {
             entry += ` ${userDefinedChangelogEntry}`


### PR DESCRIPTION
###### Summary

Some release note entries in PRs contained additional whitespace before the entry text, resulting in it not being captured and falling back to the PR title. Correct the regex we use to handle this.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
