### PR TITLE
Add stack frame information to exceptions event source

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSourceIdentifierCacheCallback.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSourceIdentifierCacheCallback.cs
@@ -52,6 +52,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
                 data.Name);
         }
 
+        public override void OnStackFrameData(ulong frameId, StackFrameData data)
+        {
+            _source.StackFrameDescription(
+                frameId,
+                data.MethodId,
+                data.ILOffset);
+        }
+
         public override void OnTokenData(ulong moduleId, uint typeToken, TokenData data)
         {
             _source.TokenDescription(

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifier.cs
@@ -21,7 +21,21 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             ExceptionType = ex.GetType();
 
             StackTrace stackTrace = new(ex, fNeedFileInfo: false);
-            foreach (StackFrame stackFrame in stackTrace.GetFrames())
+            SetThrowingFrame(stackTrace.GetFrames());
+        }
+
+        public ExceptionIdentifier(Exception ex, ReadOnlySpan<StackFrame> stackFrames)
+        {
+            ArgumentNullException.ThrowIfNull(ex);
+
+            ExceptionType = ex.GetType();
+
+            SetThrowingFrame(stackFrames);
+        }
+
+        private void SetThrowingFrame(ReadOnlySpan<StackFrame> stackFrames)
+        {
+            foreach (StackFrame stackFrame in stackFrames)
             {
                 ThrowingMethod = stackFrame.GetMethod();
                 if (null != ThrowingMethod)
@@ -34,8 +48,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 
         public Type ExceptionType { get; }
 
-        public MethodBase? ThrowingMethod { get; }
+        public MethodBase? ThrowingMethod { get; private set; }
 
-        public int ILOffset { get; }
+        public int ILOffset { get; private set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             return actualFrameId;
         }
 
-        public ulong[] GetOrAdd(StackFrame[] frames)
+        public ulong[] GetOrAdd(ReadOnlySpan<StackFrame> frames)
         {
             ulong[] frameIds;
             if (frames.Length > 0)

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 
         /// <summary>
         /// Gets the identifier of the <see cref="StackFrame"/> instance and
-        /// caches its data if it has not be encountered yet.
+        /// caches its data if it has not been encountered yet.
         /// </summary>
         /// <returns>
         /// An identifier that uniquely identifies the <see cref="StackFrame"/> in this cache.

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCache.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
     /// </summary>
     internal sealed class ExceptionIdentifierCache
     {
+        private const ulong InvalidId = 0;
+
         // List of callbacks to invoke for newly provided metadata.
         private readonly IEnumerable<ExceptionIdentifierCacheCallback> _callbacks;
 
@@ -83,6 +85,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         /// </returns>
         public ulong GetOrAdd(MethodBase method)
         {
+            // Dynamic methods do not have method handles and can be detected by checking if their declaring type is null
+            // Do not attempt to create an identifier for these and skip them.
+            // CONSIDER: Can an artificial identifier be created that does not collide with the algorithm used in GetId(MethodBase)?
+            if (null == method.DeclaringType)
+            {
+                return InvalidId;
+            }
+
             ulong methodId = GetId(method);
             if (!_nameCache.FunctionData.ContainsKey(methodId))
             {

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCacheCallback.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionIdentifierCacheCallback.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         {
         }
 
+        public virtual void OnStackFrameData(
+            ulong frameId,
+            StackFrameData data)
+        {
+        }
+
         public virtual void OnTokenData(
             ulong moduleId,
             uint typeToken,

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/StackFrameData.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/StackFrameData.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    internal class StackFrameData
+    {
+        public ulong MethodId { get; set; }
+        public int ILOffset { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/StackFrameIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/StackFrameIdentifier.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
+{
+    internal sealed record class StackFrameIdentifier(ulong MethodId, int ILOffset);
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -5,6 +5,7 @@ using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing;
 using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 {
@@ -42,7 +43,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             {
                 ulong identifier = _identifierCache.GetOrAdd(new ExceptionIdentifier(exception));
 
-                _eventSource.ExceptionInstance(identifier, exception.Message);
+                StackTrace stackTrace = new(exception, fNeedFileInfo: false);
+                ulong[] frameIds = _identifierCache.GetOrAdd(stackTrace.GetFrames());
+
+                _eventSource.ExceptionInstance(
+                    identifier,
+                    exception.Message,
+                    frameIds);
             }
 
             _next(exception);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class CurrentAppDomainExceptionSourceTests
     {
         private readonly Thread _thisThread = Thread.CurrentThread;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionIdentifierTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionIdentifierTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ExceptionIdentifierTests
     {
         [Fact]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/TestExceptionIdentifierCacheCallback.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/TestExceptionIdentifierCacheCallback.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 
         public readonly Dictionary<ulong, ExceptionIdentifierData> ExceptionIdentifierData = new();
 
+        public readonly Dictionary<ulong, StackFrameData> StackFrameData = new();
+
         public override void OnClassData(ulong classId, ClassData data)
         {
             Assert.True(NameCache.ClassData.TryAdd(classId, data));
@@ -31,6 +33,11 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         public override void OnModuleData(ulong moduleId, ModuleData data)
         {
             Assert.True(NameCache.ModuleData.TryAdd(moduleId, data));
+        }
+
+        public override void OnStackFrameData(ulong frameId, StackFrameData data)
+        {
+            Assert.True(StackFrameData.TryAdd(frameId, data));
         }
 
         public override void OnTokenData(ulong moduleId, uint typeToken, TokenData data)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineBuilderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineBuilderTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ExceptionPipelineBuilderTests
     {
         [Fact]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class ExceptionPipelineTests
     {
         private static readonly Action<ExceptionPipelineBuilder> EmptyConfigure = _ => { };

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStepTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStepTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class FilterRepeatExceptionPipelineStepTests
     {
         private readonly List<Exception> _reportedExceptions = new();

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string FrameworkException = nameof(FrameworkException);
                 public const string CustomException = nameof(CustomException);
                 public const string ReversePInvokeException = nameof(ReversePInvokeException);
+                public const string DynamicMethodException = nameof(DynamicMethodException);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string AsyncException = nameof(AsyncException);
                 public const string FrameworkException = nameof(FrameworkException);
                 public const string CustomException = nameof(CustomException);
+                public const string ReversePInvokeException = nameof(ReversePInvokeException);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string CustomException = nameof(CustomException);
                 public const string ReversePInvokeException = nameof(ReversePInvokeException);
                 public const string DynamicMethodException = nameof(DynamicMethodException);
+                public const string ArrayException = nameof(ArrayException);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -138,6 +138,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 });
         }
 
+        /// <summary>
+        /// Tests that exceptions from reverse p/invoke are detectable.
+        /// </summary>
         [Fact]
         public Task EventExceptionsPipeline_ReversePInvokeException()
         {
@@ -155,6 +158,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 });
         }
 
+        /// <summary>
+        /// Tests that exceptions from dynamic methods are detectable.
+        /// </summary>
         [Fact]
         public Task EventExceptionsPipeline_DynamicMethodException()
         {
@@ -167,6 +173,26 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.ExceptionId);
                     Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomSimpleException", instance.TypeName);
+                    Assert.False(string.IsNullOrEmpty(instance.Message));
+                    Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
+                });
+        }
+
+        /// <summary>
+        /// Tests that exceptions from array types are detectable.
+        /// </summary>
+        [Fact]
+        public Task EventExceptionsPipeline_ArrayException()
+        {
+            return Execute(
+                TestAppScenarios.Exceptions.SubScenarios.ArrayException,
+                expectedInstanceCount: 1,
+                validate: instances =>
+                {
+                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    Assert.NotNull(instance);
+                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.Equal(typeof(IndexOutOfRangeException).FullName, instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
                 });

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         /// <summary>
         /// Tests that exceptions from reverse p/invoke are detectable.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "Loading profiler library from managed code on Windows x86 build leg doesn't work because process runs as x64.")]
         public Task EventExceptionsPipeline_ReversePInvokeException()
         {
             return Execute(

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -138,6 +138,23 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 });
         }
 
+        [Fact]
+        public Task EventExceptionsPipeline_ReversePInvokeException()
+        {
+            return Execute(
+                TestAppScenarios.Exceptions.SubScenarios.ReversePInvokeException,
+                expectedInstanceCount: 1,
+                validate: instances =>
+                {
+                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    Assert.NotNull(instance);
+                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomException`2[System.Int32,System.String]", instance.TypeName);
+                    Assert.False(string.IsNullOrEmpty(instance.Message));
+                    Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
+                });
+        }
+
         private async Task Execute(
             string subScenarioName,
             int expectedInstanceCount,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.ExceptionId);
-                    Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomException`2[System.Int32,System.String]", instance.TypeName);
+                    Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomGenericsException`2[System.Int32,System.String]", instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
                 });
@@ -149,7 +149,24 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.ExceptionId);
-                    Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomException`2[System.Int32,System.String]", instance.TypeName);
+                    Assert.Equal(typeof(InvalidOperationException).FullName, instance.TypeName);
+                    Assert.False(string.IsNullOrEmpty(instance.Message));
+                    Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
+                });
+        }
+
+        [Fact]
+        public Task EventExceptionsPipeline_DynamicMethodException()
+        {
+            return Execute(
+                TestAppScenarios.Exceptions.SubScenarios.DynamicMethodException,
+                expectedInstanceCount: 1,
+                validate: instances =>
+                {
+                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    Assert.NotNull(instance);
+                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomSimpleException", instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
                 });
@@ -229,12 +246,22 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             public void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message)
             {
-                Assert.True(cache.TryGetExceptionId(exceptionId, out ulong exceptionClassId, out ulong throwingMethodId, out _));
-
                 StringBuilder typeBuilder = new();
-                NameFormatter.BuildClassName(typeBuilder, cache.NameCache, exceptionClassId);
+                FunctionData throwingMethodData;
+                try
+                {
+                    Assert.True(cache.TryGetExceptionId(exceptionId, out ulong exceptionClassId, out ulong throwingMethodId, out _));
 
-                Assert.True(cache.NameCache.FunctionData.TryGetValue(throwingMethodId, out FunctionData throwingMethodData));
+                    NameFormatter.BuildClassName(typeBuilder, cache.NameCache, exceptionClassId);
+
+                    Assert.True(cache.NameCache.FunctionData.TryGetValue(throwingMethodId, out throwingMethodData));
+                }
+                catch (Exception ex)
+                {
+                    _instanceThresholdSource.TrySetException(ex);
+
+                    throw;
+                }
 
                 _instances.Add(new ExceptionInstance(exceptionId, typeBuilder.ToString(), message, throwingMethodData.Name));
                 if (++_instanceCount >= _instanceThreshold)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -4,6 +4,7 @@
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;
 using System.CommandLine;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
@@ -37,6 +38,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             CliCommand dynamicMethodExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.DynamicMethodException);
             dynamicMethodExceptionCommand.SetAction(DynamicMethodExceptionAsync);
 
+            CliCommand arrayExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.ArrayException);
+            arrayExceptionCommand.SetAction(ArrayExceptionAsync);
+
             CliCommand scenarioCommand = new(TestAppScenarios.Exceptions.Name);
             scenarioCommand.Subcommands.Add(singleExceptionCommand);
             scenarioCommand.Subcommands.Add(repeatExceptionCommand);
@@ -45,6 +49,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             scenarioCommand.Subcommands.Add(customExceptionCommand);
             scenarioCommand.Subcommands.Add(reversePInvokeExceptionCommand);
             scenarioCommand.Subcommands.Add(dynamicMethodExceptionCommand);
+            scenarioCommand.Subcommands.Add(arrayExceptionCommand);
             return scenarioCommand;
         }
 
@@ -181,6 +186,27 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                 Action dynamicMethodDelegate = (Action)dynamicMethod.CreateDelegate(typeof(Action));
 
                 dynamicMethodDelegate();
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
+        public static Task<int> ArrayExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                int[] values = Enumerable.Range(1, 100).ToArray();
+                try
+                {
+                    object value = values.GetValue(200);
+                }
+                catch (Exception)
+                {
+                }
 
                 await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -29,12 +29,16 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             CliCommand customExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.CustomException);
             customExceptionCommand.SetAction(CustomExceptionAsync);
 
+            CliCommand reversePInvokeExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.ReversePInvokeException);
+            reversePInvokeExceptionCommand.SetAction(ReversePInvokeExceptionAsync);
+
             CliCommand scenarioCommand = new(TestAppScenarios.Exceptions.Name);
             scenarioCommand.Subcommands.Add(singleExceptionCommand);
             scenarioCommand.Subcommands.Add(repeatExceptionCommand);
             scenarioCommand.Subcommands.Add(asyncExceptionCommand);
             scenarioCommand.Subcommands.Add(frameworkExceptionCommand);
             scenarioCommand.Subcommands.Add(customExceptionCommand);
+            scenarioCommand.Subcommands.Add(reversePInvokeExceptionCommand);
             return scenarioCommand;
         }
 
@@ -103,6 +107,22 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                 await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
 
                 ThrowAndCatchCustomException();
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
+        public static Task<int> ReversePInvokeExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            MonitorLibrary.InitializeResolver();
+
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                MonitorLibrary.TestHook(ThrowAndCatchInvalidOperationException);
 
                 await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/MonitorLibrary.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/MonitorLibrary.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System.Reflection;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
+{
+    internal static class MonitorLibrary
+    {
+        [DllImport(ProfilerIdentifiers.LibraryRootFileName, CallingConvention = CallingConvention.StdCall, PreserveSig = true)]
+        public static extern int TestHook([MarshalAs(UnmanagedType.FunctionPtr)] Action callback);
+
+        public static void InitializeResolver()
+        {
+            NativeLibrary.SetDllImportResolver(typeof(MonitorLibrary).Assembly, ResolveDllImport);
+        }
+
+        public static IntPtr ResolveDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            //DllImport for Windows automatically loads in-memory modules (such as the profiler). This is not the case for Linux/MacOS.
+            //If we fail resolving the DllImport, we have to load the profiler ourselves.
+
+            string profilerName = ProfilerHelper.GetPath(RuntimeInformation.ProcessArchitecture);
+            if (NativeLibrary.TryLoad(profilerName, out IntPtr handle))
+            {
+                return handle;
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             public void DoWork<U>(U test, WaitHandle handle)
             {
                 _handle = handle;
-                StacksScenario.TestHook(Callback);
+                MonitorLibrary.TestHook(Callback);
             }
 
             public void Callback()

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -98,6 +98,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         traceEvent.GetPayload<string>(NameIdentificationEvents.ModuleDescPayloads.Name)
                         );
                     break;
+                case "StackFrameDescription":
+                    // Not Yet Implemented
+                    break;
                 case "TokenDescription":
                     _cache.AddToken(
                         traceEvent.GetPayload<ulong>(NameIdentificationEvents.TokenDescPayloads.ModuleId),

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
@@ -20,12 +20,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public const int ModuleDescription = 5;
             public const int TokenDescription = 6;
             public const int Flush = 7;
+            public const int StackFrameDescription = 8;
         }
 
         public static class ExceptionInstancePayloads
         {
             public const int ExceptionId = 0;
             public const int ExceptionMessage = 1;
+            public const int StackFrameIds = 2;
         }
 
         public static class ExceptionIdentifierPayloads
@@ -34,6 +36,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public const int ExceptionClassId = 1;
             public const int ThrowingMethodId = 2;
             public const int ILOffset = 3;
+        }
+
+        public static class  StackFrameIdentifierPayloads
+        {
+            public const int StackFrameId = 0;
+            public const int FunctionId = 1;
+            public const int ILOffset = 2;
         }
     }
 }


### PR DESCRIPTION
###### Summary

- Report stack frame information (list of method and IL offset pairs) from exceptions
- Cache stack frame information so that it is not repeated through the event source
- New stack frame information is reported to the event source.
- Added tests to validate caching and event source information.
- Fix call stack gathering in order to get full call stack of thrown exception.
- Fixed TargetFrameworkMonikerTrait attributes on tests to have them correctly run when filtered by TFM (e.g. PR builds only run tests for the latest TFM)

Note: The dotnet-monitor tool does nothing with the stack frame information. This is will be implemented in a follow up PR in order to keep this one simple.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
