### PR TITLE
Move Microsoft.Extensions versions to TFM specific dependabot props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -91,15 +91,30 @@
          project references for command line builds. They should match the values in the diagnostics repo. -->
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
-    <MicrosoftExtensionsLoggingVersion>7.0.0</MicrosoftExtensionsLoggingVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET 6 Dependent" Condition=" '$(TargetFramework)' == 'net6.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions60Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging60Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions60Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole60Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftExtensionsLoggingEventSource60Version)</MicrosoftExtensionsLoggingEventSourceVersion>
+  </PropertyGroup>
+  <PropertyGroup Label=".NET 7 Dependent" Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions70Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging70Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole70Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftExtensionsLoggingEventSource70Version)</MicrosoftExtensionsLoggingEventSourceVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingEventSourceVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">
     <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,6 +92,18 @@
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      This property sets a baseline version for packages produced by the dotnet/runtime repository such that
+      the value is the same as that in the SDK OR OLDER. This property can be used for packages that ship as
+      part of the corresponding framework; this allows those packages to be referenced but not copied to the
+      output directory since the ref pack from the SDK should be the same version or newer (this causes a package
+      version conflict and will result in the framework reference winning; since it is part of the framework,
+      the assembly is not copied to the output directory). However, this cause the NuGet package dependency
+      for any NuGet packages that are created have this as the minimum version.
+      -->
+    <MicrosoftNETCoreApp80VersionFromSdk>8.0.0-preview.5.23280.8</MicrosoftNETCoreApp80VersionFromSdk>
+  </PropertyGroup>
   <PropertyGroup Label=".NET 6 Dependent" Condition=" '$(TargetFramework)' == 'net6.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
@@ -110,11 +122,11 @@
   <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
-    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingEventSourceVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingEventSourceVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">
     <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -14,10 +14,6 @@
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="$(MicrosoftOpenApiReadersVersion)" />
     <PackageReference Include="Microsoft.Identity.Web" Version="$(MicrosoftIdentityWebVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelTokensVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSourceVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />
 
     <!-- Third-party references -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/eng/dependabot/Versions.props
+++ b/eng/dependabot/Versions.props
@@ -5,11 +5,6 @@
     <AzureIdentityVersion>1.9.0</AzureIdentityVersion>
     <AzureStorageBlobsVersion>12.16.0</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.14.0</AzureStorageQueuesVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>7.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationKeyPerFileVersion>7.0.0</MicrosoftExtensionsConfigurationKeyPerFileVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>7.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>7.0.0</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>7.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftIdentityModelTokensVersion>6.31.0</MicrosoftIdentityModelTokensVersion>
     <MicrosoftIdentityWebVersion>2.12.4</MicrosoftIdentityWebVersion>
     <MicrosoftOpenApiReadersVersion>1.6.5</MicrosoftOpenApiReadersVersion>

--- a/eng/dependabot/net6.0/Packages.props
+++ b/eng/dependabot/net6.0/Packages.props
@@ -3,6 +3,11 @@
     Packages in this file have versions updated periodically by Dependabot specifically for .NET 6.
   -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions60Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging60Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions60Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsole60Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSource60Version)" />
     <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp60Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net6.0/Versions.props
+++ b/eng/dependabot/net6.0/Versions.props
@@ -1,6 +1,17 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
+    <!-- Microsoft.Extensions.Configuration.Abstractions -->
+    <MicrosoftExtensionsConfigurationAbstractions60Version>6.0.0</MicrosoftExtensionsConfigurationAbstractions60Version>
+    <!-- Microsoft.Extensions.Logging -->
+    <MicrosoftExtensionsLogging60Version>6.0.0</MicrosoftExtensionsLogging60Version>
+    <!-- Microsoft.Extensions.Logging.Abstractions -->
+    <MicrosoftExtensionsLoggingAbstractions60Version>6.0.4</MicrosoftExtensionsLoggingAbstractions60Version>
+    <!-- Microsoft.Extensions.Logging.Console -->
+    <MicrosoftExtensionsLoggingConsole60Version>6.0.0</MicrosoftExtensionsLoggingConsole60Version>
+    <!-- Microsoft.Extensions.Logging.EventSource -->
+    <MicrosoftExtensionsLoggingEventSource60Version>6.0.0</MicrosoftExtensionsLoggingEventSource60Version>
+    <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp60Version>6.0.18</MicrosoftNETCoreApp60Version>
   </PropertyGroup>
 </Project>

--- a/eng/dependabot/net7.0/Packages.props
+++ b/eng/dependabot/net7.0/Packages.props
@@ -3,6 +3,10 @@
     Packages in this file have versions updated periodically by Dependabot specifically for .NET 7.
   -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions70Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging70Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsole70Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSource70Version)" />
     <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp70Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net7.0/Versions.props
+++ b/eng/dependabot/net7.0/Versions.props
@@ -1,6 +1,15 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
+    <!-- Microsoft.Extensions.Configuration.Abstractions -->
+    <MicrosoftExtensionsConfigurationAbstractions70Version>7.0.0</MicrosoftExtensionsConfigurationAbstractions70Version>
+    <!-- Microsoft.Extensions.Logging -->
+    <MicrosoftExtensionsLogging70Version>7.0.0</MicrosoftExtensionsLogging70Version>
+    <!-- Microsoft.Extensions.Logging.Console -->
+    <MicrosoftExtensionsLoggingConsole70Version>7.0.0</MicrosoftExtensionsLoggingConsole70Version>
+    <!-- Microsoft.Extensions.Logging.EventSource -->
+    <MicrosoftExtensionsLoggingEventSource70Version>7.0.0</MicrosoftExtensionsLoggingEventSource70Version>
+    <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp70Version>7.0.7</MicrosoftNETCoreApp70Version>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/EgressHelper.cs
@@ -129,7 +129,9 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.Common
             // dependency injection.
             services.TryAddSingleton<EgressProvider<TOptions>, TProvider>();
 
+#if NET7_0_OR_GREATER
             services.MakeReadOnly();
+#endif
 
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(SchemaTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(SchemaTargetFramework)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SCHEMAGEN</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSourceVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
###### Summary

Split the `Microsoft.Extensions.*` package versions along their corresponding .NET runtime versions. Have each project only reference the `Microsoft.Extensions.*` assembly version that corresponds with the TFM.

###### Background

The `dotnet/installer` updates started failing because a type was moved from `Microsoft.Extensions.Logging` to `Microsoft.Extensions.Logging.Abstractions`. The referenced version of `Microsoft.Extensions.Logging` was set to 7.0.0 which means that when `Microsoft.Extensions.Logging` 7.0.0 is used in concert with `Microsoft.Extensions.Logging.Abstractions` 8.0.0, ambiguous type references would occur.

To solve this, I've split all of the `Microsoft.Extensions.*` versions along their corresponding .NET runtime versions. Thus, the 6.0.*, 7.0.*, and 8.0.* lines of these assemblies are versioned independently. These versions are then conditionally included based on the target framework version of the built project. This allows the projects to include the extension assemblies that correspond with their built TFM and the entire assembly list for the extension assemblies is self consistent within the major version.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
