### PR TITLE
Represent SDM Counters as Gauges In Prometheus Exposition Format

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             switch (eventType)
             {
-                // In Prometheus, rates are treated as gauges due to their non-monotonic nature;
+                // In Prometheus, rates are treated as gauges due to their non-monotonic nature
                 case EventType.Rate:
                 case EventType.Gauge:
                     return "gauge";

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -200,8 +200,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             switch (eventType)
             {
+                // In Prometheus, rates are treated as gauges due to their non-monotonic nature;
                 case EventType.Rate:
-                    return "counter";
                 case EventType.Gauge:
                     return "gauge";
                 case EventType.Histogram:

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             Assert.Equal(3, lines.Count);
             Assert.Equal($"# HELP {metricName}{payload.Unit} {payload.DisplayName}", lines[0]);
-            Assert.Equal($"# TYPE {metricName} counter", lines[1]);
+            Assert.Equal($"# TYPE {metricName} gauge", lines[1]);
             Assert.Equal($"{metricName} {payload.Value} {new DateTimeOffset(payload.Timestamp).ToUnixTimeMilliseconds()}", lines[2]);
         }
 


### PR DESCRIPTION
###### Summary

Closes #4095 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Represent System.Diagnostics.Metrics Counters as Gauges in Prometheus Exposition Format.