### PR TITLE
Basic exceptions store and route for default process

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1150,6 +1150,40 @@
         }
       }
     },
+    "/exceptions": {
+      "get": {
+        "tags": [
+          "Exceptions"
+        ],
+        "summary": "Gets the exceptions from the default process.",
+        "operationId": "GetExceptions",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/BadRequestResponse"
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/x-ndjson": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json-seq": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/metrics": {
       "get": {
         "tags": [

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             // Do not populate the cache or send via the EventSource until
             // a listener is active; otherwise, the listener will not receive the identifiers
             // for types/methods/modules/etc prior to listening to the event source. This
-            // means that exception at startup are likely to be dropped if the listener was
+            // means that exceptions at startup are likely to be dropped if the listener was
             // not registered during the diagnostic startup suspension point.
             // CONSIDER: Possible improvement is to cache the information and then send off
             // the events once the listener is registered to effectively "catch up".

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
+{
+    [Route("")]
+    [ApiController]
+    [HostRestriction]
+    [Authorize(Policy = AuthConstants.PolicyName)]
+    [ProducesErrorResponseType(typeof(ValidationProblemDetails))]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public sealed class ExceptionsController : ControllerBase
+    {
+        private readonly IExceptionsStore _exceptionsStore;
+        private readonly IInProcessFeatures _inProcessFeatures;
+        private readonly IExceptionsOperationFactory _operationFactory;
+
+        public ExceptionsController(IServiceProvider serviceProvider)
+        {
+            // The exceptions store for the default process
+            _exceptionsStore = serviceProvider.GetRequiredService<IExceptionsStore>();
+            _inProcessFeatures = serviceProvider.GetRequiredService<IInProcessFeatures>();
+            _operationFactory = serviceProvider.GetRequiredService<IExceptionsOperationFactory>();
+        }
+
+        /// <summary>
+        /// Gets the exceptions from the default process.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("exceptions", Name = nameof(GetExceptions))]
+        [ProducesWithProblemDetails(ContentTypes.ApplicationNdJson, ContentTypes.ApplicationJsonSequence, ContentTypes.TextPlain)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [EgressValidation]
+        public ActionResult GetExceptions()
+        {
+            if (!_inProcessFeatures.IsExceptionsEnabled)
+            {
+                return NotFound();
+            }
+
+            ExceptionsFormat? format = ComputeFormat(Request.GetTypedHeaders().Accept);
+            if (!format.HasValue)
+            {
+                return this.NotAcceptable();
+            }
+
+            IArtifactOperation operation = _operationFactory.Create(_exceptionsStore, format.Value);
+
+            return new OutputStreamResult(operation);
+        }
+
+        private static ExceptionsFormat? ComputeFormat(IList<MediaTypeHeaderValue> acceptedHeaders)
+        {
+            if (acceptedHeaders == null || acceptedHeaders.Count == 0)
+            {
+                return null;
+            }
+
+            if (acceptedHeaders.Contains(ContentTypeUtilities.TextPlainHeader))
+            {
+                return ExceptionsFormat.PlainText;
+            }
+            if (acceptedHeaders.Contains(ContentTypeUtilities.NdJsonHeader))
+            {
+                return ExceptionsFormat.NewlineDelimitedJson;
+            }
+            if (acceptedHeaders.Contains(ContentTypeUtilities.JsonSequenceHeader))
+            {
+                return ExceptionsFormat.JsonSequence;
+            }
+            if (acceptedHeaders.Any(ContentTypeUtilities.TextPlainHeader.IsSubsetOf))
+            {
+                return ExceptionsFormat.PlainText;
+            }
+            if (acceptedHeaders.Any(ContentTypeUtilities.NdJsonHeader.IsSubsetOf))
+            {
+                return ExceptionsFormat.NewlineDelimitedJson;
+            }
+            if (acceptedHeaders.Any(ContentTypeUtilities.JsonSequenceHeader.IsSubsetOf))
+            {
+                return ExceptionsFormat.JsonSequence;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         /// <summary>
         /// Gets the exceptions from the default process.
         /// </summary>
-        /// <returns></returns>
         [HttpGet("exceptions", Name = nameof(GetExceptions))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationNdJson, ContentTypes.ApplicationJsonSequence, ContentTypes.TextPlain)]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
-    internal record class ExceptionInstance(string TypeName, string Message)
+    internal record class ExceptionInstance(string TypeName, string ModuleName, string Message)
         : IExceptionInstance
     {
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
+{
+    internal record class ExceptionInstance(string TypeName, string Message)
+        : IExceptionInstance
+    {
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsFormat.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsFormat.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
+{
+    internal enum ExceptionsFormat
+    {
+        NewlineDelimitedJson = 1,
+        PlainText = 2,
+        JsonSequence = 3
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
+{
+    internal interface IExceptionInstance
+    {
+        string Message { get; }
+
+        string TypeName { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
     {
         string Message { get; }
 
+        string ModuleName { get; }
+
         string TypeName { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
     {
         void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message);
 
-        IEnumerable<IExceptionInstance> GetSnapshot();
+        IReadOnlyList<IExceptionInstance> GetSnapshot();
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
@@ -1,10 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
     internal interface IExceptionsStore
     {
         void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message);
+
+        IEnumerable<IExceptionInstance> GetSnapshot();
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IExceptionsOperationFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IExceptionsOperationFactory.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    /// <summary>
+    /// Factory for creating operations that capture exceptions from the target.
+    /// </summary>
+    internal interface IExceptionsOperationFactory
+    {
+        /// <summary>
+        /// Creates an operation that produces an exceptions artifact.
+        /// </summary>
+        IArtifactOperation Create(IExceptionsStore store, ExceptionsFormat format);
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _scope = scope;
         }
 
+        public OutputStreamResult(IArtifactOperation operation)
+            : this(operation.ExecuteAsync, operation.ContentType, fileDownloadName: null, new KeyValueLogScope())
+        {
+        }
+
         public OutputStreamResult(IArtifactOperation operation, string fileDownloadName, KeyValueLogScope scope)
             : this(operation.ExecuteAsync, operation.ContentType, fileDownloadName, scope)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 }
             }
 
-            public IEnumerable<IExceptionInstance> GetSnapshot()
+            public IReadOnlyList<IExceptionInstance> GetSnapshot()
             {
                 throw new NotSupportedException();
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -226,7 +226,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 }
             }
 
-            public sealed record class ExceptionInstance(ulong ExceptionId, string TypeName, string Message, string ThrowingMethodName);
+            public IEnumerable<IExceptionInstance> GetSnapshot()
+            {
+                return Instances;
+            }
+
+            public sealed record class ExceptionInstance(ulong ExceptionId, string TypeName, string Message, string ThrowingMethodName) :
+                IExceptionInstance
+            {
+            }
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -228,11 +228,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             public IEnumerable<IExceptionInstance> GetSnapshot()
             {
-                return Instances;
+                throw new NotSupportedException();
             }
 
-            public sealed record class ExceptionInstance(ulong ExceptionId, string TypeName, string Message, string ThrowingMethodName) :
-                IExceptionInstance
+            public sealed record class ExceptionInstance(ulong ExceptionId, string TypeName, string Message, string ThrowingMethodName)
             {
             }
         }

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 services.AddSingleton<ProfilerChannel>();
                 services.ConfigureCollectionRules();
                 services.ConfigureProfiler();
+                services.ConfigureExceptions();
                 services.ConfigureStartupLoggers(authConfigurator);
                 services.AddSingleton<IExperimentalFlags, ExperimentalFlags>();
                 services.ConfigureInProcessFeatures(context.Configuration);

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using Microsoft.Diagnostics.Monitoring;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
+{
+    internal sealed class ExceptionsOperation : IArtifactOperation
+    {
+        private static byte[] JsonRecordDelimiter = new byte[] { (byte)'\n' };
+
+        private static byte[] JsonSequenceRecordSeparator = new byte[] { 0x1E };
+
+        private readonly ExceptionsFormat _format;
+        private readonly IExceptionsStore _store;
+
+        public ExceptionsOperation(IExceptionsStore store, ExceptionsFormat format)
+        {
+            _store = store;
+            _format = format;
+        }
+
+        public string ContentType => _format switch
+        {
+            ExceptionsFormat.PlainText => ContentTypes.TextPlain,
+            ExceptionsFormat.NewlineDelimitedJson => ContentTypes.ApplicationNdJson,
+            ExceptionsFormat.JsonSequence => ContentTypes.ApplicationJsonSequence,
+            _ => ContentTypes.TextPlain
+        };
+
+        public bool IsStoppable => false;
+
+        public async Task ExecuteAsync(Stream outputStream, TaskCompletionSource<object> startCompletionSource, CancellationToken token)
+        {
+            startCompletionSource?.TrySetResult(null);
+
+
+            IEnumerable<IExceptionInstance> exceptions = _store.GetSnapshot();
+
+            switch (_format)
+            {
+                case ExceptionsFormat.JsonSequence:
+                case ExceptionsFormat.NewlineDelimitedJson:
+                    await WriteJson(outputStream, exceptions, token);
+                    break;
+                case ExceptionsFormat.PlainText:
+                    await WriteText(outputStream, exceptions, token);
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public string GenerateFileName()
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task StopAsync(CancellationToken token)
+        {
+            throw new MonitoringException(Strings.ErrorMessage_OperationIsNotStoppable);
+        }
+
+        private async Task WriteJson(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
+        {
+            foreach (IExceptionInstance instance in instances)
+            {
+                await WriteJsonInstance(stream, instance, token);
+            }
+        }
+
+        private async Task WriteJsonInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
+        {
+            if (_format == ExceptionsFormat.JsonSequence)
+            {
+                await stream.WriteAsync(JsonSequenceRecordSeparator, token);
+            }
+
+            await using (Utf8JsonWriter writer = new(stream, new JsonWriterOptions() { Indented = false }))
+            {
+                writer.WriteStartObject();
+                writer.WriteString("typeName", instance.TypeName);
+                writer.WriteString("moduleName", instance.ModuleName);
+                writer.WriteString("message", instance.Message);
+                writer.WriteEndObject();
+            }
+
+            await stream.WriteAsync(JsonRecordDelimiter, token);
+        }
+
+        private static async Task WriteText(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
+        {
+            foreach (IExceptionInstance instance in instances)
+            {
+                await WriteTextInstance(stream, instance, token);
+            }
+        }
+
+        private static async Task WriteTextInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
+        {
+            // This format is similar of that which is written to the console when an unhandled exception occurs. Each
+            // exception will appear as:
+
+            // First chance exception. <TypeName>: <Message>
+
+            await using StreamWriter writer = new(stream, leaveOpen: true);
+
+            await writer.WriteAsync("First chance exception. ");
+            await writer.WriteAsync(instance.TypeName);
+            await writer.WriteAsync(": ");
+            await writer.WriteLineAsync(instance.Message);
+            await writer.FlushAsync();
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -1,15 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.IO;
-using System.Text.Json;
-using System.Threading.Tasks;
-using System.Threading;
-using System;
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 {

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 {
                     writer.WriteStartObject();
                     writer.WriteString("typeName", instance.TypeName);
+                    writer.WriteString("moduleName", instance.ModuleName);
                     writer.WriteString("message", instance.Message);
                     writer.WriteEndObject();
                 }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
+{
+    public sealed class ExceptionsOperationFactory : IExceptionsOperationFactory
+    {
+        IArtifactOperation IExceptionsOperationFactory.Create(IExceptionsStore store, ExceptionsFormat format)
+        {
+            return new ExceptionsOperation(store, format);
+        }
+
+        private sealed class ExceptionsOperation : IArtifactOperation
+        {
+            private static byte[] JsonRecordDelimiter = new byte[] { (byte)'\n' };
+
+            private static byte[] JsonSequenceRecordSeparator = new byte[] { 0x1E };
+
+            private readonly ExceptionsFormat _format;
+            private readonly IExceptionsStore _store;
+
+            public ExceptionsOperation(IExceptionsStore store, ExceptionsFormat format)
+            {
+                _store = store;
+                _format = format;
+            }
+
+            public string ContentType => _format switch
+            {
+                ExceptionsFormat.PlainText => ContentTypes.TextPlain,
+                ExceptionsFormat.NewlineDelimitedJson => ContentTypes.ApplicationNdJson,
+                ExceptionsFormat.JsonSequence => ContentTypes.ApplicationJsonSequence,
+                _ => ContentTypes.TextPlain
+            };
+
+            public bool IsStoppable => false;
+
+            public async Task ExecuteAsync(Stream outputStream, TaskCompletionSource<object> startCompletionSource, CancellationToken token)
+            {
+                startCompletionSource?.TrySetResult(null);
+
+
+                IEnumerable<IExceptionInstance> exceptions = _store.GetSnapshot();
+
+                switch (_format)
+                {
+                    case ExceptionsFormat.JsonSequence:
+                    case ExceptionsFormat.NewlineDelimitedJson:
+                        await WriteJson(outputStream, exceptions, token);
+                        break;
+                    case ExceptionsFormat.PlainText:
+                        await WriteText(outputStream, exceptions, token);
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            public string GenerateFileName()
+            {
+                throw new NotSupportedException();
+            }
+
+            public Task StopAsync(CancellationToken token)
+            {
+                throw new MonitoringException(Strings.ErrorMessage_OperationIsNotStoppable);
+            }
+
+            private async Task WriteJson(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
+            {
+                foreach (IExceptionInstance instance in instances)
+                {
+                    await WriteJsonInstance(stream, instance, token);
+                }
+            }
+
+            private async Task WriteJsonInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
+            {
+                if (_format == ExceptionsFormat.JsonSequence)
+                {
+                    await stream.WriteAsync(JsonSequenceRecordSeparator, token);
+                }
+
+                await using (Utf8JsonWriter writer = new(stream, new JsonWriterOptions() { Indented = false }))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("typeName", instance.TypeName);
+                    writer.WriteString("message", instance.Message);
+                    writer.WriteEndObject();
+                }
+
+                await stream.WriteAsync(JsonRecordDelimiter, token);
+            }
+
+            private static async Task WriteText(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
+            {
+                foreach (IExceptionInstance instance in instances)
+                {
+                    await WriteTextInstance(stream, instance, token);
+                }
+            }
+
+            private static async Task WriteTextInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
+            {
+                // This format is similar of that which is written to the console when an unhandled exception occurs. Each
+                // exception will appear as:
+
+                // First chance exception. <TypeName>: <Message>
+
+                await using StreamWriter writer = new(stream, leaveOpen: true);
+
+                await writer.WriteAsync("First chance exception. ");
+                await writer.WriteAsync(instance.TypeName);
+                await writer.WriteAsync(": ");
+                await writer.WriteLineAsync(instance.Message);
+                await writer.FlushAsync();
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
@@ -13,9 +13,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 {
-    public sealed class ExceptionsOperationFactory : IExceptionsOperationFactory
+    internal sealed class ExceptionsOperationFactory : IExceptionsOperationFactory
     {
-        IArtifactOperation IExceptionsOperationFactory.Create(IExceptionsStore store, ExceptionsFormat format)
+        public IArtifactOperation Create(IExceptionsStore store, ExceptionsFormat format)
         {
             return new ExceptionsOperation(store, format);
         }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperationFactory.cs
@@ -1,15 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 {
@@ -18,114 +11,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
         public IArtifactOperation Create(IExceptionsStore store, ExceptionsFormat format)
         {
             return new ExceptionsOperation(store, format);
-        }
-
-        private sealed class ExceptionsOperation : IArtifactOperation
-        {
-            private static byte[] JsonRecordDelimiter = new byte[] { (byte)'\n' };
-
-            private static byte[] JsonSequenceRecordSeparator = new byte[] { 0x1E };
-
-            private readonly ExceptionsFormat _format;
-            private readonly IExceptionsStore _store;
-
-            public ExceptionsOperation(IExceptionsStore store, ExceptionsFormat format)
-            {
-                _store = store;
-                _format = format;
-            }
-
-            public string ContentType => _format switch
-            {
-                ExceptionsFormat.PlainText => ContentTypes.TextPlain,
-                ExceptionsFormat.NewlineDelimitedJson => ContentTypes.ApplicationNdJson,
-                ExceptionsFormat.JsonSequence => ContentTypes.ApplicationJsonSequence,
-                _ => ContentTypes.TextPlain
-            };
-
-            public bool IsStoppable => false;
-
-            public async Task ExecuteAsync(Stream outputStream, TaskCompletionSource<object> startCompletionSource, CancellationToken token)
-            {
-                startCompletionSource?.TrySetResult(null);
-
-
-                IEnumerable<IExceptionInstance> exceptions = _store.GetSnapshot();
-
-                switch (_format)
-                {
-                    case ExceptionsFormat.JsonSequence:
-                    case ExceptionsFormat.NewlineDelimitedJson:
-                        await WriteJson(outputStream, exceptions, token);
-                        break;
-                    case ExceptionsFormat.PlainText:
-                        await WriteText(outputStream, exceptions, token);
-                        break;
-                    default:
-                        throw new NotSupportedException();
-                }
-            }
-
-            public string GenerateFileName()
-            {
-                throw new NotSupportedException();
-            }
-
-            public Task StopAsync(CancellationToken token)
-            {
-                throw new MonitoringException(Strings.ErrorMessage_OperationIsNotStoppable);
-            }
-
-            private async Task WriteJson(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
-            {
-                foreach (IExceptionInstance instance in instances)
-                {
-                    await WriteJsonInstance(stream, instance, token);
-                }
-            }
-
-            private async Task WriteJsonInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
-            {
-                if (_format == ExceptionsFormat.JsonSequence)
-                {
-                    await stream.WriteAsync(JsonSequenceRecordSeparator, token);
-                }
-
-                await using (Utf8JsonWriter writer = new(stream, new JsonWriterOptions() { Indented = false }))
-                {
-                    writer.WriteStartObject();
-                    writer.WriteString("typeName", instance.TypeName);
-                    writer.WriteString("moduleName", instance.ModuleName);
-                    writer.WriteString("message", instance.Message);
-                    writer.WriteEndObject();
-                }
-
-                await stream.WriteAsync(JsonRecordDelimiter, token);
-            }
-
-            private static async Task WriteText(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
-            {
-                foreach (IExceptionInstance instance in instances)
-                {
-                    await WriteTextInstance(stream, instance, token);
-                }
-            }
-
-            private static async Task WriteTextInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
-            {
-                // This format is similar of that which is written to the console when an unhandled exception occurs. Each
-                // exception will appear as:
-
-                // First chance exception. <TypeName>: <Message>
-
-                await using StreamWriter writer = new(stream, leaveOpen: true);
-
-                await writer.WriteAsync("First chance exception. ");
-                await writer.WriteAsync(instance.TypeName);
-                await writer.WriteAsync(": ");
-                await writer.WriteLineAsync(instance.Message);
-                await writer.FlushAsync();
-            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
+{
+    /// <summary>
+    /// Get exception information from default process and store it.
+    /// </summary>
+    internal sealed class ExceptionsService :
+        BackgroundService
+    {
+        private readonly IExceptionsStore _exceptionsStore;
+        private readonly IDiagnosticServices _diagnosticServices;
+        private readonly IInProcessFeatures _inProcessFeatures;
+
+        private EventExceptionsPipeline _pipeline;
+
+        public ExceptionsService(
+            IDiagnosticServices diagnosticServices,
+            IInProcessFeatures inProcessFeatures,
+            IExceptionsStore exceptionsStore)
+        {
+            _diagnosticServices = diagnosticServices;
+            _exceptionsStore = exceptionsStore;
+            _inProcessFeatures = inProcessFeatures;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (!_inProcessFeatures.IsExceptionsEnabled)
+            {
+                return;
+            }
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Get default process
+                    IProcessInfo pi = await _diagnosticServices.GetProcessAsync(processKey: null, stoppingToken);
+                    DiagnosticsClient client = new(pi.EndpointInfo.Endpoint);
+
+                    EventExceptionsPipelineSettings settings = new();
+                    _pipeline = new EventExceptionsPipeline(client, settings, _exceptionsStore);
+
+                    // Monitor for exceptions
+                    await _pipeline.RunAsync(stoppingToken);
+                }
+                catch (Exception e) when (e is not OperationCanceledException || !stoppingToken.IsCancellationRequested)
+                {
+                    if (null != _pipeline)
+                    {
+                        await _pipeline.DisposeAsync();
+                    }
+                    await Task.Delay(5000, stoppingToken);
+                }
+            }
+        }
+
+        public override async void Dispose()
+        {
+            base.Dispose();
+            if (null != _pipeline)
+            {
+                await _pipeline.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
     internal sealed class ExceptionsService :
         BackgroundService
     {
+        private readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(5);
+
         private readonly IExceptionsStore _exceptionsStore;
         private readonly IDiagnosticServices _diagnosticServices;
         private readonly IInProcessFeatures _inProcessFeatures;
@@ -60,7 +62,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                     {
                         await _pipeline.DisposeAsync();
                     }
-                    await Task.Delay(5000, stoppingToken);
+                    await Task.Delay(RetryDelay, stoppingToken);
                 }
             }
         }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         private static Channel<ExceptionInstanceEntry> CreateChannel()
         {
-            // TODO: Hook callback for when items are dropped an report appropriately.
+            // TODO: Hook callback for when items are dropped and report appropriately.
             return Channel.CreateBounded<ExceptionInstanceEntry>(
                 new BoundedChannelOptions(capacity: 1000)
                 {
@@ -96,9 +96,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         exceptionTypeName = _builder.ToString();
                     }
 
+                    string moduleName = string.Empty;
+                    if (entry.Cache.NameCache.ClassData.TryGetValue(exceptionClassId, out ClassData exceptionClassData))
+                    {
+                        moduleName = NameFormatter.GetModuleName(entry.Cache.NameCache, exceptionClassData.ModuleId);
+                    }
+
                     lock (_instances)
                     {
-                        _instances.Add(new ExceptionInstance(exceptionTypeName, entry.Message));
+                        _instances.Add(new ExceptionInstance(exceptionTypeName, moduleName, entry.Message));
                     }
                 }
 

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
+using Microsoft.Diagnostics.Monitoring.WebApi.Stacks;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
+{
+    internal sealed class ExceptionsStore : IExceptionsStore, IAsyncDisposable
+    {
+        private readonly Channel<ExceptionInstanceEntry> _channel;
+        private readonly CancellationTokenSource _disposalSource = new();
+        private readonly List<ExceptionInstance> _instances = new();
+        private readonly Task _processingTask;
+
+        private long _disposalState;
+
+        public ExceptionsStore()
+        {
+            _channel = CreateChannel();
+            _processingTask = ProcessEntriesAsync(_disposalSource.Token);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!DisposableHelper.CanDispose(ref _disposalState))
+                return;
+
+            _channel.Writer.TryComplete();
+
+            await _processingTask.SafeAwait();
+
+            _disposalSource.SafeCancel();
+
+            _disposalSource.Dispose();
+        }
+
+        void IExceptionsStore.AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message)
+        {
+            ExceptionInstanceEntry entry = new(cache, exceptionId, message);
+            // This should never fail to write because the behavior is to drop the oldest.
+            _channel.Writer.TryWrite(entry);
+        }
+
+        public IEnumerable<IExceptionInstance> GetSnapshot()
+        {
+            lock (_instances)
+            {
+                return new List<ExceptionInstance>(_instances).AsReadOnly();
+            }
+        }
+
+        private static Channel<ExceptionInstanceEntry> CreateChannel()
+        {
+            // TODO: Hook callback for when items are dropped an report appropriately.
+            return Channel.CreateBounded<ExceptionInstanceEntry>(
+                new BoundedChannelOptions(capacity: 1000)
+                {
+                    AllowSynchronousContinuations = false,
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = true
+                });
+        }
+
+        private async Task ProcessEntriesAsync(CancellationToken token)
+        {
+            StringBuilder _builder = new();
+            Dictionary<ulong, string> _exceptionTypeNameMap = new();
+
+            bool shouldReadEntry = await _channel.Reader.WaitToReadAsync(token);
+            while (shouldReadEntry)
+            {
+                ExceptionInstanceEntry entry = await _channel.Reader.ReadAsync(token);
+
+                // CONSIDER: If the exception ID could not be found, either the identification information was not sent
+                // by the EventSource in the target application OR it hasn't been sent yet due to multithreaded collision
+                // in the target application where the same exception information is being logged by two or more threads
+                // at the same time; one will return sooner and report the correct IDs potentially before those IDs are
+                // produced by the EventSource. May need to cache this incompletion information and attempt to reconstruct
+                // it in the future, with either periodic retry OR registering a callback system for the missing IDs.
+                if (entry.Cache.TryGetExceptionId(entry.ExceptionId, out ulong exceptionClassId, out _, out _))
+                {
+                    string exceptionTypeName;
+                    if (!_exceptionTypeNameMap.TryGetValue(exceptionClassId, out exceptionTypeName))
+                    {
+                        _builder.Clear();
+                        NameFormatter.BuildClassName(_builder, entry.Cache.NameCache, exceptionClassId);
+                        exceptionTypeName = _builder.ToString();
+                    }
+
+                    lock (_instances)
+                    {
+                        _instances.Add(new ExceptionInstance(exceptionTypeName, entry.Message));
+                    }
+                }
+
+                shouldReadEntry = await _channel.Reader.WaitToReadAsync(token);
+            }
+        }
+
+        private sealed class ExceptionInstanceEntry
+        {
+            public ExceptionInstanceEntry(IExceptionsNameCache cache, ulong exceptionId, string message)
+            {
+                Cache = cache;
+                ExceptionId = exceptionId;
+                Message = message;
+            }
+
+            public IExceptionsNameCache Cache { get; }
+
+            public ulong ExceptionId { get; }
+
+            public string Message { get; }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             _channel.Writer.TryWrite(entry);
         }
 
-        public IEnumerable<IExceptionInstance> GetSnapshot()
+        public IReadOnlyList<IExceptionInstance> GetSnapshot()
         {
             lock (_instances)
             {

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 {
     internal sealed class ExceptionsStore : IExceptionsStore, IAsyncDisposable
     {
+        private const int ChannelCapacity = 1000;
+
         private readonly Channel<ExceptionInstanceEntry> _channel;
         private readonly CancellationTokenSource _disposalSource = new();
         private readonly List<ExceptionInstance> _instances = new();
@@ -42,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             _disposalSource.Dispose();
         }
 
-        void IExceptionsStore.AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message)
+        public void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message)
         {
             ExceptionInstanceEntry entry = new(cache, exceptionId, message);
             // This should never fail to write because the behavior is to drop the oldest.
@@ -61,7 +63,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
         {
             // TODO: Hook callback for when items are dropped and report appropriately.
             return Channel.CreateBounded<ExceptionInstanceEntry>(
-                new BoundedChannelOptions(capacity: 1000)
+                new BoundedChannelOptions(ChannelCapacity)
                 {
                     AllowSynchronousContinuations = false,
                     FullMode = BoundedChannelFullMode.DropOldest,

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter;
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.Auth;
 using Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules;
@@ -22,6 +23,7 @@ using Microsoft.Diagnostics.Tools.Monitor.Egress;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
+using Microsoft.Diagnostics.Tools.Monitor.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.Profiler;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -250,6 +252,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.AddHostedServiceForwarder<ProfilerService>();
             services.AddSingleton<IEndpointInfoSourceCallbacks, ProfilerEndpointInfoSourceCallbacks>();
             services.TryAddSingleton<ISharedLibraryInitializer, DefaultSharedLibraryInitializer>();
+            return services;
+        }
+
+        public static IServiceCollection ConfigureExceptions(this IServiceCollection services)
+        {
+            services.AddSingleton<IExceptionsOperationFactory, ExceptionsOperationFactory>();
+            // The exceptions store for the default process; long term, create a store for each process
+            // that wants to participate in exception collection.
+            services.AddSingleton<IExceptionsStore, ExceptionsStore>();
+            services.AddHostedService<ExceptionsService>();
             return services;
         }
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1403,6 +1403,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to First chance exception. {0}: {1}.
+        /// </summary>
+        internal static string OutputFormatString_FirstChanceException {
+            get {
+                return ResourceManager.GetString("OutputFormatString_FirstChanceException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to :NOT PRESENT:.
         /// </summary>
         internal static string Placeholder_NotPresent {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -789,6 +789,11 @@
     <value>Configuration Providers (High to Low Priority):</value>
     <comment>Gets the string for displaying the configuration providers with the --show-sources flag.</comment>
   </data>
+  <data name="OutputFormatString_FirstChanceException" xml:space="preserve">
+    <value>First chance exception. {0}: {1}</value>
+    <comment>{0} = Exception type name
+{1} = Exception message</comment>
+  </data>
   <data name="Placeholder_NotPresent" xml:space="preserve">
     <value>:NOT PRESENT:</value>
     <comment>Gets a string similar to ":NOT PRESENT:".</comment>


### PR DESCRIPTION
###### Summary

- Adds a single instance of an exceptions store that contains the exception information for the default process. The exception store will quickly consume the information from the provider and queue it for processing shortly thereafter.
- Adds an exceptions service that will start the exceptions pipeline on the default process and insert the exception information into the store for the default process.
- Add the `/exceptions` route that only reports exception information from the default process. This route is authenticated and can produce `text/plain`, `application/x-ndjson`, and `application/json-seq` formats.

Example output of the `/exceptions` route:

Plain text:
```
First chance exception. System.InvalidOperationException: The current time is 2/27/2023 11:37:21 PM
First chance exception. System.InvalidOperationException: The current time is 2/27/2023 11:37:24 PM
First chance exception. System.InvalidOperationException: The current time is 2/27/2023 11:37:27 PM
First chance exception. System.InvalidOperationException: The current time is 2/27/2023 11:37:29 PM
First chance exception. System.InvalidOperationException: The current time is 2/27/2023 11:37:29 PM
```

Newline Delimited JSON:
```json
{"typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"The current time is 2/27/2023 11:37:21 PM"}
{"typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"The current time is 2/27/2023 11:37:24 PM"}
{"typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"The current time is 2/27/2023 11:37:27 PM"}
{"typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"The current time is 2/27/2023 11:37:29 PM"}
{"typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"The current time is 2/27/2023 11:37:29 PM"}
```

Caveats:

- Only the exception type and message are produced at this time. Future PRs will be able to add call stack, inner exception, and other possible ambient information such as activity IDs.
- There are no limits in place for the cache information on either the target application nor in the dotnet-monitor tool. All exception information is kept for the lifetime of each process. This will be addressed in future PRs where the caches will be cleared periodically or according to a prescribed lifetime policy (e.g. only keep exceptions for the last 15 minutes).
- The exceptions are the very beginning of the target application are not captured due to how the default process determination works. This will be addressed in a future PR where in "listen" mode, a store is created per-process and a session is initialized per-process during the diagnostic suspension point in order to capture all exception information.
- The functionality is provided via a startup hook in the target application. This startup hook is NOT automatically configured by .NET Monitor an must be manually set via the DOTNET_STARTUP_HOOKS environment variable.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Add `/exceptions` route that reports captured exceptions from the default process.