### PR TITLE
Fix build output test assembly path

### DIFF
--- a/src/Tools/dotnet-monitor/TestAssemblies.cs
+++ b/src/Tools/dotnet-monitor/TestAssemblies.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 path = Path.Combine(
                     AppContext.BaseDirectory.Substring(0, artifactsIndex),
                     ArtifactsDirectoryName,
-                    AppContext.BaseDirectory.Substring(artifactsIndex + separator.Length).Replace(thisAssembly.GetName().Name, TestStartupHookAssemblyName),
+                    AppContext.BaseDirectory.Substring(artifactsIndex + separator.Length).Replace(thisAssemblyName, assemblyName),
                     $"{assemblyName}.dll");
 
                 return File.Exists(path);


### PR DESCRIPTION
###### Summary

The test assembly path for the startup hook and hosting startup assemblies is being calculated incorrectly. This happened to work prior to the single file bundle change, but was broken when adding the assembly name to the path. This change should fix it to correctly locate the assembly that being queried.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
