### PR TITLE
Do not create tool packages for extensions

### DIFF
--- a/src/Extensions/Directory.Build.props
+++ b/src/Extensions/Directory.Build.props
@@ -5,10 +5,6 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
-    <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers Condition="'$(PackAsTool)' == 'true'">$(SignOnlyRuntimeIdentifiers)</PackAsToolShimRuntimeIdentifiers>
-    <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
###### Summary

Exclude the creation of tool packages for the extensions since we do not plan on shipping the extensions as .NET Tools.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2152275&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
