### PR TITLE
Use Z representation for UTC offset when generating release notes

### DIFF
--- a/.github/actions/generate-release-notes/index.js
+++ b/.github/actions/generate-release-notes/index.js
@@ -34,7 +34,7 @@ async function run() {
         ];
 
         const parsedLastReleaseDate = new Date(lastReleaseDate);
-        jsISODateRepresentation = parsedLastReleaseDate.toISOString();
+        const jsISODateRepresentation = parsedLastReleaseDate.toISOString();
 
         const changelog = await generateChangelog(octokit, branch, repoOwner, repoName, jsISODateRepresentation, significantLabels);
         const monikerDescriptions = generateMonikerDescriptions(significantLabels);


### PR DESCRIPTION
###### Summary

This PR fixes release notes generation - release notes generated currently have empty changelogs.


It appears there was a recent change in GitHub's APIs for PR filtering that makes it no longer accept ISO 8601 formatted strings that use a numerical representation (`+00`) for the UTC offset. Instead, it appears to only handle `Z`  representations.

To handle this, regenerate the date/time string using javascript APIs which will use the `Z` representation by default.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
