### PR TITLE
Fix build info gathering

### DIFF
--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -42,13 +42,14 @@ jobs:
         /p:DotNetPublishUsingPipelines=true
         /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
       displayName: Pack, Sign, and Publish
+    # Intentionally copying file as "dotnet-monitor.nupkg.buildversion" for back compat
     - task: powershell@2
       displayName: Generate Build Info
       inputs:
         targetType: inline
         script: |
             New-Item "$(Build.ArtifactStagingDirectory)/buildInfo" -Type Directory
-            Copy-Item "$(Build.SourcesDirectory)/artifacts/packages/Release/Shipping/dotnet-monitor.*.nupkg.buildversion" "$(Build.ArtifactStagingDirectory)/buildInfo/dotnet-monitor.nupkg.buildversion"
+            Copy-Item "$(Build.SourcesDirectory)/artifacts/packages/Release/Shipping/dotnet-monitor-*-win-x64.zip.buildversion" "$(Build.ArtifactStagingDirectory)/buildInfo/dotnet-monitor.nupkg.buildversion"
     - task: PublishPipelineArtifact@1
       displayName: Publish Build Info
       inputs:


### PR DESCRIPTION
###### Summary

Fix pipeline step that copies a buildversion file to use one that exists. The *.nupkg.buildversion file no longer exists because nupkg are no longer published to blob storage.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
