### PR TITLE
Fix typo in `releasenotes.v8.0.0-preview.4.23260.4.md`

### DIFF
--- a/documentation/releaseNotes/releaseNotes.v8.0.0-preview.4.23260.4.md
+++ b/documentation/releaseNotes/releaseNotes.v8.0.0-preview.4.23260.4.md
@@ -1,7 +1,7 @@
 Today we are releasing the next official preview version of the `dotnet monitor` tool. This release includes:
 
 - Refactor AzureBlobStorage and S3Storage egress into extensions ([#4133](https://github.com/dotnet/dotnet-monitor/pull/4133))
-- ⚠️ Disable azure developer cli creds ([#4350](https://github.com/dotnet/dotnet-monitor/pull/4350))
+- ⚠️ Disable azure developer cli credentials ([#4350](https://github.com/dotnet/dotnet-monitor/pull/4350))
 - Enable workflow identity ([#4348](https://github.com/dotnet/dotnet-monitor/pull/4348))
 
 \*⚠️ **_indicates a breaking change_**


### PR DESCRIPTION
###### Summary

Expand `creds` to `credentials`. This is resulting in spellchecking blocking PRs when manually doing merges from `main` into other branches. See: https://github.com/dotnet/dotnet-monitor/pull/4548


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
