### PR TITLE
Tweaking `needs-review` bot

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -556,25 +556,30 @@
       "version": "1.0",
       "config": {
         "conditions": {
-          "operator": "or",
+          "operator": "and",
           "operands": [
-            {
-              "name": "isAction",
-              "parameters": {
-                "action": "closed"
-              }
-            },
-            {
-              "name": "isAction",
-              "parameters": {
-                "action": "merged"
-              }
-            },
             {
               "name": "hasLabel",
               "parameters": {
                 "label": "needs-review"
               }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "merged"
+                  }
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
###### Summary

Requiring that the `needs-review` label must be in place AND the PR must be merged/closed - this was being triggered when any action on a PR occurred while the `needs-review` label was in place, creating a loop of manually tagging a PR and having it automatically removed. This may have been the true root cause of #4084, though those changes are still good practice to have in place.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
