### PR TITLE
[Egress] Support using shared framework host to execute extensions

### DIFF
--- a/src/Extensions/AzureBlobStorage/extension.json
+++ b/src/Extensions/AzureBlobStorage/extension.json
@@ -1,9 +1,10 @@
 {
-  "Id": "Microsoft.Diagnostics.Monitoring.AzureStorage",
-  "Version": "1.0.0",
-  "Program": "dotnet-monitor-egress-azureblobstorage",
-  "Name": "AzureBlobStorage",
-  "SupportedExtensionTypes": [
-    "Egress"
-  ]
+    "Id": "Microsoft.Diagnostics.Monitoring.AzureStorage",
+    "Version": "1.0.0",
+    "Program": "dotnet-monitor-egress-azureblobstorage",
+    "UseSharedDotNetHost": true,
+    "Name": "AzureBlobStorage",
+    "SupportedExtensionTypes": [
+        "Egress"
+    ]
 }

--- a/src/Extensions/S3Storage/extension.json
+++ b/src/Extensions/S3Storage/extension.json
@@ -1,9 +1,10 @@
 {
-  "Id": "Microsoft.Diagnostics.Monitoring.S3",
-  "Version": "1.0.0",
-  "Program": "dotnet-monitor-egress-s3storage",
-  "Name": "S3Storage",
-  "SupportedExtensionTypes": [
-    "Egress"
-  ]
+    "Id": "Microsoft.Diagnostics.Monitoring.S3",
+    "Version": "1.0.0",
+    "Program": "dotnet-monitor-egress-s3storage",
+    "UseSharedDotNetHost": true,
+    "Name": "S3Storage",
+    "SupportedExtensionTypes": [
+        "Egress"
+    ]
 }

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
@@ -301,8 +301,8 @@ namespace CollectionRuleActions.UnitTests
                 // fail frequently causing insertions and builds with unrelated changes to
                 // fail. See https://github.com/dotnet/dotnet-monitor/issues/807 for details.
                 return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                    DotNetHost.RuntimeVersion.Major != 3 ||
-                    DotNetHost.RuntimeVersion.Minor != 1;
+                    TestDotNetHost.RuntimeVersion.Major != 3 ||
+                    TestDotNetHost.RuntimeVersion.Minor != 1;
             }
         }
     }

--- a/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ExecuteActionTests.cs
@@ -37,7 +37,7 @@ namespace CollectionRuleActions.UnitTests
             await ValidateAction(
                 options =>
                 {
-                    options.Path = DotNetHost.GetPath();
+                    options.Path = TestDotNetHost.GetPath();
                     options.Arguments = ExecuteActionTestHelper.GenerateArgumentsString(Assembly.GetExecutingAssembly(), ActionTestsConstants.ZeroExitCode);
                 },
                 async (action, token) =>
@@ -56,7 +56,7 @@ namespace CollectionRuleActions.UnitTests
             await ValidateAction(
                 options =>
                 {
-                    options.Path = DotNetHost.GetPath();
+                    options.Path = TestDotNetHost.GetPath();
                     options.Arguments = ExecuteActionTestHelper.GenerateArgumentsString(Assembly.GetExecutingAssembly(), ActionTestsConstants.NonZeroExitCode);
                 },
                 async (action, token) =>
@@ -81,7 +81,7 @@ namespace CollectionRuleActions.UnitTests
             await ValidateAction(
                 options =>
                 {
-                    options.Path = DotNetHost.GetPath();
+                    options.Path = TestDotNetHost.GetPath();
                     options.Arguments = ExecuteActionTestHelper.GenerateArgumentsString(Assembly.GetExecutingAssembly(), ActionTestsConstants.Sleep, sleepMsArg);
                 },
                 async (action, token) =>
@@ -109,7 +109,7 @@ namespace CollectionRuleActions.UnitTests
             await ValidateAction(
                 options =>
                 {
-                    options.Path = DotNetHost.GetPath();
+                    options.Path = TestDotNetHost.GetPath();
                     options.Arguments = ExecuteActionTestHelper.GenerateArgumentsString(Assembly.GetExecutingAssembly(), ActionTestsConstants.TextFileOutput, textFileOutputPath, testMessage);
                 },
                 async (action, token) =>
@@ -150,7 +150,7 @@ namespace CollectionRuleActions.UnitTests
             await ValidateAction(
                 options =>
                 {
-                    options.Path = DotNetHost.GetPath();
+                    options.Path = TestDotNetHost.GetPath();
                     options.Arguments = ExecuteActionTestHelper.GenerateArgumentsString(Assembly.GetExecutingAssembly(), ActionTestsConstants.NonZeroExitCode);
                     options.IgnoreExitCode = true;
                 },

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/AssemblyHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
             if (tfm != TargetFrameworkMoniker.Current)
             {
-                string currentFolderName = DotNetHost.BuiltTargetFrameworkMoniker.ToFolderName();
+                string currentFolderName = TestDotNetHost.BuiltTargetFrameworkMoniker.ToFolderName();
                 string targetFolderName = tfm.ToFolderName();
 
                 assemblyPath = assemblyPath.Replace(currentFolderName, targetFolderName);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -7,7 +7,7 @@
    -->
 
   <PropertyGroup>
-    <DotNetHostGeneratedFileName>$(IntermediateOutputPath)/$(TargetFramework)/DotNetHost.g.cs</DotNetHostGeneratedFileName>
+    <DotNetHostGeneratedFileName>$(IntermediateOutputPath)/$(TargetFramework)/TestDotNetHost.g.cs</DotNetHostGeneratedFileName>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftNETCoreApp50Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</NetCoreAppVersion>
@@ -22,7 +22,7 @@
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
     <PropertyGroup>
-      <TemplateContent>$([System.IO.File]::ReadAllText('DotNetHost.cs.template'))</TemplateContent>
+      <TemplateContent>$([System.IO.File]::ReadAllText('TestDotNetHost.cs.template'))</TemplateContent>
       <TransformedContent>$(TemplateContent.Replace('$MicrosoftNetCoreAppVersion$', '$(NetCoreAppVersion)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreAppVersion$', '$(AspNetCoreAppVersion)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp31Version$', '$(MicrosoftNETCoreApp31Version)'))</TransformedContent>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         public async Task StartAsync(CancellationToken token)
         {
             StringBuilder argsBuilder = new();
-            if (DotNetHost.HasHostInRepository)
+            if (TestDotNetHost.HasHostInRepository)
             {
                 argsBuilder.Append("exec --runtimeconfig \"");
                 argsBuilder.Append(Path.ChangeExtension(EntrypointAssemblyPath, ".runtimeconfig.test.json"));
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             argsBuilder.Append("\" ");
             argsBuilder.Append(Arguments);
 
-            _process.StartInfo.FileName = DotNetHost.GetPath(Architecture);
+            _process.StartInfo.FileName = TestDotNetHost.GetPath(Architecture);
             _process.StartInfo.Arguments = argsBuilder.ToString();
 
             if (!_process.Start())

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -28,17 +28,17 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             switch (moniker)
             {
                 case TargetFrameworkMoniker.Current:
-                    return DotNetHost.CurrentAspNetCoreVersionString;
+                    return TestDotNetHost.CurrentAspNetCoreVersionString;
                 case TargetFrameworkMoniker.NetCoreApp31:
-                    return DotNetHost.AspNetCore31VersionString;
+                    return TestDotNetHost.AspNetCore31VersionString;
                 case TargetFrameworkMoniker.Net50:
-                    return DotNetHost.AspNetCore50VersionString;
+                    return TestDotNetHost.AspNetCore50VersionString;
                 case TargetFrameworkMoniker.Net60:
-                    return DotNetHost.AspNetCore60VersionString;
+                    return TestDotNetHost.AspNetCore60VersionString;
                 case TargetFrameworkMoniker.Net70:
-                    return DotNetHost.AspNetCore70VersionString;
+                    return TestDotNetHost.AspNetCore70VersionString;
                 case TargetFrameworkMoniker.Net80:
-                    return DotNetHost.AspNetCore80VersionString;
+                    return TestDotNetHost.AspNetCore80VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -48,17 +48,17 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             switch (moniker)
             {
                 case TargetFrameworkMoniker.Current:
-                    return DotNetHost.CurrentNetCoreVersionString;
+                    return TestDotNetHost.CurrentNetCoreVersionString;
                 case TargetFrameworkMoniker.NetCoreApp31:
-                    return DotNetHost.NetCore31VersionString;
+                    return TestDotNetHost.NetCore31VersionString;
                 case TargetFrameworkMoniker.Net50:
-                    return DotNetHost.NetCore50VersionString;
+                    return TestDotNetHost.NetCore50VersionString;
                 case TargetFrameworkMoniker.Net60:
-                    return DotNetHost.NetCore60VersionString;
+                    return TestDotNetHost.NetCore60VersionString;
                 case TargetFrameworkMoniker.Net70:
-                    return DotNetHost.NetCore70VersionString;
+                    return TestDotNetHost.NetCore70VersionString;
                 case TargetFrameworkMoniker.Net80:
-                    return DotNetHost.NetCore80VersionString;
+                    return TestDotNetHost.NetCore80VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
-    public partial class DotNetHost
+    public partial class TestDotNetHost
     {
         private static Lazy<bool> s_HasHostInRepositoryLazy =
             new(() => File.Exists(GetHostFromRepository()));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs.template
@@ -5,7 +5,7 @@
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
-    public partial class DotNetHost
+    public partial class TestDotNetHost
     {
         public static readonly string CurrentAspNetCoreVersionString = "$MicrosoftAspNetCoreAppVersion$";
         public static readonly string CurrentNetCoreVersionString = "$MicrosoftNetCoreAppVersion$";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -13,7 +13,6 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -214,7 +213,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 {
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
                         .SetStartupTrigger()
-                        .AddProcessNameFilter(DotNetHost.ExeNameWithoutExtension);
+                        .AddProcessNameFilter(TestDotNetHost.ExeNameWithoutExtension);
 
                     startedTask = runner.WaitForCollectionRuleStartedAsync(DefaultRuleName);
                 });

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DumpTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 configureApp: runner =>
                 {
                     // MachO not supported on .NET 5, only ELF: https://github.com/dotnet/runtime/blob/main/docs/design/coreclr/botr/xplat-minidump-generation.md#os-x
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && DotNetHost.RuntimeVersion.Major == 5)
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && TestDotNetHost.RuntimeVersion.Major == 5)
                     {
                         runner.Environment.Add(DumpTestUtilities.EnableElfDumpOnMacOS, "1");
                     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Options/CollectionRuleOptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Options/CollectionRuleOptionsExtensions.cs
@@ -173,14 +173,14 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 
         public static CollectionRuleOptions AddExecuteActionAppAction(this CollectionRuleOptions options, Assembly testAssembly, params string[] args)
         {
-            options.AddExecuteAction(DotNetHost.GetPath(), ExecuteActionTestHelper.GenerateArgumentsString(testAssembly, args));
+            options.AddExecuteAction(TestDotNetHost.GetPath(), ExecuteActionTestHelper.GenerateArgumentsString(testAssembly, args));
 
             return options;
         }
 
         public static CollectionRuleOptions AddExecuteActionAppAction(this CollectionRuleOptions options, Assembly testAssembly, bool waitForCompletion, params string[] args)
         {
-            options.AddExecuteAction(DotNetHost.GetPath(), ExecuteActionTestHelper.GenerateArgumentsString(testAssembly, args), waitForCompletion);
+            options.AddExecuteAction(TestDotNetHost.GetPath(), ExecuteActionTestHelper.GenerateArgumentsString(testAssembly, args), waitForCompletion);
 
             return options;
         }

--- a/src/Tools/dotnet-monitor/DotNetHost.Unix.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.Unix.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    partial class DotNetHost
+    {
+        private sealed class UnixDotNetHostHelper : IDotNetHostHelper
+        {
+            private const string InstallationFilePath = "/etc/dotnet/install_location";
+
+            private static readonly string CurrentArchInstallationFilePath =
+                FormattableString.Invariant($"{InstallationFilePath}_{RuntimeInformation.ProcessArchitecture.ToString("G").ToLowerInvariant()}");
+
+            public string ExecutableName => "dotnet";
+
+            public bool TryGetDefaultInstallationDirectory(out string dotnetRoot)
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    // CONSIDER: Account for emulation (emulated path would be under "./x64/")
+                    dotnetRoot = "/usr/local/share/dotnet";
+                }
+                else
+                {
+                    dotnetRoot = "/usr/share/dotnet";
+                }
+                return true;
+            }
+
+            public bool TryGetSelfRegisteredDirectory(out string dotnetRoot)
+            {
+                return TryReadFileFirstLine(CurrentArchInstallationFilePath, out dotnetRoot) ||
+                    TryReadFileFirstLine(InstallationFilePath, out dotnetRoot);
+            }
+
+            private static bool TryReadFileFirstLine(string filePath, out string content)
+            {
+                try
+                {
+                    using FileStream stream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    using StreamReader reader = new StreamReader(stream);
+                    content = reader.ReadLine();
+                    return !string.IsNullOrEmpty(content);
+                }
+                catch
+                {
+                    content = null;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/DotNetHost.Unix.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.Unix.cs
@@ -11,25 +11,31 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         private sealed class UnixDotNetHostHelper : IDotNetHostHelper
         {
-            private const string InstallationFilePath = "/etc/dotnet/install_location";
+            private const string DefaultPathLinux = $"/usr/share/{InstallationDirectoryName}";
+            private const string DefaultPathOSX = $"/usr/local/share/{InstallationDirectoryName}";
+            private const string InstallationFilePath = $"/etc/{InstallationDirectoryName}/install_location";
 
             private static readonly string CurrentArchInstallationFilePath =
                 FormattableString.Invariant($"{InstallationFilePath}_{RuntimeInformation.ProcessArchitecture.ToString("G").ToLowerInvariant()}");
 
-            public string ExecutableName => "dotnet";
+            public string ExecutableName => ExecutableRootName;
 
             public bool TryGetDefaultInstallationDirectory(out string dotnetRoot)
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     // CONSIDER: Account for emulation (emulated path would be under "./x64/")
-                    dotnetRoot = "/usr/local/share/dotnet";
+                    dotnetRoot = DefaultPathOSX;
+                    return true;
                 }
-                else
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    dotnetRoot = "/usr/share/dotnet";
+                    dotnetRoot = DefaultPathLinux;
+                    return true;
                 }
-                return true;
+
+                dotnetRoot = null;
+                return false;
             }
 
             public bool TryGetSelfRegisteredDirectory(out string dotnetRoot)

--- a/src/Tools/dotnet-monitor/DotNetHost.Windows.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.Windows.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    partial class DotNetHost
+    {
+        private sealed class WindowsDotNetHostHelper : IDotNetHostHelper
+        {
+            public string ExecutableName => "dotnet.exe";
+
+            public bool TryGetDefaultInstallationDirectory(out string dotnetRoot)
+            {
+                // CONSIDER: Account for emulation (emulated path would be under ".\x64\")
+                dotnetRoot = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet");
+                return true;
+            }
+
+            public bool TryGetSelfRegisteredDirectory(out string dotnetRoot)
+            {
+                // TODO: Lookup dotnet installation from registry
+                dotnetRoot = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/DotNetHost.Windows.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -9,18 +10,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         private sealed class WindowsDotNetHostHelper : IDotNetHostHelper
         {
-            public string ExecutableName => "dotnet.exe";
+            public string ExecutableName => FormattableString.Invariant($"{ExecutableRootName}.exe");
 
             public bool TryGetDefaultInstallationDirectory(out string dotnetRoot)
             {
                 // CONSIDER: Account for emulation (emulated path would be under ".\x64\")
-                dotnetRoot = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet");
+                dotnetRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), InstallationDirectoryName);
                 return true;
             }
 
             public bool TryGetSelfRegisteredDirectory(out string dotnetRoot)
             {
-                // TODO: Lookup dotnet installation from registry
+                // CONSIDER: Lookup dotnet installation from registry
                 dotnetRoot = null;
                 return false;
             }

--- a/src/Tools/dotnet-monitor/DotNetHost.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.cs
@@ -10,6 +10,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static partial class DotNetHost
     {
+        private const string DotNetName = "dotnet";
+        public const string ExecutableRootName = DotNetName;
+        public const string InstallationDirectoryName = DotNetName;
+
         private static readonly IDotNetHostHelper Helper =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             new WindowsDotNetHostHelper() :
@@ -18,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private static readonly Lazy<string> PathLazy =
             new Lazy<string>(GetPath, LazyThreadSafetyMode.ExecutionAndPublication);
 
-        public static string Path => PathLazy.Value;
+        public static string ExecutablePath => PathLazy.Value;
 
         private static string GetPath()
         {

--- a/src/Tools/dotnet-monitor/DotNetHost.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static partial class DotNetHost
+    {
+        private static readonly string ExecutableName =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            "dotnet.exe" :
+            "dotnet";
+
+        private static readonly Lazy<string> PathLazy =
+            new Lazy<string>(GetPath, LazyThreadSafetyMode.ExecutionAndPublication);
+
+        public static string Path => PathLazy.Value;
+
+        private static string GetPath()
+        {
+            // If current executable is already dotnet, return its path
+            string executablePath = Environment.ProcessPath;
+            if (!string.IsNullOrEmpty(executablePath) && executablePath.EndsWith(ExecutableName, StringComparison.OrdinalIgnoreCase))
+            {
+                return executablePath;
+            }
+
+            // Get dotnet root from environment variable
+            // TODO: check architecture specific environment variables (e.g. *_X86, *_X64, *_ARM64)
+            string dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                executablePath = System.IO.Path.Combine(dotnetRoot, ExecutableName);
+                if (!File.Exists(executablePath))
+                {
+                    throw new FileNotFoundException(null, executablePath);
+                }
+                return executablePath;
+            }
+
+            // Rely on PATH lookup
+            return ExecutableName;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionDeclaration.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionDeclaration.cs
@@ -33,5 +33,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
         /// This should contain values from <see cref="ExtensionTypes"/>.
         /// </summary>
         public string[] SupportedExtensionTypes { get; set; }
+
+        /// <summary>
+        /// Instructs dotnet-monitor to launch the extension using the shared .NET host (e.g. dotnet.exe).
+        /// </summary>
+        public bool UseSharedDotNetHost { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/Extensibility/ProgramExtension.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ProgramExtension.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
             string executablePath;
             if (Declaration.UseSharedDotNetHost)
             {
-                executablePath = DotNetHost.Path;
+                executablePath = DotNetHost.ExecutablePath;
 
                 string entrypointAssemblyRelativePath = Path.Combine(Path.GetDirectoryName(_exePath), $"{Declaration.Program}.dll");
 


### PR DESCRIPTION
###### Summary

Extensions can specify `"UseSharedDotNetHost": true` in their manifest in order to instruct dotnet-monitor to execute the extension using the shared framework host (e.g. `dotnet.exe`) instead of the platform-specific apphost in the extension. This allows a platform-neutral extension to be used so that extensions do not have to have separate apphost executables for each supported platform.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
