### PR TITLE
Fix `add-markdown-feedback.yml` handling of multiple markdown files

### DIFF
--- a/.github/workflows/add-markdown-feedback.yml
+++ b/.github/workflows/add-markdown-feedback.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed_source_files=$(git diff-tree --no-commit-id --name-only -r "$base_sha" "$GITHUB_SHA" -- documentation ':!documentation/releaseNotes/*' | { grep "**.md$" || test $? = 1; })
           echo "Files to validate: '${changed_source_files}'"
-          changed_source_files=$(echo "$changed_source_files" | sed 's/ documentation/,documentation/g')
+          changed_source_files=$(echo "$changed_source_files" | xargs | sed 's/ documentation/,documentation/g')
           echo "updated_files=$(echo ${changed_source_files})" >> $GITHUB_ENV
 
       - name: Append To File


### PR DESCRIPTION
###### Summary

Recently if multiple markdown files are edited in a PR the `add-markdown-feedback` workflow would fail. This is caused by `git diff-tree` delimiting the matching files by newlines, the sed command used would expect spaces instead. Use `xargs` to standardize the output before having it processed by `sed`.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
