### PR TITLE
Add exception instance identifiers to exceptions event source

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -67,20 +67,28 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
         [Event(ExceptionEvents.EventIds.ExceptionInstance)]
         public void ExceptionInstance(
+            ulong ExceptionId,
             ulong ExceptionGroupId,
             string? ExceptionMessage,
             ulong[] StackFrameIds,
-            DateTime Timestamp)
+            DateTime Timestamp,
+            ulong InnerExceptionId,
+            ulong[] InnerExceptionIds)
         {
-            Span<EventData> data = stackalloc EventData[4];
+            Span<EventData> data = stackalloc EventData[7];
             using PinnedData namePinned = PinnedData.Create(ExceptionMessage);
             Span<byte> stackFrameIdsSpan = stackalloc byte[GetArrayDataSize(StackFrameIds)];
             FillArrayData(stackFrameIdsSpan, StackFrameIds);
+            Span<byte> innerExceptionIdsSpan = stackalloc byte[GetArrayDataSize(InnerExceptionIds)];
+            FillArrayData(innerExceptionIdsSpan, InnerExceptionIds);
 
+            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionId], ExceptionId);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId], ExceptionGroupId);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage], namePinned);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds], stackFrameIdsSpan);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.Timestamp], Timestamp.ToFileTimeUtc());
+            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionId], InnerExceptionId);
+            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds], innerExceptionIdsSpan);
 
             WriteEventCore(ExceptionEvents.EventIds.ExceptionInstance, data);
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -48,10 +48,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                 ulong[] frameIds = _identifierCache.GetOrAdd(stackFrames);
 
                 _eventSource.ExceptionInstance(
+                    0, // TODO: Generate ID
                     groupId,
                     exception.Message,
                     frameIds,
-                    context.Timestamp);
+                    context.Timestamp,
+                    0, // TODO: Get ID for InnerException
+                    Array.Empty<ulong>() // TODO: Get IDs for AggregateException.InnerExceptions
+                    );
             }
 
             _next(exception, context);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
@@ -33,10 +33,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
                     case ExceptionEvents.EventIds.ExceptionInstance:
                         Exceptions.Add(
                             new ExceptionInstance(
+                                ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionId]),
                                 ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId]),
                                 ToString(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage]),
                                 ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds]),
-                                ToType<DateTime>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.Timestamp])
+                                ToType<DateTime>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.Timestamp]),
+                                ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionId]),
+                                ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds])
                             ));
                         break;
                     case ExceptionEvents.EventIds.ExceptionGroup:
@@ -141,20 +144,29 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
     internal sealed class ExceptionInstance
     {
-        public ExceptionInstance(ulong groupId, string? message, ulong[] frameIds, DateTime timestamp)
+        public ExceptionInstance(ulong id, ulong groupId, string? message, ulong[] frameIds, DateTime timestamp, ulong innerExceptionId, ulong[] innerExceptionIds)
         {
+            Id = id;
             GroupId = groupId;
             ExceptionMessage = message;
             StackFrameIds = frameIds;
             Timestamp = timestamp;
+            InnerExceptionId = innerExceptionId;
+            InnerExceptionIds = innerExceptionIds;
         }
+
+        public ulong Id { get; }
 
         public ulong GroupId { get; }
 
         public string? ExceptionMessage { get; }
 
-        public ulong[]? StackFrameIds { get; }
+        public ulong[] StackFrameIds { get; }
 
         public DateTime Timestamp { get; }
+
+        public ulong InnerExceptionId { get; }
+
+        public ulong[] InnerExceptionIds { get; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
@@ -64,12 +64,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         }
 
         [Theory]
-        [InlineData(0, null, "0,0,0")]
-        [InlineData(1, "", "1,2")]
-        [InlineData(7, InvalidOperationExceptionMessage, "")]
-        [InlineData(ulong.MaxValue - 1, OperationCancelledExceptionMessage, "3,5,7")]
-        [InlineData(ulong.MaxValue, ObjectDisposedExceptionMessage, "2,7,11")]
-        public void ExceptionsEventSource_WriteException_Event(ulong id, string message, string frameIdsString)
+        [InlineData(0, 0, null, "0,0,0", 0, "")]
+        [InlineData(1, 5, "", "1,2", 3, "1")]
+        [InlineData(7, 13, InvalidOperationExceptionMessage, "", 2, "3,5")]
+        [InlineData(ulong.MaxValue - 1, ulong.MaxValue - 1, OperationCancelledExceptionMessage, "3,5,7", ulong.MaxValue - 2, "2")]
+        [InlineData(ulong.MaxValue, ulong.MaxValue, ObjectDisposedExceptionMessage, "2,7,11", ulong.MaxValue - 1, "9,8,4")]
+        public void ExceptionsEventSource_WriteException_Event(ulong id, ulong groupId, string message, string frameIdsString, ulong innerExceptionId, string innerExceptionIdsString)
         {
             using ExceptionsEventSource source = new();
 
@@ -78,16 +78,22 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
             ulong[] frameIds = frameIdsString.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(ulong.Parse).ToArray();
             DateTime timestamp = DateTime.UtcNow;
+            ulong[] innerExceptionIds = innerExceptionIdsString.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(ulong.Parse).ToArray();
 
-            source.ExceptionInstance(id, message, frameIds, timestamp);
+            source.ExceptionInstance(id, groupId, message, frameIds, timestamp, innerExceptionId, Array.Empty<ulong>());
 
             ExceptionInstance instance = Assert.Single(listener.Exceptions);
-            Assert.Equal(id, instance.GroupId);
+            Assert.Equal(id, instance.Id);
+            Assert.Equal(groupId, instance.GroupId);
             Assert.Equal(CoalesceNull(message), instance.ExceptionMessage);
             // We would normally expect the following to return an array of the stack frame IDs
             // but in-process listener doesn't decode non-byte arrays correctly.
             Assert.Equal(Array.Empty<ulong>(), instance.StackFrameIds);
             Assert.Equal(timestamp, instance.Timestamp);
+            Assert.Equal(innerExceptionId, instance.InnerExceptionId);
+            // We would normally expect the following to return an array of the inner exception IDs
+            // but in-process listener doesn't decode non-byte arrays correctly.
+            Assert.Equal(Array.Empty<ulong>(), instance.InnerExceptionIds);
         }
 
         [Fact]
@@ -98,7 +104,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             using ExceptionsEventListener listener = new();
             listener.EnableEvents(source, EventLevel.Warning);
 
-            source.ExceptionInstance(7, ObjectDisposedExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow);
+            source.ExceptionInstance(5, 7, ObjectDisposedExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow, 2, Array.Empty<ulong>());
 
             Assert.Empty(listener.Exceptions);
         }
@@ -110,7 +116,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
             using ExceptionsEventListener listener = new();
 
-            source.ExceptionInstance(9, OperationCancelledExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow);
+            source.ExceptionInstance(7, 9, OperationCancelledExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow, 4, Array.Empty<ulong>());
 
             Assert.Empty(listener.Exceptions);
         }

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -74,9 +74,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         );
                     break;
                 case "ExceptionInstance":
+                    ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId);
                     ulong groupId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId);
                     string message = traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage);
                     DateTime timestamp = traceEvent.GetPayload<DateTime>(ExceptionEvents.ExceptionInstancePayloads.Timestamp).ToUniversalTime();
+                    ulong innerExceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.InnerExceptionId);
+                    ulong[] innerExceptionIds = traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds);
                     // Add data to cache and write directly to store; this allows the pipeline to recreate the cache without
                     // affecting the store so long as the cache is not cleared. Example of this may be that the event source
                     // wants to reset the identifiers so as to not indefinitely grow the cache and have a large memory impact.

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
@@ -25,10 +25,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         public static class ExceptionInstancePayloads
         {
-            public const int ExceptionGroupId = 0;
-            public const int ExceptionMessage = 1;
-            public const int StackFrameIds = 2;
-            public const int Timestamp = 3;
+            public const int ExceptionId = 0;
+            public const int ExceptionGroupId = 1;
+            public const int ExceptionMessage = 2;
+            public const int StackFrameIds = 3;
+            public const int Timestamp = 4;
+            public const int InnerExceptionId = 5;
+            public const int InnerExceptionIds = 6;
         }
 
         public static class ExceptionGroupPayloads


### PR DESCRIPTION
###### Summary

Add payload fields for exception identifiers:
- Each exception instance _shall_ have an identifier
- Each exception instance _may_ have a single inner exception
- Each exception instance _may_ have a list of multiple inner exceptions (e.g. AggregateException.InnerExceptions)

This change only updates the event source to produce this information. Future changes will fill in the production of real exception identifier information and consume it within dotnet-monitor.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
