### PR TITLE
Report inner exception information in exceptions route

### DIFF
--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             startCompletionSource?.TrySetResult(null);
 
 
-            IEnumerable<IExceptionInstance> exceptions = _store.GetSnapshot();
+            IReadOnlyList<IExceptionInstance> exceptions = _store.GetSnapshot();
 
             switch (_format)
             {
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             throw new MonitoringException(Strings.ErrorMessage_OperationIsNotStoppable);
         }
 
-        private async Task WriteJson(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
+        private async Task WriteJson(Stream stream, IReadOnlyList<IExceptionInstance> instances, CancellationToken token)
         {
             foreach (IExceptionInstance instance in instances)
             {
@@ -92,6 +92,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             await using (Utf8JsonWriter writer = new(stream, new JsonWriterOptions() { Indented = false }))
             {
                 writer.WriteStartObject();
+                writer.WriteNumber("id", instance.Id);
                 // Writes the timestamp in ISO 8601 format
                 writer.WriteString("timestamp", instance.Timestamp);
                 writer.WriteString("typeName", instance.TypeName);
@@ -101,6 +102,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 writer.WriteStartObject("callStack");
                 writer.WriteNumber("threadId", instance.CallStack.ThreadId);
                 writer.WriteString("threadName", instance.CallStack.ThreadName);
+
+                writer.WriteStartArray("innerExceptions");
+                foreach (ulong innerExceptionId in instance.InnerExceptionIds)
+                {
+                    writer.WriteStartObject();
+                    writer.WriteNumber("id", innerExceptionId);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
 
                 writer.WriteStartArray("frames");
 
@@ -123,47 +133,133 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             await stream.WriteAsync(JsonRecordDelimiter, token);
         }
 
-        private static async Task WriteText(Stream stream, IEnumerable<IExceptionInstance> instances, CancellationToken token)
+        private static async Task WriteText(Stream stream, IReadOnlyList<IExceptionInstance> instances, CancellationToken token)
         {
-            foreach (IExceptionInstance instance in instances)
+            Dictionary<ulong, IExceptionInstance> priorInstances = new(instances.Count);
+            foreach (IExceptionInstance currentInstance in instances)
             {
-                await WriteTextInstance(stream, instance, token);
+                // Skip writing the exception if it does not have a call stack, which
+                // indicates that the exception was not thrown. It is likely to be referenced
+                // as an inner exception of a thrown exception.
+                if (currentInstance.CallStack?.Frames.Count != 0)
+                {
+                    await WriteTextInstance(stream, currentInstance, priorInstances, token);
+                }
+                priorInstances.Add(currentInstance.Id, currentInstance);
             }
         }
 
-        private static async Task WriteTextInstance(Stream stream, IExceptionInstance instance, CancellationToken token)
+        private static async Task WriteTextInstance(
+            Stream stream,
+            IExceptionInstance currentInstance,
+            IDictionary<ulong, IExceptionInstance> priorInstances,
+            CancellationToken token)
         {
             // This format is similar of that which is written to the console when an unhandled exception occurs. Each
             // exception will appear as:
 
-            // First chance exception. <TypeName>: <Message>
-            //   at Class.Method
+            // First chance exception at <TimeStamp>
+            // <TypeName>: <Message>
+            //  ---> <InnerExceptionTypeName>: <InnerExceptionMessage>
+            //   at <StackFrameClass>.<StackFrameMethod>(<ParameterType1>, <ParameterType2>, ...)
+            //   --- End of inner exception stack trace ---
+            //   at <StackFrameClass>.<StackFrameMethod>(<ParameterType1>, <ParameterType2>, ...)
 
             await using StreamWriter writer = new(stream, leaveOpen: true);
 
-            await writer.WriteLineAsync(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    Strings.OutputFormatString_FirstChanceException,
-                    instance.TypeName,
-                    instance.Message));
+            await writer.WriteAsync("First chance exception at ");
+            await writer.WriteAsync(currentInstance.Timestamp.ToString("O", CultureInfo.InvariantCulture));
 
-            if (instance.CallStack != null)
-            {
-                foreach (CallStackFrame frame in instance.CallStack.Frames)
-                {
-                    await writer.WriteLineAsync(
-                        string.Format(
-                            CultureInfo.InvariantCulture,
-                            Strings.OutputFormatString_FirstChanceExceptionStackFrame,
-                            frame.ClassName,
-                            frame.MethodName));
-                }
-            }
+            await writer.WriteLineAsync();
+            await WriteTextExceptionFormat(writer, currentInstance);
 
+            await WriteTextInnerExceptionsAndStackFrames(writer, currentInstance, priorInstances);
+
+            await writer.WriteLineAsync();
             await writer.WriteLineAsync();
 
             await writer.FlushAsync();
+        }
+
+        // Writes the inner exceptions and stack frames of the current exception:
+        // - The primary inner exception is written with a separator message.
+        // - The call stack frames are written for the current exception
+        // - The remaining inner exceptions are written with their inner exception index
+        // The above fits the format of inner exception and call stack information reported
+        // by AggregateException instances.
+        private static async Task WriteTextInnerExceptionsAndStackFrames(TextWriter writer, IExceptionInstance currentInstance, IDictionary<ulong, IExceptionInstance> priorInstances)
+        {
+            if (currentInstance.InnerExceptionIds?.Length > 0)
+            {
+                if (priorInstances.TryGetValue(
+                        currentInstance.InnerExceptionIds[0],
+                        out IExceptionInstance primaryInnerInstance))
+                {
+                    await WriteTextInnerException(writer, primaryInnerInstance, 0, priorInstances);
+
+                    await writer.WriteLineAsync();
+                    await writer.WriteAsync("   --- End of inner exception stack trace ---");
+                }
+            }
+
+            if (null != currentInstance.CallStack)
+            {
+                foreach (CallStackFrame frame in currentInstance.CallStack.Frames)
+                {
+                    await writer.WriteLineAsync();
+                    await writer.WriteAsync("   at ");
+                    await writer.WriteAsync(frame.ClassName);
+                    await writer.WriteAsync(".");
+                    await writer.WriteAsync(frame.MethodName);
+                }
+            }
+
+            if (currentInstance.InnerExceptionIds?.Length > 1)
+            {
+                for (int index = 1; index < currentInstance.InnerExceptionIds.Length; index++)
+                {
+                    if (priorInstances.TryGetValue(
+                        currentInstance.InnerExceptionIds[index],
+                        out IExceptionInstance secondaryInnerInstance))
+                    {
+                        await WriteTextInnerException(writer, secondaryInnerInstance, index, priorInstances);
+                    }
+                }
+            }
+        }
+
+        // Writes the specified exception as an inner exception with the appropriate delimiters.
+        private static async Task WriteTextInnerException(TextWriter writer, IExceptionInstance currentInstance, int currentIndex, IDictionary<ulong, IExceptionInstance> priorInstances)
+        {
+            await writer.WriteLineAsync();
+            await writer.WriteAsync(" ---> ");
+
+            if (0 < currentIndex)
+            {
+                await writer.WriteAsync("(Inner Exception #");
+                await writer.WriteAsync(currentIndex.ToString("D", CultureInfo.InvariantCulture));
+                await writer.WriteAsync(") ");
+            }
+
+            await WriteTextExceptionFormat(writer, currentInstance);
+
+            await WriteTextInnerExceptionsAndStackFrames(writer, currentInstance, priorInstances);
+
+            if (0 < currentIndex)
+            {
+                await writer.WriteAsync("<---");
+            }
+        }
+
+        // Writes the basic exception information, namely the type and message
+        private static async Task WriteTextExceptionFormat(TextWriter writer, IExceptionInstance instance)
+        {
+            await writer.WriteAsync(instance.TypeName);
+            if (!string.IsNullOrEmpty(instance.Message))
+            {
+                await writer.WriteAsync(": ");
+                await writer.WriteAsync(instance.Message);
+            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1430,24 +1430,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to First chance exception. {0}: {1}.
-        /// </summary>
-        internal static string OutputFormatString_FirstChanceException {
-            get {
-                return ResourceManager.GetString("OutputFormatString_FirstChanceException", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to   at {0}.{1}.
-        /// </summary>
-        internal static string OutputFormatString_FirstChanceExceptionStackFrame {
-            get {
-                return ResourceManager.GetString("OutputFormatString_FirstChanceExceptionStackFrame", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to :NOT PRESENT:.
         /// </summary>
         internal static string Placeholder_NotPresent {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -164,8 +164,9 @@
     <comment>Gets a string similar to "File system egress failed.".</comment>
   </data>
   <data name="ErrorMessage_EgressMissingCredentials" xml:space="preserve">
-      <value>SharedAccessSignature, AccountKey, ManagedIdentityClientId, or UseWorkloadIdentityFromEnvironment must be specified.</value>
-      <comment>Gets a string similar to "SharedAccessSignature, AccountKey, ManagedIdentityClientId, or UseWorkflowIdentity must be specified.".</comment>  </data>
+    <value>SharedAccessSignature, AccountKey, ManagedIdentityClientId, or UseWorkloadIdentityFromEnvironment must be specified.</value>
+    <comment>Gets a string similar to "SharedAccessSignature, AccountKey, ManagedIdentityClientId, or UseWorkflowIdentity must be specified.".</comment>
+  </data>
   <data name="ErrorMessage_EgressProviderDoesNotExist" xml:space="preserve">
     <value>Egress provider '{0}' does not exist.</value>
     <comment>Gets the format string for egress provider failure due to missing provider.
@@ -796,16 +797,6 @@
   <data name="Message_ShowSources" xml:space="preserve">
     <value>Configuration Providers (High to Low Priority):</value>
     <comment>Gets the string for displaying the configuration providers with the --show-sources flag.</comment>
-  </data>
-  <data name="OutputFormatString_FirstChanceException" xml:space="preserve">
-    <value>First chance exception. {0}: {1}</value>
-    <comment>{0} = Exception type name
-{1} = Exception message</comment>
-  </data>
-  <data name="OutputFormatString_FirstChanceExceptionStackFrame" xml:space="preserve">
-    <value>  at {0}.{1}</value>
-    <comment>{0} = class name
-{1} = method name</comment>
   </data>
   <data name="Placeholder_NotPresent" xml:space="preserve">
     <value>:NOT PRESENT:</value>


### PR DESCRIPTION
Writes the inner exception information to the `/exceptions` route in the format as provided by the `AggregateException` class.

Example code generating exceptions:

```cs
List<Exception> innerInnerExceptions = new(2);

innerInnerExceptions.Add(new InvalidOperationException());
innerInnerExceptions.Add(new ArgumentException());

List<Exception> innerExceptions = new(3);
innerExceptions.Add(new AggregateException(innerInnerExceptions));
try
{
    throw new FormatException();
}
catch (Exception ex)
{
    innerExceptions.Add(ex);
}
innerExceptions.Add(new TaskCanceledException());

throw new AggregateException(innerExceptions);
```

For `text/plain`, only thrown exceptions are written at the top-level; the remaining unthrown exceptions are written inline with the thrown exceptions.

Example `text/plain` output:

```text
First chance exception at 2023-06-21T20:12:10.5579188Z
System.FormatException: One of the identified items was in an invalid format.
   at ConsoleApp3.Program.Main

First chance exception at 2023-06-21T20:12:10.5770948Z
System.AggregateException: One or more errors occurred. (One or more errors occurred. (Operation is not valid due to the current state of the object.) (Value does not fall within the expected range.)) (One of the identified items was in an invalid format.) (A task was canceled.)
 ---> System.AggregateException: One or more errors occurred. (Operation is not valid due to the current state of the object.) (Value does not fall within the expected range.)
 ---> System.InvalidOperationException: Operation is not valid due to the current state of the object.
   --- End of inner exception stack trace ---
 ---> (Inner Exception #1) System.ArgumentException: Value does not fall within the expected range.<---
   --- End of inner exception stack trace ---
   at ConsoleApp3.Program.Main
 ---> (Inner Exception #1) System.FormatException: One of the identified items was in an invalid format.
   at ConsoleApp3.Program.Main<---
 ---> (Inner Exception #2) System.Threading.Tasks.TaskCanceledException: A task was canceled.<---
```

For `application/x-ndjson`, all exceptions are written as top-level JSON objects; the inner exceptions are only referenced by ID. Note that the `innerExceptions` property is an array of JSON objects where each object has a singular `id` property on it.

Example `application/x-ndjson` output:

```json
{"id":2,"timestamp":"2023-06-21T19:45:37.7038942Z","typeName":"System.FormatException","moduleName":"System.Private.CoreLib.dll","message":"One of the identified items was in an invalid format.","callStack":{"threadId":34528,"threadName":null,"innerExceptions":[],"frames":[{"methodName":"Main","className":"ConsoleApp3.Program","moduleName":"ConsoleApp3.dll"}]}}
{"id":3,"timestamp":"2023-06-21T19:45:37.7224585Z","typeName":"System.InvalidOperationException","moduleName":"System.Private.CoreLib.dll","message":"Operation is not valid due to the current state of the object.","callStack":{"threadId":34528,"threadName":null,"innerExceptions":[],"frames":[]}}
{"id":4,"timestamp":"2023-06-21T19:45:37.7224585Z","typeName":"System.ArgumentException","moduleName":"System.Private.CoreLib.dll","message":"Value does not fall within the expected range.","callStack":{"threadId":34528,"threadName":null,"innerExceptions":[],"frames":[]}}
{"id":5,"timestamp":"2023-06-21T19:45:37.7224585Z","typeName":"System.AggregateException","moduleName":"System.Private.CoreLib.dll","message":"One or more errors occurred. (Operation is not valid due to the current state of the object.) (Value does not fall within the expected range.)","callStack":{"threadId":34528,"threadName":null,"innerExceptions":[{"id":3},{"id":4}],"frames":[]}}
{"id":6,"timestamp":"2023-06-21T19:45:37.7224585Z","typeName":"System.Threading.Tasks.TaskCanceledException","moduleName":"System.Private.CoreLib.dll","message":"A task was canceled.","callStack":{"threadId":34528,"threadName":null,"innerExceptions":[],"frames":[]}}
{"id":7,"timestamp":"2023-06-21T19:45:37.7224585Z","typeName":"System.AggregateException","moduleName":"System.Private.CoreLib.dll","message":"One or more errors occurred. (One or more errors occurred. (Operation is not valid due to the current state of the object.) (Value does not fall within the expected range.)) (One of the identified items was in an invalid format.) (A task was canceled.)","callStack":{"threadId":34528,"threadName":null,"innerExceptions":[{"id":5},{"id":2},{"id":6}],"frames":[{"methodName":"Main","className":"ConsoleApp3.Program","moduleName":"ConsoleApp3.dll"}]}}
```

Lastly, I've removed the format strings and have the text output write directly to the stream. The runtime doesn't localize any of this information (it's written directly to the console via ToString calls on the exception instance; .NET Monitor shouldn't have to localize the textual information either. This also should speed up exception reporting a little bit since there is very minimal formatting that needs to occur.