### PR TITLE
Generate unique ID for each exception instance

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                     if (exception.Data[ExceptionIdKey] is ulong exceptionIdCandidate)
                     {
                         exceptionId = exceptionIdCandidate;
-                        return false;
+                        return true;
                     }
                 }
 


### PR DESCRIPTION
###### Summary

Generate unique ID for each exception instance (that doesn't have an ID already assigned to it). This allows for correlation of exceptions to inner exceptions within .NET Monitor (not yet implemented).

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
