### PR TITLE
Rename ExceptionIdentifer to ExceptionGroupIdentifier

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -46,28 +46,28 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             base.Dispose(disposing);
         }
 
-        [Event(ExceptionEvents.EventIds.ExceptionIdentifier)]
-        public void ExceptionIdentifier(
-            ulong ExceptionId,
+        [Event(ExceptionEvents.EventIds.ExceptionGroup)]
+        public void ExceptionGroup(
+            ulong ExceptionGroupId,
             ulong ExceptionClassId,
             ulong ThrowingMethodId,
             int ILOffset)
         {
             Span<EventData> data = stackalloc EventData[4];
 
-            SetValue(ref data[ExceptionEvents.ExceptionIdentifierPayloads.ExceptionId], ExceptionId);
-            SetValue(ref data[ExceptionEvents.ExceptionIdentifierPayloads.ExceptionClassId], ExceptionClassId);
-            SetValue(ref data[ExceptionEvents.ExceptionIdentifierPayloads.ThrowingMethodId], ThrowingMethodId);
-            SetValue(ref data[ExceptionEvents.ExceptionIdentifierPayloads.ILOffset], ILOffset);
+            SetValue(ref data[ExceptionEvents.ExceptionGroupPayloads.ExceptionGroupId], ExceptionGroupId);
+            SetValue(ref data[ExceptionEvents.ExceptionGroupPayloads.ExceptionClassId], ExceptionClassId);
+            SetValue(ref data[ExceptionEvents.ExceptionGroupPayloads.ThrowingMethodId], ThrowingMethodId);
+            SetValue(ref data[ExceptionEvents.ExceptionGroupPayloads.ILOffset], ILOffset);
 
-            WriteEventCore(ExceptionEvents.EventIds.ExceptionIdentifier, data);
+            WriteEventCore(ExceptionEvents.EventIds.ExceptionGroup, data);
 
             RestartFlushingEventTimer();
         }
 
         [Event(ExceptionEvents.EventIds.ExceptionInstance)]
         public void ExceptionInstance(
-            ulong ExceptionId,
+            ulong ExceptionGroupId,
             string? ExceptionMessage,
             ulong[] StackFrameIds,
             DateTime Timestamp)
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             Span<byte> stackFrameIdsSpan = stackalloc byte[GetArrayDataSize(StackFrameIds)];
             FillArrayData(stackFrameIdsSpan, StackFrameIds);
 
-            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionId], ExceptionId);
+            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId], ExceptionGroupId);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage], namePinned);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds], stackFrameIdsSpan);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.Timestamp], Timestamp.ToFileTimeUtc());

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSourceIdentifierCacheCallback.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSourceIdentifierCacheCallback.cs
@@ -6,7 +6,7 @@ using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification;
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 {
     internal sealed class ExceptionsEventSourceIdentifierCacheCallback :
-        ExceptionIdentifierCacheCallback
+        ExceptionGroupIdentifierCacheCallback
     {
         private readonly ExceptionsEventSource _source;
 
@@ -25,10 +25,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
                 data.TypeArgs);
         }
 
-        public override void OnExceptionIdentifier(ulong registrationId, ExceptionIdentifierData data)
+        public override void OnExceptionGroupData(ulong groupId, ExceptionGroupData data)
         {
-            _source.ExceptionIdentifier(
-                registrationId,
+            _source.ExceptionGroup(
+                groupId,
                 data.ExceptionClassId,
                 data.ThrowingMethodId,
                 data.ILOffset);

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionGroupData.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionGroupData.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
-    internal sealed class ExceptionIdentifierData
+    internal sealed class ExceptionGroupData
     {
         public ulong ExceptionClassId { get; set; }
         public ulong ThrowingMethodId { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionGroupIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionGroupIdentifier.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
     /// in code. This class may be used as an identifier for determining whether
     /// exception usages are equivalent (same exception type thrown from the same location).
     /// </summary>
-    internal sealed record class ExceptionIdentifier
+    internal sealed record class ExceptionGroupIdentifier
     {
-        public ExceptionIdentifier(Exception ex)
+        public ExceptionGroupIdentifier(Exception ex)
         {
             ArgumentNullException.ThrowIfNull(ex);
 
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             SetThrowingFrame(stackTrace.GetFrames());
         }
 
-        public ExceptionIdentifier(Exception ex, ReadOnlySpan<StackFrame> stackFrames)
+        public ExceptionGroupIdentifier(Exception ex, ReadOnlySpan<StackFrame> stackFrames)
         {
             ArgumentNullException.ThrowIfNull(ex);
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionGroupIdentifierCacheCallback.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Identification/ExceptionGroupIdentifierCacheCallback.cs
@@ -3,11 +3,11 @@
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
-    internal abstract class ExceptionIdentifierCacheCallback
+    internal abstract class ExceptionGroupIdentifierCacheCallback
     {
-        public virtual void OnExceptionIdentifier(
+        public virtual void OnExceptionGroupData(
             ulong registrationId,
-            ExceptionIdentifierData data)
+            ExceptionGroupData data)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
     internal sealed class ExceptionEventsPipelineStep
     {
         private readonly ExceptionsEventSource _eventSource = new();
-        private readonly ExceptionIdentifierCache _identifierCache;
+        private readonly ExceptionGroupIdentifierCache _identifierCache;
         private readonly ExceptionPipelineDelegate _next;
 
         public ExceptionEventsPipelineStep(ExceptionPipelineDelegate next)
         {
             ArgumentNullException.ThrowIfNull(next);
 
-            List<ExceptionIdentifierCacheCallback> callbacks = new(1)
+            List<ExceptionGroupIdentifierCacheCallback> callbacks = new(1)
             {
                 new ExceptionsEventSourceIdentifierCacheCallback(_eventSource)
             };
 
-            _identifierCache = new ExceptionIdentifierCache(callbacks);
+            _identifierCache = new ExceptionGroupIdentifierCache(callbacks);
             _next = next;
         }
 
@@ -43,12 +43,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             {
                 ReadOnlySpan<StackFrame> stackFrames = ComputeEffectiveCallStack(exception);
 
-                ulong identifier = _identifierCache.GetOrAdd(new ExceptionIdentifier(exception, stackFrames));
+                ulong groupId = _identifierCache.GetOrAdd(new ExceptionGroupIdentifier(exception));
 
                 ulong[] frameIds = _identifierCache.GetOrAdd(stackFrames);
 
                 _eventSource.ExceptionInstance(
-                    identifier,
+                    groupId,
                     exception.Message,
                     frameIds,
                     context.Timestamp);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsNameCache.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsNameCache.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
     internal interface IExceptionsNameCache
     {
-        public bool TryGetExceptionId(ulong exceptionId, out ulong exceptionClassId, out ulong throwingMethodId, out int ilOffset);
+        public bool TryGetExceptionGroup(ulong groupId, out ulong exceptionClassId, out ulong throwingMethodId, out int ilOffset);
 
         NameCache NameCache { get; }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
         public List<ExceptionInstance> Exceptions { get; } = new();
 
-        public Dictionary<ulong, ExceptionIdentifierData> ExceptionIdentifiers { get; } = new();
+        public Dictionary<ulong, ExceptionGroupData> ExceptionGroups { get; } = new();
 
         public Dictionary<ulong, StackFrameIdentifier> StackFrameIdentifiers { get; } = new();
 
@@ -33,20 +33,20 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
                     case ExceptionEvents.EventIds.ExceptionInstance:
                         Exceptions.Add(
                             new ExceptionInstance(
-                                ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionId]),
+                                ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId]),
                                 ToString(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage]),
                                 ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds]),
                                 ToType<DateTime>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.Timestamp])
                             ));
                         break;
-                    case ExceptionEvents.EventIds.ExceptionIdentifier:
-                        ExceptionIdentifiers.Add(
-                            ToUInt64(eventData.Payload[ExceptionEvents.ExceptionIdentifierPayloads.ExceptionId]),
-                            new ExceptionIdentifierData()
+                    case ExceptionEvents.EventIds.ExceptionGroup:
+                        ExceptionGroups.Add(
+                            ToUInt64(eventData.Payload[ExceptionEvents.ExceptionGroupPayloads.ExceptionGroupId]),
+                            new ExceptionGroupData()
                             {
-                                ExceptionClassId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionIdentifierPayloads.ExceptionClassId]),
-                                ThrowingMethodId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionIdentifierPayloads.ThrowingMethodId]),
-                                ILOffset = ToInt32(eventData.Payload[ExceptionEvents.ExceptionIdentifierPayloads.ILOffset])
+                                ExceptionClassId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionGroupPayloads.ExceptionClassId]),
+                                ThrowingMethodId = ToUInt64(eventData.Payload[ExceptionEvents.ExceptionGroupPayloads.ThrowingMethodId]),
+                                ILOffset = ToInt32(eventData.Payload[ExceptionEvents.ExceptionGroupPayloads.ILOffset])
                             });
                         break;
                     case ExceptionEvents.EventIds.ClassDescription:
@@ -141,15 +141,15 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
     internal sealed class ExceptionInstance
     {
-        public ExceptionInstance(ulong exceptionId, string? message, ulong[] frameIds, DateTime timestamp)
+        public ExceptionInstance(ulong groupId, string? message, ulong[] frameIds, DateTime timestamp)
         {
-            ExceptionId = exceptionId;
+            GroupId = groupId;
             ExceptionMessage = message;
             StackFrameIds = frameIds;
             Timestamp = timestamp;
         }
 
-        public ulong ExceptionId { get; }
+        public ulong GroupId { get; }
 
         public string? ExceptionMessage { get; }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
@@ -22,16 +22,16 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         [InlineData(1, 0, ulong.MaxValue, 19)]
         [InlineData(7, ulong.MaxValue, 0, 17)]
         [InlineData(ulong.MaxValue, 29, 41, 0)]
-        public void ExceptionsEventSource_WriteExceptionId_Event(ulong id, ulong classId, ulong methodId, int ilOffset)
+        public void ExceptionsEventSource_WriteExceptionGroup_Event(ulong id, ulong classId, ulong methodId, int ilOffset)
         {
             using ExceptionsEventSource source = new();
 
             using ExceptionsEventListener listener = new();
             listener.EnableEvents(source, EventLevel.Informational);
 
-            source.ExceptionIdentifier(id, classId, methodId, ilOffset);
+            source.ExceptionGroup(id, classId, methodId, ilOffset);
 
-            (ulong exceptionId, ExceptionIdentifierData data) = Assert.Single(listener.ExceptionIdentifiers);
+            (ulong exceptionId, ExceptionGroupData data) = Assert.Single(listener.ExceptionGroups);
             Assert.Equal(id, exceptionId);
             Assert.Equal(classId, data.ExceptionClassId);
             Assert.Equal(methodId, data.ThrowingMethodId);
@@ -39,28 +39,28 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         }
 
         [Fact]
-        public void ExceptionsEventSource_WriteExceptionId_LevelTooHigh()
+        public void ExceptionsEventSource_WriteExceptionGroup_LevelTooHigh()
         {
             using ExceptionsEventSource source = new();
 
             using ExceptionsEventListener listener = new();
             listener.EnableEvents(source, EventLevel.Warning);
 
-            source.ExceptionIdentifier(1, 2, 3, 4);
+            source.ExceptionGroup(1, 2, 3, 4);
 
-            Assert.Empty(listener.ExceptionIdentifiers);
+            Assert.Empty(listener.ExceptionGroups);
         }
 
         [Fact]
-        public void ExceptionsEventSource_WriteExceptionId_NotEnabled()
+        public void ExceptionsEventSource_WriteExceptionGroup_NotEnabled()
         {
             using ExceptionsEventSource source = new();
 
             using ExceptionsEventListener listener = new();
 
-            source.ExceptionIdentifier(4, 3, 2, 1);
+            source.ExceptionGroup(4, 3, 2, 1);
 
-            Assert.Empty(listener.ExceptionIdentifiers);
+            Assert.Empty(listener.ExceptionGroups);
         }
 
         [Theory]
@@ -82,7 +82,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             source.ExceptionInstance(id, message, frameIds, timestamp);
 
             ExceptionInstance instance = Assert.Single(listener.Exceptions);
-            Assert.Equal(id, instance.ExceptionId);
+            Assert.Equal(id, instance.GroupId);
             Assert.Equal(CoalesceNull(message), instance.ExceptionMessage);
             // We would normally expect the following to return an array of the stack frame IDs
             // but in-process listener doesn't decode non-byte arrays correctly.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionGroupIdentifierCacheTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionGroupIdentifierCacheTests.cs
@@ -10,8 +10,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
-    [TargetFrameworkMonikerTrait(TargetFrameworkMoniker.Current)]
-    public sealed class ExceptionIdentifierCacheTests
+    public sealed class ExceptionGroupIdentifierCacheTests
     {
         private const ulong InvalidId = 0;
         private const uint InvalidToken = 0;
@@ -20,31 +19,31 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             Assembly.GetExecutingAssembly().ManifestModule.Name;
 
         [Fact]
-        public void ExceptionIdentifierCache_CallbacksNotRequired()
+        public void ExceptionGroupIdentifierCache_CallbacksNotRequired()
         {
             Exception ex = new Exception();
-            ExceptionIdentifier exceptionId = new(ex);
+            ExceptionGroupIdentifier exceptionId = new(ex);
 
-            List<ExceptionIdentifierCacheCallback> callbacks = new();
-            ExceptionIdentifierCache cache = new(callbacks);
+            List<ExceptionGroupIdentifierCacheCallback> callbacks = new();
+            ExceptionGroupIdentifierCache cache = new(callbacks);
             ulong registrationId = cache.GetOrAdd(exceptionId);
 
             Assert.NotEqual(InvalidId, registrationId);
         }
 
         [Fact]
-        public void ExceptionIdentifierCache_NotThrownException()
+        public void ExceptionGroupIdentifierCache_NotThrownException()
         {
             Exception ex = new Exception();
-            ExceptionIdentifier exceptionId = new(ex);
+            ExceptionGroupIdentifier exceptionId = new(ex);
 
-            TestExceptionIdentifierCacheCallback callback = new();
+            TestExceptionGroupIdentifierCacheCallback callback = new();
 
-            List<ExceptionIdentifierCacheCallback> callbacks = new()
+            List<ExceptionGroupIdentifierCacheCallback> callbacks = new()
             {
                 callback
             };
-            ExceptionIdentifierCache cache = new(callbacks);
+            ExceptionGroupIdentifierCache cache = new(callbacks);
             ulong registrationId = cache.GetOrAdd(exceptionId);
             Assert.NotEqual(InvalidId, registrationId);
 
@@ -76,7 +75,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             Assert.Equal(InvalidId, data.OuterToken);
 
             // Validate exception ID registration
-            (ulong registrationIdFromCallback, ExceptionIdentifierData exceptionIdData) = Assert.Single(callback.ExceptionIdentifierData);
+            (ulong registrationIdFromCallback, ExceptionGroupData exceptionIdData) = Assert.Single(callback.ExceptionGroupMap);
             Assert.Equal(registrationId, registrationIdFromCallback);
             Assert.NotNull(exceptionIdData);
             Assert.Equal(classId, exceptionIdData.ExceptionClassId);
@@ -89,10 +88,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         }
 
         [Fact]
-        public void ExceptionIdentifierCache_ThrownException()
+        public void ExceptionGroupIdentifierCache_ThrownException()
         {
             Exception ex = new ExceptionWithGenericArgs<int>();
-            ExceptionIdentifier exceptionId;
+            ExceptionGroupIdentifier exceptionId;
             try
             {
                 throw ex;
@@ -102,13 +101,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
                 exceptionId = new(caught);
             }
 
-            TestExceptionIdentifierCacheCallback callback = new();
+            TestExceptionGroupIdentifierCacheCallback callback = new();
 
-            List<ExceptionIdentifierCacheCallback> callbacks = new()
+            List<ExceptionGroupIdentifierCacheCallback> callbacks = new()
             {
                 callback
             };
-            ExceptionIdentifierCache cache = new(callbacks);
+            ExceptionGroupIdentifierCache cache = new(callbacks);
             ulong registrationId = cache.GetOrAdd(exceptionId);
             Assert.NotEqual(InvalidId, registrationId);
 
@@ -119,7 +118,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             Assert.Equal(3, callback.NameCache.TokenData.Count);
 
             // Validate exception ID registration
-            (ulong registrationIdFromCallback, ExceptionIdentifierData exceptionIdData) = Assert.Single(callback.ExceptionIdentifierData);
+            (ulong registrationIdFromCallback, ExceptionGroupData exceptionIdData) = Assert.Single(callback.ExceptionGroupMap);
             Assert.Equal(registrationId, registrationIdFromCallback);
             Assert.NotNull(exceptionIdData);
 
@@ -177,7 +176,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             Assert.Equal(ThisModuleName, throwingMethodModuleData.Name);
 
             // Validate throwing method remaining properties
-            Assert.Equal(nameof(ExceptionIdentifierCache_ThrownException), throwingMethodData.Name);
+            Assert.Equal(nameof(ExceptionGroupIdentifierCache_ThrownException), throwingMethodData.Name);
             Assert.NotEqual(InvalidId, throwingMethodData.ParentClass);
             Assert.NotEqual(InvalidToken, throwingMethodData.ParentToken);
             Assert.Empty(throwingMethodData.TypeArgs);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionGroupIdentifierTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/ExceptionGroupIdentifierTests.cs
@@ -9,13 +9,13 @@ using Xunit;
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
     [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
-    public sealed class ExceptionIdentifierTests
+    public sealed class ExceptionGroupIdentifierTests
     {
         [Fact]
-        public void ExceptionIdentifier_NotThrownException()
+        public void ExceptionGroupIdentifier_NotThrownException()
         {
             Exception ex = new();
-            ExceptionIdentifier id = new(ex);
+            ExceptionGroupIdentifier id = new(ex);
 
             Assert.Equal(ex.GetType(), id.ExceptionType);
             Assert.Null(id.ThrowingMethod);
@@ -23,30 +23,30 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         }
 
         [Fact]
-        public void ExceptionIdentifier_ThrownException()
+        public void ExceptionGroupIdentifier_ThrownException()
         {
             Exception ex = new();
-            ExceptionIdentifier id = ThrowAndCreate(ex);
+            ExceptionGroupIdentifier id = ThrowAndCreate(ex);
 
             Assert.Equal(ex.GetType(), id.ExceptionType);
             Assert.NotNull(id.ThrowingMethod);
         }
 
         [Fact]
-        public void ExceptionIdentifier_SameOrigination_Equal()
+        public void ExceptionGroupIdentifier_SameOrigination_Equal()
         {
-            ExceptionIdentifier id1 = ThrowAndCreate();
-            ExceptionIdentifier id2 = ThrowAndCreate();
+            ExceptionGroupIdentifier id1 = ThrowAndCreate();
+            ExceptionGroupIdentifier id2 = ThrowAndCreate();
 
             Assert.Equal(id1, id2);
             Assert.True(id1 == id2);
         }
 
         [Fact]
-        public void ExceptionIdentifier_SameOrigination_EqualProperties()
+        public void ExceptionGroupIdentifier_SameOrigination_EqualProperties()
         {
-            ExceptionIdentifier id1 = ThrowAndCreate();
-            ExceptionIdentifier id2 = ThrowAndCreate();
+            ExceptionGroupIdentifier id1 = ThrowAndCreate();
+            ExceptionGroupIdentifier id2 = ThrowAndCreate();
 
             Assert.Equal(id1.ExceptionType, id2.ExceptionType);
             Assert.NotNull(id1.ThrowingMethod);
@@ -56,18 +56,18 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         }
 
         [Fact]
-        public void ExceptionIdentifier_DifferentType_NotEqual()
+        public void ExceptionGroupIdentifier_DifferentType_NotEqual()
         {
-            (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair(differentTypes: true);
+            (ExceptionGroupIdentifier id1, ExceptionGroupIdentifier id2) = ThrowAndCreatePair(differentTypes: true);
 
             Assert.NotEqual(id1, id2);
             Assert.True(id1 != id2);
         }
 
         [Fact]
-        public void ExceptionIdentifier_DifferentType_NotEqualProperties()
+        public void ExceptionGroupIdentifier_DifferentType_NotEqualProperties()
         {
-            (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair(differentTypes: true);
+            (ExceptionGroupIdentifier id1, ExceptionGroupIdentifier id2) = ThrowAndCreatePair(differentTypes: true);
 
             Assert.NotEqual(id1.ExceptionType, id2.ExceptionType);
             Assert.NotNull(id1.ThrowingMethod);
@@ -77,18 +77,18 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         }
 
         [Fact]
-        public void ExceptionIdentifier_DifferentMethod_NotEqual()
+        public void ExceptionGroupIdentifier_DifferentMethod_NotEqual()
         {
-            (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair(differentMethods: true);
+            (ExceptionGroupIdentifier id1, ExceptionGroupIdentifier id2) = ThrowAndCreatePair(differentMethods: true);
 
             Assert.NotEqual(id1, id2);
             Assert.True(id1 != id2);
         }
 
         [Fact]
-        public void ExceptionIdentifier_DifferentMethod_NotEqualProperties()
+        public void ExceptionGroupIdentifier_DifferentMethod_NotEqualProperties()
         {
-            (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair(differentMethods: true);
+            (ExceptionGroupIdentifier id1, ExceptionGroupIdentifier id2) = ThrowAndCreatePair(differentMethods: true);
 
             Assert.Equal(id1.ExceptionType, id2.ExceptionType);
             Assert.NotNull(id1.ThrowingMethod);
@@ -97,18 +97,18 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
         }
 
         [Fact]
-        public void ExceptionIdentifier_DifferentOffset_NotEqual()
+        public void ExceptionGroupIdentifier_DifferentOffset_NotEqual()
         {
-            (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair();
+            (ExceptionGroupIdentifier id1, ExceptionGroupIdentifier id2) = ThrowAndCreatePair();
 
             Assert.NotEqual(id1, id2);
             Assert.True(id1 != id2);
         }
 
         [Fact]
-        public void ExceptionIdentifier_DifferentOffset_NotEqualProperties()
+        public void ExceptionGroupIdentifier_DifferentOffset_NotEqualProperties()
         {
-            (ExceptionIdentifier id1, ExceptionIdentifier id2) = ThrowAndCreatePair();
+            (ExceptionGroupIdentifier id1, ExceptionGroupIdentifier id2) = ThrowAndCreatePair();
 
             Assert.Equal(id1.ExceptionType, id2.ExceptionType);
             Assert.NotNull(id1.ThrowingMethod);
@@ -117,13 +117,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             Assert.NotEqual(id1.ILOffset, id2.ILOffset);
         }
 
-        private static ExceptionIdentifier ThrowAndCreate()
+        private static ExceptionGroupIdentifier ThrowAndCreate()
         {
             return ThrowAndCreate(new InvalidOperationException());
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static ExceptionIdentifier ThrowAndCreate(Exception ex)
+        private static ExceptionGroupIdentifier ThrowAndCreate(Exception ex)
         {
             try
             {
@@ -131,26 +131,26 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             }
             catch (Exception caughtEx)
             {
-                return new ExceptionIdentifier(caughtEx);
+                return new ExceptionGroupIdentifier(caughtEx);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization)]
-        private static (ExceptionIdentifier, ExceptionIdentifier) ThrowAndCreatePair(bool differentTypes = false, bool differentMethods = false)
+        private static (ExceptionGroupIdentifier, ExceptionGroupIdentifier) ThrowAndCreatePair(bool differentTypes = false, bool differentMethods = false)
         {
-            ExceptionIdentifier id1;
+            ExceptionGroupIdentifier id1;
             try
             {
                 throw new InvalidOperationException();
             }
             catch (Exception ex)
             {
-                id1 = new ExceptionIdentifier(ex);
+                id1 = new ExceptionGroupIdentifier(ex);
             }
 
             Exception ex2 = differentTypes ? new OperationCanceledException() : new InvalidOperationException();
 
-            ExceptionIdentifier id2;
+            ExceptionGroupIdentifier id2;
             if (differentMethods)
             {
                 id2 = ThrowAndCreate(ex2);
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
                 }
                 catch (Exception ex)
                 {
-                    id2 = new ExceptionIdentifier(ex);
+                    id2 = new ExceptionGroupIdentifier(ex);
                 }
             }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/TestExceptionIdentifierCacheCallback.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Identification/TestExceptionIdentifierCacheCallback.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
 {
-    internal sealed class TestExceptionIdentifierCacheCallback :
-        ExceptionIdentifierCacheCallback
+    internal sealed class TestExceptionGroupIdentifierCacheCallback :
+        ExceptionGroupIdentifierCacheCallback
     {
         public readonly NameCache NameCache = new();
 
-        public readonly Dictionary<ulong, ExceptionIdentifierData> ExceptionIdentifierData = new();
+        public readonly Dictionary<ulong, ExceptionGroupData> ExceptionGroupMap = new();
 
         public readonly Dictionary<ulong, StackFrameData> StackFrameData = new();
 
@@ -20,9 +20,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Identification
             Assert.True(NameCache.ClassData.TryAdd(classId, data));
         }
 
-        public override void OnExceptionIdentifier(ulong registrationId, ExceptionIdentifierData data)
+        public override void OnExceptionGroupData(ulong registrationId, ExceptionGroupData data)
         {
-            Assert.True(ExceptionIdentifierData.TryAdd(registrationId, data));
+            Assert.True(ExceptionGroupMap.TryAdd(registrationId, data));
         }
 
         public override void OnFunctionData(ulong functionId, FunctionData data)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal(typeof(InvalidOperationException).FullName, instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     TestExceptionsStore.ExceptionInstance instance2 = instances.Skip(1).Single();
                     Assert.NotNull(instance2);
 
-                    Assert.Equal(instance1.ExceptionId, instance2.ExceptionId);
+                    Assert.Equal(instance1.GroupId, instance2.GroupId);
                     Assert.Equal(instance1.TypeName, instance2.TypeName);
                     Assert.Equal(instance1.Message, instance2.Message);
                     Assert.Equal(instance1.ThrowingMethodName, instance2.ThrowingMethodName);
@@ -102,7 +102,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal(typeof(TaskCanceledException).FullName, instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -122,7 +122,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal(typeof(ArgumentNullException).FullName, instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomGenericsException`2[System.Int32,System.String]", instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal(typeof(InvalidOperationException).FullName, instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -184,7 +184,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomSimpleException", instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -204,7 +204,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
-                    Assert.NotEqual(0UL, instance.ExceptionId);
+                    Assert.NotEqual(0UL, instance.GroupId);
                     Assert.Equal(typeof(IndexOutOfRangeException).FullName, instance.TypeName);
                     Assert.False(string.IsNullOrEmpty(instance.Message));
                     Assert.False(string.IsNullOrEmpty(instance.ThrowingMethodName));
@@ -285,13 +285,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 _instanceThreshold = instanceThreshold;
             }
 
-            public void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message, DateTime timestamp)
+            public void AddExceptionInstance(IExceptionsNameCache cache, ulong groupId, string message, DateTime timestamp)
             {
                 StringBuilder typeBuilder = new();
                 FunctionData throwingMethodData;
                 try
                 {
-                    Assert.True(cache.TryGetExceptionId(exceptionId, out ulong exceptionClassId, out ulong throwingMethodId, out _));
+                    Assert.True(cache.TryGetExceptionGroup(groupId, out ulong exceptionClassId, out ulong throwingMethodId, out _));
 
                     NameFormatter.BuildClassName(typeBuilder, cache.NameCache, exceptionClassId);
 
@@ -304,7 +304,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     throw;
                 }
 
-                _instances.Add(new ExceptionInstance(exceptionId, typeBuilder.ToString(), message, throwingMethodData.Name, timestamp));
+                _instances.Add(new ExceptionInstance(groupId, typeBuilder.ToString(), message, throwingMethodData.Name, timestamp));
                 if (++_instanceCount >= _instanceThreshold)
                 {
                     _instanceThresholdSource.TrySetResult();
@@ -316,7 +316,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 throw new NotSupportedException();
             }
 
-            public sealed record class ExceptionInstance(ulong ExceptionId, string TypeName, string Message, string ThrowingMethodName, DateTime Timestamp)
+            public sealed record class ExceptionInstance(ulong GroupId, string TypeName, string Message, string ThrowingMethodName, DateTime Timestamp)
             {
             }
         }

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -65,23 +65,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         traceEvent.GetPayload<ulong[]>(NameIdentificationEvents.ClassDescPayloads.TypeArgs)
                         );
                     break;
-                case "ExceptionIdentifier":
-                    _cache.AddExceptionIdentifier(
-                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionIdentifierPayloads.ExceptionId),
-                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionIdentifierPayloads.ExceptionClassId),
-                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionIdentifierPayloads.ThrowingMethodId),
-                        traceEvent.GetPayload<int>(ExceptionEvents.ExceptionIdentifierPayloads.ILOffset)
+                case "ExceptionGroup":
+                    _cache.AddExceptionGroup(
+                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionGroupPayloads.ExceptionGroupId),
+                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionGroupPayloads.ExceptionClassId),
+                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionGroupPayloads.ThrowingMethodId),
+                        traceEvent.GetPayload<int>(ExceptionEvents.ExceptionGroupPayloads.ILOffset)
                         );
                     break;
                 case "ExceptionInstance":
-                    ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId);
+                    ulong groupId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId);
                     string message = traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage);
                     DateTime timestamp = traceEvent.GetPayload<DateTime>(ExceptionEvents.ExceptionInstancePayloads.Timestamp).ToUniversalTime();
                     // Add data to cache and write directly to store; this allows the pipeline to recreate the cache without
                     // affecting the store so long as the cache is not cleared. Example of this may be that the event source
                     // wants to reset the identifiers so as to not indefinitely grow the cache and have a large memory impact.
-                    _cache.AddExceptionInstance(exceptionId, message);
-                    _store.AddExceptionInstance(_cache, exceptionId, message, timestamp);
+                    _cache.AddExceptionInstance(groupId, message);
+                    _store.AddExceptionInstance(_cache, groupId, message, timestamp);
                     break;
                 case "FunctionDescription":
                     _cache.AddFunction(

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipelineNameCache.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipelineNameCache.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
     internal sealed class EventExceptionsPipelineNameCache : IExceptionsNameCache
     {
         private readonly List<ExceptionInstance> _exceptions = new();
-        private readonly Dictionary<ulong, ExceptionIdentifier> _exceptionIds = new();
+        private readonly Dictionary<ulong, ExceptionGroup> _exceptionGroupMap = new();
         private readonly NameCache _nameCache = new();
 
         public NameCache NameCache => _nameCache;
@@ -21,14 +21,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             _nameCache.ClassData.TryAdd(id, new ClassData(token, moduleId, flags, typeArgs ?? Array.Empty<ulong>()));
         }
 
-        public void AddExceptionIdentifier(ulong id, ulong exceptionClassId, ulong throwingMethodId, int ilOffset)
+        public void AddExceptionGroup(ulong id, ulong exceptionClassId, ulong throwingMethodId, int ilOffset)
         {
-            _exceptionIds.Add(id, new ExceptionIdentifier(exceptionClassId, throwingMethodId, ilOffset));
+            _exceptionGroupMap.Add(id, new ExceptionGroup(exceptionClassId, throwingMethodId, ilOffset));
         }
 
-        public void AddExceptionInstance(ulong exceptionId, string message)
+        public void AddExceptionInstance(ulong groupId, string message)
         {
-            _exceptions.Add(new ExceptionInstance(exceptionId, message));
+            _exceptions.Add(new ExceptionInstance(groupId, message));
         }
 
         public void AddFunction(ulong id, ulong classId, uint classToken, ulong moduleId, string name, ulong[] typeArgs)
@@ -48,13 +48,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 new TokenData(name, outerToken));
         }
 
-        public bool TryGetExceptionId(ulong exceptionId, out ulong exceptionClassId, out ulong throwingMethodId, out int ilOffset)
+        public bool TryGetExceptionGroup(ulong groupId, out ulong exceptionClassId, out ulong throwingMethodId, out int ilOffset)
         {
             exceptionClassId = 0;
             throwingMethodId = 0;
             ilOffset = 0;
 
-            if (!_exceptionIds.TryGetValue(exceptionId, out ExceptionIdentifier identifier))
+            if (!_exceptionGroupMap.TryGetValue(groupId, out ExceptionGroup identifier))
                 return false;
 
             exceptionClassId = identifier.ClassId;
@@ -63,8 +63,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             return true;
         }
 
-        private sealed record class ExceptionIdentifier(ulong ClassId, ulong ThrowingMethodId, int ILOffset);
+        private sealed record class ExceptionGroup(ulong ClassId, ulong ThrowingMethodId, int ILOffset);
 
-        private sealed record class ExceptionInstance(ulong ExceptionId, string Message);
+        private sealed record class ExceptionInstance(ulong GroupId, string Message);
     }
 }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         public static class EventIds
         {
-            public const int ExceptionIdentifier = 1;
+            public const int ExceptionGroup = 1;
             public const int ExceptionInstance = 2;
             public const int ClassDescription = 3;
             public const int FunctionDescription = 4;
@@ -25,15 +25,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         public static class ExceptionInstancePayloads
         {
-            public const int ExceptionId = 0;
+            public const int ExceptionGroupId = 0;
             public const int ExceptionMessage = 1;
             public const int StackFrameIds = 2;
             public const int Timestamp = 3;
         }
 
-        public static class ExceptionIdentifierPayloads
+        public static class ExceptionGroupPayloads
         {
-            public const int ExceptionId = 0;
+            public const int ExceptionGroupId = 0;
             public const int ExceptionClassId = 1;
             public const int ThrowingMethodId = 2;
             public const int ILOffset = 3;

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 // at the same time; one will return sooner and report the correct IDs potentially before those IDs are
                 // produced by the EventSource. May need to cache this incompletion information and attempt to reconstruct
                 // it in the future, with either periodic retry OR registering a callback system for the missing IDs.
-                if (entry.Cache.TryGetExceptionId(entry.ExceptionId, out ulong exceptionClassId, out _, out _))
+                if (entry.Cache.TryGetExceptionGroup(entry.ExceptionId, out ulong exceptionClassId, out _, out _))
                 {
                     string exceptionTypeName;
                     if (!_exceptionTypeNameMap.TryGetValue(exceptionClassId, out exceptionTypeName))


### PR DESCRIPTION
###### Summary

These changes rename the `ExceptionIdentifer` concept to `ExceptionGroupIdentifier` in order to better describe that it is identifying a group of related exceptions rather than single exception and allows for future changes to introduce an exception instance identifier without conflating the two concepts.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
