### PR TITLE
Remove release/7.0 from dependabot and syncing

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
-#@ for branch in ["main", "release/7.x", "release/7.2", "release/7.1", "release/7.0", "release/6.x"]:
+#@ for branch in ["main", "release/7.x", "release/7.2", "release/7.1", "release/6.x"]:
 #@ commit_prefix = "[" + branch + "] "
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -213,57 +213,6 @@ updates:
   directory: /eng/dependabot
   schedule:
     interval: daily
-  target-branch: release/7.0
-  ignore:
-  - dependency-name: Microsoft.Extensions.*
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/7.0] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/nuget.org
-  schedule:
-    interval: daily
-  target-branch: release/7.0
-  commit-message:
-    prefix: '[release/7.0] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net7.0
-  schedule:
-    interval: daily
-  target-branch: release/7.0
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/7.0] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net6.0
-  schedule:
-    interval: daily
-  target-branch: release/7.0
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/7.0] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/netcoreapp3.1
-  schedule:
-    interval: daily
-  target-branch: release/7.0
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/7.0] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot
-  schedule:
-    interval: daily
   target-branch: release/6.x
   ignore:
   - dependency-name: Microsoft.Extensions.*

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'dotnet/dotnet-monitor'
     strategy:
       matrix:
-        branch: ["release/6.x", "release/7.x", "release/7.2", "release/7.1", "release/7.0"]
+        branch: ["release/6.x", "release/7.x", "release/7.2", "release/7.1"]
     name: 'Sync ${{ matrix.branch }}'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
###### Summary

Remove `release/7.0` from dependenabot updates and branch syncing; it will be [out of support on June 14th](https://github.com/dotnet/dotnet-monitor/discussions/3977).

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
