### PR TITLE
Skip dependabot updates on release/8.x

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
-#@ for branch in ["main", "release/8.x", "release/7.x", "release/7.0", "release/6.x"]:
+#@ for branch in ["main", "release/7.x", "release/7.0", "release/6.x"]:
 #@ commit_prefix = "[" + branch + "] "
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,57 +60,6 @@ updates:
   directory: /eng/dependabot
   schedule:
     interval: daily
-  target-branch: release/8.x
-  ignore:
-  - dependency-name: Microsoft.Extensions.*
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/8.x] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/nuget.org
-  schedule:
-    interval: daily
-  target-branch: release/8.x
-  commit-message:
-    prefix: '[release/8.x] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net7.0
-  schedule:
-    interval: daily
-  target-branch: release/8.x
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/8.x] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net6.0
-  schedule:
-    interval: daily
-  target-branch: release/8.x
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/8.x] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/netcoreapp3.1
-  schedule:
-    interval: daily
-  target-branch: release/8.x
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/8.x] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot
-  schedule:
-    interval: daily
   target-branch: release/7.x
   ignore:
   - dependency-name: Microsoft.Extensions.*


### PR DESCRIPTION
###### Summary

We are still regularly merging main into `release/8.x`, so `main` dependency updates will still reach `release/8.x`


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
