### PR TITLE
Use CBL Mariner build images

### DIFF
--- a/eng/pipelines/jobs/build-binaries.yml
+++ b/eng/pipelines/jobs/build-binaries.yml
@@ -1,6 +1,8 @@
 # Builds dotnet-monitor for a specific platform and configuration
 
 parameters:
+  # Job prefix
+  prefix: Build
   # Operating system group (Windows, Linux, MacOS, etc)
   osGroup: Windows
   # Build configuration (Debug, Release)
@@ -9,6 +11,16 @@ parameters:
   architecture: x64
   # RID (runtime identifier) of build output
   targetRid: win-x64
+  # Additional job variables
+  variables: []
+  # Additional steps to execute before build
+  preBuildSteps: []
+  # Additional steps to execute after build
+  postBuildSteps: []
+  # Disable Component Governance injection and analysis
+  disableComponentGovernance: false
+  # Disable SBOM generation
+  disableSbom: false
   # Enable/disable publishing build output as Azure Pipeline artifact
   publishArtifacts: false
   # Enable/disable publishing binaries as Azure Pipeline artifact
@@ -17,17 +29,44 @@ parameters:
 jobs:
 - template: /eng/pipelines/jobs/build.yml
   parameters:
-    prefix: Build
+    prefix: ${{ parameters.prefix }}
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
+    disableSbom: ${{ parameters.disableSbom }}
+    variables:
+    - _CrossBuildArgs: ''
+    - _PublishProjectsArgs: ''
+    - ${{ each variable in parameters.variables }}:
+      - ${{ variable }}
 
-    ${{ if and(eq(parameters.targetRid, 'win-x64'), eq(parameters.configuration, 'Release')) }}:
-      buildArgs: '/p:PublishProjectsAfterBuild=true'
-    ${{ else }}:
-      buildArgs: '/p:PublishProjectsAfterBuild=true /p:SkipPlatformNeutralPublish=true'
+    # Cross build for all Linux builds and arm64 non-Windows builds
+    - ${{ if or(in(parameters.osGroup, 'Linux', 'Linux_Musl'), and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows'))) }}:
+      - _CrossBuildArgs: '-cross'
+
+    - ${{ if and(eq(parameters.targetRid, 'win-x64'), eq(parameters.configuration, 'Release')) }}:
+      - _PublishProjectsArgs: '/p:PublishProjectsAfterBuild=true'
+    - ${{ else }}:
+      - _PublishProjectsArgs: '/p:PublishProjectsAfterBuild=true /p:SkipPlatformNeutralPublish=true'
+
+    preBuildSteps:
+    - ${{ each step in parameters.preBuildSteps }}:
+      - ${{ step }}
+
+    buildArgs: >-
+      $(_CrossBuildArgs)
+      $(_PublishProjectsArgs)
+
+    # Set ROOTFS_DIR for Linux cross builds
+    ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:
+      buildEnv:
+        ROOTFS_DIR: '/crossrootfs/${{ parameters.architecture }}'
 
     postBuildSteps:
+    - ${{ each step in parameters.postBuildSteps }}:
+      - ${{ step }}
+
     - ${{ if eq(parameters.publishBinaries, 'true') }}:
       - task: CopyFiles@2
         displayName: Gather Artifacts (bin)

--- a/eng/pipelines/jobs/build-codeql.yml
+++ b/eng/pipelines/jobs/build-codeql.yml
@@ -11,7 +11,7 @@ parameters:
   enableTsa: false
 
 jobs:
-- template: /eng/pipelines/jobs/build.yml
+- template: /eng/pipelines/jobs/build-binaries.yml
   parameters:
     prefix: CodeQL
     osGroup: ${{ parameters.osGroup }}

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -9,6 +9,9 @@ parameters:
   configuration: Release
   # Build architecture (arm64, x64, x86, etc)
   architecture: x64
+  # Docker container in which job steps shall be run (leave empty to choose default build container).
+  # This should be empty unless exclusively testing on a specific container image.
+  container: ''
   # Additional job variables
   variables: []
   # Additional steps to execute before build
@@ -68,17 +71,20 @@ jobs:
           name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2022.amd64
 
-    ${{ if eq(parameters.osGroup, 'Linux') }}:
-      ${{ if eq(parameters.architecture, 'arm64') }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64
-      ${{ else }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
-
-    ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
-      ${{ if eq(parameters.architecture, 'arm64') }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
-      ${{ else }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
+    ${{ if ne(parameters.container, '') }}:
+      container: ${{ parameters.container }}
+    ${{ else }}:
+      # Fallback to default Linux x64 build container that optionally support cross building
+      ${{ if eq(parameters.osGroup, 'Linux') }}:
+        ${{ if eq(parameters.architecture, 'arm64') }}:
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
+        ${{ else }}:
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+      ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
+        ${{ if eq(parameters.architecture, 'arm64') }}:
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
+        ${{ else }}:
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine
 
     ${{ if ne(parameters.dependsOn, '') }}:
       dependsOn: ${{ parameters.dependsOn }}
@@ -91,7 +97,6 @@ jobs:
     - _BuildConfig: ${{ parameters.configuration }}
     - _HelixType: build/product
     - _HelixBuildConfig: ${{ parameters.configuration }}
-    - _CrossBuildArgs: ''
     - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
     - ${{ each variable in parameters.variables }}:
@@ -100,10 +105,6 @@ jobs:
     # Component Governance does not work on Musl
     - ${{ if or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}:
       - skipComponentGovernanceDetection: true
-    
-    # Cross build for arm64 non-Windows builds
-    - ${{ if and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows')) }}:
-      - _CrossBuildArgs: '-cross'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-MSRC-Storage
@@ -153,17 +154,14 @@ jobs:
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)
-        ${{ parameters.buildArgs }}
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
-        $(_CrossBuildArgs)
+        ${{ parameters.buildArgs }}
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)
       displayName: Build
       env:
         ${{ insert }}: ${{ parameters.buildEnv }}
-        ${{ if and(eq(parameters.architecture, 'arm64'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
-          ROOTFS_DIR: '/crossrootfs/arm64'
 
     - ${{ each step in parameters.postBuildSteps }}:
       - ${{ step }}

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -32,6 +32,12 @@ jobs:
     disableComponentGovernance: true
     disableSbom: true
 
+    # Override containers for Linux to test on real clib and architecture variants
+    ${{ if eq(parameters.osGroup, 'Linux') }}:
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+    ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
+
     variables:
     # If TestGroup == 'Default', choose the test group based on the type of pipeline run
     - ${{ if eq(parameters.testGroup, 'Default') }}:

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestConditions.cs
@@ -3,11 +3,13 @@
 
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
+namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     internal static class TestConditions
     {
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static bool IsNotAlpine => DistroInformation.IsAlpineLinux;
 
         public static bool IsNotWindows => !IsWindows;
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestConditions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestConditions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
     {
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-        public static bool IsNotAlpine => DistroInformation.IsAlpineLinux;
+        public static bool IsNotAlpine => !DistroInformation.IsAlpineLinux;
 
         public static bool IsNotWindows => !IsWindows;
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -70,7 +70,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.NotNull(extension);
         }
 
-        [Fact]
+        // Conditionally disable on Alpine. The apphost for the extension is currently built for glibc x64
+        // in CI builds. Need to publish the test extension for different RIDs and dynamic select which
+        // variant with which tests are run.
+        [ConditionalFact(typeof(TestConditions), nameof(TestConditions.IsNotAlpine))]
         public async Task ExtensionResponse_Success()
         {
             EgressArtifactResult result = await GetExtensionResponse(true);
@@ -79,7 +82,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.Equal(EgressExtensibilityTestsConstants.SampleArtifactPath, result.ArtifactPath);
         }
 
-        [Fact]
+        // Conditionally disable on Alpine. The apphost for the extension is currently built for glibc x64
+        // in CI builds. Need to publish the test extension for different RIDs and dynamic select which
+        // variant with which tests are run.
+        [ConditionalFact(typeof(TestConditions), nameof(TestConditions.IsNotAlpine))]
         public async Task ExtensionResponse_Failure()
         {
             EgressArtifactResult result = await GetExtensionResponse(false);


### PR DESCRIPTION
###### Summary

This change switch all of the build jobs to use CBL Mariner with cross build support for clib and architecture variants.

Overview of changes:
- Switch to using CBL Mariner as the default container for Linux builds; allow test jobs to override the container to run the tests on distros that have the target clib and architecture types.
- Move the cross-build notion up into the build-binaries job since it's only necessary when building binaries; base codeql job on this job instead of base build job.
- Disable tests the execute the test egress extension on Alpine images for now. The apphost for the extension is glibc x64, so it won't execute on Alpine. Will attempt a solution for this after this PR.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2173397&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
