### PR TITLE
[Parameter Capturing] Avoid unnecessary ReJIT callbacks from inliners

### DIFF
--- a/src/MonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.cpp
+++ b/src/MonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.cpp
@@ -246,7 +246,7 @@ HRESULT ProbeInstrumentation::InstallProbes(vector<UNPROCESSED_INSTRUMENTATION_R
     }
 
     IfFailLogRet(m_pCorProfilerInfo->RequestReJITWithInliners(
-        COR_PRF_REJIT_BLOCK_INLINING | COR_PRF_REJIT_INLINING_CALLBACKS,
+        COR_PRF_REJIT_BLOCK_INLINING,
         static_cast<ULONG>(requestedModuleIds.size()),
         requestedModuleIds.data(),
         requestedMethodDefs.data()));


### PR DESCRIPTION
###### Summary

While debugging the MacOS test instability I encountered that we were receiving rejit callbacks for additional methods outside of those explicitly requested (we handled these extra methods correctly, not installing probes into them). This could happen if:
- Method `A` inlines method `B`.
- We request probes in `B`, as a result both `A` and `B` need to be rejitted.

We are unnecessarily participating in the rejit process of method `A`. Adjust the rejit flags we use to avoid this.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
