### PR TITLE
Group similar Dependabot dependency updates together

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -23,11 +23,13 @@ updates:
       prefix: #@ commit_prefix
     groups:
       azure-storage-dependencies:
-        - "Azure.Storage.*"
+        patterns:
+          - "Azure.Storage.*"
       identity-dependencies:
-        - "Azure.Identity"
-        - "Microsoft.Identity.*"
-        - "Microsoft.IdentityModel.*"
+        patterns:
+          - "Azure.Identity"
+          - "Microsoft.Identity.*"
+          - "Microsoft.IdentityModel.*"
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot/nuget.org"
     schedule:
@@ -48,7 +50,8 @@ updates:
       prefix: #@ commit_prefix
     groups:
       runtime-dependencies:
-        - "Microsoft.Extensions.*"
-        - "Microsoft.NETCore.App.Runtime.*"
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.NETCore.App.Runtime.*"
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,13 @@ updates:
     prefix: '[main] '
   groups:
     azure-storage-dependencies:
-    - Azure.Storage.*
+      patterns:
+      - Azure.Storage.*
     identity-dependencies:
-    - Azure.Identity
-    - Microsoft.Identity.*
-    - Microsoft.IdentityModel.*
+      patterns:
+      - Azure.Identity
+      - Microsoft.Identity.*
+      - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -43,8 +45,9 @@ updates:
     prefix: '[main] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -58,8 +61,9 @@ updates:
     prefix: '[main] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -73,8 +77,9 @@ updates:
     prefix: '[main] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -88,11 +93,13 @@ updates:
     prefix: '[release/7.x] '
   groups:
     azure-storage-dependencies:
-    - Azure.Storage.*
+      patterns:
+      - Azure.Storage.*
     identity-dependencies:
-    - Azure.Identity
-    - Microsoft.Identity.*
-    - Microsoft.IdentityModel.*
+      patterns:
+      - Azure.Identity
+      - Microsoft.Identity.*
+      - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -113,8 +120,9 @@ updates:
     prefix: '[release/7.x] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -128,8 +136,9 @@ updates:
     prefix: '[release/7.x] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -143,8 +152,9 @@ updates:
     prefix: '[release/7.x] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -158,11 +168,13 @@ updates:
     prefix: '[release/7.2] '
   groups:
     azure-storage-dependencies:
-    - Azure.Storage.*
+      patterns:
+      - Azure.Storage.*
     identity-dependencies:
-    - Azure.Identity
-    - Microsoft.Identity.*
-    - Microsoft.IdentityModel.*
+      patterns:
+      - Azure.Identity
+      - Microsoft.Identity.*
+      - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -183,8 +195,9 @@ updates:
     prefix: '[release/7.2] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -198,8 +211,9 @@ updates:
     prefix: '[release/7.2] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -213,8 +227,9 @@ updates:
     prefix: '[release/7.2] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -228,11 +243,13 @@ updates:
     prefix: '[release/7.1] '
   groups:
     azure-storage-dependencies:
-    - Azure.Storage.*
+      patterns:
+      - Azure.Storage.*
     identity-dependencies:
-    - Azure.Identity
-    - Microsoft.Identity.*
-    - Microsoft.IdentityModel.*
+      patterns:
+      - Azure.Identity
+      - Microsoft.Identity.*
+      - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -253,8 +270,9 @@ updates:
     prefix: '[release/7.1] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -268,8 +286,9 @@ updates:
     prefix: '[release/7.1] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -283,8 +302,9 @@ updates:
     prefix: '[release/7.1] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
@@ -298,11 +318,13 @@ updates:
     prefix: '[release/6.x] '
   groups:
     azure-storage-dependencies:
-    - Azure.Storage.*
+      patterns:
+      - Azure.Storage.*
     identity-dependencies:
-    - Azure.Identity
-    - Microsoft.Identity.*
-    - Microsoft.IdentityModel.*
+      patterns:
+      - Azure.Identity
+      - Microsoft.Identity.*
+      - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -323,8 +345,9 @@ updates:
     prefix: '[release/6.x] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -338,8 +361,9 @@ updates:
     prefix: '[release/6.x] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -353,5 +377,6 @@ updates:
     prefix: '[release/6.x] '
   groups:
     runtime-dependencies:
-    - Microsoft.Extensions.*
-    - Microsoft.NETCore.App.Runtime.*
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*


### PR DESCRIPTION
###### Summary

Enable the new Dependabot grouped updates feature to group similar dependency updates together in the same PR. Note this feature is currently in public beta and we may need to make adjustments to the config if things change.

Example grouped updates:
- https://github.com/schmittjoseph/dotnet-monitor/pull/364
- https://github.com/schmittjoseph/dotnet-monitor/pull/362
- https://github.com/schmittjoseph/dotnet-monitor/pull/361

ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
