### PR TITLE
Allow using extensions from build output

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
@@ -16,65 +15,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         Net80
     }
 
-    public static class TargetFrameworkMonikerExtensions
+    public static partial class TargetFrameworkMonikerExtensions
     {
-        public static Version GetAspNetCoreFrameworkVersion(this TargetFrameworkMoniker moniker)
-        {
-            return ParseVersionRemoveLabel(moniker.GetAspNetCoreFrameworkVersionString());
-        }
-
-        public static string GetAspNetCoreFrameworkVersionString(this TargetFrameworkMoniker moniker)
-        {
-            switch (moniker)
-            {
-                case TargetFrameworkMoniker.Current:
-                    return TestDotNetHost.CurrentAspNetCoreVersionString;
-                case TargetFrameworkMoniker.NetCoreApp31:
-                    return TestDotNetHost.AspNetCore31VersionString;
-                case TargetFrameworkMoniker.Net50:
-                    return TestDotNetHost.AspNetCore50VersionString;
-                case TargetFrameworkMoniker.Net60:
-                    return TestDotNetHost.AspNetCore60VersionString;
-                case TargetFrameworkMoniker.Net70:
-                    return TestDotNetHost.AspNetCore70VersionString;
-                case TargetFrameworkMoniker.Net80:
-                    return TestDotNetHost.AspNetCore80VersionString;
-            }
-            throw CreateUnsupportedException(moniker);
-        }
-
-        public static string GetNetCoreAppFrameworkVersionString(this TargetFrameworkMoniker moniker)
-        {
-            switch (moniker)
-            {
-                case TargetFrameworkMoniker.Current:
-                    return TestDotNetHost.CurrentNetCoreVersionString;
-                case TargetFrameworkMoniker.NetCoreApp31:
-                    return TestDotNetHost.NetCore31VersionString;
-                case TargetFrameworkMoniker.Net50:
-                    return TestDotNetHost.NetCore50VersionString;
-                case TargetFrameworkMoniker.Net60:
-                    return TestDotNetHost.NetCore60VersionString;
-                case TargetFrameworkMoniker.Net70:
-                    return TestDotNetHost.NetCore70VersionString;
-                case TargetFrameworkMoniker.Net80:
-                    return TestDotNetHost.NetCore80VersionString;
-            }
-            throw CreateUnsupportedException(moniker);
-        }
-
-        // Checks if the specified moniker is the same as the test value or if it is Current
-        // then matches the same TFM for which this assembly was built.
-        public static bool IsEffectively(this TargetFrameworkMoniker moniker, TargetFrameworkMoniker test)
-        {
-            if (TargetFrameworkMoniker.Current == test)
-            {
-                throw new ArgumentException($"Parameter {nameof(test)} cannot be TargetFrameworkMoniker.Current");
-            }
-
-            return moniker == test || (TargetFrameworkMoniker.Current == moniker && CurrentTargetFrameworkMoniker == test);
-        }
-
         public static string ToFolderName(this TargetFrameworkMoniker moniker)
         {
             switch (moniker)
@@ -96,17 +38,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         private static ArgumentException CreateUnsupportedException(TargetFrameworkMoniker moniker)
         {
             return new ArgumentException($"Unsupported target framework moniker: {moniker:G}");
-        }
-
-        private static Version ParseVersionRemoveLabel(string versionString)
-        {
-            Assert.NotNull(versionString);
-            int prereleaseLabelIndex = versionString.IndexOf('-');
-            if (prereleaseLabelIndex >= 0)
-            {
-                versionString = versionString.Substring(0, prereleaseLabelIndex);
-            }
-            return Version.Parse(versionString);
         }
 
         public const TargetFrameworkMoniker CurrentTargetFrameworkMoniker =

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerExtensions.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
+{
+    public static partial class TargetFrameworkMonikerExtensions
+    {
+        public static Version GetAspNetCoreFrameworkVersion(this TargetFrameworkMoniker moniker)
+        {
+            return ParseVersionRemoveLabel(moniker.GetAspNetCoreFrameworkVersionString());
+        }
+
+        public static string GetAspNetCoreFrameworkVersionString(this TargetFrameworkMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case TargetFrameworkMoniker.Current:
+                    return TestDotNetHost.CurrentAspNetCoreVersionString;
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return TestDotNetHost.AspNetCore31VersionString;
+                case TargetFrameworkMoniker.Net50:
+                    return TestDotNetHost.AspNetCore50VersionString;
+                case TargetFrameworkMoniker.Net60:
+                    return TestDotNetHost.AspNetCore60VersionString;
+                case TargetFrameworkMoniker.Net70:
+                    return TestDotNetHost.AspNetCore70VersionString;
+                case TargetFrameworkMoniker.Net80:
+                    return TestDotNetHost.AspNetCore80VersionString;
+            }
+            throw CreateUnsupportedException(moniker);
+        }
+
+        public static string GetNetCoreAppFrameworkVersionString(this TargetFrameworkMoniker moniker)
+        {
+            switch (moniker)
+            {
+                case TargetFrameworkMoniker.Current:
+                    return TestDotNetHost.CurrentNetCoreVersionString;
+                case TargetFrameworkMoniker.NetCoreApp31:
+                    return TestDotNetHost.NetCore31VersionString;
+                case TargetFrameworkMoniker.Net50:
+                    return TestDotNetHost.NetCore50VersionString;
+                case TargetFrameworkMoniker.Net60:
+                    return TestDotNetHost.NetCore60VersionString;
+                case TargetFrameworkMoniker.Net70:
+                    return TestDotNetHost.NetCore70VersionString;
+                case TargetFrameworkMoniker.Net80:
+                    return TestDotNetHost.NetCore80VersionString;
+            }
+            throw CreateUnsupportedException(moniker);
+        }
+
+        // Checks if the specified moniker is the same as the test value or if it is Current
+        // then matches the same TFM for which this assembly was built.
+        public static bool IsEffectively(this TargetFrameworkMoniker moniker, TargetFrameworkMoniker test)
+        {
+            if (TargetFrameworkMoniker.Current == test)
+            {
+                throw new ArgumentException($"Parameter {nameof(test)} cannot be TargetFrameworkMoniker.Current");
+            }
+
+            return moniker == test || (TargetFrameworkMoniker.Current == moniker && CurrentTargetFrameworkMoniker == test);
+        }
+
+        private static Version ParseVersionRemoveLabel(string versionString)
+        {
+            Assert.NotNull(versionString);
+            int prereleaseLabelIndex = versionString.IndexOf('-');
+            if (prereleaseLabelIndex >= 0)
+            {
+                versionString = versionString.Substring(0, prereleaseLabelIndex);
+            }
+            return Version.Parse(versionString);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutput.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutput.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
+{
+    internal static class BuildOutput
+    {
+        public const string ConfigurationName =
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+
+        // This is the binary output directory when built from the dotnet-monitor repo: <repoRoot>/artifacts/bin
+        public static readonly string RootPath =
+            Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", ".."));
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputExtensionRepository.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputExtensionRepository.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using System.IO;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
+{
+    internal sealed class BuildOutputExtensionRepository : ExtensionRepository
+    {
+        private readonly ILogger<ProgramExtension> _logger;
+
+        public BuildOutputExtensionRepository(ILogger<ProgramExtension> logger)
+        {
+            _logger = logger;
+        }
+
+        public override bool TryFindExtension(string extensionName, out IExtension extension)
+        {
+            string libraryPath = GetExtensionPath(extensionName);
+            if (Directory.Exists(libraryPath))
+            {
+                extension = CreateProgramExtension(extensionName, libraryPath);
+                return true;
+            }
+
+            extension = null;
+            return false;
+        }
+
+        private static string GetExtensionPath(string extensionName)
+        {
+            // The extension name happens to be the project name and output folder name
+            // for the current list of extensions. This path looks like:
+            // <repo>/artifacts/bin/<extension>/<configuration>/<tfm>
+            return Path.Combine(
+                BuildOutput.RootPath,
+                extensionName,
+                BuildOutput.ConfigurationName,
+                TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker.ToFolderName());
+        }
+
+        private IExtension CreateProgramExtension(string extensionName, string extensionPath)
+        {
+            return new ProgramExtension(
+                extensionName,
+                extensionPath,
+                new PhysicalFileProvider(extensionPath),
+                Constants.ExtensionDefinitionFile,
+                _logger);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputManagedFileProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputManagedFileProvider.cs
@@ -14,13 +14,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
     /// </summary>
     internal sealed class BuildOutputManagedFileProvider : IFileProvider
     {
-        private const string ConfigurationName =
-#if DEBUG
-            "Debug";
-#else
-            "Release";
-#endif
-
         private readonly string _managedFileBasePath;
         private readonly string _targetFramework;
 
@@ -48,7 +41,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
         public IFileInfo GetFileInfo(string subpath)
         {
             string libraryName = Path.GetFileNameWithoutExtension(subpath);
-            FileInfo fileInfo = new FileInfo(Path.Combine(_managedFileBasePath, libraryName, ConfigurationName, _targetFramework, subpath));
+            FileInfo fileInfo = new FileInfo(Path.Combine(_managedFileBasePath, libraryName, BuildOutput.ConfigurationName, _targetFramework, subpath));
             if (fileInfo.Exists)
             {
                 return new PhysicalFileInfo(fileInfo);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputNativeFileProvider.cs
@@ -28,14 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
         /// </summary>
         public static IFileProvider Create(string runtimeIdentifier, string sharedLibraryPath)
         {
-            string configurationName =
-#if DEBUG
-            "Debug";
-#else
-            "Release";
-#endif
-
-            string nativeOutputPath = Path.Combine(sharedLibraryPath, $"{runtimeIdentifier}.{configurationName}");
+            string nativeOutputPath = Path.Combine(sharedLibraryPath, $"{runtimeIdentifier}.{BuildOutput.ConfigurationName}");
 
             return new BuildOutputNativeFileProvider(nativeOutputPath);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
@@ -5,17 +5,11 @@ using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
-using System.IO;
-using System.Reflection;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
 {
     internal sealed class BuildOutputSharedLibraryInitializer : ISharedLibraryInitializer
     {
-        // This is the binary output directory when built from the dotnet-monitor repo: <repoRoot>/artifacts/bin
-        private static readonly string SharedLibrarySourcePath =
-            Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", ".."));
-
         private readonly ILogger<BuildOutputSharedLibraryInitializer> _logger;
 
         public BuildOutputSharedLibraryInitializer(ILogger<BuildOutputSharedLibraryInitializer> logger)
@@ -25,7 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
 
         public IFileProviderFactory Initialize()
         {
-            _logger.SharedLibraryPath(SharedLibrarySourcePath);
+            _logger.SharedLibraryPath(BuildOutput.RootPath);
 
             return new Factory();
         }
@@ -34,12 +28,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
         {
             public IFileProvider CreateManaged(string targetFramework)
             {
-                return BuildOutputManagedFileProvider.Create(targetFramework, SharedLibrarySourcePath);
+                return BuildOutputManagedFileProvider.Create(targetFramework, BuildOutput.RootPath);
             }
 
             public IFileProvider CreateNative(string runtimeIdentifier)
             {
-                return BuildOutputNativeFileProvider.Create(runtimeIdentifier, SharedLibrarySourcePath);
+                return BuildOutputNativeFileProvider.Create(runtimeIdentifier, BuildOutput.RootPath);
             }
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/HostingStartup.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/HostingStartup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup;
+using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,6 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
         {
             builder.ConfigureServices((context, services) =>
             {
+                services.AddSingleton<ExtensionRepository, BuildOutputExtensionRepository>();
                 services.AddSingleton<ISharedLibraryInitializer, BuildOutputSharedLibraryInitializer>();
             });
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\TargetFrameworkMoniker.cs" Link="TargetFrameworkMoniker.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionRepository.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionRepository.cs
@@ -6,16 +6,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {
     internal abstract class ExtensionRepository
     {
-        public ExtensionRepository(string displayName)
-        {
-            DisplayName = displayName;
-        }
-
-        /// <summary>
-        /// Gets a friendly name to describe this instance of an <see cref="ExtensionRepository"/>. This is used in Logs.
-        /// </summary>
-        public string DisplayName { get; private init; }
-
         /// <summary>
         /// Gets a callable <see cref="IExtension"/> for the given extension moniker.
         /// </summary>

--- a/src/Tools/dotnet-monitor/Extensibility/FolderExtensionRepository.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/FolderExtensionRepository.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
-using System.Globalization;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {
@@ -15,7 +14,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
         private readonly ILogger<ProgramExtension> _logger;
 
         public FolderExtensionRepository(IFileProvider fileSystem, ILogger<ProgramExtension> logger, string targetFolder)
-            : base(string.Format(CultureInfo.CurrentCulture, Strings.Message_FolderExtensionRepoName, targetFolder))
         {
             _fileSystem = fileSystem;
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1493,15 +1493,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to folder &apos;{0}&apos;.
-        /// </summary>
-        internal static string Message_FolderExtensionRepoName {
-            get {
-                return ResourceManager.GetString("Message_FolderExtensionRepoName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Generated ApiKey for dotnet-monitor; use the following header for authorization:.
         /// </summary>
         internal static string Message_GenerateApiKey {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -867,10 +867,6 @@
   <data name="Message_ExperienceSurvey" xml:space="preserve">
     <value>Tell us about your experience with dotnet monitor: {0}</value>
   </data>
-  <data name="Message_FolderExtensionRepoName" xml:space="preserve">
-    <value>folder '{0}'</value>
-    <comment>Gets the string for describing a folder extension repo</comment>
-  </data>
   <data name="Message_GenerateApiKey" xml:space="preserve">
     <value>Generated ApiKey for dotnet-monitor; use the following header for authorization:</value>
     <comment>Gets a header string for the output of GenerateApiKeyCommand.</comment>


### PR DESCRIPTION
###### Summary

Allow building and using extensions directly from debug build output without having to stage the egress extensions.

This is done by adding another ExtensionRepository implementation to the test hosting startup that understands how to locate extensions from the build output directory.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
