### PR TITLE
Add timestamp information to exception history

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionSource.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 
         private void CurrentDomain_FirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
         {
+            DateTime timestamp = DateTime.UtcNow;
+
             if (_handlingException.Value)
             {
                 // Exception handling is already in progress on this thread. The current exception is likely
@@ -38,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             {
                 _handlingException.Value = true;
 
-                RaiseExceptionThrown(e.Exception);
+                RaiseExceptionThrown(e.Exception, timestamp);
             }
             catch
             {

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         public void ExceptionInstance(
             ulong ExceptionId,
             string? ExceptionMessage,
-            ulong[] StackFrameIds)
+            ulong[] StackFrameIds,
+            DateTime Timestamp)
         {
-            Span<EventData> data = stackalloc EventData[3];
+            Span<EventData> data = stackalloc EventData[4];
             using PinnedData namePinned = PinnedData.Create(ExceptionMessage);
             Span<byte> stackFrameIdsSpan = stackalloc byte[GetArrayDataSize(StackFrameIds)];
             FillArrayData(stackFrameIdsSpan, StackFrameIds);
@@ -79,6 +80,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionId], ExceptionId);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage], namePinned);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds], stackFrameIdsSpan);
+            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.Timestamp], Timestamp.ToFileTimeUtc());
 
             WriteEventCore(ExceptionEvents.EventIds.ExceptionInstance, data);
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionEventArgs.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionEventArgs.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    internal sealed class ExceptionEventArgs : EventArgs
+    {
+        public ExceptionEventArgs(Exception exception, DateTime timestamp)
+        {
+            Exception = exception;
+            Timestamp = timestamp;
+        }
+
+        public Exception Exception { get; }
+
+        public DateTime Timestamp { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
     /// </summary>
     internal abstract class ExceptionSourceBase
     {
-        protected void RaiseExceptionThrown(Exception ex)
+        protected void RaiseExceptionThrown(Exception ex, DateTime timestamp)
         {
-            ExceptionThrown?.Invoke(this, ex);
+            ExceptionThrown?.Invoke(this, new ExceptionEventArgs(ex, timestamp));
         }
 
         /// <summary>
         /// Event that is raised each time an exception is thrown.
         /// </summary>
-        public event EventHandler<Exception>? ExceptionThrown;
+        public event EventHandler<ExceptionEventArgs>? ExceptionThrown;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
             _exceptionSource.ExceptionThrown += ExceptionSource_ExceptionThrown;
         }
 
-        private void ExceptionSource_ExceptionThrown(object? sender, Exception e)
+        private void ExceptionSource_ExceptionThrown(object? sender, ExceptionEventArgs args)
         {
             // DESIGN: While async patterns are typically favored over synchronous patterns,
             // this is intentionally synchronous. Use cases for making this asynchronous typically
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
             // (e.g. EventSource provides events but diagnostic pipe events are queued and asynchronously emitted).
             // Synchronous execution is required for scenarios where the exception needs to be held
             // at the site of where it is thrown before allowing it to unwind (e.g. capturing a dump of the exception).
-            _exceptionHandler.Invoke(e);
+            _exceptionHandler.Invoke(args.Exception, new ExceptionPipelineExceptionContext(args.Timestamp));
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineBuilder.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
     /// </summary>
     internal sealed class ExceptionPipelineBuilder
     {
-        private static readonly ExceptionPipelineDelegate Empty = _ => { };
+        private static readonly ExceptionPipelineDelegate Empty = (_, _) => { };
 
         private List<Func<ExceptionPipelineDelegate, ExceptionPipelineDelegate>> _steps = new();
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineDelegate.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineDelegate.cs
@@ -8,5 +8,5 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
     /// <summary>
     /// Delegate representing an exception handler in the exception processing pipeline.
     /// </summary>
-    internal delegate void ExceptionPipelineDelegate(Exception exception);
+    internal delegate void ExceptionPipelineDelegate(Exception exception, ExceptionPipelineExceptionContext context);
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineExceptionContext.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineExceptionContext.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
+{
+    internal sealed class ExceptionPipelineExceptionContext
+    {
+        public ExceptionPipelineExceptionContext(DateTime timestamp)
+        {
+            Timestamp = timestamp;
+        }
+
+        public DateTime Timestamp { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             _next = next;
         }
 
-        public void Invoke(Exception exception)
+        public void Invoke(Exception exception, ExceptionPipelineExceptionContext context)
         {
             ArgumentNullException.ThrowIfNull(exception);
 
@@ -50,10 +50,11 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                 _eventSource.ExceptionInstance(
                     identifier,
                     exception.Message,
-                    frameIds);
+                    frameIds,
+                    context.Timestamp);
             }
 
-            _next(exception);
+            _next(exception, context);
         }
 
         private static ReadOnlySpan<StackFrame> ComputeEffectiveCallStack(Exception exception)

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStep.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             _next = next;
         }
 
-        public void Invoke(Exception exception)
+        public void Invoke(Exception exception, ExceptionPipelineExceptionContext context)
         {
             ArgumentNullException.ThrowIfNull(exception);
 
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             {
                 MarkObservance(exception);
 
-                _next(exception);
+                _next(exception, context);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
-    internal record class ExceptionInstance(string TypeName, string ModuleName, string Message)
+    internal record class ExceptionInstance(string TypeName, string ModuleName, string Message, DateTime Timestamp)
         : IExceptionInstance
     {
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
     internal interface IExceptionInstance
@@ -10,5 +12,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
         string ModuleName { get; }
 
         string TypeName { get; }
+
+        DateTime Timestamp { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
@@ -1,13 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
     internal interface IExceptionsStore
     {
-        void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message);
+        void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message, DateTime timestamp);
 
         IReadOnlyList<IExceptionInstance> GetSnapshot();
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainExceptionSourceTests.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
     {
         private readonly Thread _thisThread = Thread.CurrentThread;
 
-        private EventHandler<Exception> CreateHandler(List<Exception> reportedExceptions)
+        private EventHandler<ExceptionEventArgs> CreateHandler(List<Exception> reportedExceptions)
         {
-            return (sender, exception) =>
+            return (sender, args) =>
             {
                 if (Thread.CurrentThread == _thisThread)
                 {
-                    reportedExceptions.Add(exception);
+                    reportedExceptions.Add(args.Exception);
                 }
             };
         }
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
         public void CurrentAppDomainExceptionSource_ReentrancyPrevented()
         {
             bool handled = false;
-            EventHandler<Exception> handler = (sender, exception) =>
+            EventHandler<ExceptionEventArgs> handler = (sender, args) =>
             {
                 if (Thread.CurrentThread == _thisThread)
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
                             new ExceptionInstance(
                                 ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionId]),
                                 ToString(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage]),
-                                ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds])
+                                ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds]),
+                                ToType<DateTime>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.Timestamp])
                             ));
                         break;
                     case ExceptionEvents.EventIds.ExceptionIdentifier:
@@ -140,11 +141,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
     internal sealed class ExceptionInstance
     {
-        public ExceptionInstance(ulong exceptionId, string? message, ulong[] frameIds)
+        public ExceptionInstance(ulong exceptionId, string? message, ulong[] frameIds, DateTime timestamp)
         {
             ExceptionId = exceptionId;
             ExceptionMessage = message;
             StackFrameIds = frameIds;
+            Timestamp = timestamp;
         }
 
         public ulong ExceptionId { get; }
@@ -152,5 +154,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         public string? ExceptionMessage { get; }
 
         public ulong[]? StackFrameIds { get; }
+
+        public DateTime Timestamp { get; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
@@ -77,7 +77,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             listener.EnableEvents(source, EventLevel.Informational);
 
             ulong[] frameIds = frameIdsString.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(ulong.Parse).ToArray();
-            source.ExceptionInstance(id, message, frameIds);
+            DateTime timestamp = DateTime.UtcNow;
+
+            source.ExceptionInstance(id, message, frameIds, timestamp);
 
             ExceptionInstance instance = Assert.Single(listener.Exceptions);
             Assert.Equal(id, instance.ExceptionId);
@@ -85,6 +87,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             // We would normally expect the following to return an array of the stack frame IDs
             // but in-process listener doesn't decode non-byte arrays correctly.
             Assert.Equal(Array.Empty<ulong>(), instance.StackFrameIds);
+            Assert.Equal(timestamp, instance.Timestamp);
         }
 
         [Fact]
@@ -95,7 +98,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             using ExceptionsEventListener listener = new();
             listener.EnableEvents(source, EventLevel.Warning);
 
-            source.ExceptionInstance(7, ObjectDisposedExceptionMessage, Array.Empty<ulong>());
+            source.ExceptionInstance(7, ObjectDisposedExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow);
 
             Assert.Empty(listener.Exceptions);
         }
@@ -107,7 +110,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
             using ExceptionsEventListener listener = new();
 
-            source.ExceptionInstance(9, OperationCancelledExceptionMessage, Array.Empty<ulong>());
+            source.ExceptionInstance(9, OperationCancelledExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow);
 
             Assert.Empty(listener.Exceptions);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 
         public void ProvideException(Exception exception)
         {
-            RaiseExceptionThrown(exception);
+            RaiseExceptionThrown(exception, DateTime.UtcNow);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineBuilderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/ExceptionPipelineBuilderTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 
             Assert.NotNull(handler);
 
-            handler.Invoke(new Exception());
+            handler.Invoke(new Exception(), new ExceptionPipelineExceptionContext(DateTime.UtcNow));
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 
             Assert.Empty(stepOrder);
 
-            handler.Invoke(new Exception());
+            handler.Invoke(new Exception(), new ExceptionPipelineExceptionContext(DateTime.UtcNow));
 
             Assert.Equal(new int[] { Step1Id, Step2Id, Step3Id }, stepOrder);
         }
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 
             Assert.Empty(stepOrder);
 
-            handler.Invoke(new Exception());
+            handler.Invoke(new Exception(), new ExceptionPipelineExceptionContext(DateTime.UtcNow));
 
             Assert.Equal(new int[] { Step1Id, Step2Id }, stepOrder);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/AppendIntegerPipelineStep.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/AppendIntegerPipelineStep.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             _shortCircuit = shortCircuit;
         }
 
-        public void Invoke(Exception ex)
+        public void Invoke(Exception ex, ExceptionPipelineExceptionContext context)
         {
             _list.Add(_id);
             if (!_shortCircuit)
             {
-                _next.Invoke(ex);
+                _next.Invoke(ex, context);
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStepTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/FilterRepeatExceptionPipelineStepTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 
         public FilterRepeatExceptionPipelineStepTests()
         {
-            _finalHandler = _reportedExceptions.Add;
+            _finalHandler = (ex, context) => _reportedExceptions.Add(ex);
         }
 
         [Fact]
@@ -25,10 +25,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             FilterRepeatExceptionPipelineStep action = new(_finalHandler);
 
             Exception firstException = new();
-            action.Invoke(firstException);
+            ExceptionPipelineExceptionContext firstContext = new(DateTime.UtcNow);
+
+            action.Invoke(firstException, firstContext);
 
             Exception secondException = new();
-            action.Invoke(secondException);
+            ExceptionPipelineExceptionContext secondContext = new(DateTime.UtcNow);
+
+            action.Invoke(secondException, secondContext);
 
             IEnumerable<Exception> allExceptions = new List<Exception>()
             {
@@ -45,13 +49,20 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             FilterRepeatExceptionPipelineStep action = new(_finalHandler);
 
             Exception firstException = new();
-            action.Invoke(firstException);
-            action.Invoke(firstException);
-            action.Invoke(firstException);
+
+            ExceptionPipelineExceptionContext firstContext = new(DateTime.UtcNow);
+            action.Invoke(firstException, firstContext);
+            firstContext = new ExceptionPipelineExceptionContext(DateTime.UtcNow);
+            action.Invoke(firstException, firstContext);
+            firstContext = new ExceptionPipelineExceptionContext(DateTime.UtcNow);
+            action.Invoke(firstException, firstContext);
 
             Exception secondException = new();
-            action.Invoke(secondException);
-            action.Invoke(secondException);
+
+            ExceptionPipelineExceptionContext secondContext = new(DateTime.UtcNow);
+            action.Invoke(secondException, secondContext);
+            secondContext = new ExceptionPipelineExceptionContext(DateTime.UtcNow);
+            action.Invoke(secondException, secondContext);
 
             IEnumerable<Exception> allExceptions = new List<Exception>()
             {

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -76,11 +76,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 case "ExceptionInstance":
                     ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId);
                     string message = traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage);
+                    DateTime timestamp = traceEvent.GetPayload<DateTime>(ExceptionEvents.ExceptionInstancePayloads.Timestamp).ToUniversalTime();
                     // Add data to cache and write directly to store; this allows the pipeline to recreate the cache without
                     // affecting the store so long as the cache is not cleared. Example of this may be that the event source
                     // wants to reset the identifiers so as to not indefinitely grow the cache and have a large memory impact.
                     _cache.AddExceptionInstance(exceptionId, message);
-                    _store.AddExceptionInstance(_cache, exceptionId, message);
+                    _store.AddExceptionInstance(_cache, exceptionId, message, timestamp);
                     break;
                 case "FunctionDescription":
                     _cache.AddFunction(

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public const int ExceptionId = 0;
             public const int ExceptionMessage = 1;
             public const int StackFrameIds = 2;
+            public const int Timestamp = 3;
         }
 
         public static class ExceptionIdentifierPayloads

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -91,6 +91,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             await using (Utf8JsonWriter writer = new(stream, new JsonWriterOptions() { Indented = false }))
             {
                 writer.WriteStartObject();
+                // Writes the timestamp in ISO 8601 format
+                writer.WriteString("timestamp", instance.Timestamp);
                 writer.WriteString("typeName", instance.TypeName);
                 writer.WriteString("moduleName", instance.ModuleName);
                 writer.WriteString("message", instance.Message);

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             _disposalSource.Dispose();
         }
 
-        public void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message)
+        public void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message, DateTime timestamp)
         {
-            ExceptionInstanceEntry entry = new(cache, exceptionId, message);
+            ExceptionInstanceEntry entry = new(cache, exceptionId, message, timestamp);
             // This should never fail to write because the behavior is to drop the oldest.
             _channel.Writer.TryWrite(entry);
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
                     lock (_instances)
                     {
-                        _instances.Add(new ExceptionInstance(exceptionTypeName, moduleName, entry.Message));
+                        _instances.Add(new ExceptionInstance(exceptionTypeName, moduleName, entry.Message, entry.Timestamp));
                     }
                 }
 
@@ -116,11 +116,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         private sealed class ExceptionInstanceEntry
         {
-            public ExceptionInstanceEntry(IExceptionsNameCache cache, ulong exceptionId, string message)
+            public ExceptionInstanceEntry(IExceptionsNameCache cache, ulong exceptionId, string message, DateTime timestamp)
             {
                 Cache = cache;
                 ExceptionId = exceptionId;
                 Message = message;
+                Timestamp = timestamp;
             }
 
             public IExceptionsNameCache Cache { get; }
@@ -128,6 +129,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public ulong ExceptionId { get; }
 
             public string Message { get; }
+
+            public DateTime Timestamp { get; }
         }
     }
 }


### PR DESCRIPTION
###### Summary

These changes capture the time at which the exception is thrown, propagates it as UTC, and reports it in the exception history store. For JSON, it is formatted using ISO 8601 for standard interchange. Example output:

```
{"timestamp":"2023-05-10T23:04:35.572644Z","typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"I don\u0027t like the count!"}
{"timestamp":"2023-05-10T23:04:42.4341469Z","typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"I don\u0027t like the count!"}
```

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
