### PR TITLE
Remove restriction of running tests in cross build

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -74,10 +74,8 @@ if ($archive) {
 
 # Run the xunit tests
 if ($test) {
-    if (-not $crossbuild) {
-        Invoke-Expression "& `"$engroot\common\build.ps1`" -test -configuration $configuration -verbosity $verbosity /p:BuildArch=$architecture -nobl /bl:$logdir\Test.binlog /p:TestGroup=$testgroup $managedArgs $remainingargs"
-        if ($lastExitCode -ne 0) {
-            exit $lastExitCode
-        }
+    Invoke-Expression "& `"$engroot\common\build.ps1`" -test -configuration $configuration -verbosity $verbosity /p:BuildArch=$architecture -nobl /bl:$logdir\Test.binlog /p:TestGroup=$testgroup $managedArgs $remainingargs"
+    if ($lastExitCode -ne 0) {
+        exit $lastExitCode
     }
 }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -242,45 +242,21 @@ fi
 #
 
 if [[ "$__Test" == 1 ]]; then
-   if [[ "$__CrossBuild" == 0 ]]; then
-      if [[ -z "$LLDB_PATH" ]]; then
-          export LLDB_PATH="$(which lldb-3.9.1 2> /dev/null)"
-          if [[ -z "$LLDB_PATH" ]]; then
-              export LLDB_PATH="$(which lldb-3.9 2> /dev/null)"
-              if [[ -z "$LLDB_PATH" ]]; then
-                  export LLDB_PATH="$(which lldb-4.0 2> /dev/null)"
-                  if [[ -z "$LLDB_PATH" ]]; then
-                      export LLDB_PATH="$(which lldb-5.0 2> /dev/null)"
-                      if [[ -z "$LLDB_PATH" ]]; then
-                          export LLDB_PATH="$(which lldb 2> /dev/null)"
-                      fi
-                  fi
-              fi
-          fi
-      fi
+    "$__RepoRootDir/eng/common/build.sh" \
+    --test \
+    --configuration "$__BuildType" \
+    /p:BuildArch="$__TargetArch" \
+    -nobl \
+    /bl:"$__LogsDir"/Test.binlog \
+    /p:TestGroup="$__TestGroup" \
+    $__CommonMSBuildArgs \
+    $__ManagedBuildArgs \
+    $__ArcadeScriptArgs \
+    $__UnprocessedBuildArgs
 
-      if [[ -z "$GDB_PATH" ]]; then
-          export GDB_PATH="$(which gdb 2> /dev/null)"
-      fi
-
-      echo "lldb: '$LLDB_PATH' gdb: '$GDB_PATH'"
-
-      "$__RepoRootDir/eng/common/build.sh" \
-        --test \
-        --configuration "$__BuildType" \
-        /p:BuildArch="$__TargetArch" \
-        -nobl \
-        /bl:"$__LogsDir"/Test.binlog \
-        /p:TestGroup="$__TestGroup" \
-        $__CommonMSBuildArgs \
-        $__ManagedBuildArgs \
-        $__ArcadeScriptArgs \
-        $__UnprocessedBuildArgs
-
-      if [ $? != 0 ]; then
-          exit 1
-      fi
-   fi
+    if [ $? != 0 ]; then
+        exit 1
+    fi
 fi
 
 echo "BUILD: Repo sucessfully built."


### PR DESCRIPTION
###### Summary

Remove the restriction that testing cannot be done from a cross build (e.g. x64 host building arm64). The future Helix test project will be relying on the computation of the target runtime identifier, which is only accurately available during a cross build. Our builds currently do not invoke tests during cross builds so it shouldn't be an issue. Additionally, remove the LLDB path calculation for non-Windows builds as it is unused.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
