### PR TITLE
Update RID support to match dotnet-monitor

### DIFF
--- a/src/Extensions/Directory.Build.props
+++ b/src/Extensions/Directory.Build.props
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64;osx-x64;linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(SignOnlyRuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
###### Summary

Update the RID specifications for extensions to match dotnet-monitor.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2116266&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
