### PR TITLE
[Experimental] Add/Remove `needs-review` label to PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -367,6 +367,126 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "synchronize"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-review"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestReviewResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "needs-review"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "submitted"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request_review"
+        ],
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-review"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "needs-review"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": {
+                      "type": "author"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-review"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -375,12 +375,30 @@
       "version": "1.0",
       "config": {
         "conditions": {
-          "operator": "and",
+          "operator": "or",
           "operands": [
             {
               "name": "isAction",
               "parameters": {
                 "action": "synchronize"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "reopened"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "review_requested"
               }
             }
           ]
@@ -398,7 +416,8 @@
               "label": "needs-review"
             }
           }
-        ]
+        ],
+        "taskName": "Add needs-review Label On Change"
       }
     },
     {
@@ -417,10 +436,24 @@
               }
             },
             {
-              "name": "isAction",
-              "parameters": {
-                "action": "submitted"
-              }
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "submitted"
+                  }
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "isOpen",
+                      "parameters": {}
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -435,7 +468,8 @@
               "label": "needs-review"
             }
           }
-        ]
+        ],
+        "taskName": "Remove needs-review Label On Review"
       }
     },
     {
@@ -485,7 +519,8 @@
               "label": "needs-review"
             }
           }
-        ]
+        ],
+        "taskName": "Remove needs-review Label On Comment"
       }
     }
   ],


### PR DESCRIPTION
###### Summary

After discussing some of the main issues we face with PRs, it seemed like one of the main issues was that PRs start to get stale (especially after multiple review cycles). By default, GitHub doesn't offer a clear way to tell when an item is still being worked on versus when it needs another round of feedback. This PR adds a `needs-review` label whenever a contributor pushes a new commit to their PR - whenever someone reviews or leaves a comment on the PR, the label should automatically be taken away. This _should_ require no manual intervention, and provides a visual way to quickly tell which things need a fresh review (the label is neon green, so it should stand out at a glance).

Since this uses fabricbot, I haven't been able to verify that this works - I intend to test it once it's checked in and make changes (or remove it) as necessary.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
