### PR TITLE
Capture inner exceptions in startup hook

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -28,6 +28,7 @@
         "coreclr",
         "darc",
         "dbug",
+        "Demultiplexer",
         "disambiguator",
         "discoverability",
         "Distro",

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
@@ -24,8 +24,11 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 
         private static void ConfigurePipeline(ExceptionPipelineBuilder builder)
         {
+            // Process current exception and its inner exceptions
+            builder.Add(next => new ExceptionDemultiplexerPipelineStep(next).Invoke);
             // Prevent rethrows from being evaluated; only care about origination of exceptions.
             builder.Add(next => new FilterRepeatExceptionPipelineStep(next).Invoke);
+            // Report exception through event source
             builder.Add(next => new ExceptionEventsPipelineStep(next).Invoke);
         }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineExceptionContext.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipelineExceptionContext.cs
@@ -5,12 +5,20 @@ using System;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
 {
-    internal sealed class ExceptionPipelineExceptionContext
+    internal readonly ref struct ExceptionPipelineExceptionContext
     {
         public ExceptionPipelineExceptionContext(DateTime timestamp)
+            : this(timestamp, isInnerException: false)
+        {
+        }
+
+        public ExceptionPipelineExceptionContext(DateTime timestamp, bool isInnerException)
         {
             Timestamp = timestamp;
+            IsInnerException = isInnerException;
         }
+
+        public bool IsInnerException { get; }
 
         public DateTime Timestamp { get; }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 {
@@ -28,28 +25,18 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
         {
             ExceptionPipelineExceptionContext innerContext = new(context.Timestamp, isInnerException: true);
 
-            if (null != exception.InnerException)
-            {
-                Invoke(exception.InnerException, innerContext);
-            }
-
+            // AggregateException will always pull the first exception out of the list of inner exceptions
+            // and use that as its InnerException property. No need to report the InnerException property value.
             if (exception is AggregateException aggregateException)
             {
-                int startingIndex = 0;
-                // Skip the first exception since it was already reported for the InnerException property
-                // AggregateException will always pull the first exception out of the list of inner exceptions
-                // and use that as its InnerException property.
-                if (null != exception.InnerException)
-                {
-                    Debug.Assert(aggregateException.InnerExceptions.Count == 0 || aggregateException.InnerExceptions[0] == exception.InnerException);
-
-                    startingIndex = 1;
-                }
-
-                for (int i = startingIndex; i < aggregateException.InnerExceptions.Count; i++)
+                for (int i = 0; i < aggregateException.InnerExceptions.Count; i++)
                 {
                     Invoke(aggregateException.InnerExceptions[i], innerContext);
                 }
+            }
+            else if (null != exception.InnerException)
+            {
+                Invoke(exception.InnerException, innerContext);
             }
 
             _next(exception, context);

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    /// <summary>
+    /// An exception pipeline step that reports the related exception instances of
+    /// the provided exception, namely the inner exception instances, as well as the main
+    /// exception itself.
+    /// </summary>
+    internal class ExceptionDemultiplexerPipelineStep
+    {
+        private readonly ExceptionPipelineDelegate _next;
+
+        public ExceptionDemultiplexerPipelineStep(ExceptionPipelineDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(next);
+
+            _next = next;
+        }
+
+        public void Invoke(Exception exception, ExceptionPipelineExceptionContext context)
+        {
+            ExceptionPipelineExceptionContext innerContext = new(context.Timestamp, isInnerException: true);
+
+            if (null != exception.InnerException)
+            {
+                Invoke(exception.InnerException, innerContext);
+            }
+
+            if (exception is AggregateException aggregateException)
+            {
+                int startingIndex = 0;
+                // Skip the first exception since it was already reported for the InnerException property
+                // AggregateException will always pull the first exception out of the list of inner exceptions
+                // and use that as its InnerException property.
+                if (null != exception.InnerException)
+                {
+                    Debug.Assert(aggregateException.InnerExceptions.Count == 0 || aggregateException.InnerExceptions[0] == exception.InnerException);
+
+                    startingIndex = 1;
+                }
+
+                for (int i = startingIndex; i < aggregateException.InnerExceptions.Count; i++)
+                {
+                    Invoke(aggregateException.InnerExceptions[i], innerContext);
+                }
+            }
+
+            _next(exception, context);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             StackTrace exceptionStackTrace = new(exception, fNeedFileInfo: false);
 
             // Inner exceptions have complete call stacks because they were caught or do not
-            // have an call stacks because they were never thrown. Report the stack frames as-is.
+            // have any call stacks because they were never thrown. Report the stack frames as-is.
             if (isInnerException)
                 return exceptionStackTrace.GetFrames();
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStepTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStepTests.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System.Collections.Generic;
+using System;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    public sealed class ExceptionDemultiplexerPipelineStepTests
+    {
+        private readonly Dictionary<Exception, int> _reportedExceptionCounts = new();
+        private readonly ExceptionPipelineDelegate _finalHandler;
+
+        public ExceptionDemultiplexerPipelineStepTests()
+        {
+            _finalHandler = (ex, context) =>
+            {
+                _reportedExceptionCounts[ex] = _reportedExceptionCounts.GetValueOrDefault(ex) + 1;
+            };
+        }
+
+        [Fact]
+        public void ExceptionDemultiplexerPipelineStep_SimpleException()
+        {
+            ExceptionDemultiplexerPipelineStep action = new(_finalHandler);
+
+            Exception ex = new();
+            ExceptionPipelineExceptionContext context = new(DateTime.UtcNow);
+
+            action.Invoke(ex, context);
+
+            (Exception reportedException, int exceptionCount) = Assert.Single(_reportedExceptionCounts);
+            Assert.Equal(ex, reportedException);
+            Assert.Equal(1, exceptionCount);
+        }
+
+        [Fact]
+        public void ExceptionDemultiplexerPipelineStep_InnerException()
+        {
+            ExceptionDemultiplexerPipelineStep action = new(_finalHandler);
+
+            Exception innerException = new();
+            Exception outerException = new(null, innerException);
+            ExceptionPipelineExceptionContext context = new(DateTime.UtcNow);
+
+            action.Invoke(outerException, context);
+
+            Assert.Equal(2, _reportedExceptionCounts.Count);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(innerException, out int innerCount));
+            Assert.Equal(1, innerCount);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(outerException, out int outerCount));
+            Assert.Equal(1, outerCount);
+        }
+
+        [Fact]
+        public void ExceptionDemultiplexerPipelineStep_DeepInnerException()
+        {
+            ExceptionDemultiplexerPipelineStep action = new(_finalHandler);
+
+            Exception innerInnerException = new();
+            Exception innerException = new(null, innerInnerException);
+            Exception outerException = new(null, innerException);
+            ExceptionPipelineExceptionContext context = new(DateTime.UtcNow);
+
+            action.Invoke(outerException, context);
+
+            Assert.Equal(3, _reportedExceptionCounts.Count);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(innerInnerException, out int innerInnerCount));
+            Assert.Equal(1, innerInnerCount);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(innerException, out int innerCount));
+            Assert.Equal(1, innerCount);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(outerException, out int outerCount));
+            Assert.Equal(1, outerCount);
+        }
+
+        [Fact]
+        public void ExceptionDemultiplexerPipelineStep_AggregateException()
+        {
+            ExceptionDemultiplexerPipelineStep action = new(_finalHandler);
+
+            Exception innerException1 = new();
+            Exception innerException2 = new();
+            Exception innerException3 = new();
+            Exception outerException = new AggregateException(innerException1, innerException2, innerException3);
+            ExceptionPipelineExceptionContext context = new(DateTime.UtcNow);
+
+            action.Invoke(outerException, context);
+
+            Assert.Equal(4, _reportedExceptionCounts.Count);
+
+            // While the InnerException is the same as the first exception in InnerExceptions, the
+            // pipeline step is expected to only report it once.
+            Assert.True(_reportedExceptionCounts.TryGetValue(innerException1, out int inner1Count));
+            Assert.Equal(1, inner1Count);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(innerException2, out int inner2Count));
+            Assert.Equal(1, inner2Count);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(innerException3, out int inner3Count));
+            Assert.Equal(1, inner3Count);
+
+            Assert.True(_reportedExceptionCounts.TryGetValue(outerException, out int outerCount));
+            Assert.Equal(1, outerCount);
+        }
+    }
+}


### PR DESCRIPTION
###### Summary

These changes add a new step to the exceptions processor list that demultiplexes the `Exception` typed parts of the given `Exception` instance (specifically, it will report the `InnerException` property value, the `AggregateException.InnerExceptions` property value, and the exception itself). This allows for reporting of inner exceptions through the rest of the pipeline and eventually eventing the inner exception information.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
