### PR TITLE
Fix update-docker tag workflow

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -131,4 +131,8 @@ stages:
 # This sets up the bits to do a Release.
 - template: /eng/pipelines/stages/preparerelease.yml
   parameters:
-    updateDocker: ${{ parameters.updateDocker }}
+    ${{ if eq(parameters.updateDocker, 'true') }}:
+      updateDockerCondition: true
+    ${{ else }}:
+      # If scheduled build from main and nightly update from main enabled
+      updateDockerCondition: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['NightlyUpdateDockerFromMain'], 'true'))

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: updateDockerCondition
+  type: string
+  default: false
+
 stages:
 - stage: StageBuildAssetsStage
   displayName: Stage Build Assets


### PR DESCRIPTION
###### Summary

The update docker tag workflow wasn't ported back from main. This manually ports the latest changes so builds can kick off docker updates.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
