### PR TITLE
Split library sharing initialization from profiler service.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IInProcessFeatures.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IInProcessFeatures.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         bool IsExceptionsEnabled { get; }
 
         bool IsProfilerRequired { get; }
+
+        bool IsLibrarySharingRequired { get; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 using System;
 using System.IO;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
+namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
 {
     /// <summary>
     /// An abstraction around how native library files are found in the build output.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Tools.Monitor;
-using Microsoft.Diagnostics.Tools.Monitor.Profiler;
+using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using System.IO;
@@ -23,16 +23,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
             _logger = logger;
         }
 
-        public INativeFileProviderFactory Initialize()
+        public IFileProviderFactory Initialize()
         {
             _logger.SharedLibraryPath(SharedLibrarySourcePath);
 
             return new Factory();
         }
 
-        private sealed class Factory : INativeFileProviderFactory
+        private sealed class Factory : IFileProviderFactory
         {
-            public IFileProvider Create(string runtimeIdentifier)
+            public IFileProvider CreateNative(string runtimeIdentifier)
             {
                 return BuildOutputNativeFileProvider.Create(runtimeIdentifier, SharedLibrarySourcePath);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/HostingStartup.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/HostingStartup.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup;
-using Microsoft.Diagnostics.Tools.Monitor.Profiler;
+using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Extensions.DependencyInjection;
 
 [assembly: HostingStartup(typeof(HostingStartup))]

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 services.ConfigureDefaultProcess(context.Configuration);
                 services.AddSingleton<ProfilerChannel>();
                 services.ConfigureCollectionRules();
+                services.ConfigureLibrarySharing();
                 services.ConfigureProfiler();
                 services.ConfigureStartupLoggers(authConfigurator);
                 services.AddSingleton<IExperimentalFlags, ExperimentalFlags>();

--- a/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeatures.cs
+++ b/src/Tools/dotnet-monitor/InProcessFeatures/InProcessFeatures.cs
@@ -23,5 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public bool IsExceptionsEnabled => _options.GetEnabled() && _experimentalFlags.IsExceptionsEnabled;
 
         public bool IsProfilerRequired => IsCallStacksEnabled;
+
+        public bool IsLibrarySharingRequired => IsCallStacksEnabled || IsExceptionsEnabled;
     }
 }

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     internal sealed class DefaultSharedLibraryInitializer :
         ISharedLibraryInitializer
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
             _sharedLibraryTargetPath = _storageOptions.Value.SharedLibraryPath;
         }
 
-        public INativeFileProviderFactory Initialize()
+        public IFileProviderFactory Initialize()
         {
             // Copy the shared libraries to the path specified by Storage:SharedLibraryPath.
             // Copying, instead of linking or using them in-place, prevents file locks from the target process.
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
             return new Factory(sharedLibraryPath);
         }
 
-        private sealed class Factory : INativeFileProviderFactory
+        private sealed class Factory : IFileProviderFactory
         {
             private readonly string _sharedLibraryPath;
 
@@ -94,9 +94,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
                 _sharedLibraryPath = sharedLibraryPath;
             }
 
-            public IFileProvider Create(string runtimeIdentifier)
+            public IFileProvider CreateNative(string runtimeIdentifier)
             {
-                return SharedNativeFileProvider.Create(runtimeIdentifier, _sharedLibraryPath);
+                return SharedFileProvider.CreateNative(runtimeIdentifier, _sharedLibraryPath);
             }
         }
     }

--- a/src/Tools/dotnet-monitor/LibrarySharing/IFileProviderFactory.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/IFileProviderFactory.cs
@@ -3,10 +3,10 @@
 
 using Microsoft.Extensions.FileProviders;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
-    internal interface INativeFileProviderFactory
+    public interface IFileProviderFactory
     {
-        IFileProvider Create(string runtimeIdentifier);
+        IFileProvider CreateNative(string runtimeIdentifier);
     }
 }

--- a/src/Tools/dotnet-monitor/LibrarySharing/ISharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/ISharedLibraryInitializer.cs
@@ -1,10 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     internal interface ISharedLibraryInitializer
     {
-        INativeFileProviderFactory Initialize();
+        IFileProviderFactory Initialize();
     }
 }

--- a/src/Tools/dotnet-monitor/LibrarySharing/ISharedLibraryService.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/ISharedLibraryService.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
+{
+    public interface ISharedLibraryService
+    {
+        Task<IFileProviderFactory> GetFactoryAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/dotnet-monitor/LibrarySharing/NativeLibraryHelper.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/NativeLibraryHelper.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     internal static class NativeLibraryHelper
     {

--- a/src/Tools/dotnet-monitor/LibrarySharing/SharedFileProvider.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/SharedFileProvider.cs
@@ -7,27 +7,27 @@ using Microsoft.Extensions.Primitives;
 using System;
 using System.IO;
 
-namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     /// <summary>
-    /// An abstraction around how native library files are found in the file system.
+    /// An abstraction around how library files are found in the file system.
     /// </summary>
-    internal sealed class SharedNativeFileProvider : IFileProvider
+    internal sealed class SharedFileProvider : IFileProvider
     {
-        private readonly string _nativeFileBasePath;
+        private readonly string _basePath;
 
-        private SharedNativeFileProvider(string nativeFileBasePath)
+        private SharedFileProvider(string basePath)
         {
-            _nativeFileBasePath = nativeFileBasePath;
+            _basePath = basePath;
         }
 
         /// <summary>
         /// Creates an <see cref="IFileProvider"/> that can return native files from the shared library layout.
         /// The path of a returned file is {sharedLibraryPath}/{runtimeIdentifier}/native/{fileName}.
         /// </summary>
-        public static IFileProvider Create(string runtimeIdentifier, string sharedLibraryPath)
+        public static IFileProvider CreateNative(string runtimeIdentifier, string sharedLibraryPath)
         {
-            return new SharedNativeFileProvider(Path.Combine(sharedLibraryPath, runtimeIdentifier, "native"));
+            return new SharedFileProvider(Path.Combine(sharedLibraryPath, runtimeIdentifier, "native"));
         }
 
         public IDirectoryContents GetDirectoryContents(string subpath)
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
 
         public IFileInfo GetFileInfo(string subpath)
         {
-            FileInfo fileInfo = new FileInfo(Path.Combine(_nativeFileBasePath, subpath));
+            FileInfo fileInfo = new FileInfo(Path.Combine(_basePath, subpath));
             if (fileInfo.Exists)
             {
                 return new PhysicalFileInfo(fileInfo);

--- a/src/Tools/dotnet-monitor/LibrarySharing/SharedLibraryService.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/SharedLibraryService.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
+{
+    internal sealed class SharedLibraryService :
+        BackgroundService,
+        ISharedLibraryService
+    {
+        private readonly TaskCompletionSource<IFileProviderFactory> _fileProviderFactorySource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly IInProcessFeatures _inProcessFeatures;
+        private readonly ISharedLibraryInitializer _sharedLibraryInitializer;
+        private readonly ILogger<SharedLibraryService> _logger;
+
+        public SharedLibraryService(
+            ISharedLibraryInitializer sharedLibraryInitializer,
+            IInProcessFeatures inProcessFeatures,
+            ILogger<SharedLibraryService> logger)
+        {
+            _inProcessFeatures = inProcessFeatures;
+            _logger = logger;
+            _sharedLibraryInitializer = sharedLibraryInitializer;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (!_inProcessFeatures.IsLibrarySharingRequired)
+            {
+                _fileProviderFactorySource.SetException(new NotSupportedException());
+                return;
+            }
+
+            using IDisposable _ = stoppingToken.Register(() => _fileProviderFactorySource.TrySetCanceled(stoppingToken));
+
+            // Yield to allow other hosting services to start
+            await Task.Yield();
+
+            try
+            {
+                _fileProviderFactorySource.SetResult(_sharedLibraryInitializer.Initialize());
+            }
+            catch (Exception ex)
+            {
+                _logger.FailedInitializeSharedLibraryStorage(ex);
+
+                _fileProviderFactorySource.SetException(ex);
+            }
+        }
+
+        public Task<IFileProviderFactory> GetFactoryAsync(CancellationToken cancellationToken)
+        {
+            return _fileProviderFactorySource.Task.WaitAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Microsoft.Diagnostics.Tools.Monitor.Egress;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.AzureBlob;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
+using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Diagnostics.Tools.Monitor.Profiler;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -244,12 +245,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return services;
         }
 
+        public static IServiceCollection ConfigureLibrarySharing(this IServiceCollection services)
+        {
+            services.AddSingleton<SharedLibraryService>();
+            services.AddSingletonForwarder<ISharedLibraryService, SharedLibraryService>();
+            services.AddHostedServiceForwarder<SharedLibraryService>();
+            services.TryAddSingleton<ISharedLibraryInitializer, DefaultSharedLibraryInitializer>();
+            return services;
+        }
+
         public static IServiceCollection ConfigureProfiler(this IServiceCollection services)
         {
             services.AddSingleton<ProfilerService>();
-            services.AddHostedServiceForwarder<ProfilerService>();
             services.AddSingleton<IEndpointInfoSourceCallbacks, ProfilerEndpointInfoSourceCallbacks>();
-            services.TryAddSingleton<ISharedLibraryInitializer, DefaultSharedLibraryInitializer>();
             return services;
         }
 


### PR DESCRIPTION
###### Summary

Refactor library sharing from the profiler service so that other features that are not dependent on the profiler can use library sharing with target processes.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
