### PR TITLE
Use zip artifact when calculating release version for release notes

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -44,7 +44,7 @@ jobs:
           if [[ "$TEST_RUN" == "true" ]]; then
             qualified_release_version="test-$release_version"
           else
-            version_url="https://aka.ms/dotnet/diagnostics/monitor${major_minor_version}/release/dotnet-monitor.nupkg.version"
+            version_url="https://aka.ms/dotnet/diagnostics/monitor${major_minor_version}/release/dotnet-monitor-win-x64.zip.version"
             qualified_release_version=$(curl -sL $version_url)
             # Check if the aka.ms url existed
             if [[ "$qualified_release_version" =~ "<html" || -z "$qualified_release_version" ]]; then


### PR DESCRIPTION
###### Summary

As mentioned in https://github.com/dotnet/dotnet-monitor/pull/4139, nupkgs are no longer published to blob storage so the aka.ms links that release notes generation relied on are no longer updated. Switch to checking the zip archive instead.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
