### PR TITLE
Implement `--exit-on-stdin-disconnect` flag for dotnet-monitor collect

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -4,6 +4,7 @@
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -18,6 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
     /// <summary>
     /// Runner for running the unit test application.
     /// </summary>
+    [DebuggerDisplay(@"\{AppRunner:{_runner.StateForDebuggerDisplay,nq}\}")]
     public sealed class AppRunner : IAsyncDisposable
     {
         private readonly LoggingRunnerAdapter _adapter;
@@ -71,6 +73,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
         public int ExitCode => _adapter.ExitCode;
 
+        public bool HasExited => _adapter.HasExited;
+
         public Task<int> ProcessIdTask => _adapter.ProcessIdTask;
 
         /// <summary>
@@ -117,7 +121,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             _runner.Dispose();
         }
 
-        public async Task StartAsync(CancellationToken token)
+        public async Task StartAsync(CancellationToken token, bool waitForReady = true)
         {
             if (string.IsNullOrEmpty(ScenarioName))
             {
@@ -165,7 +169,10 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
 
             await _adapter.StartAsync(token).ConfigureAwait(false);
 
-            await _readySource.WithCancellation(token);
+            if (waitForReady)
+            {
+                await _readySource.WithCancellation(token);
+            }
         }
 
         public Task StopAsync(CancellationToken token)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/DotNetRunner.cs
@@ -15,8 +15,14 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
     /// <summary>
     /// Runner for running dotnet processes.
     /// </summary>
+    [DebuggerDisplay(@"\{DotNetRunner:{StateForDebuggerDisplay,nq}\}")]
     public sealed class DotNetRunner : IDisposable
     {
+        private string StateForDebuggerDisplay =>
+            !HasStarted ? "Not started" :
+            HasExited ? $"Exited with code: {ExitCode}" :
+            FormattableString.Invariant($"ProcessId={ProcessId}");
+
         // Event handler for the Process.Exited event
         private readonly EventHandler _exitedHandler;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/LoggingRunnerAdapter.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
         public int ExitCode => _runner.HasExited ?
             _runner.ExitCode : throw new InvalidOperationException("Must call WaitForExitAsync before getting exit code.");
 
+        public bool HasExited => _runner.HasExited;
+
         public Task<int> ProcessIdTask => _processIdSource.Task;
 
         public event Action<string> ReceivedStandardErrorLine;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Close the tool's stdin, which should cause it to exit.
             toolRunner.StandardInput.Close();
 
-            using (CancellationTokenSource monitorExitCancellationTokenSource = new(TimeSpan.FromSeconds(10)))
+            using (CancellationTokenSource monitorExitCancellationTokenSource = new(TestTimeouts.DotnetMonitorExitAfterStdinCloseTimeout))
             {
                 await toolRunner.WaitForExitAsync(monitorExitCancellationTokenSource.Token);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorCollectRunner.cs
@@ -97,6 +97,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         /// </summary>
         public string DotNetMonitorUrls { get; set; }
 
+        /// <summary>
+        /// Determines whether the dotnet-monitor process should exit when stdin is disconnected.
+        /// </summary>
+        public bool ExitOnStdinDisconnect { get; set; }
 
         public MonitorCollectRunner(ITestOutputHelper outputHelper)
             : base(outputHelper)
@@ -170,6 +174,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             if (UseTempApiKey)
             {
                 argsList.Add("--temp-apikey");
+            }
+
+            if (ExitOnStdinDisconnect)
+            {
+                argsList.Add("--exit-on-stdin-disconnect");
             }
 
             using IDisposable _ = token.Register(() => CancelCompletionSources(token));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Tools.Monitor;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
@@ -18,6 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
     /// <summary>
     /// Runner for the dotnet-monitor tool.
     /// </summary>
+    [DebuggerDisplay(@"\{MonitorRunner:{_runner.StateForDebuggerDisplay,nq}\}")]
     internal class MonitorRunner : IAsyncDisposable
     {
         private const string TestHostingStartupAssemblyName = "Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup";
@@ -52,6 +54,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         /// <see cref="DotNetRunner.ExitedTask"/> which is used to wait for process exit.
         /// </summary>
         protected Task<int> RunnerExitedTask => _runner.ExitedTask;
+
+        /// <summary>
+        /// Gets the standard input of the dotnet-monitor process
+        /// </summary>
+        public StreamWriter StandardInput => _runner.StandardInput;
+
+        public bool HasExited => _runner.HasExited;
+
+        public int ExitCode => _runner.ExitCode;
 
         /// <summary>
         /// The path to dotnet-monitor.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/TestTimeouts.cs
@@ -38,5 +38,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// Timeout for waiting for a collection rule to run its action list to completion.
         /// </summary>
         public static readonly TimeSpan CollectionRuleActionsCompletedTimeout = CommonTestTimeouts.GeneralTimeout;
+
+        /// <summary>
+        /// Timeout for waiting for the dotnet-monitor process to exit after closing StandardInput.
+        /// </summary>
+        public static readonly TimeSpan DotnetMonitorExitAfterStdinCloseTimeout = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -92,6 +92,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         StartupHookEnvironmentMissing = 80,
         StartupHookMissing = 81,
         StartupHookInstructions = 82,
+        /* Gap for events declared in v8 */
+        WatchForStdinDisconnectFailure = 98
     }
 
     internal static class LoggingEventIdsExtensions

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -464,6 +464,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_StartupHookInstructions);
 
+        private static readonly Action<ILogger, Exception> _unableToWatchForDisconnect =
+            LoggerMessage.Define(
+                eventId: LoggingEventIds.WatchForStdinDisconnectFailure.EventId(),
+                logLevel: LogLevel.Error,
+                formatString: Strings.LogFormatString_UnableToWatchForDisconnect);
+
         public static void EgressProviderInvalidOptions(this ILogger logger, string providerName)
         {
             _egressProviderInvalidOptions(logger, providerName, null);
@@ -851,6 +857,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public static void StartupHookInstructions(this ILogger logger, string startupHookLibraryPath)
         {
             _startupHookInstructions(logger, startupHookLibraryPath, null);
+        }
+
+        public static void UnableToWatchForDisconnect(this ILogger logger, Exception exception)
+        {
+            _unableToWatchForDisconnect(logger, exception);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 NoAuthOption,
                 TempApiKeyOption,
                 NoHttpEgressOption,
-                ConfigurationFilePathOption
+                ConfigurationFilePathOption,
+                ExitOnStdinDisconnect
             };
 
             command.SetAction((result, token) =>
@@ -57,7 +58,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     result.GetValue(NoAuthOption),
                     result.GetValue(TempApiKeyOption),
                     result.GetValue(NoHttpEgressOption),
-                    result.GetValue(ConfigurationFilePathOption));
+                    result.GetValue(ConfigurationFilePathOption),
+                    result.GetValue(ExitOnStdinDisconnect));
             });
 
             return command;
@@ -190,6 +192,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 DefaultValueFactory = (_) => false,
                 Description = Strings.HelpDescription_OptionShowSources,
                 HelpName = "showSources"
+            };
+
+        private static CliOption<bool> ExitOnStdinDisconnect =
+            new CliOption<bool>("--exit-on-stdin-disconnect")
+            {
+                DefaultValueFactory = (_) => false,
+                Description = Strings.HelpDescription_OptionExitOnStdinDisconnect
             };
 
         public static Task<int> Main(string[] args)

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -566,6 +566,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If specified, dotnet-monitor will monitor `stdin`, and if it closes, will exit. This is useful when dotnet-monitor is started remotely without a pseudo-terminal, and the caller wishes for it to exit when the connection is dropped (example: `docker exec -i ...`)..
+        /// </summary>
+        internal static string HelpDescription_OptionExitOnStdinDisconnect {
+            get {
+                return ResourceManager.GetString("HelpDescription_OptionExitOnStdinDisconnect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configuration level. Unredacted configuration can show sensitive information..
         /// </summary>
         internal static string HelpDescription_OptionLevel {
@@ -1336,6 +1345,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string LogFormatString_UnableToListenToAddress {
             get {
                 return ResourceManager.GetString("LogFormatString_UnableToListenToAddress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to watch &apos;stdin&apos; for disconnect..
+        /// </summary>
+        internal static string LogFormatString_UnableToWatchForDisconnect {
+            get {
+                return ResourceManager.GetString("LogFormatString_UnableToWatchForDisconnect", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -389,6 +389,10 @@
     <value>The fully qualified path and filename of the diagnostic port to which runtime instances can connect.</value>
     <comment>Gets the string to display in help that explains what the '--diagnostic-port' option does.</comment>
   </data>
+  <data name="HelpDescription_OptionExitOnStdinDisconnect" xml:space="preserve">
+    <value>If specified, dotnet-monitor will monitor `stdin`, and if it closes, will exit. This is useful when dotnet-monitor is started remotely without a pseudo-terminal, and the caller wishes for it to exit when the connection is dropped (example: `docker exec -i ...`).</value>
+    <comment>Gets the string to display in help that explains what the '--exit-on-stdin-disconnect' option does.</comment>
+  </data>
   <data name="HelpDescription_OptionLevel" xml:space="preserve">
     <value>Configuration level. Unredacted configuration can show sensitive information.</value>
     <comment>Gets the string to display in help that explains what the '--level' option does.</comment>
@@ -756,6 +760,9 @@
     <comment>Gets the format string that is printed in the 15:UnableToListenToAddress event.
 1 Format Parameter:
 1. url: The URL that could not have a listener attached to it</comment>
+  </data>
+  <data name="LogFormatString_UnableToWatchForDisconnect" xml:space="preserve">
+    <value>Unable to watch 'stdin' for disconnect.</value>
   </data>
   <data name="LogFormatString_WritingMessageToQueueFailed" xml:space="preserve">
     <value>Unable to send message to the queue {0}.</value>


### PR DESCRIPTION
###### Summary

This PR adds a new `--exit-on-stdin-disconnect` command line switch to `dotnet collect`. When specified, this will cause dotnet-monitor to watch stdin, and if it closes, will initiate graceful shutdown.

This also made some minor debuggability improvements to the unit test code to make it faster to see which processes were spawned.

###### Release Notes Entry
Adds new `--exit-on-stdin-disconnect` command line switch to `dotnet collect`