### PR TITLE
Allow skipping publishing of projects in archive and package legs

### DIFF
--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -3,10 +3,10 @@
   <Import Project="$(RepoRoot)src\archives\dotnet-monitor\ProjectsToPublish.props" />
   <Import Project="$(RepoRoot)src\Microsoft.Diagnostics.Monitoring.StartupHook\ProjectsToPublish.props" />
 
-  <!-- Only publish projects after build if opt-in -->
+  <!-- Only publish projects after build if opt-in and not skipped -->
   <Target Name="PublishProjectsAfterBuild"
           AfterTargets="Build"
-          Condition="'$(PublishProjectsAfterBuild)' == 'true' and '$(CreateArchives)' != 'true'">
+          Condition="'$(PublishProjectsAfterBuild)' == 'true' and '$(SkipPublishProjects)' != 'true'">
     <CallTarget Targets="PublishProjects" />
   </Target>
 

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -35,7 +35,7 @@ jobs:
       -pack
       -skipmanaged
       -skipnative
-      /p:PublishProjectsAfterBuild=true
+      /p:SkipPublishProjects=true
       /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
 
     postBuildSteps:

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -40,6 +40,7 @@ jobs:
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
         /p:DotNetSignType=real
         /p:DotNetPublishUsingPipelines=true
+        /p:SkipPublishProjects=true
         /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
       displayName: Pack, Sign, and Publish
     # Intentionally copying file as "dotnet-monitor.nupkg.buildversion" for back compat

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -65,7 +65,7 @@
 
   <!-- Publish projects if they were not published after build -->
   <Target Name="PublishProjectsBeforePack"
-          Condition="'$(PublishProjectsAfterBuild)' != 'true'">
+          Condition="'$(SkipPublishProjects)' != 'true'">
     <CallTarget Targets="PublishProjects" />
   </Target>
 

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -63,7 +63,7 @@
   <Import Project="$(RepoRoot)src\Microsoft.Diagnostics.Monitoring.StartupHook\ProjectsToPublish.props" />
   <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />
 
-  <!-- Publish projects if they were not published after build -->
+  <!-- Publish projects unless skipped -->
   <Target Name="PublishProjectsBeforePack"
           Condition="'$(SkipPublishProjects)' != 'true'">
     <CallTarget Targets="PublishProjects" />

--- a/src/archives/PublishedProjectPackage.targets
+++ b/src/archives/PublishedProjectPackage.targets
@@ -6,9 +6,9 @@
     <PublishSymbolsToDiskDependsOn>CollectPublishedFilesToArchive</PublishSymbolsToDiskDependsOn>
   </PropertyGroup>
 
-  <!-- Publish projects if they were not published after build -->
+  <!-- Ensure publishable projects are published unless skipped. -->
   <Target Name="PublishProjectsBeforeArchive"
-          Condition="'$(PublishProjectsAfterBuild)' != 'true'">
+          Condition="'$(SkipPublishProjects)' != 'true'">
     <CallTarget Targets="PublishProjects" />
   </Target>
 


### PR DESCRIPTION
###### Summary

Allow the archive and package legs to explicitly opt out of publishing projects and relying on the build legs to provide the published binaries. This change requires #3883 as seen from the example build where it fails to package due to missing published binaries.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2130279&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
