### PR TITLE
Validate FileSystem egress options

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.Options/FileSystemEgressProviderOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/FileSystemEgressProviderOptions.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
     internal sealed class FileSystemEgressProviderOptions :
         IEgressProviderCommonOptions
     {
+        public const int CopyBufferSize_MinValue = 1;
+        public const int CopyBufferSize_MaxValue = int.MaxValue;
+
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_FileSystemEgressProviderOptions_DirectoryPath))]
@@ -26,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CommonEgressProviderOptions_CopyBufferSize))]
-        [Range(1, int.MaxValue)]
+        [Range(CopyBufferSize_MinValue, CopyBufferSize_MaxValue)]
         public int? CopyBufferSize { get; set; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/FileSystemEgressExtensionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/FileSystemEgressExtensionTests.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    public sealed class FileSystemEgressExtensionTests
+    {
+        const string ProviderName = "TestProvider";
+
+        private static readonly string CopyBufferSize_RangeErrorMessage = CreateRangeMessage<int>(
+            nameof(FileSystemEgressProviderOptions.CopyBufferSize),
+            FileSystemEgressProviderOptions.CopyBufferSize_MinValue.ToString(),
+            FileSystemEgressProviderOptions.CopyBufferSize_MaxValue.ToString());
+
+        private readonly ITestOutputHelper _outputHelper;
+
+        public FileSystemEgressExtensionTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public async Task FileSystemEgressExtension_EmptyConfiguration_ThrowsException()
+        {
+            // Arrange
+            Mock<IEgressConfigurationProvider> mockConfigurationProvider = new();
+            mockConfigurationProvider.Setup(provider => provider.GetProviderConfigurationSection(EgressProviderTypes.FileSystem, ProviderName))
+                .Returns(CreateConfigurationSection());
+
+            Mock<ILogger<FileSystemEgressExtension>> mockLogger = new();
+
+            FileSystemEgressExtension extension = new(mockConfigurationProvider.Object, mockLogger.Object);
+
+            // Act & Assert
+            OptionsValidationException exception = await Assert.ThrowsAsync<OptionsValidationException>(
+                () => extension.EgressArtifact(ProviderName, null, (stream, token) => Task.CompletedTask, CancellationToken.None));
+            string errorMessage = Assert.Single(exception.Failures);
+            Assert.Equal(CreateRequiredMessage(nameof(FileSystemEgressProviderOptions.DirectoryPath)), errorMessage);
+        }
+
+        [Fact]
+        public async Task FileSystemEgressExtension_CopyBufferSizeZero_ThrowsException()
+        {
+            // Arrange
+            using TemporaryDirectory temporaryDirectory = new(_outputHelper);
+
+            IConfigurationSection egressProviderSection = CreateConfigurationSection();
+            egressProviderSection[nameof(FileSystemEgressProviderOptions.DirectoryPath)] = temporaryDirectory.FullName;
+            egressProviderSection[nameof(FileSystemEgressProviderOptions.CopyBufferSize)] = "0";
+
+            Mock<IEgressConfigurationProvider> mockConfigurationProvider = new();
+            mockConfigurationProvider.Setup(provider => provider.GetProviderConfigurationSection(EgressProviderTypes.FileSystem, ProviderName))
+                .Returns(egressProviderSection);
+
+            Mock<ILogger<FileSystemEgressExtension>> mockLogger = new();
+
+            FileSystemEgressExtension extension = new(mockConfigurationProvider.Object, mockLogger.Object);
+
+            // Act & Assert
+            OptionsValidationException exception = await Assert.ThrowsAsync<OptionsValidationException>(
+                () => extension.EgressArtifact(ProviderName, null, (stream, token) => Task.CompletedTask, CancellationToken.None));
+            string errorMessage = Assert.Single(exception.Failures);
+            Assert.Equal(CopyBufferSize_RangeErrorMessage, errorMessage);
+        }
+
+        [Fact]
+        public async Task FileSystemEgressExtension_DirectoryPath_Success()
+        {
+            const string ExpectedFileName = "EgressedData.txt";
+
+            // Arrange
+            using TemporaryDirectory temporaryDirectory = new(_outputHelper);
+
+            IConfigurationSection egressProviderSection = CreateConfigurationSection();
+            egressProviderSection[nameof(FileSystemEgressProviderOptions.DirectoryPath)] = temporaryDirectory.FullName;
+
+            Mock<IEgressConfigurationProvider> mockConfigurationProvider = new();
+            mockConfigurationProvider.Setup(provider => provider.GetProviderConfigurationSection(EgressProviderTypes.FileSystem, ProviderName))
+                .Returns(egressProviderSection);
+
+            Mock<ILogger<FileSystemEgressExtension>> mockLogger = new();
+
+            FileSystemEgressExtension extension = new(mockConfigurationProvider.Object, mockLogger.Object);
+
+            EgressArtifactSettings settings = new EgressArtifactSettings() { Name = ExpectedFileName };
+
+            // Act
+            EgressArtifactResult result = await extension.EgressArtifact(ProviderName, settings, (stream, token) => Task.CompletedTask, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Succeeded, "Expected egress to succeed.");
+            Assert.True(File.Exists(Path.Combine(temporaryDirectory.FullName, ExpectedFileName)), "Expected file to be written.");
+        }
+
+        private static IConfigurationSection CreateConfigurationSection()
+        {
+            List<IConfigurationProvider> configProviders = new()
+            {
+                new EmptyConfigurationProvider()
+            };
+            ConfigurationRoot configurationRoot = new(configProviders);
+            string configurationPath = ConfigurationPath.Combine(ConfigurationKeys.Egress, EgressProviderTypes.FileSystem, ProviderName);
+            return new ConfigurationSection(configurationRoot, configurationPath);
+        }
+
+        private static string CreateRangeMessage<T>(string fieldName, string min, string max)
+        {
+            return (new RangeAttribute(typeof(T), min, max)).FormatErrorMessage(fieldName);
+        }
+
+        private static string CreateRequiredMessage(string fieldName)
+        {
+            return (new RequiredAttribute()).FormatErrorMessage(fieldName);
+        }
+
+        private sealed class EmptyConfigurationProvider : ConfigurationProvider { }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.Options\Microsoft.Diagnostics.Monitoring.Options.csproj" />
     <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj" />
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
@@ -4,7 +4,10 @@
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
 using System.Security;
@@ -40,6 +43,25 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
 
             FileSystemEgressProviderOptions options = new();
             configuration.Bind(options);
+
+            ValidationContext context = new(options);
+            List<ValidationResult> results = new();
+            if (!Validator.TryValidateObject(options, context, results, validateAllProperties: true))
+            {
+                IList<string> failures = new List<string>();
+                foreach (ValidationResult result in results)
+                {
+                    if (ValidationResult.Success != result)
+                    {
+                        failures.Add(result.ErrorMessage);
+                    }
+                }
+
+                if (failures.Count > 0)
+                {
+                    throw new OptionsValidationException(string.Empty, typeof(FileSystemEgressProviderOptions), failures);
+                }
+            }
 
             if (!Directory.Exists(options.DirectoryPath))
             {


### PR DESCRIPTION
###### Summary

FileSystem egress options validation was accidentally removed in #4082. This change adds it back to the extension implementation and adds tests to check that the validation exists and is correct.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
