### PR TITLE
Avoid trying to stop an S3 operation if it never started

### DIFF
--- a/src/Tools/dotnet-monitor/Egress/S3/S3StorageEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/S3/S3StorageEgressProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.S3
             }
             catch (AmazonS3Exception e)
             {
-                if (!uploadDone)
+                if (uploadId != null && !uploadDone)
                     await client.AbortMultipartUploadAsync(uploadId, token);
                 throw CreateException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressS3FailedDetailed, e.Message));
             }


### PR DESCRIPTION
###### Summary

If an S3 egress operation fails before it has begun trying to upload the data (e.g. due to bad configuration) we would still try to stop the upload operation despite not existing. This would cause additional exceptions and ultimately result in no errors being logged to the user.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
