### PR TITLE
Remove targeting pack and Microsoft.Extensions.Logging.EventSource versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,18 +92,6 @@
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <!--
-      This property sets a baseline version for packages produced by the dotnet/runtime repository such that
-      the value is the same as that in the SDK OR OLDER. This property can be used for packages that ship as
-      part of the corresponding framework; this allows those packages to be referenced but not copied to the
-      output directory since the ref pack from the SDK should be the same version or newer (this causes a package
-      version conflict and will result in the framework reference winning; since it is part of the framework,
-      the assembly is not copied to the output directory). However, this cause the NuGet package dependency
-      for any NuGet packages that are created have this as the minimum version.
-      -->
-    <MicrosoftNETCoreApp80VersionFromSdk>8.0.0-preview.5.23280.8</MicrosoftNETCoreApp80VersionFromSdk>
-  </PropertyGroup>
   <PropertyGroup Label=".NET 6 Dependent" Condition=" '$(TargetFramework)' == 'net6.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp60Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
@@ -111,22 +99,19 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging60Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions60Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole60Version)</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftExtensionsLoggingEventSource60Version)</MicrosoftExtensionsLoggingEventSourceVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET 7 Dependent" Condition=" '$(TargetFramework)' == 'net7.0' ">
     <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions70Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging70Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole70Version)</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftExtensionsLoggingEventSource70Version)</MicrosoftExtensionsLoggingEventSourceVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
-    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingEventSourceVersion>$(MicrosoftNETCoreApp80VersionFromSdk)</MicrosoftExtensionsLoggingEventSourceVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingConsoleVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">
     <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>

--- a/eng/dependabot/net6.0/Packages.props
+++ b/eng/dependabot/net6.0/Packages.props
@@ -7,7 +7,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging60Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions60Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsole60Version)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSource60Version)" />
     <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp60Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net6.0/Versions.props
+++ b/eng/dependabot/net6.0/Versions.props
@@ -9,8 +9,6 @@
     <MicrosoftExtensionsLoggingAbstractions60Version>6.0.4</MicrosoftExtensionsLoggingAbstractions60Version>
     <!-- Microsoft.Extensions.Logging.Console -->
     <MicrosoftExtensionsLoggingConsole60Version>6.0.0</MicrosoftExtensionsLoggingConsole60Version>
-    <!-- Microsoft.Extensions.Logging.EventSource -->
-    <MicrosoftExtensionsLoggingEventSource60Version>6.0.0</MicrosoftExtensionsLoggingEventSource60Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp60Version>6.0.18</MicrosoftNETCoreApp60Version>
   </PropertyGroup>

--- a/eng/dependabot/net7.0/Packages.props
+++ b/eng/dependabot/net7.0/Packages.props
@@ -6,7 +6,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions70Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging70Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsole70Version)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSource70Version)" />
     <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp70Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net7.0/Versions.props
+++ b/eng/dependabot/net7.0/Versions.props
@@ -7,8 +7,6 @@
     <MicrosoftExtensionsLogging70Version>7.0.0</MicrosoftExtensionsLogging70Version>
     <!-- Microsoft.Extensions.Logging.Console -->
     <MicrosoftExtensionsLoggingConsole70Version>7.0.0</MicrosoftExtensionsLoggingConsole70Version>
-    <!-- Microsoft.Extensions.Logging.EventSource -->
-    <MicrosoftExtensionsLoggingEventSource70Version>7.0.0</MicrosoftExtensionsLoggingEventSource70Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp70Version>7.0.7</MicrosoftNETCoreApp70Version>
   </PropertyGroup>


### PR DESCRIPTION
###### Summary

Remove the target pack fallback version so that the Microsoft.Extensions.* packages are consistent with the test runtimes. Also remove the unused Microsoft.Extensions.Logging.EventSource version.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
