### PR TITLE
Fix `needs-review` label toggling issue

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -416,6 +416,17 @@
                   }
                 }
               ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "needs-review"
+                  }
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
###### Summary

When telling Fabricbot to add a label, it appears that behind the scenes it's actually just toggling the state of the label. See this PR as an example of what happens when changes are pushed currently: https://github.com/dotnet/dotnet-monitor/pull/4083. This change puts an explicit check on the "add label" task, ensuring the label is not already there. All other `needs-review` tasks already had this check in place. 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
