### PR TITLE
Validate configured egress providers at startup

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesConfigurations/CollectionRules.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesConfigurations/CollectionRules.json
@@ -7,13 +7,7 @@
         {
           "Type": "CollectGCDump"
         },
-        "ActionTemplate2",
-        {
-          "Type": "CollectDump",
-          "Settings": {
-            "Egress": "monitorBlob"
-          }
-        }
+        "ActionTemplate2"
       ],
       "Filters": [
         {
@@ -28,7 +22,13 @@
       "Trigger": "TriggerTemplateINVALID",
       "Actions": [
         "ActionTemplate1",
-        "ActionTemplate2"
+        "ActionTemplate2",
+        {
+          "Type": "CollectDump",
+          "Settings": {
+            "Egress": "monitorBlob"
+          }
+        }
       ],
       "Filters": [
         "FilterTemplateINVALID"

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesConfigurations/Templates.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesConfigurations/Templates.json
@@ -19,7 +19,7 @@
       "ActionTemplate2": {
         "Type": "CollectTrace",
         "Settings": {
-          "Egress": "monitorBlob",
+          "Egress": "artifacts2",
           "Profile": "Cpu"
         }
       }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/TemplatesTests.cs
@@ -55,16 +55,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 Assert.Equal(TimeSpan.Parse("00:01:00"), ((AspNetRequestCountOptions)options.Trigger.Settings).SlidingWindowDuration);
 
                 // Actions Comparison
-                Assert.Equal(4, options.Actions.Count);
+                Assert.Equal(3, options.Actions.Count);
                 Assert.Equal(KnownCollectionRuleActions.CollectGCDump, options.Actions[0].Type);
                 Assert.Equal("artifacts", ((CollectGCDumpOptions)options.Actions[0].Settings).Egress);
                 Assert.Equal(KnownCollectionRuleActions.CollectGCDump, options.Actions[1].Type);
                 Assert.Equal("artifacts2", ((CollectGCDumpOptions)options.Actions[1].Settings).Egress);
                 Assert.Equal(KnownCollectionRuleActions.CollectTrace, options.Actions[2].Type);
-                Assert.Equal("monitorBlob", ((CollectTraceOptions)options.Actions[2].Settings).Egress);
+                Assert.Equal("artifacts2", ((CollectTraceOptions)options.Actions[2].Settings).Egress);
                 Assert.Equal(WebApi.Models.TraceProfile.Cpu, ((CollectTraceOptions)options.Actions[2].Settings).Profile);
-                Assert.Equal(KnownCollectionRuleActions.CollectDump, options.Actions[3].Type);
-                Assert.Equal("monitorBlob", ((CollectDumpOptions)options.Actions[3].Settings).Egress);
 
                 // Filters Comparison
                 Assert.Equal(2, options.Filters.Count);

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigurationProvider.cs
@@ -59,7 +59,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
         /// <inheritdoc/>
         public IConfigurationSection GetProviderTypeConfigurationSection(string providerType)
         {
-            return GetProviderSections().First(s => s.Key == providerType);
+            foreach (IConfigurationSection providerTypeSection in GetProviderSections())
+            {
+                if (providerType == providerTypeSection.Key)
+                {
+                    return providerTypeSection;
+                }
+            }
+
+            throw new EgressException(string.Format(CultureInfo.InvariantCulture, Strings.ErrorMessage_EgressProviderTypeNotRegistered, providerType));
         }
 
         public IChangeToken GetReloadToken()

--- a/src/Tools/dotnet-monitor/Egress/EgressProviderSource.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProviderSource.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    internal sealed class EgressProviderSource : IDisposable
+    {
+        private readonly IEgressConfigurationProvider _configurationProvider;
+        private readonly ExtensionDiscoverer _extensionDiscoverer;
+        private readonly ILogger _logger;
+        private readonly IDictionary<string, string> _providerNameToTypeMap;
+
+        private IDisposable _changeRegistration;
+        private long _initialized;
+
+        public EgressProviderSource(
+            IEgressConfigurationProvider configurationProvider,
+            ExtensionDiscoverer extensionDiscoverer,
+            ILogger<EgressProviderSource> logger)
+        {
+            _configurationProvider = configurationProvider;
+            _extensionDiscoverer = extensionDiscoverer;
+            _logger = logger;
+            _providerNameToTypeMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public void Dispose()
+        {
+            _changeRegistration.Dispose();
+        }
+
+        public void Initialize()
+        {
+            if (0 != Interlocked.CompareExchange(ref _initialized, 1, 0))
+                return;
+
+            _changeRegistration = ChangeToken.OnChange(
+                _configurationProvider.GetReloadToken,
+                Reload);
+
+            Reload();
+        }
+
+        public IEgressExtension GetEgressProvider(string name)
+        {
+            if (!_providerNameToTypeMap.TryGetValue(name, out string providerType))
+            {
+                throw new EgressException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressProviderDoesNotExist, name));
+            }
+
+            return _extensionDiscoverer.FindExtension<IEgressExtension>(providerType);
+        }
+
+        private void Reload()
+        {
+            _providerNameToTypeMap.Clear();
+
+            foreach (string providerType in _configurationProvider.ProviderTypes)
+            {
+                try
+                {
+                    IEgressExtension _ = _extensionDiscoverer.FindExtension<IEgressExtension>(providerType);
+                }
+                catch (ExtensionException)
+                {
+                    _logger.EgressProviderTypeNotExist(providerType);
+                }
+
+                IConfigurationSection typeSection = _configurationProvider.GetProviderTypeConfigurationSection(providerType);
+
+                foreach (IConfigurationSection optionsSection in typeSection.GetChildren())
+                {
+                    string providerName = optionsSection.Key;
+                    if (_providerNameToTypeMap.TryGetValue(providerName, out string existingProviderType))
+                    {
+                        _logger.DuplicateEgressProviderIgnored(providerName, providerType, existingProviderType);
+                    }
+                    else
+                    {
+                        _providerNameToTypeMap.Add(providerName, providerType);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/EgressStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressStartupLogger.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Egress
+{
+    internal sealed class EgressStartupLogger : IStartupLogger
+    {
+        private readonly EgressProviderSource _source;
+
+        public EgressStartupLogger(EgressProviderSource source)
+        {
+            _source = source;
+        }
+
+        public void Log()
+        {
+            _source.Initialize();
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Egress/Extension/EgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/EgressExtension.cs
@@ -191,8 +191,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         private Dictionary<string, string> GetConfigurationSection(string providerName, string providerType)
         {
-            IConfigurationSection providerTypeSection = _configurationProvider.GetProviderTypeConfigurationSection(providerType);
-            IConfigurationSection providerNameSection = providerTypeSection.GetSection(providerName);
+            IConfigurationSection providerNameSection = _configurationProvider.GetProviderConfigurationSection(providerType, providerName);
 
             if (!providerNameSection.Exists())
             {

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -104,7 +104,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         ExtensionErrorMessage = 92,
         ExtensionNotOfType = 93,
         ExtensionManifestNotParsable = 94,
-        ExtensionMalformedOutput = 95
+        ExtensionMalformedOutput = 95,
+        EgressProviderTypeNotExist = 96
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -488,6 +488,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_StartupHookInstructions);
 
+        private static readonly Action<ILogger, string, Exception> _egressProviderTypeNotExist =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.EgressProviderTypeNotExist.EventId(),
+                logLevel: LogLevel.Warning,
+                formatString: Strings.LogFormatString_EgressProviderTypeNotExist);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -896,6 +902,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void StartupHookInstructions(this ILogger logger, string startupHookLibraryPath)
         {
             _startupHookInstructions(logger, startupHookLibraryPath, null);
+        }
+
+        public static void EgressProviderTypeNotExist(this ILogger logger, string providerType)
+        {
+            _egressProviderTypeNotExist(logger, providerType, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -297,6 +297,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static IServiceCollection ConfigureEgress(this IServiceCollection services)
         {
             services.AddSingleton<IEgressConfigurationProvider, EgressConfigurationProvider>();
+            services.AddSingleton<EgressProviderSource>();
             services.AddSingleton<IEgressService, EgressService>();
 
             return services;
@@ -351,6 +352,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 ILogger<Startup> logger = services.GetRequiredService<ILogger<Startup>>();
                 return authConfigurator.CreateStartupLogger(logger, services);
             });
+            services.AddSingleton<IStartupLogger, EgressStartupLogger>();
             return services;
         }
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1106,6 +1106,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Egress provider type &apos;{type}&apos; does not exist..
+        /// </summary>
+        internal static string LogFormatString_EgressProviderTypeNotExist {
+            get {
+                return ResourceManager.GetString("LogFormatString_EgressProviderTypeNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unexpected timeout from process {processId}. Process will no longer be monitored..
         /// </summary>
         internal static string LogFormatString_EndpointTimeout {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -901,4 +901,7 @@
   <data name="ErrorMessage_ExtensionFileNotFound" xml:space="preserve">
     <value>The extension file '{0}' for extension '{1}' could not be found.</value>
   </data>
+  <data name="LogFormatString_EgressProviderTypeNotExist" xml:space="preserve">
+    <value>Egress provider type '{type}' does not exist.</value>
+  </data>
 </root>


### PR DESCRIPTION
###### Summary

- Moved enumeration and caching of egress providers into separate class named `EgressProviderSource`.
- Add startup logger that initializes the `EgressProviderSource`, which causes it to log any missing egress providers.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
