### PR TITLE
Use embedded WebApi documentation file for OpenApi XML comments

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,6 +11,9 @@
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
 
+  <Target Name="GetDocumentationFile"
+          Returns="@(DocFileItem)" />
+
   <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
   <Target Name="GenerateArchivePackageProjectFiles"
           AfterTargets="_CreateArchive"

--- a/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
@@ -10,6 +10,8 @@ using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.IO;
+using System.Reflection;
+using System.Xml.XPath;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Swagger
 {
@@ -27,8 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger
             options.OperationFilter<UnauthorizedResponseOperationFilter>();
 
             string documentationFile = $"{typeof(DiagController).Assembly.GetName().Name}.xml";
-            string documentationPath = Path.Combine(AppContext.BaseDirectory, documentationFile);
-            options.IncludeXmlComments(documentationPath);
+            options.IncludeXmlComments(() => new XPathDocument(Assembly.GetExecutingAssembly().GetManifestResourceStream(documentationFile)));
         }
 
         public static void AddBearerTokenAuthOption(this SwaggerGenOptions options, string securityDefinitionName)

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -57,6 +57,23 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <Target Name="EmbedWebApiXmlDocumentation"
+          DependsOnTargets="ResolveAssemblyReferences"
+          BeforeTargets="AssignTargetPaths">
+    <MSBuild Projects="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Microsoft.Diagnostics.Monitoring.WebApi.csproj"
+             Properties="TargetFramework=$(TargetFramework)"
+             RemoveProperties="RuntimeIdentifier"
+             Targets="GetDocumentationFile">
+      <Output ItemName="_WebApiDocumentationFiles" TaskParameter="TargetOutputs" />
+    </MSBuild>
+    <!-- Add the WebApi documentation file as an embedded resource. -->
+    <ItemGroup>
+      <EmbeddedResource Include="@(_WebApiDocumentationFiles)">
+        <LogicalName>%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
   <!-- Targets and properties for ensuring publish before pack. -->
   <Import Project="$(RepoRoot)src\Microsoft.Diagnostics.Monitoring.StartupHook\ProjectsToPublish.props" />
   <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />


### PR DESCRIPTION
###### Summary

The single file bundle experiment is unable to server HTTP requests because the Swagger configuration expects the WebApi XML documentation file to be next to the running executable; this file doesn't exist in the single file bundle mode.

This change embeds the XML documentation file into the dotnet-monitor assembly and updates the Swagger configuration to get the manifest resource instead of the file on disk.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
