### PR TITLE
Generate schema based on .NET 6 types

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -2416,10 +2416,6 @@
         "Indented": {
           "type": "boolean"
         },
-        "MaxDepth": {
-          "type": "integer",
-          "format": "int32"
-        },
         "SkipValidation": {
           "type": "boolean"
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class SchemaGenerationTests
     {
         private readonly ITestOutputHelper _outputHelper;
@@ -31,7 +32,10 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
         private const string SchemaGeneratorName = "Microsoft.Diagnostics.Monitoring.ConfigurationSchema";
 
         private static readonly string SchemaGeneratorPath =
-            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), SchemaGeneratorName);
+            AssemblyHelper.GetAssemblyArtifactBinPath(
+                Assembly.GetExecutingAssembly(),
+                SchemaGeneratorName,
+                TargetFrameworkMoniker.Net60);
 
         public SchemaGenerationTests(ITestOutputHelper outputHelper)
         {


### PR DESCRIPTION
###### Summary

Schema generation test is failing due to change in Microsoft.Extension library version usage. This was not caught in PR because the test was never run in PR.

The schema is not generated with .NET 6 types since that is a subset of the available schema for .NET 6 and .NET 8 variants of the tool within the same package. The test has been updated to execute for each testing target framework (thus it will run in PR) but only invoke the schema generation tool for .NET 6.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
