### PR TITLE
Allow VS using repository SDK to build for latest TFM

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,8 +28,8 @@
   <Import Project="$(MSBuildThisFileDirectory)Common.props" />
   <PropertyGroup Label="TargetFrameworks">
     <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
-    <ExcludeLatestTargetFramework>false</ExcludeLatestTargetFramework>
-    <ExcludeLatestTargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework>
+    <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == '' and '$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework>
+    <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == ''">false</ExcludeLatestTargetFramework>
     <!-- The TFMs of the dotnet-monitor tool.  -->
     <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
     <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);$(LatestTargetFramework)</ToolTargetFrameworks>


### PR DESCRIPTION
###### Summary

The `startvs.cmd` script will set the `ExcludeLatestTargetFramework` environment variable to `false` in order to indicate that the latest TFM can be used to build in Visual Studio. However, this is automatically overwritten by the existing property definitions. They've been fixed to check if the property was previously defined, then check if building in Visual Studio, and then default to `false`.

This allows command line builds and Visual Studio builds that are launched from `startvs.cmd` to build the latest TFM so that the latest in-development TFM SDK does not have to be installed.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
