### PR TITLE
Stable version file and link

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -44,7 +44,7 @@ jobs:
           if [[ "$TEST_RUN" == "true" ]]; then
             qualified_release_version="test-$release_version"
           else
-            version_url="https://aka.ms/dotnet/diagnostics/monitor${major_minor_version}/release/dotnet-monitor-win-x64.zip.version"
+            version_url="https://aka.ms/dotnet/diagnostics/monitor${major_minor_version}/release/dotnet-monitor.version"
             qualified_release_version=$(curl -sL $version_url)
             # Check if the aka.ms url existed
             if [[ "$qualified_release_version" =~ "<html" || -z "$qualified_release_version" ]]; then

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles</PublishDependsOnTargets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles;CollectVersionArtifactFiles</PublishDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
@@ -195,6 +195,30 @@
       <ItemsToPushToBlobFeed Include="@(_VersionContainerBlobItem)" Condition="'$(_BuildVersion)' != ''">
         <!-- Place blobs into versioned container so that stable package versions do not collide. -->
         <RelativeBlobPath>diagnostics/monitor/$(_BuildVersion)/%(_VersionContainerBlobItem.Filename)%(_VersionContainerBlobItem.Extension)</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CollectVersionArtifactFiles"
+          DependsOnTargets="CalculateBlobGroupAndBuildVersion">
+    <PropertyGroup>
+      <VersionFileName>dotnet-monitor-$(_BuildVersion).version</VersionFileName>
+      <VersionFilePath>$(ArtifactsTmpDir)$(VersionFileName)</VersionFilePath>
+    </PropertyGroup>
+
+    <!-- Write three-part version number -->
+    <WriteLinesToFile File="$(VersionFilePath)"
+                      Lines="$(_OriginalVersionPrefix)" />
+
+    <!--
+      Place product version files into versioned container; this will cause the auto aka.ms link generation
+      to be something like aka.ms/dotnet/diagnostics/monitor{Major.Minor}/release/dotnet-monitor.version; this
+      is used to provide a stable production version file and link regardless of the actual product packages.
+      -->
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="$(VersionFilePath)" Condition="'$(_BlobGroupName)' != ''">
+        <RelativeBlobPath>diagnostics/monitor$(_BlobGroupName)/$(VersionFileName)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPushToBlobFeed>
     </ItemGroup>


### PR DESCRIPTION
###### Summary

Creates a stable version file that is published to blob storage (which then creates an aka.ms latest link) to allow for stable access to the latest version within each major.minor version bubble. This is currently only used for release note generation.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
