### PR TITLE
Update call stacks documentation

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -28,6 +28,7 @@ When running a dotnet application, differences in diverse local and production e
     - [`/info`](./api/info.md)
     - [`/operations`](./api/operations.md)
     - [`/collectionrules`](./api/collectionrules.md)
+    - [`/stacks`](./api/stacks.md)
 - [Configuration](./configuration/README.md)
     - [JSON Schema](./schema.json)
 - [Authentication](./authentication.md)

--- a/documentation/api/README.md
+++ b/documentation/api/README.md
@@ -17,7 +17,7 @@ The following are the root routes on the HTTP API surface.
 | [`/trace`](trace.md) | Captures traces of processes without using a profiler. | 6.0 |
 | [`/metrics`](metrics.md) | Captures metrics of a process in the Prometheus exposition format. | 6.0 |
 | [`/livemetrics`](livemetrics.md) | Captures live metrics of a process. | 6.0 |
-  [`/stacks`](stacks.md) | **[Experimental]** Gets the current callstacks of all .NET threads. | 7.0 |
+  [`/stacks`](stacks.md) | Gets the current callstacks of all .NET threads. | 8.0 Preview 7 |
 | [`/logs`](logs.md) | Captures logs of processes. | 6.0 |
 | [`/info`](info.md) | Gets info about `dotnet monitor`. | 6.0 |
 | [`/operations`](operations.md) | Gets egress operation status or cancels operations. | 6.0 |

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -5,25 +5,31 @@
 
 >**Note**: Some features are [experimental](./../experimental.md) and are denoted as `**[Experimental]**` in this document.
 
-## **[Experimental]** CallStack (7.0+)
+## CallStack
+
+First Available: 8.0 Preview 7
 
 | Name | Type | Description |
 |---|---|---|
 | `threadId` | int | The native thread id of the managed thread. |
 | `threadName` | string | Optional name of the managed thread. |
-| `frames` | [CallStackFrame](#experimental-callstackframe-70)[] | Managed frame for the thread at the time of collection. |
+| `frames` | [CallStackFrame](#callstackframe)[] | Managed frame for the thread at the time of collection. |
 
-## **[Experimental]** CallStackFormat (7.0+)
+## CallStackFormat
+
+First Available: 8.0 Preview 7
 
 Enumeration that describes the output format of the collected call stacks.
 
 | Name | Description |
 |---|---|
-| `Json` | Stacks are formatted in Json. See [CallStackResult](#experimental-callstackresult-70). |
+| `Json` | Stacks are formatted in Json. See [CallStackResult](#callstackresult). |
 | `PlainText` | Stacks are formatted in plain text. |
 | `Speedscope` | Stacks are formatted in [speedscope](https://www.speedscope.app). Note that performance data is not present. |
 
-## **[Experimental]** CallStackFrame (7.0+)
+## CallStackFrame
+
+First Available: 8.0 Preview 7
 
 | Name | Type | Description |
 |---|---|---|
@@ -31,11 +37,13 @@ Enumeration that describes the output format of the collected call stacks.
 | `className` | string | Name of the class for this frame. This includes generic parameters. |
 | `moduleName` | string | Name of the module for this frame. |
 
-## **[Experimental]** CallStackResult (7.0+)
+## CallStackResult
+
+First Available: 8.0 Preview 7
 
 | Name | Type | Description |
 |---|---|---|
-| `stacks` | [CallStack](#experimental-callstack-70)[] | List of all managed stacks at the time of collection. |
+| `stacks` | [CallStack](#callstack)[] | List of all managed stacks at the time of collection. |
 
 ## CollectionRuleDescription (6.3+)
 

--- a/documentation/api/stacks.md
+++ b/documentation/api/stacks.md
@@ -3,9 +3,9 @@
 
 # Stacks - Get
 
-Captures the call stacks of the currently running process. Note that only managed frames are collected.
+Captures the call stacks of a target process. Note that only managed frames are collected.
 
->**Note**: This feature is [experimental](./../experimental.md). To enable this feature, set `DotnetMonitor_Experimental_Feature_CallStacks` to `true` as an environment variable on the `dotnet monitor` process or container. Additionally, the [in-process features](./../configuration/README.md#experimental-in-process-features-configuration-70) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
+>**Note**: This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
 
 ## HTTP Route
 
@@ -45,7 +45,7 @@ Allowed schemes:
 
 | Name | Type | Description | Content Type |
 |---|---|---|---|
-| 200 OK | [CallStackResult](definitions.md#experimental-callstackresult-70) | Callstacks for all managed threads in the process. | `application/json` |
+| 200 OK | [CallStackResult](definitions.md#callstackresult) | Callstacks for all managed threads in the process. | `application/json` |
 | 200 OK | text | Text representation of callstacks in the process. | `text/plain` |
 | 202 Accepted | | When an egress provider is specified, the artifact has begun being collected. | |
 | 400 Bad Request | [ValidationProblemDetails](definitions.md#validationproblemdetails) | An error occurred due to invalid input. The response body describes the specific problem(s). | `application/problem+json` |

--- a/documentation/configuration/README.md
+++ b/documentation/configuration/README.md
@@ -18,7 +18,7 @@
 - **[Default Process Configuration](./default-process-configuration.md)** - Used to determine which process is used for metrics and in situations where the process is not specified in the query to retrieve an artifact.
 - **[Metrics Configuration](./metrics-configuration.md)** - Configuration of the `/metrics` endpoint for live metrics collection
 - **[Egress Configuration](./egress-configuration.md)** - When `dotnet-monitor` is used to produce artifacts such as dumps or traces, an egress provider enables the artifacts to be stored in a manner suitable for the hosting environment rather than streamed back directly.]
-- **[In-Process Features Configuration](#experimental-in-process-features-configuration-70)** - Some features of `dotnet monitor` require loading libraries into target applications that may have performance impact on memory and CPU utilization
+- **[In-Process Features Configuration](./in-process-features-configuration.md)** - Some features of `dotnet monitor` require loading libraries into target applications that may have performance impact on memory and CPU utilization
 - **[Garbage Collector Mode](#garbage-collector-mode)** - Configure which GC mode is used by the `dotnet monitor` process.
 
 ## Kestrel Configuration
@@ -44,48 +44,6 @@ To get completion support in your editor, simply add the `$schema` property to t
 Once you've added the `$schema` property, you should have support for completions in your editor.
 
 ![completions](https://user-images.githubusercontent.com/4734691/115377729-bf2bb600-a184-11eb-9b8e-50f361c112f0.gif)
-
-
-## **[Experimental]** In-Process Features Configuration (7.0+)
-
-Some features of `dotnet monitor` require loading libraries into target applications. These libraries ship with `dotnet monitor` and are provisioned to be available to target applications using the `DefaultSharedPath` option in the [storage configuration](./storage-configuration.md) section. The following features require these in-process libraries to be used:
-
-- Call stack collection
-
-Because these libraries are loaded into the target application (they are not loaded into `dotnet monitor`), they may have performance impact on memory and CPU utilization in the target application. These features are off by default and may be enabled via the `InProcessFeatures` configuration section.
-
-### Example
-
-To enable in-process features, such as call stack collection, use the following configuration:
-
-<details>
-  <summary>JSON</summary>
-
-  ```json
-  {
-    "InProcessFeatures": {
-      "Enabled": true
-    }
-  }
-  ```
-</details>
-
-<details>
-  <summary>Kubernetes ConfigMap</summary>
-  
-  ```yaml
-  InProcessFeatures__Enabled: "true"
-  ```
-</details>
-
-<details>
-  <summary>Kubernetes Environment Variables</summary>
-  
-  ```yaml
-  - name: DotnetMonitor_InProcessFeatures__Enabled
-    value: "true"
-  ```
-</details>
 
 ## Garbage Collector Mode
 

--- a/documentation/configuration/collection-rule-configuration.md
+++ b/documentation/configuration/collection-rule-configuration.md
@@ -21,7 +21,7 @@ Collection rules are specified in configuration as a named item under the `Colle
   - [CollectLiveMetrics](#collectlivemetrics-action)
   - [CollectLogs](#collectlogs-action)
   - [Execute](#execute-action)
-  - [CollectStacks](#experimental-collectstacks-action-70)
+  - [CollectStacks](#collectstacks-action)
   - [LoadProfiler](#loadprofiler-action)
   - [SetEnvironmentVariable](#setenvironmentvariable-action)
   - [GetEnvironmentVariable](#getenvironmentvariable-action)
@@ -912,17 +912,19 @@ Usage that executes a .NET executable named `myapp.dll` using `dotnet`.
   ```
 </details>
 
-### **[Experimental]** `CollectStacks` Action (7.0+)
+### `CollectStacks` Action
+
+First Available: 8.0 Preview 7
 
 Collect call stacks from the target process.
 
->**Note**: This feature is [experimental](../experimental.md). To enable this feature, set `DotnetMonitor_Experimental_Feature_CallStacks` to `true` as an environment variable on the `dotnet monitor` process or container. Additionally, the [in-process features](#experimental-in-process-features-configuration-70) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
+>**Note**: This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
 
 #### Properties
 
 | Name | Type | Required | Description | Default Value |
 |---|---|---|---|---|
-| `Format` | [CallStackFormat](../api/definitions.md#experimental-callstackformat-70) | false | The format of the collected call stack. | `Json` |
+| `Format` | [CallStackFormat](../api/definitions.md#callstackformat) | false | The format of the collected call stack. | `Json` |
 | `Egress` | string | true | The named [egress provider](../egress.md) for egressing the collected stacks. | |
 
 ### `LoadProfiler` Action

--- a/documentation/configuration/in-process-features-configuration.md
+++ b/documentation/configuration/in-process-features-configuration.md
@@ -1,0 +1,116 @@
+### Was this documentation helpful? [Share feedback](https://www.research.net/r/DGDQWXH?src=documentation%2Fconfiguration%2Fin-process-features-configuration)
+
+# In-Process Features Configuration
+
+First Available: 8.0 Preview 7
+
+Some features of `dotnet monitor` require loading libraries into target applications. These libraries ship with `dotnet monitor` and are provisioned to be available to target applications using the `DefaultSharedPath` option in the [storage configuration](./storage-configuration.md) section. The following features require these in-process libraries to be used:
+
+- [Call Stacks](#call-stacks)
+
+Because these libraries are loaded into the target application (they are not loaded into `dotnet monitor`), they may have performance impact on memory and CPU utilization in the target application. These features are off by default and may be enabled via the `InProcessFeatures` configuration section.
+
+### Example
+
+To enable all available in-process features, use the following configuration:
+
+<details>
+  <summary>JSON</summary>
+
+  ```json
+  {
+    "InProcessFeatures": {
+      "Enabled": true
+    }
+  }
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes ConfigMap</summary>
+  
+  ```yaml
+  InProcessFeatures__Enabled: "true"
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes Environment Variables</summary>
+  
+  ```yaml
+  - name: DotnetMonitor_InProcessFeatures__Enabled
+    value: "true"
+  ```
+</details>
+
+## Call Stacks
+
+The call stacks feature is individually enabled by setting the `Enabled` property of the `CallStacks` section to `true`:
+
+<details>
+  <summary>JSON</summary>
+
+  ```json
+  {
+    "InProcessFeatures": {
+      "CallStacks": {
+        "Enabled": true
+      }
+    }
+  }
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes ConfigMap</summary>
+  
+  ```yaml
+  InProcessFeatures__CallStacks__Enabled: "true"
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes Environment Variables</summary>
+  
+  ```yaml
+  - name: DotnetMonitor_InProcessFeatures__CallStacks__Enabled
+    value: "true"
+  ```
+</details>
+
+Similarly, the call stacks feature can be individually disabled by setting the same property to `false`:
+
+<details>
+  <summary>JSON</summary>
+
+  ```json
+  {
+    "InProcessFeatures": {
+      "Enabled": true,
+      "CallStacks": {
+        "Enabled": false
+      }
+    }
+  }
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes ConfigMap</summary>
+  
+  ```yaml
+  InProcessFeatures__Enabled: "true"
+  InProcessFeatures__CallStacks__Enabled: "false"
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes Environment Variables</summary>
+  
+  ```yaml
+  - name: InProcessFeatures__Enabled
+    value: "true"
+  - name: DotnetMonitor_InProcessFeatures__CallStacks__Enabled
+    value: "false"
+  ```
+</details>

--- a/documentation/configuration/storage-configuration.md
+++ b/documentation/configuration/storage-configuration.md
@@ -9,8 +9,8 @@ Some diagnostic features (e.g. memory dumps, stack traces) require that a direct
 
 The default shared path option (`DefaultSharedPath`) can be set, which allows artifacts to be shared automatically without requiring additional configuration for each artifact type. By setting this property with an appropriate value, the following become available:
 - dumps are temporarily stored in this directory or in a subdirectory.
-- **[Experimental]** shared libraries are shared from `dotnet monitor` to target applications in this directory or in a subdirectory.
-- **[Experimental]** in-process diagnostics share files back to `dotnet monitor` in this directory or in a subdirectory.
+- (8.0+) shared libraries are shared from `dotnet monitor` to target applications in this directory or in a subdirectory.
+- (8.0+) in-process diagnostics share files back to `dotnet monitor` in this directory or in a subdirectory.
 
 <details>
   <summary>JSON</summary>
@@ -76,7 +76,9 @@ Unlike the other diagnostic artifacts (for example, traces), memory dumps aren't
   ```
 </details>
 
-## **[Experimental]** Shared Library Path (7.0+)
+## Shared Library Path
+
+First Available: 8.0 Preview 7
 
 The shared library path option (`SharedLibraryPath`) allows specifying the path to where shared libraries are copied from the `dotnet monitor` installation to make them available to target applications for in-process diagnostics scenarios, such as call stack collection.
 

--- a/documentation/experimental.md
+++ b/documentation/experimental.md
@@ -6,4 +6,5 @@ The following are the current set of experimental features:
 
 | Name | Description | First Available Version | How to Enable |
 |---|---|---|---|
-| Call Stacks | Collect call stacks from target processes as a diagnostic artifact using either the `/stacks` route or the `CollectStacks` collection rule action. | 7.0 RC 1 | Set `DotnetMonitor_Experimental_Feature_CallStacks` to `true` as an environment variable on the `dotnet monitor` process or container. |
+
+As of 8.0 Preview 7, there are no experimental features.


### PR DESCRIPTION
###### Summary

Update call stacks documentation to bring it out of experimental. I've also made adjustments to the headers to remove the `[Experimental]` moniker as well as the version number and move that to the next line as `First Available: X.Y` in order to make the links less complicated; for the latter, I can update the rest of the documentation to use the same pattern once we agree on that change.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
