### PR TITLE
Fix GetBuildVersion script

### DIFF
--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -19,7 +19,7 @@ Write-Verbose 'ReleaseData:'
 $releaseDataJson = $releaseData | ConvertTo-Json
 Write-Verbose $releaseDataJson
 
-[array]$matchingData = $releaseData | Where-Object { $_.name -match '.nupkg.buildversion$' }
+[array]$matchingData = $releaseData | Where-Object { $_.name -match '.nupkg.buildversion$' -and $_.nonShipping -ieq 'false' }
 
 if ($matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'


### PR DESCRIPTION
###### Summary

Now that non-shipping assets are included in the publishing to the Build Asset Registry, they appear in assets for the build. Need to filter out non-shipping assets before determining the build version.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
