### PR TITLE
[Egress Extensibility] Change Logging Message For When Extension Starts

### DIFF
--- a/src/Tools/dotnet-monitor/Extensibility/ProgramExtension.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ProgramExtension.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 
             using OutputParser<EgressArtifactResult> parser = new(p, _logger);
 
-            _logger.ExtensionStarting(pStart.FileName, pStart.Arguments);
+            _logger.ExtensionStarting(_extensionName);
             if (!p.Start())
             {
                 ExtensionException.ThrowLaunchFailure(_extensionName);

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -332,8 +332,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_ExtensionProbeFailed);
 
-        private static readonly Action<ILogger, string, string, Exception> _extensionStarting =
-            LoggerMessage.Define<string, string>(
+        private static readonly Action<ILogger, string, Exception> _extensionStarting =
+            LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExtensionStarting.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ExtensionStarting);
@@ -774,9 +774,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _extensionProbeFailed(logger, extensionName, null);
         }
 
-        public static void ExtensionStarting(this ILogger logger, string extensionPath, string arguments)
+        public static void ExtensionStarting(this ILogger logger, string extensionName)
         {
-            _extensionStarting(logger, extensionPath, arguments, null);
+            _extensionStarting(logger, extensionName, null);
         }
 
         public static void ExtensionConfigured(this ILogger logger, string extensionPath, int pid)

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1223,7 +1223,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starting extension &apos;{extensionPath} {cmdArgs}&apos;..
+        ///   Looks up a localized string similar to Starting extension &apos;{extensionName}&apos;..
         /// </summary>
         internal static string LogFormatString_ExtensionStarting {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -727,11 +727,10 @@
 3. program: The program defined to launch the executable</comment>
   </data>
   <data name="LogFormatString_ExtensionStarting" xml:space="preserve">
-    <value>Starting extension '{extensionPath} {cmdArgs}'.</value>
+    <value>Starting extension '{extensionName}'.</value>
     <comment>Gets the format string that is printed in the 66:ExtensionStarting event.
-2 Format Parameters:
-1. extensionPath: Path to the executable extension
-2. cmdArgs: the commandline arguments being passed to the executable</comment>
+1 Format Parameter:
+1. extensionName: The name of the extension or moniker</comment>
   </data>
   <data name="LogFormatString_ExperimentalFeatureEnabled" xml:space="preserve">
     <value>Experimental feature '{name}' is enabled.</value>


### PR DESCRIPTION
###### Summary

The extension started message currently prints the path to the file that's starting up - with the recent changes to using the dotnet executable, this message isn't helpful for users (on linux: `Starting extension '/usr/share/dotnet/dotnet '`).

For human-readability, this switches the logging statement to show the name of the extension (now: `Starting extension 'AzureBlobStorage'.`)

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
