### PR TITLE
Use Ubuntu 18.04 for Linux x64 builds

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -73,7 +73,7 @@ jobs:
       ${{ if eq(parameters.architecture, 'arm64') }}:
         container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64
       ${{ else }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
 
     ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
       ${{ if eq(parameters.architecture, 'arm64') }}:


### PR DESCRIPTION
###### Summary

Recent changes in the minimum requirement for the glibc version for .NET 8 prevent it from being installed on CentOS 7 (has a glibc version of 2.17). The new minimum is 2.23 (see https://github.com/dotnet/core/pull/8401). To resolve this for the medium term, switch over to using Ubuntu 18.04, which has a glibc version of 2.27. The longer term fix to use glibc version 2.23 will require much more churn in the build process, but it should be addressed prior to shipping .NET Monitor 8.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
