### PR TITLE
Enable operation tracking for trigger actions

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
@@ -49,15 +49,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _operation = operation;
         }
 
-        // The below constructors don't need EgressProcessInfo as their callers don't store to the operations table.
-        public EgressOperation(Func<Stream, CancellationToken, Task> action, string endpointName, string artifactName, IEndpointInfo source, string contentType, KeyValueLogScope scope, CollectionRuleMetadata collectionRuleMetadata)
+        public EgressOperation(IArtifactOperation operation, TaskCompletionSource<object> taskCompletionSource, string endpointName, IProcessInfo processInfo, KeyValueLogScope scope, string tags, CollectionRuleMetadata collectionRuleMetadata = null)
+            : this((stream, token) => operation.ExecuteAsync(stream, taskCompletionSource, token), endpointName, operation.GenerateFileName(), processInfo, operation.ContentType, scope, tags, collectionRuleMetadata)
         {
-            _egress = (service, token) => service.EgressAsync(endpointName, action, artifactName, contentType, source, collectionRuleMetadata, token);
-            EgressProviderName = endpointName;
-            _scope = scope;
+            _operation = operation;
         }
 
-        public EgressOperation(Func<CancellationToken, Task<Stream>> action, string endpointName, string artifactName, IEndpointInfo source, string contentType, KeyValueLogScope scope, CollectionRuleMetadata collectionRuleMetadata)
+        // TODO Remove this constructor once Callstacks and GCDumps move to IArtifactOperation implementations
+        public EgressOperation(Func<Stream, CancellationToken, Task> action, string endpointName, string artifactName, IEndpointInfo source, string contentType, KeyValueLogScope scope, CollectionRuleMetadata collectionRuleMetadata)
         {
             _egress = (service, token) => service.EgressAsync(endpointName, action, artifactName, contentType, source, collectionRuleMetadata, token);
             EgressProviderName = endpointName;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             ProcessName = processName ?? ProcessFieldUnknownValue;
         }
 
+        public static async Task<IProcessInfo> FromEndpointInfoAsync(IEndpointInfo endpointInfo, TimeSpan? timeout = null)
+        {
+            using CancellationTokenSource tokenSource = new CancellationTokenSource(timeout ?? ExtendedProcessInfoTimeout);
+            return await FromEndpointInfoAsync(endpointInfo, tokenSource.Token);
+        }
+
         // Creates an IProcessInfo object from the IEndpointInfo. Attempts to get the command line using event pipe
         // if the endpoint information doesn't provide it. The cancellation token can be used to timebox this fallback
         // mechanism.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimitTracker.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimitTracker.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal sealed class RequestLimitTracker
     {
+        public static readonly string Unlimited = string.Empty;
+
         private sealed class RequestCount : IDisposable
         {
             private int _count;
@@ -35,6 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _requestLimitTable.Add(Utilities.ArtifactType_Trace, 3);
             _requestLimitTable.Add(Utilities.ArtifactType_Metrics, 3);
             _requestLimitTable.Add(Utilities.ArtifactType_Stacks, 1);
+            _requestLimitTable.Add(Unlimited, int.MaxValue);
 
             _logger = logger;
         }

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectDumpActionTests.cs
@@ -74,13 +74,13 @@ namespace CollectionRuleActions.UnitTests
 
                 await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
 
-                Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                Task<IProcessInfo> newProcessInfoTask = callback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                 await runner.ExecuteAsync(async () =>
                 {
-                    IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                    IProcessInfo processInfo = await newProcessInfoTask;
 
-                    ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                    ICollectionRuleAction action = factory.Create(processInfo, options);
 
                     CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(action, CommonTestTimeouts.DumpTimeout);
 

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectGCDumpActionTests.cs
@@ -74,13 +74,13 @@ namespace CollectionRuleActions.UnitTests
 
                 await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
 
-                Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                Task<IProcessInfo> processInfoTask = callback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                 await runner.ExecuteAsync(async () =>
                 {
-                    IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                    IProcessInfo processInfo = await processInfoTask;
 
-                    ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                    ICollectionRuleAction action = factory.Create(processInfo, options);
 
                     CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(action, CommonTestTimeouts.GCDumpTimeout);
 

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLiveMetricsActionTests.cs
@@ -79,13 +79,13 @@ namespace CollectionRuleActions.UnitTests
 
                 await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
 
-                Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                Task<IProcessInfo> processInfoTask = callback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                 await runner.ExecuteAsync(async () =>
                 {
-                    IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                    IProcessInfo processInfo = await processInfoTask;
 
-                    ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                    ICollectionRuleAction action = factory.Create(processInfo, options);
 
                     CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(action, CommonTestTimeouts.LiveMetricsTimeout);
 
@@ -150,13 +150,13 @@ namespace CollectionRuleActions.UnitTests
                 await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
                 runner.ScenarioName = TestAppScenarios.Metrics.Name;
 
-                Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                Task<IProcessInfo> processInfoTask = callback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                 await runner.ExecuteAsync(async () =>
                 {
-                    IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                    IProcessInfo processInfo = await processInfoTask;
 
-                    ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                    ICollectionRuleAction action = factory.Create(processInfo, options);
 
                     CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(action, CommonTestTimeouts.LiveMetricsTimeout);
 

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectLogsActionTests.cs
@@ -245,13 +245,13 @@ namespace CollectionRuleActions.UnitTests
                 await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
                 runner.ScenarioName = TestAppScenarios.Logger.Name;
 
-                Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                Task<IProcessInfo> processInfoTask = endpointInfoCallback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                 await runner.ExecuteAsync(async () =>
                 {
-                    IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                    IProcessInfo processInfo = await processInfoTask;
 
-                    ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                    ICollectionRuleAction action = factory.Create(processInfo, options);
 
                     using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(CommonTestTimeouts.LogsTimeout);
 

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectTraceActionTests.cs
@@ -97,13 +97,13 @@ namespace CollectionRuleActions.UnitTests
 
             await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
 
-            Task<IEndpointInfo> newEndpointInfoTask = callback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+            Task<IProcessInfo> processInfoTask = callback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
             await runner.ExecuteAsync(async () =>
             {
-                IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                IProcessInfo processInfo = await processInfoTask;
 
-                ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                ICollectionRuleAction action = factory.Create(processInfo, options);
 
                 CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(action, CommonTestTimeouts.TraceTimeout);
 

--- a/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
@@ -67,13 +67,12 @@ namespace CollectionRuleActions.UnitTests
                     await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
                     runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
 
-                    Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
-
+                    Task<IProcessInfo> processInfoTask = endpointInfoCallback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
                     await runner.ExecuteAsync(async () =>
                     {
-                        IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                        IProcessInfo processInfo = await processInfoTask;
 
-                        ICollectionRuleAction setAction = setFactory.Create(endpointInfo, setOpts);
+                        ICollectionRuleAction setAction = setFactory.Create(processInfo, setOpts);
 
                         await ActionTestsHelper.ExecuteAndDisposeAsync(setAction, CommonTestTimeouts.EnvVarsTimeout);
 
@@ -118,13 +117,13 @@ namespace CollectionRuleActions.UnitTests
                     await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
                     runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
 
-                    Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                    Task<IProcessInfo> processInfoTask = endpointInfoCallback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                     await runner.ExecuteAsync(async () =>
                     {
-                        IEndpointInfo endpointInfo = await newEndpointInfoTask;
+                        IProcessInfo processInfo = await processInfoTask;
 
-                        ICollectionRuleAction getAction = getFactory.Create(endpointInfo, getOpts);
+                        ICollectionRuleAction getAction = getFactory.Create(processInfo, getOpts);
 
                         await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.IncVar);
                         Assert.Equal("1", await runner.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName, CommonTestTimeouts.EnvVarsTimeout));
@@ -138,7 +137,7 @@ namespace CollectionRuleActions.UnitTests
                         await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.IncVar);
                         Assert.Equal("3", await runner.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.IncrementVariableName, CommonTestTimeouts.EnvVarsTimeout));
 
-                        ICollectionRuleAction getActionFailure = getFactory.Create(endpointInfo, getFailOpts);
+                        ICollectionRuleAction getActionFailure = getFactory.Create(processInfo, getFailOpts);
                         CollectionRuleActionException thrownEx = await Assert.ThrowsAsync<CollectionRuleActionException>(async () =>
                         {
                             await ActionTestsHelper.ExecuteAndDisposeAsync(getActionFailure, CommonTestTimeouts.EnvVarsTimeout);
@@ -185,14 +184,13 @@ namespace CollectionRuleActions.UnitTests
                     await using AppRunner runner = _endpointUtilities.CreateAppRunner(Assembly.GetExecutingAssembly(), sourceHolder.TransportName, tfm);
                     runner.ScenarioName = TestAppScenarios.EnvironmentVariables.Name;
 
-                    Task<IEndpointInfo> newEndpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+                    Task<IProcessInfo> newProcessInfoTask = endpointInfoCallback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
                     await runner.ExecuteAsync(async () =>
                         {
-                            IEndpointInfo endpointInfo = await newEndpointInfoTask;
-
-                            ICollectionRuleAction setAction = setFactory.Create(endpointInfo, setOpts);
-                            ICollectionRuleAction getAction = getFactory.Create(endpointInfo, getOpts);
+                            IProcessInfo processInfo = await newProcessInfoTask;
+                            ICollectionRuleAction setAction = setFactory.Create(processInfo, setOpts);
+                            ICollectionRuleAction getAction = getFactory.Create(processInfo, getOpts);
 
                             await ActionTestsHelper.ExecuteAndDisposeAsync(setAction, CommonTestTimeouts.EnvVarsTimeout);
                             CollectionRuleActionResult getResult = await ActionTestsHelper.ExecuteAndDisposeAsync(getAction, CommonTestTimeouts.EnvVarsTimeout);

--- a/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/LoadProfilerActionTests.cs
@@ -94,7 +94,9 @@ namespace CollectionRuleActions.UnitTests
             {
                 SetEnvironmentVariableOptions envOptions = ActionTestsHelper.GetActionOptions<SetEnvironmentVariableOptions>(_host, DefaultRuleName, actionIndex: 0);
                 Assert.True(_host.Services.GetService<ICollectionRuleActionOperations>().TryCreateFactory(KnownCollectionRuleActions.SetEnvironmentVariable, out ICollectionRuleActionFactoryProxy setEnvFactory));
-                ICollectionRuleAction setEnvAction = setEnvFactory.Create(endpointInfo, envOptions);
+
+                IProcessInfo processInfo = await ProcessInfoImpl.FromEndpointInfoAsync(endpointInfo, token);
+                ICollectionRuleAction setEnvAction = setEnvFactory.Create(processInfo, envOptions);
                 await ActionTestsHelper.ExecuteAndDisposeAsync(setEnvAction, CommonTestTimeouts.EnvVarsTimeout);
 
                 // Load the profiler into the target process
@@ -103,7 +105,7 @@ namespace CollectionRuleActions.UnitTests
                 ICollectionRuleActionFactoryProxy factory;
                 Assert.True(_host.Services.GetService<ICollectionRuleActionOperations>().TryCreateFactory(KnownCollectionRuleActions.LoadProfiler, out factory));
 
-                ICollectionRuleAction action = factory.Create(endpointInfo, options);
+                ICollectionRuleAction action = factory.Create(processInfo, options);
 
                 CollectionRuleActionResult result = await ActionTestsHelper.ExecuteAndDisposeAsync(action, CommonTestTimeouts.LoadProfilerTimeout);
                 Assert.Null(result.OutputValues);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
             _outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
         }
 
+        public Uri BaseAddress => _httpClient.BaseAddress;
+
         /// <summary>
         /// GET /
         /// </summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
@@ -429,6 +429,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
             return await client.GetOperations(tags, timeoutSource.Token).ConfigureAwait(false);
         }
 
+        public static Task<HttpStatusCode> StopEgressOperation(this ApiClient client, Guid operationId)
+        {
+            return StopEgressOperation(client, new Uri(client.BaseAddress, FormattableString.Invariant($"operations/{operationId}")));
+        }
+
         public static async Task<HttpStatusCode> StopEgressOperation(this ApiClient client, Uri operation)
         {
             using CancellationTokenSource timeoutSource = new(TestTimeouts.HttpApi);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/CallbackAction.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/CallbackAction.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             _service = service;
         }
 
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, BaseRecordOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, BaseRecordOptions options)
         {
             return new CallbackAction(_service);
         }
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             _service = service;
         }
 
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, BaseRecordOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, BaseRecordOptions options)
         {
             return new DelayedCallbackAction(_service);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/PassThroughAction.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/CollectionRules/Actions/PassThroughAction.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     internal sealed class PassThroughActionFactory : ICollectionRuleActionFactory<PassThroughOptions>
     {
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, PassThroughOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, PassThroughOptions options)
         {
             return new PassThroughAction(options);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointInfoSourceCallback.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/EndpointInfoSourceCallback.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 timeout);
         }
 
+        public async Task<IProcessInfo> WaitAddedProcessInfoAsync(AppRunner runner, TimeSpan timeout)
+        {
+            IEndpointInfo endpointInfo = await WaitAddedEndpointInfoAsync(runner, timeout);
+            return await ProcessInfoImpl.FromEndpointInfoAsync(endpointInfo, timeout);
+        }
+
         public Task<IEndpointInfo> WaitRemovedEndpointInfoAsync(AppRunner runner, TimeSpan timeout)
         {
             return WaitForCompletionAsync(

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
@@ -25,13 +25,15 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             List<IConfigurationSource> overrideSource = null)
         {
             IHost host = CreateHost(outputHelper, setup, servicesCallback, loggingCallback, overrideSource);
-
             try
             {
+                //It is necessary to start the host so that the OperationsStore background service is started.
+                await host.StartAsync();
                 await hostCallback(host);
             }
             finally
             {
+                await host.StopAsync();
                 await DisposableHelper.DisposeAsync(host);
             }
         }
@@ -100,6 +102,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     services.AddSingleton<OperationTrackerService>();
                     services.ConfigureCollectionRules();
                     services.ConfigureEgress();
+                    services.AddSingleton<RequestLimitTracker>();
+                    services.ConfigureOperationStore();
 
                     services.ConfigureDiagnosticPort(context.Configuration);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             public string ProcessArchitecture => EndpointInfo.ProcessArchitecture;
 
-            public string ProcessName => throw new NotImplementedException();
+            public string ProcessName => ProcessInfoImpl.GetProcessName(CommandLine, OperatingSystem);
         }
 
         private sealed class TestEndpointInfo : WebApi.EndpointInfoBase

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTestsHelper.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             runner.DiagnosticPortPath = sourceHolder.TransportName;
             runner.ScenarioName = scenarioName;
 
-            Task<IEndpointInfo> endpointInfoTask = endpointInfoCallback.WaitAddedEndpointInfoAsync(runner, CommonTestTimeouts.StartProcess);
+            Task<IProcessInfo> processInfoTask = endpointInfoCallback.WaitAddedProcessInfoAsync(runner, CommonTestTimeouts.StartProcess);
 
             await runner.ExecuteAsync(async () =>
             {
-                IEndpointInfo endpointInfo = await endpointInfoTask;
+                IProcessInfo processInfo = await processInfoTask;
 
                 await TestHostHelper.CreateCollectionRulesHost(
                     outputHelper,
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                         CollectionRuleContext context = new(
                             collectionRuleName,
                             optionsMonitor.Get(collectionRuleName),
-                            endpointInfo,
+                            processInfo,
                             logger,
                             clock,
                             callbacks.NotifyActionsThrottled);

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                         }
 
                         object newSettings = dependencyAnalyzer.SubstituteOptionValues(actionResults, actionIndex, actionOption.Settings);
-                        ICollectionRuleAction action = factory.Create(context.EndpointInfo, newSettings);
+                        ICollectionRuleAction action = factory.Create(context.ProcessInfo, newSettings);
 
                         try
                         {

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                 RuntimeId = _ruleContext.EndpointInfo?.RuntimeInstanceCookie ?? Guid.Empty,
                 ProcessId = _ruleContext.EndpointInfo?.ProcessId ?? 0,
                 CommandLine = commandLine,
-                ProcessName = Monitoring.WebApi.ProcessInfoImpl.GetProcessName(commandLine, _ruleContext.EndpointInfo?.OperatingSystem)
+                ProcessName = _ruleContext.ProcessInfo?.ProcessName ?? string.Empty
             });
 
             return settings;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
     {
         private readonly IServiceProvider _serviceProvider;
 
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, CollectTraceOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, CollectTraceOptions options)
         {
             if (null == options)
             {
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             ValidationContext context = new(options, _serviceProvider, items: null);
             Validator.ValidateObject(options, context, validateAllProperties: true);
 
-            return new CollectTraceAction(_serviceProvider, endpointInfo, options);
+            return new CollectTraceAction(_serviceProvider, processInfo, options);
         }
 
         public CollectTraceActionFactory(IServiceProvider serviceProvider)
@@ -41,22 +41,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         }
 
         private sealed class CollectTraceAction :
-            CollectionRuleActionBase<CollectTraceOptions>
+            CollectionRuleEgressActionBase<CollectTraceOptions>
         {
-            private readonly IServiceProvider _serviceProvider;
             private readonly IOptionsMonitor<GlobalCounterOptions> _counterOptions;
 
-            public CollectTraceAction(IServiceProvider serviceProvider, IEndpointInfo endpointInfo, CollectTraceOptions options)
-                : base(endpointInfo, options)
+            public CollectTraceAction(IServiceProvider serviceProvider, IProcessInfo processInfo, CollectTraceOptions options)
+                : base(serviceProvider, processInfo, options)
             {
-                _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-                _counterOptions = _serviceProvider.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
+                _counterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
             }
 
-            protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
-                TaskCompletionSource<object> startCompletionSource,
-                CollectionRuleMetadata collectionRuleMetadata,
-                CancellationToken token)
+            protected override EgressOperation CreateArtifactOperation(TaskCompletionSource<object> startCompletionSource,
+                CollectionRuleMetadata collectionRuleMetadata)
             {
                 TimeSpan duration = Options.Duration.GetValueOrDefault(TimeSpan.Parse(CollectTraceOptionsDefaults.Duration));
                 string egressProvider = Options.Egress;
@@ -82,7 +78,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
                 KeyValueLogScope scope = Utils.CreateArtifactScope(Utils.ArtifactType_Trace, EndpointInfo);
 
-                ITraceOperationFactory operationFactory = _serviceProvider.GetRequiredService<ITraceOperationFactory>();
+                ITraceOperationFactory operationFactory = ServiceProvider.GetRequiredService<ITraceOperationFactory>();
                 IArtifactOperation operation;
                 if (stoppingEvent == null)
                 {
@@ -103,31 +99,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 }
 
                 EgressOperation egressOperation = new EgressOperation(
-                    async (outputStream, token) =>
-                    {
-                        await operation.ExecuteAsync(outputStream, startCompletionSource, token);
-                    },
+                    operation,
+                    startCompletionSource,
                     egressProvider,
-                    operation.GenerateFileName(),
-                    EndpointInfo,
-                    operation.ContentType,
+                    ProcessInfo,
                     scope,
+                    null,
                     collectionRuleMetadata);
 
-                ExecutionResult<EgressResult> result = await egressOperation.ExecuteAsync(_serviceProvider, token);
-                if (null != result.Exception)
-                {
-                    throw new CollectionRuleActionException(result.Exception);
-                }
-                string traceFilePath = result.Result.Value;
-
-                return new CollectionRuleActionResult()
-                {
-                    OutputValues = new Dictionary<string, string>(StringComparer.Ordinal)
-                    {
-                        { CollectionRuleActionConstants.EgressPathOutputValueName, traceFilePath }
-                    }
-                };
+                return egressOperation;
             }
         }
     }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
         protected CollectionRuleActionBase(IProcessInfo processInfo, TOptions options)
         {
-            // TODO: Allow null endpointInfo to allow tests to pass, but this should be provided by
+            // TODO: Allow null processInfo to allow tests to pass, but this should be provided by
             // tests since it will be required by all aspects in the future. For example, the ActionListExecutor
             // (which uses null in tests) will require this when needing to get process information for
             // the actions property bag used for token replacement.
-            //EndpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
+            //ProcessInfo = processInfo ?? throw new ArgumentNullException(nameof(processInfo));
             ProcessInfo = processInfo;
             Options = options ?? throw new ArgumentNullException(nameof(options));
         }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
@@ -17,18 +17,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         private Task<CollectionRuleActionResult> _completionTask;
         private long _disposedState;
 
-        protected IEndpointInfo EndpointInfo { get; }
+        protected IEndpointInfo EndpointInfo => ProcessInfo?.EndpointInfo;
+
+        protected IProcessInfo ProcessInfo { get; }
 
         protected TOptions Options { get; }
 
-        protected CollectionRuleActionBase(IEndpointInfo endpointInfo, TOptions options)
+        protected CollectionRuleActionBase(IProcessInfo processInfo, TOptions options)
         {
             // TODO: Allow null endpointInfo to allow tests to pass, but this should be provided by
             // tests since it will be required by all aspects in the future. For example, the ActionListExecutor
             // (which uses null in tests) will require this when needing to get process information for
             // the actions property bag used for token replacement.
             //EndpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
-            EndpointInfo = endpointInfo;
+            ProcessInfo = processInfo;
             Options = options ?? throw new ArgumentNullException(nameof(options));
         }
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionFactoryProxy.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         }
 
         /// <inheritdoc/>
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, object options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, object options)
         {
             TOptions typedOptions = options as TOptions;
             if (null != options && null == typedOptions)
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 throw new ArgumentException(nameof(options));
             }
 
-            return _factory.Create(endpointInfo, typedOptions);
+            return _factory.Create(processInfo, typedOptions);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleEgressActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleEgressActionBase.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
+{
+    internal abstract class CollectionRuleEgressActionBase<TOptions> : CollectionRuleActionBase<TOptions>
+    {
+        protected IServiceProvider ServiceProvider { get; }
+
+        protected EgressOperationStore EgressOperationStore { get; }
+
+        protected CollectionRuleEgressActionBase(IServiceProvider serviceProvider, IProcessInfo processInfo, TOptions options)
+            : base(processInfo, options)
+        {
+            ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            EgressOperationStore = ServiceProvider.GetRequiredService<EgressOperationStore>();
+        }
+
+        protected abstract EgressOperation CreateArtifactOperation(TaskCompletionSource<object> startCompletionSource,
+                CollectionRuleMetadata collectionRuleMetadata);
+
+        protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(TaskCompletionSource<object> startCompletionSource, CollectionRuleMetadata collectionRuleMetadata, CancellationToken token)
+        {
+            EgressOperation egressOperation = CreateArtifactOperation(startCompletionSource, collectionRuleMetadata);
+
+            ExecutionResult<EgressResult> result = await EgressOperationStore.ExecuteOperation(egressOperation);
+            if (null != result.Exception)
+            {
+                throw new CollectionRuleActionException(result.Exception);
+            }
+            string artifactPath = result.Result.Value;
+
+            return new CollectionRuleActionResult()
+            {
+                OutputValues = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        { CollectionRuleActionConstants.EgressPathOutputValueName, artifactPath }
+                    }
+            };
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ExecuteAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ExecuteAction.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
     internal sealed class ExecuteActionFactory :
         ICollectionRuleActionFactory<ExecuteOptions>
     {
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, ExecuteOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, ExecuteOptions options)
         {
             if (null == options)
             {
@@ -29,14 +29,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             ValidationContext context = new(options, null, items: null);
             Validator.ValidateObject(options, context, validateAllProperties: true);
 
-            return new ExecuteAction(endpointInfo, options);
+            return new ExecuteAction(processInfo, options);
         }
 
         internal sealed class ExecuteAction :
             CollectionRuleActionBase<ExecuteOptions>
         {
-            public ExecuteAction(IEndpointInfo endpointInfo, ExecuteOptions options)
-                : base(endpointInfo, options)
+            public ExecuteAction(IProcessInfo processInfo, ExecuteOptions options)
+                : base(processInfo, options)
             {
             }
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _logger = logger ?? throw new ArgumentNullException(nameof(serviceProvider));
         }
 
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, GetEnvironmentVariableOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, GetEnvironmentVariableOptions options)
         {
             if (null == options)
             {
@@ -36,21 +36,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             ValidationContext context = new(options, _serviceProvider, items: null);
             Validator.ValidateObject(options, context, validateAllProperties: true);
 
-            return new GetEnvironmentVariableAction(_logger, endpointInfo, options);
+            return new GetEnvironmentVariableAction(_logger, processInfo, options);
         }
 
         internal sealed partial class GetEnvironmentVariableAction :
             CollectionRuleActionBase<GetEnvironmentVariableOptions>
         {
-            private readonly IEndpointInfo _endpointInfo;
             private readonly ILogger _logger;
             private readonly GetEnvironmentVariableOptions _options;
 
-            public GetEnvironmentVariableAction(ILogger logger, IEndpointInfo endpointInfo, GetEnvironmentVariableOptions options)
-                : base(endpointInfo, options)
+            public GetEnvironmentVariableAction(ILogger logger, IProcessInfo processInfo, GetEnvironmentVariableOptions options)
+                : base(processInfo, options)
             {
                 _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-                _endpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
                 _options = options ?? throw new ArgumentNullException(nameof(options));
             }
 
@@ -61,9 +59,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             {
                 try
                 {
-                    DiagnosticsClient client = new DiagnosticsClient(_endpointInfo.Endpoint);
+                    DiagnosticsClient client = new DiagnosticsClient(EndpointInfo.Endpoint);
 
-                    _logger.GettingEnvironmentVariable(_options.Name, _endpointInfo.ProcessId);
+                    _logger.GettingEnvironmentVariable(_options.Name, EndpointInfo.ProcessId);
                     Dictionary<string, string> envBlock = await client.GetProcessEnvironmentAsync(token);
                     if (!envBlock.TryGetValue(Options.Name, out string value))
                     {

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactory.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 {
     internal interface ICollectionRuleActionFactory<TOptions>
     {
-        ICollectionRuleAction Create(IEndpointInfo endpointInfo, TOptions options);
+        ICollectionRuleAction Create(IProcessInfo endpointInfo, TOptions options);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactoryProxy.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         /// Executes the underlying action with the specified parameters, verifying
         /// that the passed options are of the correct type.
         /// </summary>
-        ICollectionRuleAction Create(IEndpointInfo endpointInfo, object options);
+        ICollectionRuleAction Create(IProcessInfo endpointInfo, object options);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/LoadProfilerAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/LoadProfilerAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _logger = logger ?? throw new ArgumentNullException(nameof(serviceProvider));
         }
 
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, LoadProfilerOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, LoadProfilerOptions options)
         {
             if (null == options)
             {
@@ -35,21 +35,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             ValidationContext context = new(options, _serviceProvider, items: null);
             Validator.ValidateObject(options, context, validateAllProperties: true);
 
-            return new LoadProfilerAction(_logger, endpointInfo, options);
+            return new LoadProfilerAction(_logger, processInfo, options);
         }
 
         internal sealed partial class LoadProfilerAction :
             CollectionRuleActionBase<LoadProfilerOptions>
         {
-            private readonly IEndpointInfo _endpointInfo;
             private readonly ILogger _logger;
             private readonly LoadProfilerOptions _options;
 
-            public LoadProfilerAction(ILogger logger, IEndpointInfo endpointInfo, LoadProfilerOptions options)
-                : base(endpointInfo, options)
+            public LoadProfilerAction(ILogger logger, IProcessInfo processInfo, LoadProfilerOptions options)
+                : base(processInfo, options)
             {
                 _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-                _endpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
                 _options = options ?? throw new ArgumentNullException(nameof(options));
             }
 
@@ -60,9 +58,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             {
                 try
                 {
-                    DiagnosticsClient client = new DiagnosticsClient(_endpointInfo.Endpoint);
+                    DiagnosticsClient client = new DiagnosticsClient(EndpointInfo.Endpoint);
 
-                    _logger.LoadingProfiler(_options.Clsid, _options.Path, _endpointInfo.ProcessId);
+                    _logger.LoadingProfiler(_options.Clsid, _options.Path, EndpointInfo.ProcessId);
                     await client.SetStartupProfilerAsync(_options.Clsid, _options.Path, token);
 
                     if (!startCompletionSource.TrySetResult(null))

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public ICollectionRuleAction Create(IEndpointInfo endpointInfo, SetEnvironmentVariableOptions options)
+        public ICollectionRuleAction Create(IProcessInfo processInfo, SetEnvironmentVariableOptions options)
         {
             if (null == options)
             {
@@ -35,21 +35,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             ValidationContext context = new(options, _serviceProvider, items: null);
             Validator.ValidateObject(options, context, validateAllProperties: true);
 
-            return new SetEnvironmentVariableAction(_logger, endpointInfo, options);
+            return new SetEnvironmentVariableAction(_logger, processInfo, options);
         }
 
         internal sealed partial class SetEnvironmentVariableAction :
             CollectionRuleActionBase<SetEnvironmentVariableOptions>
         {
-            private readonly IEndpointInfo _endpointInfo;
             private readonly ILogger _logger;
             private readonly SetEnvironmentVariableOptions _options;
 
-            public SetEnvironmentVariableAction(ILogger logger, IEndpointInfo endpointInfo, SetEnvironmentVariableOptions options)
-                : base(endpointInfo, options)
+            public SetEnvironmentVariableAction(ILogger logger, IProcessInfo processInfo, SetEnvironmentVariableOptions options)
+                : base(processInfo, options)
             {
                 _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-                _endpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
                 _options = options ?? throw new ArgumentNullException(nameof(options));
             }
 
@@ -60,9 +58,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             {
                 try
                 {
-                    DiagnosticsClient client = new DiagnosticsClient(_endpointInfo.Endpoint);
+                    DiagnosticsClient client = new DiagnosticsClient(EndpointInfo.Endpoint);
 
-                    _logger.SettingEnvironmentVariable(_options.Name, _endpointInfo.ProcessId);
+                    _logger.SettingEnvironmentVariable(_options.Name, EndpointInfo.ProcessId);
                     await client.SetEnvironmentVariableAsync(_options.Name, _options.Value, token);
 
                     if (!startCompletionSource.TrySetResult(null))

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                 _logger.CollectionRuleStarted(ruleName);
 
-                CollectionRuleContext context = new(ruleName, options, _processInfo.EndpointInfo, _logger, _systemClock);
+                CollectionRuleContext context = new(ruleName, options, _processInfo, _logger, _systemClock);
 
                 await using CollectionRulePipeline pipeline = new(
                     _actionListExecutor,

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             // tests since it will be required by all aspects in the future. For example, the ActionListExecutor
             // (which uses null in tests) will require this when needing to get process information for
             // the actions property bag used for token replacement.
-            //ProcessInfo = endpprocessInfoointInfo ?? throw new ArgumentNullException(nameof(processInfo));
+            //ProcessInfo = processInfo ?? throw new ArgumentNullException(nameof(processInfo));
             ProcessInfo = processInfo;
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Options = options ?? throw new ArgumentNullException(nameof(options));

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 {
     internal class CollectionRuleContext
     {
-        public CollectionRuleContext(string name, CollectionRuleOptions options, IEndpointInfo endpointInfo, ILogger logger, ISystemClock clock, Action throttledCallback = null)
+        public CollectionRuleContext(string name, CollectionRuleOptions options, IProcessInfo processInfo, ILogger logger, ISystemClock clock, Action throttledCallback = null)
         {
-            // TODO: Allow null endpointInfo to allow tests to pass, but this should be provided by
+            // TODO: Allow null processInfo to allow tests to pass, but this should be provided by
             // tests since it will be required by all aspects in the future. For example, the ActionListExecutor
             // (which uses null in tests) will require this when needing to get process information for
             // the actions property bag used for token replacement.
-            //EndpointInfo = endpointInfo ?? throw new ArgumentNullException(nameof(endpointInfo));
-            EndpointInfo = endpointInfo;
+            //ProcessInfo = endpprocessInfoointInfo ?? throw new ArgumentNullException(nameof(processInfo));
+            ProcessInfo = processInfo;
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Options = options ?? throw new ArgumentNullException(nameof(options));
             Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -28,7 +28,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         public ISystemClock Clock { get; }
 
-        public IEndpointInfo EndpointInfo { get; }
+        public IProcessInfo ProcessInfo { get; }
+
+        public IEndpointInfo EndpointInfo => ProcessInfo?.EndpointInfo;
 
         public ILogger Logger { get; }
 

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                         Context.Logger.CollectionRuleTriggerStarted(Context.Name, Context.Options.Trigger.Type);
 
                         trigger = factory.Create(
-                            Context.ProcessInfo.EndpointInfo,
+                            Context.EndpointInfo,
                             () => triggerSatisfiedSource.TrySetResult(null),
                             Context.Options.Trigger.Settings);
 

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                         Context.Logger.CollectionRuleTriggerStarted(Context.Name, Context.Options.Trigger.Type);
 
                         trigger = factory.Create(
-                            Context.EndpointInfo,
+                            Context.ProcessInfo.EndpointInfo,
                             () => triggerSatisfiedSource.TrySetResult(null),
                             Context.Options.Trigger.Settings);
 


### PR DESCRIPTION
###### Summary
Adds collection rule actions to the operations table.

TODO
- Collection rules do not have limits, since there is no obvious action to take when a limit is reached.
- There is no way to distinguish operation types initiated by direct api access vs. collection rules. 
- Associate operations at the /collectionrules endpoint.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
