### PR TITLE
[Parameter Capturing] Workaround requested methods not being rejitted

### DIFF
--- a/src/MonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.cpp
+++ b/src/MonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.cpp
@@ -303,9 +303,9 @@ void ProbeInstrumentation::AddProfilerEventMask(DWORD& eventsLow)
     // Workaround:
     // Enable COR_PRF_MONITOR_JIT_COMPILATION even though we don't need the callbacks.
     // It appears that without this flag set our RequestReJITWithInliners calls will sometimes
-    // not actually trigger a rejit despite returning succesfully.
+    // not actually trigger a rejit despite returning successfully.
     //
-    // This issue most commonoly repros on MacOS.
+    // This issue most commonly occurs on MacOS.
     //
     eventsLow |= COR_PRF_MONITOR::COR_PRF_ENABLE_REJIT | COR_PRF_MONITOR::COR_PRF_MONITOR_JIT_COMPILATION;
 }


### PR DESCRIPTION
###### Summary

Our functional tests were consistently encountering issues (most commonly on MacOS) where methods we requested rejitting for wouldn't actually be rejitted.  The call to `RequestReJITWithInliners` would succeed, but the rejit would never happen. I've found that enabling `COR_PRF_MONITOR_JIT_COMPILATION` (even without doing anything in the callbacks) in our profiler resolves this problem.

My best guess is that there's a bug with `RequestReJITWithInliners` and multicore jitting. Enabling `COR_PRF_MONITOR_JIT_COMPILATION` turns off multicore jitting: [vmprofilinghelper.cpp#L1291](https://github.com/dotnet/runtime/blob/84a3d0e37e8f22b0b55f8bf932cb788b2bdd728f/src/coreclr/vm/profilinghelper.cpp#L1291). While the runtime does have tests for `RequestReJITWithInliners`, those tests always set `COR_PRF_MONITOR_JIT_COMPILATION`: [rejitprofiler.cpp#L75](https://github.com/dotnet/runtime/blob/84a3d0e37e8f22b0b55f8bf932cb788b2bdd728f/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp#L75).

I'll also open a bug in the runtime repo with this issue.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
