### PR TITLE
Remove InnerExceptionId payload and ThrowingMethodName property

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -72,10 +72,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             string? ExceptionMessage,
             ulong[] StackFrameIds,
             DateTime Timestamp,
-            ulong InnerExceptionId,
             ulong[] InnerExceptionIds)
         {
-            Span<EventData> data = stackalloc EventData[7];
+            Span<EventData> data = stackalloc EventData[6];
             using PinnedData namePinned = PinnedData.Create(ExceptionMessage);
             Span<byte> stackFrameIdsSpan = stackalloc byte[GetArrayDataSize(StackFrameIds)];
             FillArrayData(stackFrameIdsSpan, StackFrameIds);
@@ -87,7 +86,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage], namePinned);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds], stackFrameIdsSpan);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.Timestamp], Timestamp.ToFileTimeUtc());
-            SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionId], InnerExceptionId);
             SetValue(ref data[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds], innerExceptionIdsSpan);
 
             WriteEventCore(ExceptionEvents.EventIds.ExceptionInstance, data);

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                     exception.Message,
                     frameIds,
                     context.Timestamp,
-                    GetExceptionId(exception.InnerException),
                     GetInnerExceptionsIds(exception)
                     );
             }
@@ -156,6 +155,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 
         private ulong[] GetInnerExceptionsIds(Exception exception)
         {
+            // AggregateException will always pull the first exception out of the list of inner exceptions
+            // and use that as its InnerException property. No need to report the InnerException property value.
             if (exception is AggregateException aggregateException)
             {
                 ulong[] exceptionIds = new ulong[aggregateException.InnerExceptions.Count];
@@ -164,6 +165,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                     exceptionIds[i] = GetExceptionId(aggregateException.InnerExceptions[i]);
                 }
                 return exceptionIds;
+            }
+            else if (null != exception.InnerException)
+            {
+                return new ulong[] { GetExceptionId(exception.InnerException) };
             }
             return Array.Empty<ulong>();
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventListener.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
                                 ToString(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage]),
                                 ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.StackFrameIds]),
                                 ToType<DateTime>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.Timestamp]),
-                                ToUInt64(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionId]),
                                 ToArray<ulong>(eventData.Payload[ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds])
                             ));
                         break;
@@ -144,14 +143,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
     internal sealed class ExceptionInstance
     {
-        public ExceptionInstance(ulong id, ulong groupId, string? message, ulong[] frameIds, DateTime timestamp, ulong innerExceptionId, ulong[] innerExceptionIds)
+        public ExceptionInstance(ulong id, ulong groupId, string? message, ulong[] frameIds, DateTime timestamp, ulong[] innerExceptionIds)
         {
             Id = id;
             GroupId = groupId;
             ExceptionMessage = message;
             StackFrameIds = frameIds;
             Timestamp = timestamp;
-            InnerExceptionId = innerExceptionId;
             InnerExceptionIds = innerExceptionIds;
         }
 
@@ -164,8 +162,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         public ulong[] StackFrameIds { get; }
 
         public DateTime Timestamp { get; }
-
-        public ulong InnerExceptionId { get; }
 
         public ulong[] InnerExceptionIds { get; }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
@@ -64,12 +64,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
         }
 
         [Theory]
-        [InlineData(0, 0, null, "0,0,0", 0, "")]
-        [InlineData(1, 5, "", "1,2", 3, "1")]
-        [InlineData(7, 13, InvalidOperationExceptionMessage, "", 2, "3,5")]
-        [InlineData(ulong.MaxValue - 1, ulong.MaxValue - 1, OperationCancelledExceptionMessage, "3,5,7", ulong.MaxValue - 2, "2")]
-        [InlineData(ulong.MaxValue, ulong.MaxValue, ObjectDisposedExceptionMessage, "2,7,11", ulong.MaxValue - 1, "9,8,4")]
-        public void ExceptionsEventSource_WriteException_Event(ulong id, ulong groupId, string message, string frameIdsString, ulong innerExceptionId, string innerExceptionIdsString)
+        [InlineData(0, 0, null, "0,0,0", "")]
+        [InlineData(1, 5, "", "1,2", "1")]
+        [InlineData(7, 13, InvalidOperationExceptionMessage, "", "3,5")]
+        [InlineData(ulong.MaxValue - 1, ulong.MaxValue - 1, OperationCancelledExceptionMessage, "3,5,7", "2")]
+        [InlineData(ulong.MaxValue, ulong.MaxValue, ObjectDisposedExceptionMessage, "2,7,11", "9,8,4")]
+        public void ExceptionsEventSource_WriteException_Event(ulong id, ulong groupId, string message, string frameIdsString, string innerExceptionIdsString)
         {
             using ExceptionsEventSource source = new();
 
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             DateTime timestamp = DateTime.UtcNow;
             ulong[] innerExceptionIds = innerExceptionIdsString.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(ulong.Parse).ToArray();
 
-            source.ExceptionInstance(id, groupId, message, frameIds, timestamp, innerExceptionId, innerExceptionIds);
+            source.ExceptionInstance(id, groupId, message, frameIds, timestamp, innerExceptionIds);
 
             ExceptionInstance instance = Assert.Single(listener.Exceptions);
             Assert.Equal(id, instance.Id);
@@ -90,7 +90,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             // but in-process listener doesn't decode non-byte arrays correctly.
             Assert.Equal(Array.Empty<ulong>(), instance.StackFrameIds);
             Assert.Equal(timestamp, instance.Timestamp);
-            Assert.Equal(innerExceptionId, instance.InnerExceptionId);
             // We would normally expect the following to return an array of the inner exception IDs
             // but in-process listener doesn't decode non-byte arrays correctly.
             Assert.Equal(Array.Empty<ulong>(), instance.InnerExceptionIds);
@@ -104,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             using ExceptionsEventListener listener = new();
             listener.EnableEvents(source, EventLevel.Warning);
 
-            source.ExceptionInstance(5, 7, ObjectDisposedExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow, 2, Array.Empty<ulong>());
+            source.ExceptionInstance(5, 7, ObjectDisposedExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow, Array.Empty<ulong>());
 
             Assert.Empty(listener.Exceptions);
         }
@@ -116,7 +115,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
 
             using ExceptionsEventListener listener = new();
 
-            source.ExceptionInstance(7, 9, OperationCancelledExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow, 4, Array.Empty<ulong>());
+            source.ExceptionInstance(7, 9, OperationCancelledExceptionMessage, Array.Empty<ulong>(), DateTime.UtcNow, Array.Empty<ulong>());
 
             Assert.Empty(listener.Exceptions);
         }

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -78,7 +78,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                     ulong groupId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId);
                     string message = traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage);
                     DateTime timestamp = traceEvent.GetPayload<DateTime>(ExceptionEvents.ExceptionInstancePayloads.Timestamp).ToUniversalTime();
-                    ulong innerExceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.InnerExceptionId);
                     ulong[] innerExceptionIds = traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds);
                     ulong[] stackFrameIds = traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.StackFrameIds);
                     _store.AddExceptionInstance(_cache, groupId, message, timestamp, stackFrameIds, traceEvent.ThreadID);

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
@@ -30,8 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public const int ExceptionMessage = 2;
             public const int StackFrameIds = 3;
             public const int Timestamp = 4;
-            public const int InnerExceptionId = 5;
-            public const int InnerExceptionIds = 6;
+            public const int InnerExceptionIds = 5;
         }
 
         public static class ExceptionGroupPayloads


### PR DESCRIPTION
###### Summary

Remove the InnerExceptionId (note this is singular) payload; all inner exceptions whether there is one or multiple are reported through the InnerExceptionIds (note this is plural) payload. I've also removed ThrowingMethodName from the pipeline tests; this property is largely superfluous now that a call stack is available and would have caused more pain in future changes to allow for exceptions that have not been thrown.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
