### PR TITLE
No longer publish nupkg to blob feeds

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -12,10 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" IsShipping="true" />
     <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.tar.gz" IsShipping="true" />
     <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.zip" IsShipping="true" />
-    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.tar.gz" IsShipping="false" />
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.zip" IsShipping="false" />
   </ItemGroup>
@@ -137,7 +135,6 @@
 
     <!-- Package artifact file paths -->
     <PropertyGroup>
-      <!-- Example nupkg file name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg -->
       <!-- Example archive file name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip -->
       <_PackageWithBuildVersionFileName>@(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFileName>
       <_PackageWithBuildVersionFilePath>%(PackageToPublish.RootDir)%(PackageToPublish.Directory)$(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFilePath>
@@ -148,7 +145,6 @@
 
     <!--
       A file that contains the version of the package.
-      Example nupkg name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.version
       Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.version
       -->
     <WriteLinesToFile File="$(_PackageVersionFilePath)"
@@ -158,7 +154,6 @@
     <!--
       A file that contains the build version of the package. The name of this file contains the build
       version in order to avoid collisions when uploaded to blob storage.
-      Example nupkg name: dotnet-monitor.7.0.0-rtm.12345.6.nupkg.buildversion
       Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.buildversion
       -->
     <WriteLinesToFile File="$(_BuildVersionFilePath)"
@@ -168,11 +163,6 @@
     <!-- Calculate manifest artifact data for each file type. -->
     <ItemGroup>
       <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageToPublish.IsShipping)' != 'true'" />
-    </ItemGroup>
-    <ItemGroup>
-      <_PackageArtifactData Include="@(_CommonArtifactData)" />
-      <!-- Set Category to OTHER so that nupkgs are also published to blob storage. -->
-      <_PackageArtifactData Include="Category=OTHER" Condition="'%(PackageToPublish.Extension)' == '.nupkg'" />
     </ItemGroup>
 
     <!-- Capture items that need to be published under the blob group. -->
@@ -190,10 +180,8 @@
       <_VersionContainerBlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_VersionContainerBlobItem>
-      <!-- Publish the nupkg as a blob in addition to their normal publishing mechanism
-           so that they can be retrieved from a stable location. -->
       <_VersionContainerBlobItem Include="%(PackageToPublish.FullPath)" Condition="Exists('%(PackageToPublish.FullPath)')" >
-        <ManifestArtifactData Condition="'@(_PackageArtifactData)' != ''">@(_PackageArtifactData)</ManifestArtifactData>
+        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_VersionContainerBlobItem>
     </ItemGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -12,14 +12,6 @@
   </ItemGroup>
 
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
-  <Target Name="GenerateNuGetPackageProjectFiles"
-          AfterTargets="Pack"
-          Condition="'$(DisableCustomBlobStoragePublishing)' != 'true' and '$(IsPackable)' == 'true'">
-    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.projectpath"
-                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
-                      Overwrite="true" />
-  </Target>
   <Target Name="GenerateArchivePackageProjectFiles"
           AfterTargets="_CreateArchive"
           Condition="'$(DisableCustomBlobStoragePublishing)' != 'true' and '$(IsArchivable)' == 'true'">
@@ -60,7 +52,6 @@
   <Target Name="GetPackageFileName"
           Returns="@(PackageFileName)">
     <ItemGroup>
-      <PackageFileName Include="$(PackageId).$(PackageVersion).nupkg" Condition="'$(IsPackable)' == 'true'" />
       <!-- The archive targets use Version instead of PackageVersion; do the same to be consistent. -->
       <PackageFileName Include="$(ArchiveName)-$(Version)-$(RuntimeIdentifier).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' != 'true' " />
       <!-- Symbols archive names reverse the order of the version and runtime identifier compared to the product archive. -->


### PR DESCRIPTION
###### Summary

With the usage of the archives in the dotnet-docker images, the nupkgs no longer need to be publshed to blob storage since there are no remaining scenarios that acquire them via blob storage. Anything else should be using either `dotnet tool`, the dotnet-tools feed, or the darc-pub-*/darc-int-* feeds for final releases.

Here's a diff of the relevant sections of the assert manifest for a build before and after the change.

```diff
<Build>
...
-    <Blob Id="diagnostics/monitor/7.1.0-rtm.23109.6/dotnet-monitor.7.1.0.nupkg" Category="OTHER" />
-    <Blob Id="diagnostics/monitor/7.1.0-rtm.23109.6/dotnet-monitor.7.1.0.nupkg.sha512" />
-    <Blob Id="diagnostics/monitor/7.1.0-rtm.23109.6/Microsoft.Diagnostics.Monitoring.WebApi.7.1.0-rtm.23109.6.nupkg" Category="OTHER" NonShipping="true" />
-    <Blob Id="diagnostics/monitor/7.1.0-rtm.23109.6/Microsoft.Diagnostics.Monitoring.WebApi.7.1.0-rtm.23109.6.nupkg.sha512" NonShipping="true" />
...
-    <Blob Id="diagnostics/monitor7.1/release/dotnet-monitor.7.1.0-rtm.23109.6.nupkg.buildversion" />
-    <Blob Id="diagnostics/monitor7.1/release/dotnet-monitor.7.1.0-rtm.23109.6.nupkg.version" />
-    <Blob Id="diagnostics/monitor7.1/release/Microsoft.Diagnostics.Monitoring.WebApi.7.1.0-rtm.23109.6.nupkg.buildversion" NonShipping="true" />
-    <Blob Id="diagnostics/monitor7.1/release/Microsoft.Diagnostics.Monitoring.WebApi.7.1.0-rtm.23109.6.nupkg.version" NonShipping="true" />
...
</Build>
```

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2109654&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
