### PR TITLE
Adjust Bounds For Unstable SDM Histogram Test

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                             options.MeterName = LiveMetricsTestConstants.ProviderName1;
                             options.InstrumentName = LiveMetricsTestConstants.HistogramName1;
                             options.HistogramPercentile = 95;
-                            options.GreaterThan = 60;
+                            options.GreaterThan = 0;
                             options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
                         })
                         .AddAction(CallbackAction.ActionName);
@@ -320,7 +320,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                             options.MeterName = LiveMetricsTestConstants.ProviderName1;
                             options.InstrumentName = LiveMetricsTestConstants.HistogramName1;
                             options.HistogramPercentile = 50;
-                            options.LessThan = 75;
+                            options.LessThan = 101;
                             options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
                         })
                         .AddAction(CallbackAction.ActionName);


### PR DESCRIPTION
###### Summary

The SDM Histogram `LessThan` test has occasional failures - before completely disabling the test, wanted to experiment with pushing the bounds to the extremes (I also did this for the `GreaterThan` test). If instability persists after this change, I'll disable the `LessThan` test.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
