### PR TITLE
Move egress configuration parsing into EgressExtension

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputExtensionRepository.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputExtensionRepository.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
-using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Extension;
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
-using Microsoft.Extensions.Logging;
 using System.IO;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
 {
     internal sealed class BuildOutputExtensionRepository : ExtensionRepository
     {
-        private readonly ILogger<EgressExtension> _logger;
+        private readonly EgressExtensionFactory _egressExtensionFactory;
 
-        public BuildOutputExtensionRepository(ILogger<EgressExtension> logger)
+        public BuildOutputExtensionRepository(
+            EgressExtensionFactory egressExtensionFactory)
         {
-            _logger = logger;
+            _egressExtensionFactory = egressExtensionFactory;
         }
 
         public override bool TryFindExtension(string extensionName, out IExtension extension)
@@ -47,10 +47,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
         {
             string manifestPath = Path.Combine(extensionPath, ExtensionManifest.DefaultFileName);
 
-            return new EgressExtension(
+            return _egressExtensionFactory.Create(
                 ExtensionManifest.FromPath(manifestPath),
-                extensionPath,
-                _logger);
+                extensionPath);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressProviderConfigurationProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
@@ -36,8 +37,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
             }
         }
 
+        public IConfigurationSection GetProviderConfigurationSection(string providerType, string providerName)
+        {
+            IConfigurationSection section = GetProviderTypeConfigurationSection(providerType).GetSection(providerName);
+
+            if (!section.Exists())
+            {
+                throw new EgressException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressProviderDoesNotExist, providerName));
+            }
+
+            return section;
+        }
+
         /// <inheritdoc/>
-        public IConfigurationSection GetConfigurationSection(string providerType)
+        public IConfigurationSection GetProviderTypeConfigurationSection(string providerType)
         {
             return _optionsMapper.GetProviderSections(this.OptionsType).First(s => s.Key == providerType);
         }

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressProviderConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressProviderConfigurationProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
     internal interface IEgressProviderConfigurationProvider
     {
         /// <summary>
-        /// The name of the provider types defined in configuration that use this options type. These keys can be passed to <see cref="GetConfigurationSection(string)"/> to get the specific configuration section.
+        /// The name of the provider types defined in configuration that use this options type. These keys can be passed to <see cref="GetProviderTypeConfigurationSection(string)"/> to get the specific configuration section.
         /// </summary>
         IEnumerable<string> ProviderTypes { get; }
 
@@ -24,10 +24,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
         Type OptionsType { get; }
 
         /// <summary>
+        /// Gets the <see cref="IConfigurationSection"/> associated with the given <paramref name="providerType"/> and <paramref name="providerName"/>.
+        /// </summary>
+        /// <param name="providerType">The provider type, the element under "Egress:" in configuration. You can use <see cref="ProviderTypes"/> to get valid strings to use here.</param>
+        /// <param name="providerName">The provider name, the element under "Egress:{providerType}:" in configuration.</param>
+        IConfigurationSection GetProviderConfigurationSection(string providerType, string providerName);
+
+        /// <summary>
         /// Gets the <see cref="IConfigurationSection"/> associated with the given <paramref name="providerType"/>.
         /// </summary>
         /// <param name="providerType">The provider type, the element under "Egress:" in configuration. You can use <see cref="ProviderTypes"/> to get valid strings to use here.</param>
-        IConfigurationSection GetConfigurationSection(string providerType);
+        IConfigurationSection GetProviderTypeConfigurationSection(string providerType);
 
         /// <summary>
         /// The configuration section that should be monitored for changes. This will return the minimum set of <see cref="IConfigurationSection"/> to monitor for changes.

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
                 foreach (string providerType in provider.ProviderTypes)
                 {
                     _egressProviderMap.Add(providerType, provider);
-                    IConfigurationSection typeSection = provider.GetConfigurationSection(providerType);
+                    IConfigurationSection typeSection = provider.GetProviderTypeConfigurationSection(providerType);
 
                     foreach (IConfigurationSection optionsSection in typeSection.GetChildren())
                     {

--- a/src/Tools/dotnet-monitor/Egress/Extension/EgressExtensionFactory.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/EgressExtensionFactory.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Extension
+{
+    internal sealed class EgressExtensionFactory
+    {
+        private readonly IEgressProviderConfigurationProvider _configurationProvider;
+        private readonly ILogger<EgressExtension> _logger;
+        private readonly IEgressPropertiesProvider _propertiesProvider;
+
+        public EgressExtensionFactory(
+            IEgressProviderConfigurationProvider configurationProvider,
+            IEgressPropertiesProvider propertiesProvider,
+            ILogger<EgressExtension> logger)
+        {
+            _configurationProvider = configurationProvider;
+            _logger = logger;
+            _propertiesProvider = propertiesProvider;
+        }
+
+        public IEgressExtension Create(ExtensionManifest manifest, string path)
+        {
+            return new EgressExtension(manifest, path, _configurationProvider, _propertiesProvider, _logger);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/Extension/IEgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/IEgressExtension.cs
@@ -17,10 +17,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         /// <summary>
         /// Calls the given external extension to egress an artifact.
         /// </summary>
-        /// <param name="configPayload">This will become the json configuration payload that starts the standard in stream.</param>
-        /// <param name="getStreamAction">This <see cref="Func{Stream, CancellationToken, Task}" /> is used to get the artifact stream. The output stream is passed to this Func and the egress payload will be written to the provided stream.</param>
+        /// <param name="providerName">The egress provider name.</param>
+        /// <param name="settings">The settings and context for the artifact to be egressed.</param>
+        /// <param name="action">This <see cref="Func{Stream, CancellationToken, Task}" /> is used to get the artifact stream. The output stream is passed to this Func and the egress payload will be written to the provided stream.</param>
         /// <param name="token"><see cref="CancellationToken"/> for aborting egress.</param>
         /// <returns><see cref="EgressArtifactResult"/> representing the result of the operation, <see cref="EgressArtifactResult.Succeeded"/> should be checked.</returns>
-        Task<EgressArtifactResult> EgressArtifact(ExtensionEgressPayload configPayload, Func<Stream, CancellationToken, Task> getStreamAction, CancellationToken token);
+        Task<EgressArtifactResult> EgressArtifact(
+            string providerName,
+            EgressArtifactSettings settings,
+            Func<Stream, CancellationToken, Task> action,
+            CancellationToken token);
     }
 }

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
@@ -1,10 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Security;
@@ -19,29 +19,34 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
     internal class FileSystemEgressExtension :
         IEgressExtension
     {
+        private readonly IEgressProviderConfigurationProvider _configurationProvider;
         private readonly ILogger<FileSystemEgressExtension> _logger;
 
         public string DisplayName => EgressProviderTypes.FileSystem;
 
-        public FileSystemEgressExtension(ILogger<FileSystemEgressExtension> logger)
+        public FileSystemEgressExtension(IEgressProviderConfigurationProvider configurationProvider, ILogger<FileSystemEgressExtension> logger)
         {
+            _configurationProvider = configurationProvider;
             _logger = logger;
         }
 
         public async Task<EgressArtifactResult> EgressArtifact(
-            ExtensionEgressPayload payload,
+            string providerName,
+            EgressArtifactSettings settings,
             Func<Stream, CancellationToken, Task> action,
             CancellationToken token)
         {
+            IConfigurationSection configuration = _configurationProvider.GetProviderConfigurationSection(EgressProviderTypes.FileSystem, providerName);
+
             FileSystemEgressProviderOptions options = new();
-            Bind(options, payload.Configuration);
+            configuration.Bind(options);
 
             if (!Directory.Exists(options.DirectoryPath))
             {
                 WrapException(() => Directory.CreateDirectory(options.DirectoryPath));
             }
 
-            string targetPath = Path.Combine(options.DirectoryPath, payload.Settings.Name);
+            string targetPath = Path.Combine(options.DirectoryPath, settings.Name);
 
             if (!string.IsNullOrEmpty(options.IntermediateDirectoryPath))
             {
@@ -166,34 +171,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
             else
             {
                 return Strings.ErrorMessage_EgressFileFailedGeneric;
-            }
-        }
-
-        // This is a temporary stop-gap that simulates options binding from configuration. To do this properly, the extension
-        // egress provider or service should pass the configuration directly to the IEgressExtension implementation and allow
-        // it to decide how to pull information out of the configuration section.
-        private static void Bind(FileSystemEgressProviderOptions options, IDictionary<string, string> configuration)
-        {
-            if (configuration.TryGetValue(nameof(FileSystemEgressProviderOptions.CopyBufferSize), out string copyBufferSizeString) &&
-                !string.IsNullOrEmpty(copyBufferSizeString))
-            {
-                try
-                {
-                    options.CopyBufferSize = (int)TypeDescriptor.GetConverter(typeof(int)).ConvertFromInvariantString(copyBufferSizeString);
-                }
-                catch
-                {
-                }
-            }
-
-            if (configuration.TryGetValue(nameof(FileSystemEgressProviderOptions.DirectoryPath), out string directoryPath))
-            {
-                options.DirectoryPath = directoryPath;
-            }
-
-            if (configuration.TryGetValue(nameof(FileSystemEgressProviderOptions.IntermediateDirectoryPath), out string intermediateDirectoryPath))
-            {
-                options.IntermediateDirectoryPath = intermediateDirectoryPath;
             }
         }
     }

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtensionFactory.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtensionFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using Microsoft.Extensions.Logging;
 
@@ -8,16 +9,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
 {
     internal sealed class FileSystemEgressExtensionFactory : IWellKnownExtensionFactory
     {
+        private readonly IEgressProviderConfigurationProvider _configurationProvider;
         private readonly ILogger<FileSystemEgressExtension> _logger;
 
-        public FileSystemEgressExtensionFactory(ILogger<FileSystemEgressExtension> logger)
+        public FileSystemEgressExtensionFactory(
+            IEgressProviderConfigurationProvider configurationProvider,
+            ILogger<FileSystemEgressExtension> logger)
         {
+            _configurationProvider = configurationProvider;
             _logger = logger;
         }
 
         IEgressExtension IWellKnownExtensionFactory.Create()
         {
-            return new FileSystemEgressExtension(_logger);
+            return new FileSystemEgressExtension(_configurationProvider, _logger);
         }
 
 

--- a/src/Tools/dotnet-monitor/Extensibility/FolderExtensionRepository.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/FolderExtensionRepository.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Extension;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using System;
@@ -11,11 +11,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {
     internal class FolderExtensionRepository : ExtensionRepository
     {
+        private readonly EgressExtensionFactory _egressExtensionFactory;
         private readonly IFileProvider _fileSystem;
-        private readonly ILogger<EgressExtension> _logger;
+        private readonly ILogger<FolderExtensionRepository> _logger;
 
-        public FolderExtensionRepository(IFileProvider fileSystem, ILogger<EgressExtension> logger)
+        public FolderExtensionRepository(IFileProvider fileSystem, EgressExtensionFactory egressExtensionFactory, ILogger<FolderExtensionRepository> logger)
         {
+            _egressExtensionFactory = egressExtensionFactory;
             _fileSystem = fileSystem;
             _logger = logger;
         }
@@ -42,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 
                     if (extensionName == manifest.Name)
                     {
-                        extension = new EgressExtension(manifest, extensionDir.PhysicalPath, _logger);
+                        extension = _egressExtensionFactory.Create(manifest, extensionDir.PhysicalPath);
                         return true;
                     }
                 }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -232,9 +232,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static IServiceCollection ConfigureExtensions(this IServiceCollection services)
         {
+            // Extension discovery
             services.AddSingleton<ExtensionDiscoverer>();
-            services.AddSingleton<ExtensionRepository, WellKnownExtensionRepository>();
+            // Extension type factories
+            services.AddSingleton<EgressExtensionFactory>();
             // Well-known extensions
+            services.AddSingleton<ExtensionRepository, WellKnownExtensionRepository>();
             services.AddSingleton<IWellKnownExtensionFactory, FileSystemEgressExtensionFactory>();
             return services;
         }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers.Event
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers;
 using Microsoft.Diagnostics.Tools.Monitor.Egress;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Extension;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
 using Microsoft.Diagnostics.Tools.Monitor.Exceptions;
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
@@ -270,8 +271,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 (IServiceProvider serviceProvider) =>
                 {
                     IFileProvider fileProvider = GetFileProvider(targetExtensionFolder);
-                    ILogger<EgressExtension> logger = serviceProvider.GetRequiredService<ILogger<EgressExtension>>();
-                    return new FolderExtensionRepository(fileProvider, logger);
+                    EgressExtensionFactory egressExtensionFactory = serviceProvider.GetRequiredService<EgressExtensionFactory>();
+                    ILogger<FolderExtensionRepository> logger = serviceProvider.GetRequiredService<ILogger<FolderExtensionRepository>>();
+                    return new FolderExtensionRepository(fileProvider, egressExtensionFactory, logger);
                 };
 
             services.AddSingleton<ExtensionRepository>(createDelegate);


### PR DESCRIPTION
###### Summary

This is a "separation of concerns" fixup PR.

Move the parsing of the egress provider configuration section from `ExtensionEgressProvider` into `EgressExtension`. This allows the `FileSystemEgressExtension` to not manually look up its options from a dictionary but instead using options binding. Move the creation o the `EgressExtension` into a factory so that other callers do not have to provide the myriad of services it requires.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
