### PR TITLE
Startup hook validation for enabling exceptions capture

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             }
 
             // Ensures that the TestStartupHook is loaded early so it helps resolve other test assemblies
-            _adapter.Environment.Add("DOTNET_STARTUP_HOOKS", TestStartupHookPath);
+            _adapter.Environment.Add(ToolIdentifiers.EnvironmentVariables.StartupHooks, TestStartupHookPath);
 
             // Allow TestHostingStartup to participate in host building in the tool
             _adapter.Environment.Add("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES", TestHostingStartupAssemblyName);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputManagedFileProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputManagedFileProvider.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.IO;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
+{
+    /// <summary>
+    /// An abstraction around how managed library files are found in the build output.
+    /// </summary>
+    internal sealed class BuildOutputManagedFileProvider : IFileProvider
+    {
+        private const string ConfigurationName =
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+
+        private readonly string _managedFileBasePath;
+        private readonly string _targetFramework;
+
+        private BuildOutputManagedFileProvider(string managedFileBasePath, string targetFramework)
+        {
+            _managedFileBasePath = managedFileBasePath;
+            _targetFramework = targetFramework;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IFileProvider"/> that can return native files from the build output of a
+        /// local or CI build from the dotnet-monitor repository.
+        /// The path of a returned file is {sharedLibraryPath}/{libraryName}/{configuration}/{targetFramework}/{fileName}.
+        /// </summary>
+        public static IFileProvider Create(string targetFramework, string sharedLibraryPath)
+        {
+            return new BuildOutputManagedFileProvider(sharedLibraryPath, targetFramework);
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+            throw new NotSupportedException();
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            string libraryName = Path.GetFileNameWithoutExtension(subpath);
+            FileInfo fileInfo = new FileInfo(Path.Combine(_managedFileBasePath, libraryName, ConfigurationName, _targetFramework, subpath));
+            if (fileInfo.Exists)
+            {
+                return new PhysicalFileInfo(fileInfo);
+            }
+            else
+            {
+                return new NotFoundFileInfo(fileInfo.FullName);
+            }
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
 
         private sealed class Factory : IFileProviderFactory
         {
+            public IFileProvider CreateManaged(string targetFramework)
+            {
+                return BuildOutputManagedFileProvider.Create(targetFramework, SharedLibrarySourcePath);
+            }
+
             public IFileProvider CreateNative(string runtimeIdentifier)
             {
                 return BuildOutputNativeFileProvider.Create(runtimeIdentifier, SharedLibrarySourcePath);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 "Microsoft.Diagnostics.Monitoring.StartupHook",
                 TargetFrameworkMoniker.Net60);
 
-            runner.Environment.Add("DOTNET_STARTUP_HOOKS", startupHookPath);
+            runner.Environment.Add(ToolIdentifiers.EnvironmentVariables.StartupHooks, startupHookPath);
         }
 
         private sealed class TestExceptionsStore : IExceptionsStore

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
@@ -1,11 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tools.Monitor.StartupHook;
 using Microsoft.Extensions.Hosting;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,13 +22,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
     {
         private readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(5);
 
+        private readonly List<UniqueProcessKey> _unconfiguredProcesses = new();
         private readonly IExceptionsStore _exceptionsStore;
         private readonly IDiagnosticServices _diagnosticServices;
         private readonly IInProcessFeatures _inProcessFeatures;
+        private readonly StartupHookValidator _startupHookValidator;
 
         private EventExceptionsPipeline _pipeline;
 
         public ExceptionsService(
+            StartupHookValidator startupHookValidator,
             IDiagnosticServices diagnosticServices,
             IInProcessFeatures inProcessFeatures,
             IExceptionsStore exceptionsStore)
@@ -33,6 +39,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             _diagnosticServices = diagnosticServices;
             _exceptionsStore = exceptionsStore;
             _inProcessFeatures = inProcessFeatures;
+            _startupHookValidator = startupHookValidator;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -48,6 +55,22 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 {
                     // Get default process
                     IProcessInfo pi = await _diagnosticServices.GetProcessAsync(processKey: null, stoppingToken);
+
+                    // If previous checked configuration and it did not pass, do not check again or attempt
+                    // to start the event pipe session.
+                    UniqueProcessKey key = new(pi.EndpointInfo.ProcessId, pi.EndpointInfo.RuntimeInstanceCookie);
+                    if (_unconfiguredProcesses.Contains(key))
+                    {
+                        throw new MonitoringException(string.Empty);
+                    }
+
+                    // Validate that the process is configured correctly for collecting exceptions.
+                    if (!await _startupHookValidator.CheckAsync(pi.EndpointInfo, stoppingToken))
+                    {
+                        _unconfiguredProcesses.Add(key);
+                        throw new MonitoringException(string.Empty);
+                    }
+
                     DiagnosticsClient client = new(pi.EndpointInfo.Endpoint);
 
                     EventExceptionsPipelineSettings settings = new();
@@ -75,5 +98,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 await _pipeline.DisposeAsync();
             }
         }
+
+        private record class UniqueProcessKey(int ProcessId, Guid RuntimeInstanceId);
     }
 }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
@@ -61,14 +61,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                     UniqueProcessKey key = new(pi.EndpointInfo.ProcessId, pi.EndpointInfo.RuntimeInstanceCookie);
                     if (_unconfiguredProcesses.Contains(key))
                     {
-                        throw new MonitoringException(string.Empty);
+                        // This exception is not user visible.
+                        throw new NotSupportedException();
                     }
 
                     // Validate that the process is configured correctly for collecting exceptions.
                     if (!await _startupHookValidator.CheckAsync(pi.EndpointInfo, stoppingToken))
                     {
                         _unconfiguredProcesses.Add(key);
-                        throw new MonitoringException(string.Empty);
+
+                        // This exception is not user visible.
+                        throw new NotSupportedException();
                     }
 
                     DiagnosticsClient client = new(pi.EndpointInfo.Endpoint);

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
@@ -94,6 +94,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
                 _sharedLibraryPath = sharedLibraryPath;
             }
 
+            public IFileProvider CreateManaged(string targetFramework)
+            {
+                return SharedFileProvider.CreateManaged(targetFramework, _sharedLibraryPath);
+            }
+
             public IFileProvider CreateNative(string runtimeIdentifier)
             {
                 return SharedFileProvider.CreateNative(runtimeIdentifier, _sharedLibraryPath);

--- a/src/Tools/dotnet-monitor/LibrarySharing/IFileProviderFactory.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/IFileProviderFactory.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     public interface IFileProviderFactory
     {
+        IFileProvider CreateManaged(string targetFramework);
+
         IFileProvider CreateNative(string runtimeIdentifier);
     }
 }

--- a/src/Tools/dotnet-monitor/LibrarySharing/SharedFileProvider.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/SharedFileProvider.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
             _basePath = basePath;
         }
 
+        public static IFileProvider CreateManaged(string targetFramework, string sharedLibraryPath)
+        {
+            return new SharedFileProvider(Path.Combine(sharedLibraryPath, "any", targetFramework));
+        }
+
         /// <summary>
         /// Creates an <see cref="IFileProvider"/> that can return native files from the shared library layout.
         /// The path of a returned file is {sharedLibraryPath}/{runtimeIdentifier}/native/{fileName}.

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -88,7 +88,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         ConnectionModeConnect = 76,
         ConnectionModeListen = 77,
         ExperimentalFeatureEnabled = 78,
-        StartCollectArtifact = 79
+        StartCollectArtifact = 79,
+        StartupHookEnvironmentMissing = 80,
+        StartupHookMissing = 81,
+        StartupHookInstructions = 82,
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -446,6 +446,24 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_StartCollectArtifact);
 
+        private static readonly Action<ILogger, int, Exception> _startupHookEnvironmentMissing =
+            LoggerMessage.Define<int>(
+                eventId: LoggingEventIds.StartupHookEnvironmentMissing.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_StartupHookEnvironmentMissing);
+
+        private static readonly Action<ILogger, int, string, Exception> _startupHookMissing =
+            LoggerMessage.Define<int, string>(
+                eventId: LoggingEventIds.StartupHookMissing.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_StartupHookMissing);
+
+        private static readonly Action<ILogger, string, Exception> _startupHookInstructions =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.StartupHookInstructions.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_StartupHookInstructions);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -818,6 +836,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void StartCollectArtifact(this ILogger logger, string artifactType)
         {
             _startCollectArtifact(logger, artifactType, null);
+        }
+
+        public static void StartupHookEnvironmentMissing(this ILogger logger, int processId)
+        {
+            _startupHookEnvironmentMissing(logger, processId, null);
+        }
+
+        public static void StartupHookMissing(this ILogger logger, int processId, string startupHookLibraryName)
+        {
+            _startupHookMissing(logger, processId, startupHookLibraryName, null);
+        }
+
+        public static void StartupHookInstructions(this ILogger logger, string startupHookLibraryPath)
+        {
+            _startupHookInstructions(logger, startupHookLibraryPath, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static Task<int> Main(string[] args)
         {
             // Prevent child processes from inheriting startup hooks
-            Environment.SetEnvironmentVariable("DOTNET_STARTUP_HOOKS", null);
+            Environment.SetEnvironmentVariable(ToolIdentifiers.EnvironmentVariables.StartupHooks, null);
 
             TestAssemblies.SimulateStartupHook();
 

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
 using Microsoft.Diagnostics.Tools.Monitor.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Diagnostics.Tools.Monitor.Profiler;
+using Microsoft.Diagnostics.Tools.Monitor.StartupHook;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -270,6 +271,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             // that wants to participate in exception collection.
             services.AddSingleton<IExceptionsStore, ExceptionsStore>();
             services.AddHostedService<ExceptionsService>();
+            services.AddSingleton<StartupHookValidator>();
             return services;
         }
 

--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookValidator.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookValidator.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
+{
+    internal sealed class StartupHookValidator
+    {
+        private const string StartupHookFileName = "Microsoft.Diagnostics.Monitoring.StartupHook.dll";
+        private const string StartupHookTargetFramework = "net6.0";
+
+
+        private readonly ILogger _logger;
+        private readonly ISharedLibraryService _sharedLibraryService;
+
+        public StartupHookValidator(
+            ISharedLibraryService sharedLibraryService,
+            ILogger<StartupHookValidator> logger)
+        {
+            _logger = logger;
+            _sharedLibraryService = sharedLibraryService;
+        }
+
+        public async Task<bool> CheckAsync(IEndpointInfo endpointInfo, CancellationToken token)
+        {
+            IFileProviderFactory fileProviderFactory = await _sharedLibraryService.GetFactoryAsync(token);
+
+            IFileProvider managedFileProvider = fileProviderFactory.CreateManaged(StartupHookTargetFramework);
+
+            IFileInfo startupHookLibraryFileInfo = managedFileProvider.GetFileInfo(StartupHookFileName);
+            if (!startupHookLibraryFileInfo.Exists)
+            {
+                // This would be a bug in dotnet-monitor; throw appropriate non-MonitoringException instance.
+                throw new FileNotFoundException(null, startupHookLibraryFileInfo.Name);
+            }
+
+            DiagnosticsClient client = new(endpointInfo.Endpoint);
+            IDictionary<string, string> env = await client.GetProcessEnvironmentAsync(token);
+
+            if (!env.TryGetValue(ToolIdentifiers.EnvironmentVariables.StartupHooks, out string startupHookPaths))
+            {
+                _logger.StartupHookEnvironmentMissing(endpointInfo.ProcessId);
+
+                LogInstructions(startupHookLibraryFileInfo);
+
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(startupHookPaths) || !startupHookPaths.Contains(StartupHookFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.StartupHookMissing(endpointInfo.ProcessId, startupHookLibraryFileInfo.Name);
+
+                LogInstructions(startupHookLibraryFileInfo);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private void LogInstructions(IFileInfo startupHookLibraryFileInfo)
+        {
+            _logger.StartupHookInstructions(startupHookLibraryFileInfo.PhysicalPath);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookValidator.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookValidator.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
 {
     internal sealed class StartupHookValidator
     {
+        // Intent is to ship a single TFM of the startup hook, which should be the lowest supported version.
+        // If necessary, the startup hook should dynamically access APIs for higher version TFMs and handle
+        // all exceptions appropriately.
         private const string StartupHookFileName = "Microsoft.Diagnostics.Monitoring.StartupHook.dll";
         private const string StartupHookTargetFramework = "net6.0";
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1295,6 +1295,33 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The DOTNET_STARTUP_HOOKS environment variable is missing from target process {processId}..
+        /// </summary>
+        internal static string LogFormatString_StartupHookEnvironmentMissing {
+            get {
+                return ResourceManager.GetString("LogFormatString_StartupHookEnvironmentMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception-based features require that the DOTNET_STARTUP_HOOKS environment variable is set on the target process and must contain the path to the .NET Monitor startup hook library. The path to the library is &quot;{path}&quot;..
+        /// </summary>
+        internal static string LogFormatString_StartupHookInstructions {
+            get {
+                return ResourceManager.GetString("LogFormatString_StartupHookInstructions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The DOTNET_STARTUP_HOOKS environment variable for target process {processId} does not contain the &apos;{name}&apos; startup hook..
+        /// </summary>
+        internal static string LogFormatString_StartupHookMissing {
+            get {
+                return ResourceManager.GetString("LogFormatString_StartupHookMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to apply profiler..
         /// </summary>
         internal static string LogFormatString_UnableToApplyProfiler {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -739,6 +739,15 @@
   <data name="LogFormatString_StartCollectArtifact" xml:space="preserve">
     <value>Started capturing {artifactType} artifact.</value>
   </data>
+  <data name="LogFormatString_StartupHookEnvironmentMissing" xml:space="preserve">
+    <value>The DOTNET_STARTUP_HOOKS environment variable is missing from target process {processId}.</value>
+  </data>
+  <data name="LogFormatString_StartupHookInstructions" xml:space="preserve">
+    <value>Exception-based features require that the DOTNET_STARTUP_HOOKS environment variable is set on the target process and must contain the path to the .NET Monitor startup hook library. The path to the library is "{path}".</value>
+  </data>
+  <data name="LogFormatString_StartupHookMissing" xml:space="preserve">
+    <value>The DOTNET_STARTUP_HOOKS environment variable for target process {processId} does not contain the '{name}' startup hook.</value>
+  </data>
   <data name="LogFormatString_UnableToApplyProfiler" xml:space="preserve">
     <value>Unable to apply profiler.</value>
   </data>

--- a/src/Tools/dotnet-monitor/ToolIdentifiers.cs
+++ b/src/Tools/dotnet-monitor/ToolIdentifiers.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             // This environment variable is manually applied to target processes to inform dotnet-monitor
             // which runtime variant of the shared libraries should be loaded into target processes.
             public const string RuntimeIdentifier = StandardPrefix + nameof(RuntimeIdentifier);
+
+            public const string StartupHooks = "DOTNET_STARTUP_HOOKS";
         }
     }
 }


### PR DESCRIPTION
###### Summary

These changes check that if the exceptions features are enabled then the default process needs to be configured correctly (the `DOTNET_STARTUP_HOOKS` environment variable needs to be set appropriately). The startup hook validator will log warning messages as to why the startup configuration of the target process is not sufficient. At this time, startup hook environment variable is the only way to configure target processes load the exceptions logging infrastructure.

Changes also include the ability to query for the managed libraries from the shared libraries path.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
