### PR TITLE
[Egress Extensibility] Re-enable data annotation validation and other minor logging-related fixes

### DIFF
--- a/src/Extensions/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
+++ b/src/Extensions/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
@@ -5,7 +5,9 @@ using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,6 +36,18 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
                 string jsonConfig = Console.ReadLine();
                 ExtensionEgressPayload configPayload = JsonSerializer.Deserialize<ExtensionEgressPayload>(jsonConfig);
                 TOptions options = BuildOptions(configPayload, configureOptions);
+
+                var context = new ValidationContext(options);
+
+                var results = new List<ValidationResult>();
+
+                if (!Validator.TryValidateObject(options, context, results, true))
+                {
+                    if (results.Count > 0)
+                    {
+                        throw new EgressException(results.First().ErrorMessage);
+                    }
+                }
 
                 Console.CancelKeyPress += Console_CancelKeyPress;
 

--- a/src/Extensions/S3Storage/S3StorageEgressProvider.cs
+++ b/src/Extensions/S3Storage/S3StorageEgressProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
             {
                 if (uploadId != null && !uploadDone)
                     await client.AbortMultipartUploadAsync(uploadId, token);
-                throw CreateException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressS3FailedDetailed, e.Message));
+                throw CreateException(e.Message);
             }
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
         {
             return !string.IsNullOrEmpty(innerMessage)
                 ? string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressS3FailedDetailed, innerMessage)
-                : Strings.ErrorMessage_EgressFileFailedGeneric;
+                : Strings.ErrorMessage_EgressS3FailedGeneric;
         }
     }
 }

--- a/src/Extensions/S3Storage/Strings.Designer.cs
+++ b/src/Extensions/S3Storage/Strings.Designer.cs
@@ -61,20 +61,20 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File system egress failed..
-        /// </summary>
-        internal static string ErrorMessage_EgressFileFailedGeneric {
-            get {
-                return ResourceManager.GetString("ErrorMessage_EgressFileFailedGeneric", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to S3 storage egress failed: {0}.
         /// </summary>
         internal static string ErrorMessage_EgressS3FailedDetailed {
             get {
                 return ResourceManager.GetString("ErrorMessage_EgressS3FailedDetailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to S3 system egress failed..
+        /// </summary>
+        internal static string ErrorMessage_EgressS3FailedGeneric {
+            get {
+                return ResourceManager.GetString("ErrorMessage_EgressS3FailedGeneric", resourceCulture);
             }
         }
         
@@ -111,15 +111,6 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         internal static string LogFormatString_EgressProviderSavedStream {
             get {
                 return ResourceManager.GetString("LogFormatString_EgressProviderSavedStream", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Provider {providerType}: Unable to find &apos;{keyName}&apos; key in egress properties.
-        /// </summary>
-        internal static string LogFormatString_EgressProviderUnableToFindPropertyKey {
-            get {
-                return ResourceManager.GetString("LogFormatString_EgressProviderUnableToFindPropertyKey", resourceCulture);
             }
         }
     }

--- a/src/Extensions/S3Storage/Strings.resx
+++ b/src/Extensions/S3Storage/Strings.resx
@@ -117,15 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ErrorMessage_EgressFileFailedGeneric" xml:space="preserve">
-    <value>File system egress failed.</value>
-    <comment>Gets a string similar to "File system egress failed.".</comment>
-  </data>
   <data name="ErrorMessage_EgressS3FailedDetailed" xml:space="preserve">
     <value>S3 storage egress failed: {0}</value>
     <comment>Gets the format string for egress failure to S3 storage (with an inner message).
 1 Format Parameter:
 0. innerMessage: The detailed inner message with additional error context.</comment>
+  </data>
+  <data name="ErrorMessage_EgressS3FailedGeneric" xml:space="preserve">
+    <value>S3 system egress failed.</value>
+    <comment>Gets a string similar to S3 system egress failed.".</comment>
   </data>
   <data name="ErrorMessage_EgressS3FailedMissingOption" xml:space="preserve">
     <value>The {0} field is required.</value>
@@ -149,12 +149,5 @@
 2 Format Parameters:
 1. providerType: Type of the provider
 2. path: path where provider saved the stream</comment>
-  </data>
-  <data name="LogFormatString_EgressProviderUnableToFindPropertyKey" xml:space="preserve">
-    <value>Provider {providerType}: Unable to find '{keyName}' key in egress properties</value>
-    <comment>Gets the format string that is printed in the 10:EgressProviderUnableToFindPropertyKey event.
-2 Format Parameters:
-1. providerType: Type of the provider
-2. keyName: Name of the property that could not be found</comment>
   </data>
 </root>


### PR DESCRIPTION
###### Summary

Re-enables data annotation validation for egress providers; fixes the issue with S3 exceptions double-including their "egress failed" prefix.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
