### PR TITLE
Only disable CG if explicitly set

### DIFF
--- a/eng/pipelines/jobs/build-binaries.yml
+++ b/eng/pipelines/jobs/build-binaries.yml
@@ -18,7 +18,7 @@ parameters:
   # Additional steps to execute after build
   postBuildSteps: []
   # Disable Component Governance injection and analysis
-  disableComponentGovernance: false
+  disableComponentGovernance: ''
   # Disable SBOM generation
   disableSbom: false
   # Enable/disable publishing build output as Azure Pipeline artifact

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -23,7 +23,7 @@ parameters:
   # Job dependencies
   dependsOn: ''
   # Disable Component Governance injection and analysis
-  disableComponentGovernance: false
+  disableComponentGovernance: ''
   # Disable SBOM generation
   disableSbom: false
   buildArgs: ''
@@ -36,7 +36,7 @@ jobs:
     displayName: ${{ format('{0} {1} {2} {3}', parameters.prefix, parameters.osGroup, parameters.architecture, parameters.configuration) }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableTelemetry: true
-    disableComponentGovernance: ${{ or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
     ${{ if eq(parameters.disableSbom, 'true') }}:
       enableSbom: false
     helixRepo: dotnet/dotnet-monitor
@@ -101,10 +101,6 @@ jobs:
     - _InternalBuildArgs: ''
     - ${{ each variable in parameters.variables }}:
       - ${{ variable }}
-
-    # Component Governance does not work on Musl
-    - ${{ if or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}:
-      - skipComponentGovernanceDetection: true
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-MSRC-Storage


### PR DESCRIPTION
###### Summary

Arcade pipeline templates now dynamically component governance based on the branch name and the build type. Switch to using the default value (empty string) so that Arcade can make this determination; non-default value are passed directly through to the CG task to explicitly enable or disable the task.

We shouldn't need the carve out for Alpine x64 since transitioning to using CBL Mariner for build.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
