### PR TITLE
Add delay when retrying process discovery during tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
@@ -180,6 +180,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
                 {
                     return processInfo;
                 }
+
+                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("Unable to get process information that has a process name.");


### PR DESCRIPTION
###### Summary

The recent nosuspend stack tests appear to be flaky, failing with the error:
> System.InvalidOperationException : Unable to get process information that has a process name.

Add a delay in-between process discovery attempts to hopefully address this.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
