### PR TITLE
Skip checking markdown links for dotnetfoundation.org

### DIFF
--- a/.github/linters/check-markdown-links-config.json
+++ b/.github/linters/check-markdown-links-config.json
@@ -8,6 +8,9 @@
         },
         {
             "pattern": "^https://pkgs\\.dev\\.azure\\.com/dnceng/public/_packaging/.*"
+        },
+        {
+            "pattern": "^https://www\\.dotnetfoundation.org/.*"
         }
     ],
     "aliveStatusCodes": [


### PR DESCRIPTION
###### Summary

Our PR gate is consistently failing on dotnetfoundation.org/projects, ignore `dotnetfoundation.org` to fix the gate.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
