### PR TITLE
Publish single file bundle to blob storage

### DIFF
--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -7,7 +7,7 @@
   <!-- Only publish projects after build if opt-in -->
   <Target Name="PublishProjectsAfterBuild"
           AfterTargets="Build"
-          Condition="'$(PublishProjectsAfterBuild)' == 'true' and '$(CreateArchives)' != 'true'">
+          Condition="'$(PublishProjectsAfterBuild)' == 'true' and '$(CreateArchives)' != 'true' and '$(CreateSingleFileBundles)' != 'true'">
     <CallTarget Targets="PublishProjects" />
   </Target>
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -2,4 +2,6 @@
   <Import Project="$(MSBuildThisFileDirectory)Common.props" />
   <Import Project="$(RepoRoot)src\archives\dotnet-monitor\ProjectsToBuild.props"
           Condition="'$(CreateArchives)' == 'true'" />
+  <Import Project="$(RepoRoot)src\singlefile\dotnet-monitor\ProjectsToBuild.props"
+          Condition="'$(CreateSingleFileBundles)' == 'true'" />
 </Project>

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -2,5 +2,6 @@
   <!-- These properties are shared among the Arcade build infrastructure as well as individual project build. -->
   <PropertyGroup>
     <LatestTargetFramework>net7.0</LatestTargetFramework>
+    <ArtifactsNonShippingBundlesDir>$(ArtifactsDir)bundles\$(Configuration)\NonShipping\</ArtifactsNonShippingBundlesDir>
   </PropertyGroup>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles;CollectVersionArtifactFiles</PublishDependsOnTargets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles;CollectBundleArtifactFiles;CollectVersionArtifactFiles</PublishDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,18 @@
     <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.zip" IsShipping="true" />
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.tar.gz" IsShipping="false" />
     <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.zip" IsShipping="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/linux-arm64/*" Rid="linux-arm64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/linux-x64/*" Rid="linux-x64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/linux-musl-arm64/*" Rid="linux-musl-arm64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/linux-musl-x64/*" Rid="linux-musl-x64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/osx-arm64/*" Rid="osx-arm64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/osx-x64/*" Rid="osx-x64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/win-arm64/*" Rid="win-arm64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/win-x64/*" Rid="win-x64" IsShipping="false" />
+    <BundleFile Include="$(ArtifactsNonShippingBundlesDir)/win-x86/*" Rid="win-x86" IsShipping="false" />
   </ItemGroup>
 
   <Target Name="CalculateBlobGroupAndBuildVersion">
@@ -195,6 +207,20 @@
       <ItemsToPushToBlobFeed Include="@(_VersionContainerBlobItem)" Condition="'$(_BuildVersion)' != ''">
         <!-- Place blobs into versioned container so that stable package versions do not collide. -->
         <RelativeBlobPath>diagnostics/monitor/$(_BuildVersion)/%(_VersionContainerBlobItem.Filename)%(_VersionContainerBlobItem.Extension)</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CollectBundleArtifactFiles"
+          DependsOnTargets="CalculateBlobGroupAndBuildVersion">
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(BundleFile)"
+                             RemoveMetadata="IsShipping;Rid"
+                             Condition="'$(_BuildVersion)' != ''">
+        <!-- Place blobs into versioned container so that stable versions (or lack of version) do not collide. -->
+        <RelativeBlobPath>diagnostics/monitor/$(_BuildVersion)/%(BundleFile.Rid)/%(BundleFile.Filename)%(BundleFile.Extension)</RelativeBlobPath>
+        <ManifestArtifactData Condition="'%(BundleFile.IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPushToBlobFeed>
     </ItemGroup>

--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -36,6 +36,7 @@ jobs:
       -skipmanaged
       -skipnative
       /p:PublishProjectsAfterBuild=true
+      /p:CreateSingleFileBundles=true
       /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
 
     postBuildSteps:
@@ -44,6 +45,12 @@ jobs:
       inputs:
         SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+    
+    - task: CopyFiles@2
+      displayName: Gather Artifacts (bundles)
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/bundles'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bundles'
 
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifacts (Unified)

--- a/src/singlefile/Directory.Build.props
+++ b/src/singlefile/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <BundleSuffix Condition="$(PackageRid.Contains(win))">.exe</BundleSuffix>
+    <BundleSuffix Condition="!$(PackageRid.Contains(win))"></BundleSuffix>
+    <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
+  </PropertyGroup>
+</Project>

--- a/src/singlefile/Directory.Build.targets
+++ b/src/singlefile/Directory.Build.targets
@@ -1,0 +1,23 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <BuildDependsOn>$(BuildDependsOn);PublishProjectsBeforeBundle;CopyBundle</BuildDependsOn>
+  </PropertyGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />
+
+  <!-- Publish projects if they were not published after build -->
+  <Target Name="PublishProjectsBeforeBundle"
+          Condition="'$(PublishProjectsAfterBuild)' != 'true'">
+    <CallTarget Targets="PublishProjects" />
+  </Target>
+
+  <Target Name="CopyBundle">
+    <MakeDir Directories="$(ArtifactsNonShippingBundlesDir)$(PackageRid)" />
+    <Copy SourceFiles="$(DotnetMonitorPublishSfbPath)$(BundleName)$(BundleSuffix)"
+          DestinationFolder="$(ArtifactsNonShippingBundlesDir)$(PackageRid)" />
+    <Message Text="$(BundleName)$(BundleSuffix) -> $(ArtifactsNonShippingBundlesDir)$(PackageRid)"
+             Importance="High" />
+  </Target>
+</Project>

--- a/src/singlefile/dotnet-monitor/ProjectsToBuild.props
+++ b/src/singlefile/dotnet-monitor/ProjectsToBuild.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <ProjectToBuild Include="$(MSBuildThisFileDirectory)dotnet-monitor-singlefile.proj">
+      <AdditionalProperties>TargetFramework=$(LatestTargetFramework);RuntimeIdentifier=$(PackageRid)</AdditionalProperties>
+    </ProjectToBuild>
+  </ItemGroup>
+</Project>

--- a/src/singlefile/dotnet-monitor/dotnet-monitor-singlefile.proj
+++ b/src/singlefile/dotnet-monitor/dotnet-monitor-singlefile.proj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <Import Project="$(MSBuildThisFileDirectory)ProjectsToPublish.props" />
+
+  <PropertyGroup>
+    <BundleName>dotnet-monitor</BundleName>
+    <TargetFramework>$(DotnetMonitorPublishTargetFramework)</TargetFramework>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
###### Summary

Theses changes allow the publishing of the single file bundles to blob storage accounts and have them marked as non-shipping. It piggybacks of the archive job to copy the built bundles from the `pub` directory to the `artifacts/bundles/Release/NonShipping/<RID>/` directory from which the Publishing.props file will detect it and write entries into BAR manifest as appropriate. Because these files are in the `pub` directory during the signing job, they are also getting signed.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2201872&view=results

An example blob storage URI for the win-x64 single file bundle (if the above build was actually uploading them) would be `https://dotnetbuilds.blob.core.windows.net/public/diagnostics/monitor/7.3.0-alpha.1.23315.4/win-x64/dotnet-monitor.exe`

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
