### PR TITLE
Nest extension content in archives under extensions folder

### DIFF
--- a/src/archives/AzureBlobStorage/Package.props
+++ b/src/archives/AzureBlobStorage/Package.props
@@ -5,9 +5,12 @@
     <ExecutableName>dotnet-monitor-egress-azureblobstorage</ExecutableName>
     <ArchiveName>dotnet-monitor-egress-azureblobstorage</ArchiveName>
     <ArchiveContentRootPath>$(AzureBlobStoragePlatformSpecificPublishPath)</ArchiveContentRootPath>
+    <ArchiveContentPackagePath>extensions/AzureBlobStorage/</ArchiveContentPackagePath>
   </PropertyGroup>
   <!-- These items are included in addition to those from publishing the AzureBlobStorage project. -->
   <ItemGroup>
-    <FileToArchive Include="$(RepoRoot)LICENSE.TXT" />
+    <FileToArchive Include="$(RepoRoot)LICENSE.TXT">
+      <PackagePath>$(ArchiveContentPackagePath)</PackagePath>
+    </FileToArchive>
   </ItemGroup>
 </Project>

--- a/src/archives/PublishedProjectPackage.targets
+++ b/src/archives/PublishedProjectPackage.targets
@@ -19,7 +19,12 @@
     <Error Text="The archive content root path '$(ArchiveContentRootPath)' does not exist."
            Condition="!Exists($(ArchiveContentRootPath))" />
     <ItemGroup>
-      <FileToArchive Include="$(ArchiveContentRootPath)**" />
+      <PublishedFile Include="$(ArchiveContentRootPath)**" />
+    </ItemGroup>
+    <ItemGroup>
+      <FileToArchive Include="@(PublishedFile)">
+        <PackagePath>$(ArchiveContentPackagePath)%(RecursiveDir)</PackagePath>
+      </FileToArchive>
     </ItemGroup>
     <ItemGroup>
       <FileToArchive Remove="$(ArchiveContentRootPath)**\*.dbg" />
@@ -27,9 +32,14 @@
       <FileToArchive Remove="$(ArchiveContentRootPath)**\*.pdb" />
     </ItemGroup>
     <ItemGroup>
-      <SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.dbg" />
-      <SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.dwarf" />
-      <SymbolFileToArchive Include="$(ArchiveContentRootPath)**\*.pdb" />
+      <PublishedSymbolFile Include="$(ArchiveContentRootPath)**\*.dbg" />
+      <PublishedSymbolFile Include="$(ArchiveContentRootPath)**\*.dwarf" />
+      <PublishedSymbolFile Include="$(ArchiveContentRootPath)**\*.pdb" />
+    </ItemGroup>
+    <ItemGroup>
+      <SymbolFileToArchive Include="@(PublishedSymbolFile)">
+        <PackagePath>$(ArchiveContentPackagePath)%(RecursiveDir)</PackagePath>
+      </SymbolFileToArchive>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/archives/S3Storage/Package.props
+++ b/src/archives/S3Storage/Package.props
@@ -5,9 +5,12 @@
     <ExecutableName>dotnet-monitor-egress-s3storage</ExecutableName>
     <ArchiveName>dotnet-monitor-egress-s3storage</ArchiveName>
     <ArchiveContentRootPath>$(S3StoragePlatformSpecificPublishPath)</ArchiveContentRootPath>
+    <ArchiveContentPackagePath>extensions/S3Storage/</ArchiveContentPackagePath>
   </PropertyGroup>
   <!-- These items are included in addition to those from publishing the S3Storage project. -->
   <ItemGroup>
-    <FileToArchive Include="$(RepoRoot)LICENSE.TXT" />
+    <FileToArchive Include="$(RepoRoot)LICENSE.TXT">
+      <PackagePath>$(ArchiveContentPackagePath)</PackagePath>
+    </FileToArchive>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
###### Summary

Nest the contents of the extensions under the `extensions/<extension_name>` subfolder within the archives. This allows unpacking of the dotnet-monitor and extension archives into the same root directory without having to know which folders the extension archives would need to be unpacked.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
