### PR TITLE
The type of "MaxConnections" is error

### DIFF
--- a/documentation/configuration/diagnostic-port-configuration.md
+++ b/documentation/configuration/diagnostic-port-configuration.md
@@ -88,7 +88,7 @@ When operating in `Listen` mode, you can also specify the maximum number of inco
   ```json
   {
     "DiagnosticPort": {
-      "MaxConnections": "10"
+      "MaxConnections": 10
     }
   }
   ```


### PR DESCRIPTION
Base on the official [json schema](https://raw.githubusercontent.com/dotnet/dotnet-monitor/main/documentation/schema.json), 
"MaxConnections" has been changed the type from string to int.

Json schema code block:
```        "MaxConnections": {
          "type": [
            "integer",
            "null"
          ],
          "description": "In 'Listen' mode, the maximum amount of connections to accept.",
          "format": "int32"
        },
```