### PR TITLE
Rework how shipped branches are managed to be compatible with internal tooling

### DIFF
--- a/.github/workflows/track-shipping-version.yml
+++ b/.github/workflows/track-shipping-version.yml
@@ -30,7 +30,8 @@ jobs:
         uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
         with:
           script: |
-            const refName = `heads/${{ steps.calculate-branch-name.outputs.result }}`;
+            const branchName = `${{ steps.calculate-branch-name.outputs.result }}`;
+            const refName = `heads/${branchName}`;
 
             // Check if the ref already exists, if so we will need to fast forward it.
             let needToCreateRef = true;
@@ -68,7 +69,7 @@ jobs:
             await github.rest.repos.createOrUpdateFileContents({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: `${{ steps.calculate-branch-name.outputs.result }}`,
+              branch: branchName,
               message: 'Trigger branch mirroring',
               path: '.mirror',
               content: ''


### PR DESCRIPTION
###### Summary

This PR reworks how `shipped/*` branches are created and updated to:
1. Create a new git ref directly via the GitHub api instead of creating and pushing up the entire new branch. This avoids pushing up commits that may contain workflow file updates which require additional privileges.
2. Create a new commit on the updated `shipped/*` branch with an empty file to trigger branch mirroring. Branch mirroring is only activated if there's content updates on the given branch so empty commits and new refs won't trigger it.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
