### PR TITLE
Re-enable linter suggestions on PRs from forks

### DIFF
--- a/.github/workflows/add-markdown-feedback.yml
+++ b/.github/workflows/add-markdown-feedback.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   add-markdown-feedback:
+    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     name: 'Add Markdown Feedback'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   lint-csharp:
+    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     name: 'C# Linting'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/submit-linter-suggestions.yml
+++ b/.github/workflows/submit-linter-suggestions.yml
@@ -19,6 +19,16 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: 'Verify user is a collaborator'
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        with:
+          script: |
+            await github.rest.repos.checkCollaborator({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.workflow_run.triggering_actor.login
+            });
+
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
@@ -45,19 +55,6 @@ jobs:
           run_id: ${{github.event.workflow_run.id }}
           name: pr-linter
           path: ./pr-linter
-
-      - name: Validate PR number
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
-        with:
-          script: |
-            const prNumber = context.payload.workflow_run.pull_requests[0].number;
-            const actionUtils = require('./.github/actions/action-utils.js');
-
-            const parsedArtifactEvent = JSON.parse(await actionUtils.readFile('./pr-linter/pr-event.json'));
-            if (parsedArtifactEvent.number !== prNumber ||
-                parsedArtifactEvent.pull_request.number !== prNumber) {
-              core.setFailed("Invalid artifact");
-            }
 
       - name: 'Setup reviewdog'
         uses: reviewdog/action-setup@8e48baae926e97848f0863ae248f3b08e089c81f


### PR DESCRIPTION
###### Summary

PRs from forks are no longer receiving linter suggestions. This is because the `submit-linter-suggestions` workflow no longer seems to have `context.payload.workflow_run.pull_requests` filled with information when the PR originates from a fork. 

Replace this validation with a check for if the PR author is a collaborator of this repo instead. Note that this does mean community contribution PRs won't receive linter suggestions for now.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
