### PR TITLE
Automatically Solicit Feedback From First-Time Issues

### DIFF
--- a/.github/workflows/respond_to_first_issue.yml
+++ b/.github/workflows/respond_to_first_issue.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types:
       - opened
+
+permissions:
+  issues: write
+
 jobs:
   check-if-new-user:
     runs-on: ubuntu-latest
@@ -13,4 +17,4 @@ jobs:
       - uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "## Welcome to dotnet-monitor!\nThanks for creating your first issue; let us know what you think of dotnet-monitor by filling out our [survey](https://aka.ms/dotnet-monitor-survey)."
+          issue-message: "## Welcome to dotnet-monitor!\nThanks for creating your first issue; let us know what you think of dotnet-monitor by filling out our [survey](https://aka.ms/dotnet-monitor-survey?src=firstissue)."

--- a/.github/workflows/respond_to_first_issue.yml
+++ b/.github/workflows/respond_to_first_issue.yml
@@ -1,0 +1,16 @@
+name: Respond To First Issue
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  check-if-new-user:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "## Welcome to dotnet-monitor!\nThanks for creating your first issue; let us know what you think of dotnet-monitor by filling out our [survey](https://aka.ms/dotnet-monitor-survey)."

--- a/.github/workflows/respond_to_first_issue.yml
+++ b/.github/workflows/respond_to_first_issue.yml
@@ -11,9 +11,6 @@ jobs:
   check-if-new-user:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
###### Summary

Mark and I were chatting yesterday about ways to engage more with users, and one of the things we talked about was finding a way to get more feedback through our surveys. As opposed to having a passive survey link in our docs that gets skimmed over, we meet users where they are by asking them for feedback when they've demonstrated a desire to interact with us (i.e. creating an issue). Having a bot automatically create a comment should hopefully improve our survey's CTR, and this message is only presented for someone's first issue (to prevent it from becoming spam). Here's an example of Mark trying it on my fork: https://github.com/kkeirstead/dotnet-monitor/issues/150


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
