### PR TITLE
Remove stale references to aka.ms links in `release-process.md`

### DIFF
--- a/documentation/release-process.md
+++ b/documentation/release-process.md
@@ -32,15 +32,6 @@ The official build will not automatically trigger for release branches. Each tim
 1. Wait for changes to be mirrored from [GitHub repository](https://github.com/dotnet/dotnet-monitor) to the [internal repository](https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor).
 1. Invoke the [internal pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=954) for the release branch. Make sure the `Update dotnet-docker?` parameter is set to true. Setting this will cause a successful build to trigger an update in the `dotnet-docker` repository.
 
-The result of the successful build pushes packages to the [dotnet-tools](https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json) feed, pushes symbols to symbol feeds, and generates aka.ms links for the following:
-- `aka.ms/dotnet/diagnostics/monitor{channel}/dotnet-monitor.nupkg.version`
-- `aka.ms/dotnet/diagnostics/monitor{channel}/dotnet-monitor.nupkg.sha512`
-
-> **Note**:
-> The `channel` value is:
-> - `{major}.{minor}/daily` for builds from non-release branches. For example, `channel` is `5.0/daily` for the `main` branch.
-> - `{majorVersion}.{minorVersion}/release` for final release in release branches. For example, `channel` is `5.0/release` for the `release/5.0` if its `<BlobGroupBuildQuality>` is set to `release`.
-
 ## Update Nightly Docker Ingestion
 
 ### Updating tags


### PR DESCRIPTION
###### Summary

We no longer publish nupkgs to blob storage, so these aka.ms links are no longer updated.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
