### PR TITLE
Update AzureAd auth version availibity in documentation

### DIFF
--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -5,7 +5,7 @@
 
 Authenticated requests to `dotnet monitor` help protect sensitive diagnostic artifacts from unauthorized users and lower privileged processes. `dotnet monitor` can be configured to use any one of the following authentication modes:
 - [API Key](#api-key-authentication)
-- [Azure Active Directory Authentication](#azure-active-directory-authentication) (8.0+)
+- [Azure Active Directory Authentication](#azure-active-directory-authentication) (7.1+)
 - [Windows Authentication](#windows-authentication)
 
 It is also possible, although strongly not recommended, to [disable authentication](#disabling-authentication).

--- a/documentation/configuration/azure-ad-authentication-configuration.md
+++ b/documentation/configuration/azure-ad-authentication-configuration.md
@@ -1,7 +1,7 @@
 
 ### Was this documentation helpful? [Share feedback](https://www.research.net/r/DGDQWXH?src=documentation%2Fconfiguration%2Fazure-ad-authentication-configuration)
 
-# Azure Active Directory Authentication Configuration (8.0+)
+# Azure Active Directory Authentication Configuration (7.1+)
 
 Azure Active Directory authentication must be configured before `dotnet monitor` starts, it does not support being configured or changed at runtime.
 


### PR DESCRIPTION
###### Summary

AzureAd auth has been backported to 7.x and will be available in 7.1+.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
