### PR TITLE
Use MergeManifest to lookup build version

### DIFF
--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -19,7 +19,7 @@ Write-Verbose 'ReleaseData:'
 $releaseDataJson = $releaseData | ConvertTo-Json
 Write-Verbose $releaseDataJson
 
-[array]$matchingData = $releaseData | Where-Object { $_.name -match '.nupkg.buildversion$' -and $_.nonShipping -ieq 'false' }
+[array]$matchingData = $releaseData | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping -ieq 'true' }
 
 if ($matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'


### PR DESCRIPTION
###### Summary

In #3645, the *.nupkg.* files will no longer be produced. Update the `GetBuildVersion.ps1` script to use the `MergeManifest.xml` file from the build; there should only ever be one of these and it should never be marked as shipping, thus it should have the build version rather than the final product version.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
