### PR TITLE
Only publish platform neutral outputs on win-x64 release leg

### DIFF
--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -31,6 +31,10 @@ jobs:
     architecture: ${{ parameters.architecture }}
 
     variables:
+    - _PublishAfterBuildArgs: '/p:PublishProjectsAfterBuild=true /p:SkipPlatformNeutralPublish=true'
+    - ${{ if and(eq(parameters.targetRid, 'win-x64'), eq(parameters.configuration, 'Release')) }}:
+      - _PublishAfterBuildArgs: '/p:PublishProjectsAfterBuild=true'
+
     - ${{ if and(ne(parameters.testGroup, 'None'), ne(parameters.architecture, 'arm64')) }}:
       # If TestGroup == 'Default', choose the test group based on the type of pipeline run
       - ${{ if eq(parameters.testGroup, 'Default') }}:
@@ -78,7 +82,7 @@ jobs:
         - script: echo "##vso[task.prependpath]/usr/share/node/bin"
           displayName: Add Azurite to PATH
 
-    buildArgs: '/p:PublishProjectsAfterBuild=true'
+    buildArgs: '$(_PublishAfterBuildArgs)'
 
     postBuildSteps:
     - ${{ if and(eq(parameters.publishArtifacts, 'true'), eq(parameters.configuration, 'Release')) }}:
@@ -111,6 +115,11 @@ jobs:
           inputs:
             SourceFolder: '$(Build.SourcesDirectory)/artifacts/obj'
             TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/obj'
+        - task: CopyFiles@2
+          displayName: Gather Artifacts (pub)
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/pub'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/pub'
       - ${{ else }}:
         - task: CopyFiles@2
           displayName: Gather Artifacts (bin/${{ parameters.targetRid }}.${{ parameters.configuration }})

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ProjectsToPublish.props
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ProjectsToPublish.props
@@ -6,7 +6,7 @@
     <StartupHookLibraryPath>$(StartupHookPublishPath)$(StartupHookLibraryName).dll</StartupHookLibraryPath>
     <StartupHookSymbolsPath>$(StartupHookPublishPath)$(StartupHookLibraryName).pdb</StartupHookSymbolsPath>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(SkipPlatformNeutralPublish)' != 'true'">
     <ProjectToPublish Include="$(MSBuildThisFileDirectory)Microsoft.Diagnostics.Monitoring.StartupHook.csproj">
       <!-- The RuntimeIdentifier is intentionally left blank to get a platform-neutral publish output. -->
       <AdditionalProperties>TargetFramework=$(StartupHookTargetFramework);RuntimeIdentifier=;PublishDir=$(StartupHookPublishPath)</AdditionalProperties>


### PR DESCRIPTION
###### Summary

Currently, each build leg is publishing platform neutral outputs and uploading them to the same build artifact and sub path. This can cause a race condition between two build legs that are publishing at the same time. This change fixes this behavior by only publishing platform neutral outputs on the win-x64 release build leg. Additionally, the publish outputs for this build leg are also uploaded to the Build_Unified_Release artifact so that nupkg creation can consume it without publishing it (currently, the nupkg creation leg is invoking publish, but this will be fixed in a different change).

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2130271&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
