### PR TITLE
Add inner exception information to exception store

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 {
@@ -25,13 +26,25 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
         {
             ExceptionPipelineExceptionContext innerContext = new(context.Timestamp, isInnerException: true);
 
-            // AggregateException will always pull the first exception out of the list of inner exceptions
-            // and use that as its InnerException property. No need to report the InnerException property value.
             if (exception is AggregateException aggregateException)
             {
+                // AggregateException will always pull the first exception out of the list of inner exceptions
+                // and use that as its InnerException property. No need to report the InnerException property value.
                 for (int i = 0; i < aggregateException.InnerExceptions.Count; i++)
                 {
                     Invoke(aggregateException.InnerExceptions[i], innerContext);
+                }
+            }
+            if (exception is ReflectionTypeLoadException reflectionTypeLoadException)
+            {
+                // ReflectionTypeLoadException does not set InnerException. No need to report the InnerException property value.
+                for (int i = 0; i < reflectionTypeLoadException.LoaderExceptions.Length; i++)
+                {
+                    Exception? loaderException = reflectionTypeLoadException.LoaderExceptions[i];
+                    if (null != loaderException)
+                    {
+                        Invoke(loaderException, innerContext);
+                    }
                 }
             }
             else if (null != exception.InnerException)

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionDemultiplexerPipelineStep.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                     Invoke(aggregateException.InnerExceptions[i], innerContext);
                 }
             }
-            if (exception is ReflectionTypeLoadException reflectionTypeLoadException)
+            else if (exception is ReflectionTypeLoadException reflectionTypeLoadException)
             {
                 // ReflectionTypeLoadException does not set InnerException. No need to report the InnerException property value.
                 for (int i = 0; i < reflectionTypeLoadException.LoaderExceptions.Length; i++)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
-    internal record class ExceptionInstance(string TypeName, string ModuleName, string Message, DateTime Timestamp, CallStack CallStack)
+    internal record class ExceptionInstance(ulong Id, string TypeName, string ModuleName, string Message, DateTime Timestamp, CallStack CallStack, ulong[] InnerExceptionIds)
         : IExceptionInstance
     {
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
         DateTime Timestamp { get; }
 
         CallStack CallStack { get; }
+
+        ulong[] InnerExceptionIds { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
     internal interface IExceptionInstance
     {
+        ulong Id { get; }
+
         string Message { get; }
 
         string ModuleName { get; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionsStore.cs
@@ -8,7 +8,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
     internal interface IExceptionsStore
     {
-        void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, string message, DateTime timestamp, ulong[] stackFrameIds, int threadId);
+        void AddExceptionInstance(
+            IExceptionsNameCache cache,
+            ulong exceptionId,
+            ulong groupId,
+            string message,
+            DateTime timestamp,
+            ulong[] stackFrameIds,
+            int threadId,
+            ulong[] innerExceptionIds);
 
         IReadOnlyList<IExceptionInstance> GetSnapshot();
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string InnerUnthrownException = nameof(InnerUnthrownException);
                 public const string InnerThrownException = nameof(InnerThrownException);
                 public const string AggregateException = nameof(AggregateException);
+                public const string ReflectionTypeLoadException = nameof(ReflectionTypeLoadException);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string ReversePInvokeException = nameof(ReversePInvokeException);
                 public const string DynamicMethodException = nameof(DynamicMethodException);
                 public const string ArrayException = nameof(ArrayException);
+                public const string InnerUnthrownException = nameof(InnerUnthrownException);
+                public const string InnerThrownException = nameof(InnerThrownException);
+                public const string AggregateException = nameof(AggregateException);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -237,23 +237,21 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance instance1 = instances.First();
-                    Assert.NotNull(instance1);
+                    TestExceptionsStore.ExceptionInstance innerInstance = instances.First();
+                    Assert.NotNull(innerInstance);
 
-                    Assert.NotEqual(0UL, instance1.Id);
-                    Assert.Equal(typeof(FormatException).FullName, instance1.TypeName);
-                    Assert.Empty(instance1.InnerExceptionIds);
-                    Assert.Empty(instance1.CallStack.Frames); // Indicates this exception was not thrown
+                    Assert.NotEqual(0UL, innerInstance.Id);
+                    Assert.Equal(typeof(FormatException).FullName, innerInstance.TypeName);
+                    Assert.Empty(innerInstance.InnerExceptionIds);
+                    Assert.Empty(innerInstance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance instance2 = instances.Skip(1).Single();
-                    Assert.NotNull(instance2);
+                    TestExceptionsStore.ExceptionInstance outerInstance = instances.Skip(1).Single();
+                    Assert.NotNull(outerInstance);
                     
-                    Assert.NotEqual(0UL, instance2.Id);
-                    Assert.Equal(typeof(InvalidOperationException).FullName, instance2.TypeName);
-                    ulong instance2InnerExceptionId = Assert.Single(instance2.InnerExceptionIds);
-                    Assert.NotEmpty(instance2.CallStack.Frames); // Indicates this exception was thrown
-
-                    Assert.Equal(instance1.Id, instance2InnerExceptionId);
+                    Assert.NotEqual(0UL, outerInstance.Id);
+                    Assert.Equal(typeof(InvalidOperationException).FullName, outerInstance.TypeName);
+                    Assert.Equal(innerInstance.Id, Assert.Single(outerInstance.InnerExceptionIds));
+                    Assert.NotEmpty(outerInstance.CallStack.Frames); // Indicates this exception was thrown
                 });
         }
 
@@ -272,27 +270,21 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance instance1 = instances.First();
-                    Assert.NotNull(instance1);
+                    TestExceptionsStore.ExceptionInstance innerInstance = instances.First();
+                    Assert.NotNull(innerInstance);
 
-                    Assert.NotEqual(0UL, instance1.Id);
-                    Assert.Equal(typeof(FormatException).FullName, instance1.TypeName);
-                    Assert.Empty(instance1.InnerExceptionIds);
-                    Assert.NotEmpty(instance1.CallStack.Frames); // Indicates this exception was thrown
+                    Assert.NotEqual(0UL, innerInstance.Id);
+                    Assert.Equal(typeof(FormatException).FullName, innerInstance.TypeName);
+                    Assert.Empty(innerInstance.InnerExceptionIds);
+                    Assert.NotEmpty(innerInstance.CallStack.Frames); // Indicates this exception was thrown
 
-                    CallStackFrame instance1Frame1 = instance1.CallStack.Frames.First();
+                    TestExceptionsStore.ExceptionInstance outerInstance = instances.Skip(1).Single();
+                    Assert.NotNull(outerInstance);
 
-                    TestExceptionsStore.ExceptionInstance instance2 = instances.Skip(1).Single();
-                    Assert.NotNull(instance2);
-
-                    Assert.NotEqual(0UL, instance2.Id);
-                    Assert.Equal(typeof(InvalidOperationException).FullName, instance2.TypeName);
-                    ulong instance2InnerExceptionId = Assert.Single(instance2.InnerExceptionIds);
-                    Assert.NotEmpty(instance1.CallStack.Frames); // Indicates this exception was thrown
-
-                    CallStackFrame instance2Frame1 = instance2.CallStack.Frames.First();
-
-                    Assert.Equal(instance1.Id, instance2InnerExceptionId);
+                    Assert.NotEqual(0UL, outerInstance.Id);
+                    Assert.Equal(typeof(InvalidOperationException).FullName, outerInstance.TypeName);
+                    Assert.Equal(innerInstance.Id, Assert.Single(outerInstance.InnerExceptionIds));
+                    Assert.NotEmpty(innerInstance.CallStack.Frames); // Indicates this exception was thrown
                 });
         }
 
@@ -313,43 +305,43 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance instance1 = instanceList[0];
-                    Assert.NotNull(instance1);
+                    TestExceptionsStore.ExceptionInstance inner1Instance = instanceList[0];
+                    Assert.NotNull(inner1Instance);
 
-                    Assert.NotEqual(0UL, instance1.Id);
-                    Assert.Equal(typeof(InvalidOperationException).FullName, instance1.TypeName);
-                    Assert.Empty(instance1.InnerExceptionIds);
-                    Assert.Empty(instance1.CallStack.Frames); // Indicates this exception was not thrown
+                    Assert.NotEqual(0UL, inner1Instance.Id);
+                    Assert.Equal(typeof(InvalidOperationException).FullName, inner1Instance.TypeName);
+                    Assert.Empty(inner1Instance.InnerExceptionIds);
+                    Assert.Empty(inner1Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance instance2 = instanceList[1];
-                    Assert.NotNull(instance2);
+                    TestExceptionsStore.ExceptionInstance inner2Instance = instanceList[1];
+                    Assert.NotNull(inner2Instance);
 
-                    Assert.NotEqual(0UL, instance2.Id);
-                    Assert.Equal(typeof(FormatException).FullName, instance2.TypeName);
-                    Assert.Empty(instance2.InnerExceptionIds);
-                    Assert.Empty(instance2.CallStack.Frames); // Indicates this exception was not thrown
+                    Assert.NotEqual(0UL, inner2Instance.Id);
+                    Assert.Equal(typeof(FormatException).FullName, inner2Instance.TypeName);
+                    Assert.Empty(inner2Instance.InnerExceptionIds);
+                    Assert.Empty(inner2Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance instance3 = instanceList[2];
-                    Assert.NotNull(instance3);
+                    TestExceptionsStore.ExceptionInstance inner3Instance = instanceList[2];
+                    Assert.NotNull(inner3Instance);
 
-                    Assert.NotEqual(0UL, instance3.Id);
-                    Assert.Equal(typeof(TaskCanceledException).FullName, instance3.TypeName);
-                    Assert.Empty(instance3.InnerExceptionIds);
-                    Assert.Empty(instance3.CallStack.Frames); // Indicates this exception was not thrown
+                    Assert.NotEqual(0UL, inner3Instance.Id);
+                    Assert.Equal(typeof(TaskCanceledException).FullName, inner3Instance.TypeName);
+                    Assert.Empty(inner3Instance.InnerExceptionIds);
+                    Assert.Empty(inner3Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance instance4 = instanceList[3];
-                    Assert.NotNull(instance4);
+                    TestExceptionsStore.ExceptionInstance outerInstance = instanceList[3];
+                    Assert.NotNull(outerInstance);
 
-                    Assert.NotEqual(0UL, instance4.Id);
-                    Assert.Equal(typeof(AggregateException).FullName, instance4.TypeName);
-                    Assert.NotEmpty(instance4.InnerExceptionIds);
-                    Assert.NotEmpty(instance4.CallStack.Frames); // Indicates this exception was thrown
+                    Assert.NotEqual(0UL, outerInstance.Id);
+                    Assert.Equal(typeof(AggregateException).FullName, outerInstance.TypeName);
+                    Assert.NotEmpty(outerInstance.InnerExceptionIds);
+                    Assert.NotEmpty(outerInstance.CallStack.Frames); // Indicates this exception was thrown
 
                     // Verify inner exceptions of AggregateException instance
-                    Assert.Equal(3, instance4.InnerExceptionIds.Length);
-                    Assert.Equal(instance1.Id, instance4.InnerExceptionIds[0]);
-                    Assert.Equal(instance2.Id, instance4.InnerExceptionIds[1]);
-                    Assert.Equal(instance3.Id, instance4.InnerExceptionIds[2]);
+                    Assert.Equal(3, outerInstance.InnerExceptionIds.Length);
+                    Assert.Equal(inner1Instance.Id, outerInstance.InnerExceptionIds[0]);
+                    Assert.Equal(inner2Instance.Id, outerInstance.InnerExceptionIds[1]);
+                    Assert.Equal(inner3Instance.Id, outerInstance.InnerExceptionIds[2]);
                 });
         }
 
@@ -368,37 +360,37 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     List<TestExceptionsStore.ExceptionInstance> instanceList = new(instances);
 
-                    Assert.Equal(ExpectedInstanceCount, instances.Count());
+                    Assert.Equal(ExpectedInstanceCount, instanceList.Count);
 
-                    TestExceptionsStore.ExceptionInstance instance1 = instanceList[0];
-                    Assert.NotNull(instance1);
+                    TestExceptionsStore.ExceptionInstance inner1Instance = instanceList[0];
+                    Assert.NotNull(inner1Instance);
 
-                    Assert.NotEqual(0UL, instance1.Id);
-                    Assert.Equal(typeof(MissingMethodException).FullName, instance1.TypeName);
-                    Assert.Empty(instance1.InnerExceptionIds);
-                    Assert.Empty(instance1.CallStack.Frames); // Indicates this exception was not thrown
+                    Assert.NotEqual(0UL, inner1Instance.Id);
+                    Assert.Equal(typeof(MissingMethodException).FullName, inner1Instance.TypeName);
+                    Assert.Empty(inner1Instance.InnerExceptionIds);
+                    Assert.Empty(inner1Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance instance2 = instanceList[1];
-                    Assert.NotNull(instance2);
+                    TestExceptionsStore.ExceptionInstance inner2Instance = instanceList[1];
+                    Assert.NotNull(inner2Instance);
 
-                    Assert.NotEqual(0UL, instance2.Id);
-                    Assert.Equal(typeof(MissingFieldException).FullName, instance2.TypeName);
-                    Assert.Empty(instance2.InnerExceptionIds);
-                    Assert.Empty(instance2.CallStack.Frames); // Indicates this exception was not thrown
+                    Assert.NotEqual(0UL, inner2Instance.Id);
+                    Assert.Equal(typeof(MissingFieldException).FullName, inner2Instance.TypeName);
+                    Assert.Empty(inner2Instance.InnerExceptionIds);
+                    Assert.Empty(inner2Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance instance3 = instanceList[2];
-                    Assert.NotNull(instance3);
+                    TestExceptionsStore.ExceptionInstance outerInstance = instanceList[2];
+                    Assert.NotNull(outerInstance);
 
-                    Assert.NotEqual(0UL, instance3.Id);
-                    Assert.Equal(typeof(ReflectionTypeLoadException).FullName, instance3.TypeName);
-                    Assert.NotEmpty(instance3.InnerExceptionIds);
-                    Assert.NotEmpty(instance3.CallStack.Frames); // Indicates this exception was thrown
+                    Assert.NotEqual(0UL, outerInstance.Id);
+                    Assert.Equal(typeof(ReflectionTypeLoadException).FullName, outerInstance.TypeName);
+                    Assert.NotEmpty(outerInstance.InnerExceptionIds);
+                    Assert.NotEmpty(outerInstance.CallStack.Frames); // Indicates this exception was thrown
 
                     // Verify inner exceptions of ReflectionTypeLoadException instance
-                    Assert.Equal(3, instance3.InnerExceptionIds.Length);
-                    Assert.Equal(instance1.Id, instance3.InnerExceptionIds[0]);
-                    Assert.Equal(0UL, instance3.InnerExceptionIds[1]); // Second loaded exception is null
-                    Assert.Equal(instance2.Id, instance3.InnerExceptionIds[2]);
+                    Assert.Equal(3, outerInstance.InnerExceptionIds.Length);
+                    Assert.Equal(inner1Instance.Id, outerInstance.InnerExceptionIds[0]);
+                    Assert.Equal(0UL, outerInstance.InnerExceptionIds[1]); // Second loaded exception is null
+                    Assert.Equal(inner2Instance.Id, outerInstance.InnerExceptionIds[2]);
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -18,7 +18,6 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using CallStack = Microsoft.Diagnostics.Monitoring.WebApi.Models.CallStack;
-using CallStackFrame = Microsoft.Diagnostics.Monitoring.WebApi.Models.CallStackFrame;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
@@ -47,7 +46,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal(typeof(InvalidOperationException).FullName, instance.TypeName);
@@ -76,10 +75,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance instance1 = instances.First();
+                    IExceptionInstance instance1 = instances.First();
                     Assert.NotNull(instance1);
 
-                    TestExceptionsStore.ExceptionInstance instance2 = instances.Skip(1).Single();
+                    IExceptionInstance instance2 = instances.Skip(1).Single();
                     Assert.NotNull(instance2);
 
                     Assert.NotEqual(instance1.Id, instance2.Id);
@@ -105,7 +104,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal(typeof(TaskCanceledException).FullName, instance.TypeName);
@@ -126,7 +125,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal(typeof(ArgumentNullException).FullName, instance.TypeName);
@@ -147,7 +146,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomGenericsException`2[System.Int32,System.String]", instance.TypeName);
@@ -169,7 +168,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal(typeof(InvalidOperationException).FullName, instance.TypeName);
@@ -191,7 +190,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal("Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario+CustomSimpleException", instance.TypeName);
@@ -212,7 +211,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 expectedInstanceCount: 1,
                 validate: instances =>
                 {
-                    TestExceptionsStore.ExceptionInstance instance = Assert.Single(instances);
+                    IExceptionInstance instance = Assert.Single(instances);
                     Assert.NotNull(instance);
                     Assert.NotEqual(0UL, instance.Id);
                     Assert.Equal(typeof(IndexOutOfRangeException).FullName, instance.TypeName);
@@ -237,7 +236,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance innerInstance = instances.First();
+                    IExceptionInstance innerInstance = instances.First();
                     Assert.NotNull(innerInstance);
 
                     Assert.NotEqual(0UL, innerInstance.Id);
@@ -245,7 +244,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(innerInstance.InnerExceptionIds);
                     Assert.Empty(innerInstance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance outerInstance = instances.Skip(1).Single();
+                    IExceptionInstance outerInstance = instances.Skip(1).Single();
                     Assert.NotNull(outerInstance);
                     
                     Assert.NotEqual(0UL, outerInstance.Id);
@@ -270,7 +269,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance innerInstance = instances.First();
+                    IExceptionInstance innerInstance = instances.First();
                     Assert.NotNull(innerInstance);
 
                     Assert.NotEqual(0UL, innerInstance.Id);
@@ -278,7 +277,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(innerInstance.InnerExceptionIds);
                     Assert.NotEmpty(innerInstance.CallStack.Frames); // Indicates this exception was thrown
 
-                    TestExceptionsStore.ExceptionInstance outerInstance = instances.Skip(1).Single();
+                    IExceptionInstance outerInstance = instances.Skip(1).Single();
                     Assert.NotNull(outerInstance);
 
                     Assert.NotEqual(0UL, outerInstance.Id);
@@ -301,11 +300,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 ExpectedInstanceCount,
                 validate: instances =>
                 {
-                    List<TestExceptionsStore.ExceptionInstance> instanceList = new(instances);
+                    List<IExceptionInstance> instanceList = new(instances);
 
                     Assert.Equal(ExpectedInstanceCount, instances.Count());
 
-                    TestExceptionsStore.ExceptionInstance inner1Instance = instanceList[0];
+                    IExceptionInstance inner1Instance = instanceList[0];
                     Assert.NotNull(inner1Instance);
 
                     Assert.NotEqual(0UL, inner1Instance.Id);
@@ -313,7 +312,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(inner1Instance.InnerExceptionIds);
                     Assert.Empty(inner1Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance inner2Instance = instanceList[1];
+                    IExceptionInstance inner2Instance = instanceList[1];
                     Assert.NotNull(inner2Instance);
 
                     Assert.NotEqual(0UL, inner2Instance.Id);
@@ -321,7 +320,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(inner2Instance.InnerExceptionIds);
                     Assert.Empty(inner2Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance inner3Instance = instanceList[2];
+                    IExceptionInstance inner3Instance = instanceList[2];
                     Assert.NotNull(inner3Instance);
 
                     Assert.NotEqual(0UL, inner3Instance.Id);
@@ -329,7 +328,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(inner3Instance.InnerExceptionIds);
                     Assert.Empty(inner3Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance outerInstance = instanceList[3];
+                    IExceptionInstance outerInstance = instanceList[3];
                     Assert.NotNull(outerInstance);
 
                     Assert.NotEqual(0UL, outerInstance.Id);
@@ -358,11 +357,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 ExpectedInstanceCount,
                 validate: instances =>
                 {
-                    List<TestExceptionsStore.ExceptionInstance> instanceList = new(instances);
+                    List<IExceptionInstance> instanceList = new(instances);
 
                     Assert.Equal(ExpectedInstanceCount, instanceList.Count);
 
-                    TestExceptionsStore.ExceptionInstance inner1Instance = instanceList[0];
+                    IExceptionInstance inner1Instance = instanceList[0];
                     Assert.NotNull(inner1Instance);
 
                     Assert.NotEqual(0UL, inner1Instance.Id);
@@ -370,7 +369,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(inner1Instance.InnerExceptionIds);
                     Assert.Empty(inner1Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance inner2Instance = instanceList[1];
+                    IExceptionInstance inner2Instance = instanceList[1];
                     Assert.NotNull(inner2Instance);
 
                     Assert.NotEqual(0UL, inner2Instance.Id);
@@ -378,7 +377,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.Empty(inner2Instance.InnerExceptionIds);
                     Assert.Empty(inner2Instance.CallStack.Frames); // Indicates this exception was not thrown
 
-                    TestExceptionsStore.ExceptionInstance outerInstance = instanceList[2];
+                    IExceptionInstance outerInstance = instanceList[2];
                     Assert.NotNull(outerInstance);
 
                     Assert.NotEqual(0UL, outerInstance.Id);
@@ -397,7 +396,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         private async Task Execute(
             string subScenarioName,
             int expectedInstanceCount,
-            Action<IEnumerable<TestExceptionsStore.ExceptionInstance>> validate,
+            Action<IEnumerable<IExceptionInstance>> validate,
             Architecture? architecture = null)
         {
             EndpointInfoSourceCallback callback = new(_outputHelper);
@@ -435,11 +434,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 // Wait for the expected number of exceptions to have been reported
                 await store.InstanceThresholdTask.WaitAsync(timeoutSource.Token);
 
-                validate(store.Instances);
+                validate(store.GetSnapshot());
             });
         }
 
-        private static void ValidateStack(TestExceptionsStore.ExceptionInstance instance, string expectedMethodName, string expectedModuleName, string expectedClassName)
+        private static void ValidateStack(IExceptionInstance instance, string expectedMethodName, string expectedModuleName, string expectedClassName)
         {
             CallStack stack = instance.CallStack;
             Assert.NotEmpty(stack.Frames);
@@ -471,8 +470,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             public Task InstanceThresholdTask => _instanceThresholdSource.Task;
 
-            public IEnumerable<ExceptionInstance> Instances => _instances;
-
             public TestExceptionsStore(int instanceThreshold = 1)
             {
                 _instanceThreshold = instanceThreshold;
@@ -480,6 +477,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             public void AddExceptionInstance(IExceptionsNameCache cache, ulong exceptionId, ulong groupId, string message, DateTime timestamp, ulong[] stackFrameIds, int threadId, ulong[] innerExceptionIds)
             {
+                string moduleName = string.Empty;
                 StringBuilder typeBuilder = new();
                 CallStack callStack;
                 try
@@ -487,6 +485,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                     Assert.True(cache.TryGetExceptionGroup(groupId, out ulong exceptionClassId, out _, out _));
 
                     NameFormatter.BuildClassName(typeBuilder, cache.NameCache, exceptionClassId);
+
+                    if (cache.NameCache.ClassData.TryGetValue(exceptionClassId, out ClassData exceptionClassData))
+                    {
+                        moduleName = NameFormatter.GetModuleName(cache.NameCache, exceptionClassData.ModuleId);
+                    }
 
                     callStack = ExceptionsStore.GenerateCallStack(stackFrameIds, cache, threadId);
                 }
@@ -499,6 +502,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
                 _instances.Add(new ExceptionInstance(
                     exceptionId,
+                    moduleName,
                     typeBuilder.ToString(),
                     message,
                     timestamp,
@@ -513,10 +517,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             public IReadOnlyList<IExceptionInstance> GetSnapshot()
             {
-                throw new NotSupportedException();
+                return _instances;
             }
 
-            public sealed record class ExceptionInstance(ulong Id, string TypeName, string Message, DateTime Timestamp, CallStack CallStack, ulong[] InnerExceptionIds)
+            public sealed record class ExceptionInstance(ulong Id, string ModuleName, string TypeName, string Message, DateTime Timestamp, CallStack CallStack, ulong[] InnerExceptionIds)
+                : IExceptionInstance
             {
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             CliCommand aggregateExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.AggregateException);
             aggregateExceptionCommand.SetAction(AggregateExceptionAsync);
 
+            CliCommand reflectionTypeLoadExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.ReflectionTypeLoadException);
+            reflectionTypeLoadExceptionCommand.SetAction(ReflectionTypeLoadExceptionAsync);
+
             CliCommand scenarioCommand = new(TestAppScenarios.Exceptions.Name);
             scenarioCommand.Subcommands.Add(singleExceptionCommand);
             scenarioCommand.Subcommands.Add(repeatExceptionCommand);
@@ -62,6 +65,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             scenarioCommand.Subcommands.Add(innerUnthrownExceptionCommand);
             scenarioCommand.Subcommands.Add(innerThrownExceptionCommand);
             scenarioCommand.Subcommands.Add(aggregateExceptionCommand);
+            scenarioCommand.Subcommands.Add(reflectionTypeLoadExceptionCommand);
             return scenarioCommand;
         }
 
@@ -266,6 +270,33 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                         new InvalidOperationException(),
                         new FormatException(),
                         new TaskCanceledException());
+                }
+                catch (Exception)
+                {
+                }
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
+        public static Task<int> ReflectionTypeLoadExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                try
+                {
+                    throw new ReflectionTypeLoadException(
+                        classes: null,
+                        exceptions: new Exception[]
+                        {
+                            new MissingMethodException(),
+                            null,
+                            new MissingFieldException()
+                        });
                 }
                 catch (Exception)
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -41,6 +41,15 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             CliCommand arrayExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.ArrayException);
             arrayExceptionCommand.SetAction(ArrayExceptionAsync);
 
+            CliCommand innerUnthrownExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.InnerUnthrownException);
+            innerUnthrownExceptionCommand.SetAction(InnerUnthrownExceptionAsync);
+
+            CliCommand innerThrownExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.InnerThrownException);
+            innerThrownExceptionCommand.SetAction(InnerThrownExceptionAsync);
+
+            CliCommand aggregateExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.AggregateException);
+            aggregateExceptionCommand.SetAction(AggregateExceptionAsync);
+
             CliCommand scenarioCommand = new(TestAppScenarios.Exceptions.Name);
             scenarioCommand.Subcommands.Add(singleExceptionCommand);
             scenarioCommand.Subcommands.Add(repeatExceptionCommand);
@@ -50,6 +59,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             scenarioCommand.Subcommands.Add(reversePInvokeExceptionCommand);
             scenarioCommand.Subcommands.Add(dynamicMethodExceptionCommand);
             scenarioCommand.Subcommands.Add(arrayExceptionCommand);
+            scenarioCommand.Subcommands.Add(innerUnthrownExceptionCommand);
+            scenarioCommand.Subcommands.Add(innerThrownExceptionCommand);
+            scenarioCommand.Subcommands.Add(aggregateExceptionCommand);
             return scenarioCommand;
         }
 
@@ -214,12 +226,89 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             }, token);
         }
 
+        public static Task<int> InnerUnthrownExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                ThrowAndCatchInvalidOperationException(includeInnerException: true, throwInnerException: false);
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
+        public static Task<int> InnerThrownExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                ThrowAndCatchInvalidOperationException(includeInnerException: true);
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
+        public static Task<int> AggregateExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                try
+                {
+                    throw new AggregateException(
+                        new InvalidOperationException(),
+                        new FormatException(),
+                        new TaskCanceledException());
+                }
+                catch (Exception)
+                {
+                }
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowAndCatchInvalidOperationException()
         {
+            ThrowAndCatchInvalidOperationException(includeInnerException: false, throwInnerException: false);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowAndCatchInvalidOperationException(bool includeInnerException = false, bool throwInnerException = true)
+        {
             try
             {
-                throw new InvalidOperationException();
+                Exception innerException = null;
+                if (includeInnerException)
+                {
+                    if (throwInnerException)
+                    {
+                        try
+                        {
+                            throw new FormatException();
+                        }
+                        catch (Exception ex)
+                        {
+                            innerException = ex;
+                        }
+                    }
+                    else
+                    {
+                        innerException = new FormatException();
+                    }
+                }
+
+                throw new InvalidOperationException(null, innerException);
             }
             catch (Exception)
             {

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -74,13 +74,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         );
                     break;
                 case "ExceptionInstance":
-                    ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId);
-                    ulong groupId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId);
-                    string message = traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage);
-                    DateTime timestamp = traceEvent.GetPayload<DateTime>(ExceptionEvents.ExceptionInstancePayloads.Timestamp).ToUniversalTime();
-                    ulong[] innerExceptionIds = traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds);
-                    ulong[] stackFrameIds = traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.StackFrameIds);
-                    _store.AddExceptionInstance(_cache, groupId, message, timestamp, stackFrameIds, traceEvent.ThreadID);
+                    _store.AddExceptionInstance(
+                        _cache,
+                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId),
+                        traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionGroupId),
+                        traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ExceptionMessage),
+                        traceEvent.GetPayload<DateTime>(ExceptionEvents.ExceptionInstancePayloads.Timestamp).ToUniversalTime(),
+                        traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.StackFrameIds),
+                        traceEvent.ThreadID,
+                        traceEvent.GetPayload<ulong[]>(ExceptionEvents.ExceptionInstancePayloads.InnerExceptionIds));
                     break;
                 case "FunctionDescription":
                     _cache.AddFunction(


### PR DESCRIPTION
###### Summary

Add the exception instance ID and inner exception ID information to the exception store. Added a few more tests to validate the inner exception IDs match the exception instance IDs.

Additionally, add support for capturing `ReflectionTypeLoadException.LoaderExceptions` as inner exceptions.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
