### PR TITLE
Change extension common code to be public

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressArtifactSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressArtifactSettings.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Monitoring.Extension.Common
 {
-    internal sealed class EgressArtifactSettings
+    public sealed class EgressArtifactSettings
     {
         /// <summary>
         /// The content type of the blob to be created.

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressException.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressException.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
     /// <summary>
     /// Exception that egress providers can throw when an operational error occurs (e.g. failed to write the stream data).
     /// </summary>
-    internal sealed class EgressException : MonitoringException
+    public sealed class EgressException : MonitoringException
     {
         public EgressException(string message) : base(message) { }
 

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
@@ -19,13 +19,13 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.Extension.Common
 {
-    internal sealed class EgressHelper
+    public sealed class EgressHelper
     {
         private static Stream StdInStream;
         private static CancellationTokenSource CancelSource = new CancellationTokenSource();
         private const int ExpectedPayloadProtocolVersion = 1;
 
-        internal static CliCommand CreateEgressCommand<TProvider, TOptions>(Action<IServiceCollection> configureServices = null)
+        public static CliCommand CreateEgressCommand<TProvider, TOptions>(Action<IServiceCollection> configureServices = null)
             where TProvider : EgressProvider<TOptions>
             where TOptions : class, new()
         {
@@ -214,7 +214,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
             await StdInStream.CopyToAsync(outputStream, DefaultBufferSize, cancellationToken);
         }
 
-        internal static async Task ReadExactlyAsync(Memory<byte> buffer, CancellationToken token)
+        private static async Task ReadExactlyAsync(Memory<byte> buffer, CancellationToken token)
         {
 #if NET7_0_OR_GREATER
             await StdInStream.ReadExactlyAsync(buffer, token);

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressProperties.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressProperties.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Monitoring.Extension.Common
 {
-    internal sealed class EgressProperties
+    public sealed class EgressProperties
     {
         private readonly Dictionary<string, string> _properties;
 

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressProvider.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.Extension.Common
 {
-    internal abstract class EgressProvider<TOptions> where TOptions : class
+    public abstract class EgressProvider<TOptions> where TOptions : class
     {
         protected EgressProvider() { }
 

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/Microsoft.Diagnostics.Monitoring.Extension.Common.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/Microsoft.Diagnostics.Monitoring.Extension.Common.csproj
@@ -18,8 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="dotnet-monitor-egress-azureblobstorage" />
-    <InternalsVisibleTo Include="dotnet-monitor-egress-s3storage" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.AzureBlobStorageTests.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp" />

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/MonitoringException.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/MonitoringException.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Diagnostics.Monitoring.Extension.Common
 {
-    internal class MonitoringException : Exception
+    public class MonitoringException : Exception
     {
         public MonitoringException(string message) : base(message) { }
 


### PR DESCRIPTION
###### Summary

Note that `EgressHelper.GetPayload` is still internal only.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
