### PR TITLE
Use ApplyStartupHook diagnostic command in exceptions pipeline tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointInfoSourceCallback.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointInfoSourceCallback.cs
@@ -3,12 +3,15 @@
 
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Monitor;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon
@@ -35,9 +38,14 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         private readonly SemaphoreSlim _removedEndpointEntriesSemaphore = new(1);
         private readonly List<CompletionEntry> _removedEndpointEntries = new();
 
-        public EndpointInfoSourceCallback(ITestOutputHelper outputHelper)
+        // Path to a startup hook assembly that will be applied to the target runtime
+        // before it is resumed.
+        private readonly string _startupHookPath;
+
+        public EndpointInfoSourceCallback(ITestOutputHelper outputHelper, string startupHookPath = null)
         {
             _outputHelper = outputHelper;
+            _startupHookPath = startupHookPath;
         }
 
         public Task<IEndpointInfo> WaitAddedEndpointInfoAsync(AppRunner runner, TimeSpan timeout)
@@ -62,9 +70,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 timeout);
         }
 
-        public virtual Task OnBeforeResumeAsync(IEndpointInfo endpointInfo, CancellationToken token)
+        public virtual async Task OnBeforeResumeAsync(IEndpointInfo endpointInfo, CancellationToken token)
         {
-            return Task.CompletedTask;
+            if (endpointInfo.RuntimeVersion.Major >= 8 && !string.IsNullOrEmpty(_startupHookPath))
+            {
+                await ApplyStartupHookAsync(new DiagnosticsClient(endpointInfo.ProcessId), _startupHookPath, token);
+            }
         }
 
         public Task OnAddedEndpointInfoAsync(IEndpointInfo info, CancellationToken token)
@@ -87,6 +98,19 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 _outputHelper,
                 info,
                 token);
+        }
+
+        private static Task ApplyStartupHookAsync(DiagnosticsClient client, string path, CancellationToken token)
+        {
+            // DiagnosticsClient.ApplyStartupHookAsync currently is not public
+            MethodBase applyStartupHookAsync =
+                typeof(DiagnosticsClient).GetMethod(
+                    "ApplyStartupHookAsync",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.NotNull(applyStartupHookAsync);
+
+            return (Task)applyStartupHookAsync.Invoke(client, new object[] { path, token });
         }
 
         private static async Task<IEndpointInfo> WaitForCompletionAsync(string operation, SemaphoreSlim semaphore, List<CompletionEntry> entries, ITestOutputHelper outputHelper, AppRunner runner, TimeSpan timeout)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         private ITestOutputHelper _outputHelper;
         private readonly EndpointUtilities _endpointUtilities;
 
+        // Startup hook assembly is only built for net6.0 and should be forward compatible
+        private static string StartupHookPath => AssemblyHelper.GetAssemblyArtifactBinPath(
+            Assembly.GetExecutingAssembly(),
+            "Microsoft.Diagnostics.Monitoring.StartupHook",
+            TargetFrameworkMoniker.Net60);
+
         public ExceptionsPipelineTests(ITestOutputHelper outputHelper)
         {
             _outputHelper = outputHelper;
@@ -420,7 +426,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Action<IEnumerable<IExceptionInstance>> validate,
             Architecture? architecture = null)
         {
-            EndpointInfoSourceCallback callback = new(_outputHelper);
+            string startupHookPathForCallback = null;
+#if NET8_0_OR_GREATER
+            // Starting in .NET 8, the startup hook can be applied dynamically via DiagnosticsClient.
+            startupHookPathForCallback = StartupHookPath;
+#endif
+            EndpointInfoSourceCallback callback = new(_outputHelper, startupHookPathForCallback);
             await using ServerSourceHolder sourceHolder = await _endpointUtilities.StartServerAsync(callback);
 
             await using AppRunner runner = _endpointUtilities.CreateAppRunner(
@@ -430,7 +441,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             runner.Architecture = architecture;
             runner.ScenarioName = TestAppScenarios.Exceptions.Name + " " + subScenarioName;
 
-            AddStartupHookEnvironmentVariable(runner);
+#if !NET8_0_OR_GREATER
+            // Runtimes lower than .NET 8 will require setting the startup hook environment variable explicitly.
+            runner.Environment.Add(ToolIdentifiers.EnvironmentVariables.StartupHooks, StartupHookPath);
+#endif
 
             Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
@@ -468,17 +482,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.Equal(expectedModuleName, stack.Frames[0].ModuleName);
             Assert.Equal(expectedClassName, stack.Frames[0].ClassName);
             Assert.Equal(expectedParameterTypes ?? new List<string>(), stack.Frames[0].ParameterTypes);
-        }
-
-        private static void AddStartupHookEnvironmentVariable(AppRunner runner)
-        {
-            // Startup hook assembly is only built for net6.0 and should be forward compatible
-            string startupHookPath = AssemblyHelper.GetAssemblyArtifactBinPath(
-                Assembly.GetExecutingAssembly(),
-                "Microsoft.Diagnostics.Monitoring.StartupHook",
-                TargetFrameworkMoniker.Net60);
-
-            runner.Environment.Add(ToolIdentifiers.EnvironmentVariables.StartupHooks, startupHookPath);
         }
 
         private sealed class TestExceptionsStore : IExceptionsStore


### PR DESCRIPTION
###### Summary

Make use of `DiagnosticsClient.ApplyStartupHookAsync` in the exceptions pipeline tests for .NET 8+ targets instead of using the `DOTNET_STARTUP_HOOKS` environment variable.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
