### PR TITLE
Use environment variable to indicate that Azurite must initialize

### DIFF
--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -98,6 +98,8 @@ jobs:
       /m:1
 
     buildEnv:
+      # Indicate that tests based on Azurite should not be skipped if it is not initialized
+      TEST_AZURITE_MUST_INITIALIZE: 1
       # This is blank in public builds
       DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET: $(DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET)
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Fixtures/AzuriteFixture.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Fixtures/AzuriteFixture.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Fixtures
             //
             // Workaround: for now allow Windows environments to skip Azurite based tests due to configuration
             // issues in the Pipeline environment.
-            bool mustInitialize = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD"));
+            bool mustInitialize = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEST_AZURITE_MUST_INITIALIZE"));
 
             byte[] key = new byte[32];
             RandomNumberGenerator.Fill(key);


### PR DESCRIPTION
###### Summary

Use non-Azure Pipelines environment variable to indicate that Azurite must be initialized for Azurite-based tests.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
