### PR TITLE
Reenable AspNetResponseStatusTest test

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OverlappingEventSourceTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Validates that an AspNetResponseStatus trigger will fire following an HTTP trace.
         /// </summary>
-        [Theory(Skip = "https://github.com/dotnet/dotnet-monitor/issues/2762")]
+        [Theory]
         [InlineData(DiagnosticPortConnectionMode.Listen)]
         public async Task OverlappingEventSourceTests_AspNetResponseStatusTest(DiagnosticPortConnectionMode mode)
         {


### PR DESCRIPTION
###### Summary

Seems to no longer repo due to fixes in #2914

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2119826&view=results

closes #2762

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
