### PR TITLE
Publish guardian directory after validation

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -122,6 +122,7 @@ stages:
       SDLValidationParameters:
         enable: true
         continueOnError: true
+        publishGdn: true
         params: >-
           -SourceToolsList @("policheck","credscan")
           -TsaInstanceURL $(_TsaInstanceURL)


### PR DESCRIPTION
###### Summary

Publish the `.gdn` directory after validation for easier manual inspection.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
