### PR TITLE
Simplified extension manifest

### DIFF
--- a/src/Extensions/AzureBlobStorage/extension.json
+++ b/src/Extensions/AzureBlobStorage/extension.json
@@ -1,10 +1,4 @@
 {
-    "Id": "Microsoft.Diagnostics.Monitoring.AzureStorage",
-    "Version": "1.0.0",
-    "Program": "dotnet-monitor-egress-azureblobstorage",
-    "UseSharedDotNetHost": true,
     "Name": "AzureBlobStorage",
-    "SupportedExtensionTypes": [
-        "Egress"
-    ]
+    "AssemblyFileName": "dotnet-monitor-egress-azureblobstorage"
 }

--- a/src/Extensions/S3Storage/extension.json
+++ b/src/Extensions/S3Storage/extension.json
@@ -1,10 +1,4 @@
 {
-    "Id": "Microsoft.Diagnostics.Monitoring.S3",
-    "Version": "1.0.0",
-    "Program": "dotnet-monitor-egress-s3storage",
-    "UseSharedDotNetHost": true,
     "Name": "S3Storage",
-    "SupportedExtensionTypes": [
-        "Egress"
-    ]
+    "AssemblyFileName": "dotnet-monitor-egress-s3storage"
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/extension.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/extension.json
@@ -1,9 +1,4 @@
 {
-    "Id": "Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp",
-    "Version": "1.0.0",
-    "Program": "Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp",
-    "Name": "TestingProvider",
-    "SupportedExtensionTypes": [
-        "Egress"
-    ]
+    "ExecutableFileName": "Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp",
+    "Name": "TestingProvider"
 }

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionDeclaration.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionDeclaration.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 
         public void Validate()
         {
-            bool hasAssemblyFileName = string.IsNullOrEmpty(AssemblyFileName);
-            bool hasExecutableFileName = string.IsNullOrEmpty(ExecutableFileName);
+            bool hasAssemblyFileName = !string.IsNullOrEmpty(AssemblyFileName);
+            bool hasExecutableFileName = !string.IsNullOrEmpty(ExecutableFileName);
 
             if (hasAssemblyFileName && hasExecutableFileName)
             {

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionDeclaration.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionDeclaration.cs
@@ -1,42 +1,57 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-using System;
+using System.Globalization;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {
     internal class ExtensionDeclaration
     {
         /// <summary>
-        /// Id of the extension. This should be namespace qualified like nuget packages.
-        /// </summary>
-        public string Id { get; set; }
-
-        /// <summary>
-        /// The version of the extension. This should be SemVer 2.0.
-        /// </summary>
-        public Version Version { get; set; }
-
-        /// <summary>
-        /// This is the relative path to the executable file to be launched.
-        /// </summary>
-        public string Program { get; set; }
-
-        /// <summary>
         /// This is the name that users specify in configuration to refer to the extension.
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// An array of strings declaring what types of extensions are supported by this extension.
-        /// This should contain values from <see cref="ExtensionTypes"/>.
+        /// If specified, the executable file (without extension) to be launched when executing the extension.
         /// </summary>
-        public string[] SupportedExtensionTypes { get; set; }
+        /// <remarks>
+        /// Either <see cref="ExecutableFileName"/> or <see cref="AssemblyFileName"/> must be specified.
+        /// </remarks>
+        public string ExecutableFileName { get; set; }
 
         /// <summary>
-        /// Instructs dotnet-monitor to launch the extension using the shared .NET host (e.g. dotnet.exe).
+        /// If specified, executes the extension using the shared .NET host (e.g. dotnet.exe) with the specified entry point assembly (without extension). 
         /// </summary>
-        public bool UseSharedDotNetHost { get; set; }
+        /// <remarks>
+        /// Either <see cref="ExecutableFileName"/> or <see cref="AssemblyFileName"/> must be specified.
+        /// </remarks>
+        public string AssemblyFileName { get; set; }
+
+        public void Validate()
+        {
+            bool hasAssemblyFileName = string.IsNullOrEmpty(AssemblyFileName);
+            bool hasExecutableFileName = string.IsNullOrEmpty(ExecutableFileName);
+
+            if (hasAssemblyFileName && hasExecutableFileName)
+            {
+                ExtensionException.ThrowInvalidManifest(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Strings.ErrorMessage_TwoFieldsCannotBeSpecified,
+                        nameof(AssemblyFileName),
+                        nameof(ExecutableFileName)));
+            }
+
+            if (!hasAssemblyFileName && !hasExecutableFileName)
+            {
+                ExtensionException.ThrowInvalidManifest(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        Strings.ErrorMessage_TwoFieldsMissing,
+                        nameof(AssemblyFileName),
+                        nameof(ExecutableFileName)));
+            }
+        }
     }
 }

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionNotFoundException.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionNotFoundException.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Diagnostics.Monitoring;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Microsoft.Diagnostics.Monitoring;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {
@@ -17,21 +15,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
         }
 
         [DoesNotReturn]
-        public static ExtensionException ThrowNotFound(string extensionName)
+        public static void ThrowNotFound(string extensionName)
         {
             throw new ExtensionException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_ExtensionNotFound, extensionName));
         }
 
-        [DoesNotReturn]
-        public static ExtensionException ThrowLaunchFailure(string extensionName)
+        public static void ThrowInvalidManifest(string reason)
         {
-            throw new ExtensionException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_ExtensionLaunchFailed, extensionName));
+            throw new ExtensionException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_ExtensionManifestInvalid, reason));
         }
 
         [DoesNotReturn]
-        public static ExtensionException ThrowWrongType(string extensionName, string extensionPath, Type requiredType)
+        public static void ThrowLaunchFailure(string extensionName)
         {
-            throw new ExtensionException(string.Format(CultureInfo.CurrentCulture, Strings.LogFormatString_ExtensionNotOfType, extensionName, extensionPath, requiredType.Name));
+            throw new ExtensionException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_ExtensionLaunchFailed, extensionName));
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -232,6 +232,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid extension manifest: {0}.
+        /// </summary>
+        internal static string ErrorMessage_ExtensionManifestInvalid {
+            get {
+                return ResourceManager.GetString("ErrorMessage_ExtensionManifestInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to locate extension &apos;{0}&apos;..
         /// </summary>
         internal static string ErrorMessage_ExtensionNotFound {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -908,4 +908,7 @@
     <value>:REDACTED:</value>
     <comment>Gets a string similar to ":REDACTED:".</comment>
   </data>
+  <data name="ErrorMessage_ExtensionManifestInvalid" xml:space="preserve">
+    <value>Invalid extension manifest: {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
###### Summary

Simplifies the extension manifest to only have three properties:
- Name: The name of the extension e.g. AzureBlobStorage or S3Storage
- ExecutableFileName: The name of the executable entry point if to be launched using its own executable.
- AssemblyFileName: The name of the entry point assembly if to be launched using the shared .NET host (e.g. dotnet.exe).

Everything else that was removed either was unused or would lead to future confusion if we add other extensibility points.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
