### PR TITLE
Enable more tests to run in PR

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/FileSystemEgressExtensionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/FileSystemEgressExtensionTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class FileSystemEgressExtensionTests
     {
         const string ProviderName = "TestProvider";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/InProcessFeaturesOptionsBinderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/InProcessFeaturesOptionsBinderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.Options;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
@@ -9,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class InProcessFeaturesOptionsBinderTests
     {
         private const string FeatureConfigurationKey = "InProcessFeatures:TestFeature";
@@ -184,58 +186,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 {
                     { ConfigurationKeys.InProcessFeatures_Enabled, "false" },
                     { FeatureEnabledConfigurationKey, "true" }
-                })
-                .Build();
-
-            TestFeatureOptions options = new();
-
-            InProcessFeatureOptionsBinder.BindEnabled(
-                options,
-                FeatureConfigurationKey,
-                configurationRoot,
-                enabledByDefault: true);
-
-            Assert.True(options.Enabled.HasValue);
-            Assert.False(options.Enabled.Value);
-        }
-
-        /// <summary>
-        /// Tests that a feature is enabled if InProcessFeatures:<Feature> is true.
-        /// </summary>
-        [Fact]
-        public void InProcessFeaturesOptionsBinder_BindEnabled_EnabledSection()
-        {
-            IConfigurationRoot configurationRoot = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>()
-                {
-                    { FeatureConfigurationKey, "true" }
-                })
-                .Build();
-
-            TestFeatureOptions options = new();
-
-            InProcessFeatureOptionsBinder.BindEnabled(
-                options,
-                FeatureConfigurationKey,
-                configurationRoot,
-                enabledByDefault: true);
-
-            Assert.True(options.Enabled.HasValue);
-            Assert.True(options.Enabled.Value);
-        }
-
-        /// <summary>
-        /// Tests that a feature is disabled if InProcessFeatures:<Feature> is true
-        /// and InProcessFeatures:Enabled is false.
-        /// </summary>
-        [Fact]
-        public void InProcessFeaturesOptionsBinder_BindEnabled_EnabledSectionDisabledFeatures()
-        {
-            IConfigurationRoot configurationRoot = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>()
-                {
-                    { ConfigurationKeys.InProcessFeatures_Enabled, "false" },
-                    { FeatureConfigurationKey, "true" }
                 })
                 .Build();
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;
 using System;
@@ -14,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class MetricsFormattingTests
     {
         private ITestOutputHelper _outputHelper;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsSettingsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsSettingsTests.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class MetricsSettingsTests
     {
         private readonly ITestOutputHelper _outputHelper;


### PR DESCRIPTION
###### Summary

A couple of test classes are missing the TargetFrameworkMonikerTrait attribute, so they don't get run in PR. Added the attribute to the tests that are missing them and removed two tests that should have been removed in the last commit of #4764

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
