### PR TITLE
[Egress] Publish and include extensions in tool nupkg

### DIFF
--- a/eng/Common.props
+++ b/eng/Common.props
@@ -2,5 +2,7 @@
   <!-- These properties are shared among the Arcade build infrastructure as well as individual project build. -->
   <PropertyGroup>
     <LatestTargetFramework>net8.0</LatestTargetFramework>
+    <LatestToolTargetFramework>$(LatestTargetFramework)</LatestToolTargetFramework>
+    <OlderToolTargetFramework>net6.0</OlderToolTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -60,6 +60,8 @@
   </ItemGroup>
 
   <!-- Targets and properties for ensuring publish before pack. -->
+  <Import Project="$(RepoRoot)src\archives\AzureBlobStorage\ProjectsToPublish.props" />
+  <Import Project="$(RepoRoot)src\archives\S3Storage\ProjectsToPublish.props" />
   <Import Project="$(RepoRoot)src\Microsoft.Diagnostics.Monitoring.StartupHook\ProjectsToPublish.props" />
   <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />
 
@@ -94,6 +96,13 @@
       </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include="$(StartupHookSymbolsPath)">
         <PackagePath>tools/$(TargetFramework)/any/shared/any/$(StartupHookTargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+      <!-- Pack extension files -->
+      <TfmSpecificPackageFile Include="$(AzureBlobStoragePublishRootPath)$(TargetFramework)\any\**">
+        <PackagePath>tools/$(TargetFramework)/any/extensions/$(AzureBlobStorageExtensionFolderName)</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(S3StoragePublishRootPath)$(TargetFramework)\any\**">
+        <PackagePath>tools/$(TargetFramework)/any/extensions/$(S3StorageExtensionFolderName)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>

--- a/src/archives/AzureBlobStorage/Package.props
+++ b/src/archives/AzureBlobStorage/Package.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ExecutableName>dotnet-monitor-egress-azureblobstorage</ExecutableName>
     <ArchiveName>dotnet-monitor-egress-azureblobstorage</ArchiveName>
-    <ArchiveContentRootPath>$(AzureBlobStoragePublishPath)</ArchiveContentRootPath>
+    <ArchiveContentRootPath>$(AzureBlobStoragePlatformSpecificPublishPath)</ArchiveContentRootPath>
   </PropertyGroup>
   <!-- These items are included in addition to those from publishing the AzureBlobStorage project. -->
   <ItemGroup>

--- a/src/archives/AzureBlobStorage/ProjectsToPublish.props
+++ b/src/archives/AzureBlobStorage/ProjectsToPublish.props
@@ -1,12 +1,23 @@
 <Project>
   <PropertyGroup>
-    <AzureBlobStoragePublishTargetFramework>$(LatestTargetFramework)</AzureBlobStoragePublishTargetFramework>
+    <AzureBlobStorageExtensionFolderName>AzureBlobStorage</AzureBlobStorageExtensionFolderName>
+    <AzureBlobStorageProjectPath>$(RepoRoot)src\Extensions\AzureBlobStorage\AzureBlobStorage.csproj</AzureBlobStorageProjectPath>
+    <AzureBlobStoragePublishTargetFramework>$(LatestToolTargetFramework)</AzureBlobStoragePublishTargetFramework>
     <AzureBlobStoragePublishTargetFramework Condition="'$(TargetFramework)' != ''">$(TargetFramework)</AzureBlobStoragePublishTargetFramework>
-    <AzureBlobStoragePublishPath>$(ArtifactsDir)pub\dotnet-monitor-egress-azureblobstorage\$(Configuration)\$(AzureBlobStoragePublishTargetFramework)\$(PackageRid)\</AzureBlobStoragePublishPath>
+    <AzureBlobStoragePublishRootPath>$(ArtifactsDir)pub\dotnet-monitor-egress-azureblobstorage\$(Configuration)\</AzureBlobStoragePublishRootPath>
+    <AzureBlobStoragePlatformSpecificPublishPath>$(AzureBlobStoragePublishRootPath)$(AzureBlobStoragePublishTargetFramework)\$(PackageRid)\</AzureBlobStoragePlatformSpecificPublishPath>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectToPublish Include="$(RepoRoot)src\Extensions\AzureBlobStorage\AzureBlobStorage.csproj">
-      <AdditionalProperties>TargetFramework=$(AzureBlobStoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(AzureBlobStoragePublishPath)</AdditionalProperties>
+    <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
+      <AdditionalProperties>TargetFramework=$(AzureBlobStoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(AzureBlobStoragePlatformSpecificPublishPath)</AdditionalProperties>
+    </ProjectToPublish>
+  </ItemGroup>
+  <ItemGroup Condition="'$(SkipPlatformNeutralPublish)' != 'true'">
+    <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
+      <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(AzureBlobStoragePublishRootPath)$(LatestToolTargetFramework)\any\</AdditionalProperties>
+    </ProjectToPublish>
+    <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
+      <AdditionalProperties>TargetFramework=$(OlderToolTargetFramework);RuntimeIdentifier=;PublishDir=$(AzureBlobStoragePublishRootPath)$(OlderToolTargetFramework)\any\</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
 </Project>

--- a/src/archives/S3Storage/Package.props
+++ b/src/archives/S3Storage/Package.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ExecutableName>dotnet-monitor-egress-s3storage</ExecutableName>
     <ArchiveName>dotnet-monitor-egress-s3storage</ArchiveName>
-    <ArchiveContentRootPath>$(S3StoragePublishPath)</ArchiveContentRootPath>
+    <ArchiveContentRootPath>$(S3StoragePlatformSpecificPublishPath)</ArchiveContentRootPath>
   </PropertyGroup>
   <!-- These items are included in addition to those from publishing the S3Storage project. -->
   <ItemGroup>

--- a/src/archives/S3Storage/ProjectsToPublish.props
+++ b/src/archives/S3Storage/ProjectsToPublish.props
@@ -1,12 +1,23 @@
 <Project>
   <PropertyGroup>
+    <S3StorageExtensionFolderName>S3Storage</S3StorageExtensionFolderName>
+    <S3StorageProjectPath>$(RepoRoot)src\Extensions\S3Storage\S3Storage.csproj</S3StorageProjectPath>
     <S3StoragePublishTargetFramework>$(LatestTargetFramework)</S3StoragePublishTargetFramework>
     <S3StoragePublishTargetFramework Condition="'$(TargetFramework)' != ''">$(TargetFramework)</S3StoragePublishTargetFramework>
-    <S3StoragePublishPath>$(ArtifactsDir)pub\dotnet-monitor-egress-s3storage\$(Configuration)\$(S3StoragePublishTargetFramework)\$(PackageRid)\</S3StoragePublishPath>
+    <S3StoragePublishRootPath>$(ArtifactsDir)pub\dotnet-monitor-egress-s3storage\$(Configuration)\</S3StoragePublishRootPath>
+    <S3StoragePlatformSpecificPublishPath>$(ArtifactsDir)pub\dotnet-monitor-egress-s3storage\$(Configuration)\$(S3StoragePublishTargetFramework)\$(PackageRid)\</S3StoragePlatformSpecificPublishPath>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectToPublish Include="$(RepoRoot)src\Extensions\S3Storage\S3Storage.csproj">
-      <AdditionalProperties>TargetFramework=$(S3StoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(S3StoragePublishPath)</AdditionalProperties>
+    <ProjectToPublish Include="$(S3StorageProjectPath)">
+      <AdditionalProperties>TargetFramework=$(S3StoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(S3StoragePlatformSpecificPublishPath)</AdditionalProperties>
+    </ProjectToPublish>
+  </ItemGroup>
+  <ItemGroup Condition="'$(SkipPlatformNeutralPublish)' != 'true'">
+    <ProjectToPublish Include="$(S3StorageProjectPath)">
+      <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(S3StoragePublishRootPath)$(LatestToolTargetFramework)\any\</AdditionalProperties>
+    </ProjectToPublish>
+    <ProjectToPublish Include="$(S3StorageProjectPath)">
+      <AdditionalProperties>TargetFramework=$(OlderToolTargetFramework);RuntimeIdentifier=;PublishDir=$(S3StoragePublishRootPath)$(OlderToolTargetFramework)\any\</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
###### Summary

Publish platform neutral variants of the extensions and include them in the dotnet-monitor tool nupkg under `extensions/AzureBlobStorage` and `extensions/S3Storage`. Separate changes are required to execute the extensions from dotnet-monitor using the shared framework host (`dotnet`) instead of searching for a platform-specific executable.

Note that the extensions are intentionally not packed into the dotnet-monitor archive files since that should remain minimal to allow for custom composition.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2130927&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
