### PR TITLE
Skip `CollectionRulePipeline_EventMeterTriggerTest_Histogram_LessThan`

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         /// <summary>
         /// Test that the pipeline works with the EventMeter trigger less-than (histogram instrument).
         /// </summary>
-        [Theory(Skip  = "https://github.com/dotnet/dotnet-monitor/issues/4184")]
+        [Theory(Skip = "https://github.com/dotnet/dotnet-monitor/issues/4184")]
         [MemberData(nameof(GetCurrentTfm))]
         public Task CollectionRulePipeline_EventMeterTriggerTest_Histogram_LessThan(TargetFrameworkMoniker appTfm)
         {


### PR DESCRIPTION
###### Summary

The test appears to frequently time out now in CI builds. Skip this test for now.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
