### PR TITLE
Fixing Egress Extensibility Tests To Follow Updated StdIn Protocol

### DIFF
--- a/src/Extensions/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
+++ b/src/Extensions/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
             EgressArtifactResult result = new();
             try
             {
-                byte[] payloadBuffer = await GetPayloadBuffer(token);
-                ExtensionEgressPayload configPayload = JsonSerializer.Deserialize<ExtensionEgressPayload>(payloadBuffer);
+                ExtensionEgressPayload configPayload = await GetPayload(token);
 
                 ServiceCollection services = CreateServices<TOptions>(configPayload, configureServices);
 
@@ -91,7 +90,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
             return result.Succeeded ? 0 : 1;
         }
 
-        internal static async Task<byte[]> GetPayloadBuffer(CancellationToken token)
+        internal static async Task<ExtensionEgressPayload> GetPayload(CancellationToken token)
         {
             StdInStream = Console.OpenStandardInput();
 
@@ -118,7 +117,9 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
             payloadBuffer = new byte[payloadLengthBuffer];
             await ReadExactlyAsync(payloadBuffer, token);
 
-            return payloadBuffer;
+            ExtensionEgressPayload configPayload = JsonSerializer.Deserialize<ExtensionEgressPayload>(payloadBuffer);
+
+            return configPayload;
         }
 
         private static ServiceCollection CreateServices<TOptions>(ExtensionEgressPayload payload, Action<IServiceCollection> configureServices)

--- a/src/Extensions/Microsoft.Diagnostics.Monitoring.Extension.Common/Microsoft.Diagnostics.Monitoring.Extension.Common.csproj
+++ b/src/Extensions/Microsoft.Diagnostics.Monitoring.Extension.Common/Microsoft.Diagnostics.Monitoring.Extension.Common.csproj
@@ -20,6 +20,7 @@
     <InternalsVisibleTo Include="dotnet-monitor-egress-s3storage" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.AzureBlobStorageTests.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Extensions\Microsoft.Diagnostics.Monitoring.Extension.Common\Microsoft.Diagnostics.Monitoring.Extension.Common.csproj" />
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
   </ItemGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Program.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp
             CliCommand egressCmd = new CliCommand("Egress");
 
             egressCmd.SetAction((result, token) => Egress(token));
-            //egressCmd.SetAction(Egress);
 
             rootCommand.Add(egressCmd);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Program.cs
@@ -33,9 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp
             EgressArtifactResult result = new();
             try
             {
-                byte[] payloadBuffer = await EgressHelper.GetPayloadBuffer(token);
-
-                ExtensionEgressPayload configPayload = JsonSerializer.Deserialize<ExtensionEgressPayload>(payloadBuffer);
+                ExtensionEgressPayload configPayload = await EgressHelper.GetPayload(token);
                 TestEgressProviderOptions options = BuildOptions(configPayload);
 
                 Assert.Single(options.Metadata.Keys);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -19,7 +19,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class EgressExtensibilityTests
     {
         private ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
     public sealed class EgressExtensibilityTests
     {
         private ITestOutputHelper _outputHelper;


### PR DESCRIPTION
###### Summary

This should have been updated in #4179 and was inadvertently left out. This directly copies the logic being used in that PR to be used in the tests.

I might make some improvements to this testing in the future, but for now this PR should stop builds from failing.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
