### PR TITLE
Allow building of latest TFM in VS if using startvs script

### DIFF
--- a/startvs.cmd
+++ b/startvs.cmd
@@ -14,6 +14,9 @@ SET DOTNET_MULTILEVEL_LOOKUP=0
 :: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
 SET PATH=%DOTNET_ROOT%;%PATH%
 
+:: Allow building of the latest target framework because SDK from the repository will be used to build
+SET ExcludeLatestTargetFramework=false
+
 SET sln=%~1
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (


### PR DESCRIPTION
###### Summary

If the `startvs.cmd` script is used to launch Visual Studio, then the latest TFM can be built because the SDK from the repository will be used by Visual Studio instead of the SDK from the global installation location.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
