### PR TITLE
Profiler runtime identifier fallback algorithm

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
         public int AppId { get; }
 
-        public bool SetRuntimeIdentifier { get; set; } = true;
+        public bool SetRuntimeIdentifier { get; set; }
 
         public string ProfilerLogLevel { get; set; }
 

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -105,7 +105,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         ExtensionNotOfType = 93,
         ExtensionManifestNotParsable = 94,
         ExtensionMalformedOutput = 95,
-        EgressProviderTypeNotExist = 96
+        EgressProviderTypeNotExist = 96,
+        ProfilerRuntimeIdentifier = 97
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -494,6 +494,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_EgressProviderTypeNotExist);
 
+        private static readonly Action<ILogger, string, Exception> _profilerRuntimeIdentifier =
+            LoggerMessage.Define<string>(
+                eventId: LoggingEventIds.ProfilerRuntimeIdentifier.EventId(),
+                logLevel: LogLevel.Debug,
+                formatString: Strings.LogFormatString_ProfilerRuntimeIdentifier);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -907,6 +913,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void EgressProviderTypeNotExist(this ILogger logger, string providerType)
         {
             _egressProviderTypeNotExist(logger, providerType, null);
+        }
+
+        public static void ProfilerRuntimeIdentifier(this ILogger logger, string runtimeIdentifier)
+        {
+            _profilerRuntimeIdentifier(logger, runtimeIdentifier, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1385,6 +1385,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using &apos;{runtimeIdentifier}&apos; runtime identifier for profiler enablement..
+        /// </summary>
+        internal static string LogFormatString_ProfilerRuntimeIdentifier {
+            get {
+                return ResourceManager.GetString("LogFormatString_ProfilerRuntimeIdentifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The queue {0} does not exist; ensure that the {queueName} and {queueAccountUri} fields are set correctly..
         /// </summary>
         internal static string LogFormatString_QueueDoesNotExist {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -906,4 +906,7 @@
 0. providerName: The name of the provider that failed validation.
 1. errorMessage: The validation failure message</comment>
   </data>
+  <data name="LogFormatString_ProfilerRuntimeIdentifier" xml:space="preserve">
+    <value>Using '{runtimeIdentifier}' runtime identifier for profiler enablement.</value>
+  </data>
 </root>


### PR DESCRIPTION
###### Summary

Implement a fallback algorithm for the profiler runtime identifier so that specifying the identifier on the target process is not unconditionally required. This should allow .NET Monitor to detect the runtime identifier if its running in the same process namespace as the target process; it might also work across process namespace boundaries but will require further testing to confirm.

To validate this, I've removed the default setting of the runtime identifier on the target process in tests; any test involving .NET Monitor and the profiler in the target application should now be using the fallback algorithm.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Make best effort to dynamically determine portable runtime identifier without explicit setting.