### PR TITLE
Rewrite extension response tests to use in-place test egress extension

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/extension.json
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/extension.json
@@ -1,4 +1,4 @@
 {
     "ExecutableFileName": "Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp",
-    "Name": "TestingProvider"
+    "Name": "TestEgress"
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -8,13 +8,8 @@ using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -70,56 +65,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.NotNull(extension);
         }
 
-        [Fact]
-        public async Task ExtensionResponse_Success()
-        {
-            EgressArtifactResult result = await GetExtensionResponse(true);
-
-            Assert.True(result.Succeeded);
-            Assert.Equal(EgressExtensibilityTestsConstants.SampleArtifactPath, result.ArtifactPath);
-        }
-
-        [Fact]
-        public async Task ExtensionResponse_Failure()
-        {
-            EgressArtifactResult result = await GetExtensionResponse(false);
-
-            Assert.False(result.Succeeded);
-            Assert.Equal(EgressExtensibilityTestsConstants.SampleFailureMessage, result.FailureMessage);
-        }
-
-        private async Task<EgressArtifactResult> GetExtensionResponse(bool shouldSucceed)
-        {
-            using TemporaryDirectory sharedConfigDir = new(_outputHelper);
-            using TemporaryDirectory userConfigDir = new(_outputHelper);
-
-            // Set up the initial settings used to create the host builder.
-            HostBuilderSettings settings = new()
-            {
-                SharedConfigDirectory = sharedConfigDir.FullName,
-                UserConfigDirectory = userConfigDir.FullName
-            };
-
-            EgressExtension extension = (EgressExtension)FindEgressExtension(ConfigDirectory.UserConfigDirectory, settings);
-
-            // This addresses an issue with the extension process not being able to find the required version of dotnet
-            // Runtime Directory example: 'C:\\Users\\abc\\dotnet-monitor\\.dotnet\\shared\\Microsoft.NETCore.App\\6.0.11\\
-            string dotnetPath = Directory.GetParent(RuntimeEnvironment.GetRuntimeDirectory()).Parent.Parent.Parent.FullName;
-            extension.AddEnvironmentVariable("DOTNET_ROOT", dotnetPath);
-
-            ExtensionEgressPayload payload = new();
-
-            payload.Configuration = new Dictionary<string, string>()
-            {
-                { "ShouldSucceed", shouldSucceed.ToString() },
-                { $"Metadata:{EgressExtensibilityTestsConstants.Key}", EgressExtensibilityTestsConstants.Value }
-            };
-
-            CancellationTokenSource tokenSource = new(CommonTestTimeouts.GeneralTimeout);
-
-            return await extension.EgressArtifact(payload, GetStream, ExtensionMode.Execute, tokenSource.Token);
-        }
-
         private IEgressExtension FindEgressExtension(ConfigDirectory configDirectory, HostBuilderSettings settings)
         {
             IHost host = TestHostHelper.CreateHost(_outputHelper, rootOptions => { }, host => { }, settings: settings);
@@ -133,41 +78,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             CopyExtensionFiles(extensionDirPath);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                string executablePath = Path.Combine(extensionDirPath, EgressExtensibilityTestsConstants.AppName);
-
-#if NET7_0_OR_GREATER
-                File.SetUnixFileMode(executablePath, UnixFileMode.UserExecute);
-#else
-                ProcessStartInfo startInfo = new()
-                {
-                    FileName = "chmod",
-                    UseShellExecute = true
-                };
-                startInfo.ArgumentList.Add("+x");
-                startInfo.ArgumentList.Add(executablePath);
-
-                using Process proc = Process.Start(startInfo);
-                if (!proc.WaitForExit(60_000)) // 1 minute
-                {
-                    throw new InvalidOperationException("Unable to make extension executable: Timed out.");
-                }
-                if (0 != proc.ExitCode)
-                {
-                    throw new InvalidOperationException("Unable to make extension executable: Failed.");
-                }
-#endif
-            }
-
             var extensionDiscoverer = host.Services.GetService<ExtensionDiscoverer>();
-            return extensionDiscoverer.FindExtension<IEgressExtension>(EgressExtensibilityTestsConstants.ProviderName);
-        }
-
-        private static async Task GetStream(Stream stream, CancellationToken cancellationToken)
-        {
-            // The test extension currently does not do anything with this stream.
-            await stream.WriteAsync(EgressExtensibilityTestsConstants.ByteArray, cancellationToken);
+            return extensionDiscoverer.FindExtension<IEgressExtension>(EgressExtensibilityTestsConstants.ProviderTypeName);
         }
 
         private static void CopyExtensionFiles(string extensionDirPath)
@@ -184,23 +96,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 File.Copy(testAppFilePath, extensionFilePath, true);
             }
-        }
-
-        private static bool IsExecutablePath(string path)
-        {
-            if (Path.GetFileNameWithoutExtension(path) == EgressExtensibilityTestsConstants.AppName)
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Path.GetExtension(path) == ".exe")
-                {
-                    return true;
-                }
-                else
-                {
-                    return Path.GetExtension(path) == string.Empty;
-                }
-            }
-
-            return false;
         }
 
         private static string GetExtensionDirectoryName(HostBuilderSettings settings, IDotnetToolsFileSystem dotnetToolsFileSystem, ConfigDirectory configDirectory)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTestsConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTestsConstants.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         public const string ExtensionsFolder = "extensions";
         public const string SampleArtifactPath = "sample\\path";
         public const string SampleFailureMessage = "the extension failed";
-        public const string ProviderName = "TestingProvider"; // Must match the name in extension.json
+        public const string ProviderTypeName = "TestEgress"; // Must match the name in extension.json
+        public const string ProviderName = "TestProvider";
         public const string AppName = "Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp";
         public static readonly string DotnetToolsExtensionDir = Path.Combine(".store", "tool-name", "7.0", "tool-name", "7.0", "tools", "net7.0", "any");
         public const string DotnetToolsExeDir = "";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensionTests.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.Diagnostics.Tools.Monitor.Egress;
+using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
+using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    public class EgressExtensionTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task EgressExtension_Execute_SuccessResponse(bool useExecutable)
+        {
+            EgressArtifactResult result = await GetExtensionResponse(useExecutable, shouldSucceed: true);
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(EgressExtensibilityTestsConstants.SampleArtifactPath, result.ArtifactPath);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task EgressExtension_Execute_FailureResponse(bool useExecutable)
+        {
+            EgressArtifactResult result = await GetExtensionResponse(useExecutable, shouldSucceed: false);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(EgressExtensibilityTestsConstants.SampleFailureMessage, result.FailureMessage);
+        }
+
+        private static async Task<EgressArtifactResult> GetExtensionResponse(bool useExecutable, bool shouldSucceed)
+        {
+            EgressExtension extension = CreateExtension(useExecutable, shouldSucceed);
+
+            if (!useExecutable)
+            {
+                // Instruct the extension apphost where the dotnet root is in order to use repository installation
+                extension.AddEnvironmentVariable("DOTNET_ROOT", Path.GetDirectoryName(DotNetHost.ExecutablePath));
+            }
+
+            using CancellationTokenSource tokenSource = new(CommonTestTimeouts.GeneralTimeout);
+
+            EgressArtifactSettings settings = new()
+            {
+                Name = "test.txt",
+                ContentType = ContentTypes.TextPlain
+            };
+
+            return await extension.EgressArtifact(
+                EgressExtensibilityTestsConstants.ProviderName,
+                settings,
+                GetStream,
+                tokenSource.Token);
+        }
+
+        private static async Task GetStream(Stream stream, CancellationToken cancellationToken)
+        {
+            // The test extension currently does not do anything with this stream.
+            await stream.WriteAsync(EgressExtensibilityTestsConstants.ByteArray, cancellationToken);
+        }
+
+        private static EgressExtension CreateExtension(bool useExecutable, bool shouldSucceed)
+        {
+            // Logger
+            Mock<ILogger<EgressExtension>> mockLogger = new();
+
+            // Configuration provider
+            List<IConfigurationProvider> configProviders = new()
+            {
+                new EmptyConfigurationProvider()
+            };
+            ConfigurationRoot configurationRoot = new(configProviders);
+            string configurationPath = ConfigurationPath.Combine(ConfigurationKeys.Egress, EgressExtensibilityTestsConstants.ProviderTypeName, EgressExtensibilityTestsConstants.ProviderName);
+            ConfigurationSection configurationSection = new(configurationRoot, configurationPath);
+
+            // Configuration data
+            configurationSection["ShouldSucceed"] = shouldSucceed.ToString();
+            configurationSection[ConfigurationPath.Combine("Metadata", EgressExtensibilityTestsConstants.Key)] = EgressExtensibilityTestsConstants.Value;
+
+            Mock<IEgressConfigurationProvider> mockConfigurationProvider = new();
+            mockConfigurationProvider.Setup(provider => provider.GetProviderConfigurationSection(EgressExtensibilityTestsConstants.ProviderTypeName, EgressExtensibilityTestsConstants.ProviderName))
+                .Returns(configurationSection);
+
+            // Manifest
+            string assemblyPath = AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), EgressExtensibilityTestsConstants.AppName);
+            string extensionPath = Path.GetDirectoryName(assemblyPath);
+
+            ExtensionManifest manifest = ExtensionManifest.FromPath(Path.Combine(extensionPath, ExtensionManifest.DefaultFileName));
+
+            if (useExecutable)
+            {
+                manifest.AssemblyFileName = null;
+                manifest.ExecutableFileName = EgressExtensibilityTestsConstants.AppName;
+            }
+            else
+            {
+                manifest.AssemblyFileName = Path.GetFileNameWithoutExtension(assemblyPath);
+                manifest.ExecutableFileName = null;
+            }
+
+            // Create extension
+            return new EgressExtension(
+                manifest,
+                extensionPath,
+                mockConfigurationProvider.Object,
+                mockLogger.Object);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensionTests.cs
@@ -10,9 +10,12 @@ using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -107,6 +110,32 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             {
                 manifest.AssemblyFileName = null;
                 manifest.ExecutableFileName = EgressExtensibilityTestsConstants.AppName;
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    string executablePath = Path.Combine(extensionPath, EgressExtensibilityTestsConstants.AppName);
+#if NET7_0_OR_GREATER
+                    File.SetUnixFileMode(executablePath, UnixFileMode.UserExecute);
+#else
+                    ProcessStartInfo startInfo = new()
+                    {
+                        FileName = "chmod",
+                        UseShellExecute = true
+                    };
+                    startInfo.ArgumentList.Add("+x");
+                    startInfo.ArgumentList.Add(executablePath);
+
+                    using Process proc = Process.Start(startInfo);
+                    if (!proc.WaitForExit(60_000)) // 1 minute
+                    {
+                        throw new InvalidOperationException("Unable to make extension executable: Timed out.");
+                    }
+                    if (0 != proc.ExitCode)
+                    {
+                        throw new InvalidOperationException("Unable to make extension executable: Failed.");
+                    }
+#endif
+                }
             }
             else
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EmptyConfigurationProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EmptyConfigurationProvider.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    internal sealed class EmptyConfigurationProvider : ConfigurationProvider
+    {
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/FileSystemEgressExtensionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/FileSystemEgressExtensionTests.cs
@@ -198,7 +198,5 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             string content = File.ReadAllText(filePath);
             Assert.Equal(ExpectedFileContent, content);
         }
-
-        private sealed class EmptyConfigurationProvider : ConfigurationProvider { }
     }
 }


### PR DESCRIPTION
###### Summary

The ExtensionResponse tests are causing failures when changing the build to CBL Mariner for building binaries. The cause is likely due to a permissions issue from copying the test extension from the output directory to a temporary directory. I've tried several ways of fixing up the existing test to no avail. This solution uses the test extension from the output directory as-is; as part of the change, I've moved these affected tests to a separate test class to make it clear as to what they are testing (e.g. the location of the test extension is not important).

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
