### PR TITLE
Add Helix project and supporting targets

### DIFF
--- a/eng/Helix.CrossTarget.targets
+++ b/eng/Helix.CrossTarget.targets
@@ -1,0 +1,16 @@
+<Project>
+  <Target Name="CollectHelixWorkItems"
+          Outputs="@(HelixWorkItem)">
+    <ItemGroup>
+      <_TargetFrameworks Remove="@(_TargetFrameworks)" />
+      <_TargetFrameworks Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="CollectHelixWorkItems"
+             Properties="TargetFramework=%(_TargetFrameworks.Identity)"
+             RemoveProperties="TargetFrameworks">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="HelixWorkItem" />
+    </MSBuild>
+  </Target>
+</Project>

--- a/eng/Helix.SingleTarget.targets
+++ b/eng/Helix.SingleTarget.targets
@@ -1,0 +1,14 @@
+<Project>
+  <ItemGroup>
+    <!-- Set TEST_DOTNET_ROOT to same as DOTNET_ROOT (which is provided by the dotnet cli correlation payload) -->
+    <HelixWorkItemPreCommand Include="export TEST_DOTNET_ROOT=${DOTNET_ROOT}"
+                             Condition="'$(IsHelixPosixShell)' == 'true'" />
+    <HelixWorkItemPreCommand Include="SET TEST_DOTNET_ROOT=%DOTNET_ROOT%"
+                             Condition="'$(IsHelixPosixShell)' != 'true'" />
+  </ItemGroup>
+
+  <!-- TODO: Add Helix work item PreCommands to install Node and Azurite -->
+
+  <Target Name="CollectHelixWorkItems"
+          Outputs="@(HelixWorkItem)" />
+</Project>

--- a/eng/Helix.props
+++ b/eng/Helix.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <IsHelixPosixShell>true</IsHelixPosixShell>
+    <IsHelixPosixShell Condition="$(HelixTargetQueue.Contains('windows'))">false</IsHelixPosixShell>
+  </PropertyGroup>
+</Project>

--- a/eng/Helix.targets
+++ b/eng/Helix.targets
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+    MSBuild uses the IsCrossTargetingBuild property (which checks
+    that TargetFrameworks is non-empty and that TargetFramework is empty).
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Helix.CrossTarget.targets"  Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)Helix.SingleTarget.targets"  Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+</Project>

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -1,0 +1,164 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk"
+         DefaultTargets="Test">
+
+  <PropertyGroup>
+    <HelixConfiguration>$(Configuration)</HelixConfiguration>
+    <HelixArchitecture>$(BuildArch)</HelixArchitecture>
+    <UseOpenQueues>true</UseOpenQueues>
+    <UseOpenQueues Condition="'$(HelixAccessToken)' != ''">false</UseOpenQueues>
+    <!-- Ensure dotnet correlation payloads match the tested RID -->
+    <DotNetCliRuntime>$(PackageRid)</DotNetCliRuntime>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseOpenQueues)' == 'true'">
+    <QueueSuffix>.open</QueueSuffix>
+    <!-- Open queues require a creator to be set. -->
+    <Creator Condition=" '$(USERNAME)' != '' ">$(USERNAME)</Creator>
+    <Creator Condition=" '$(USER)' != '' ">$(USER)</Creator>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SYSTEM_COLLECTIONURI)' == 'https://dev.azure.com/dnceng/'">
+    <HelixSourcePrefix Condition="'$(BUILD_REASON)' == 'Manual'">pr</HelixSourcePrefix>
+    <HelixSourcePrefix Condition="'$(BUILD_REASON)' == 'PullRequest'">pr</HelixSourcePrefix>
+    <HelixSourcePrefix Condition="'$(HelixSourcePrefix)' == ''">official</HelixSourcePrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <HelixSourcePrefix Condition="'$(HelixSourcePrefix)' == ''">pr</HelixSourcePrefix>
+    <HelixSource>$(HelixSourcePrefix)/dotnet/dotnet-monitor</HelixSource>
+    <HelixSource Condition="'$(BUILD_SOURCEBRANCH)' != ''">$(HelixSource)/$(BUILD_SOURCEBRANCH)</HelixSource>
+    <HelixType>test/binaries/</HelixType>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <HelixAvailableTargetQueue>
+      <AdditionalProperties>Platform=$(HelixArchitecture)</AdditionalProperties>
+    </HelixAvailableTargetQueue>
+  </ItemDefinitionGroup>
+
+  <!-- List of all available Helix machines: https://helix.dot.net/ -->
+
+  <!-- Windows queues -->
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
+    <!-- win-arm64 -->
+    <HelixAvailableTargetQueue Include="windows.11.arm64$(QueueSuffix)"
+                               Condition="'$(HelixArchitecture)' == 'arm64'">
+      <TestRunName>Windows 11 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <!-- win-x64 -->
+    <HelixAvailableTargetQueue Include="windows.10.amd64.client$(QueueSuffix)"
+                               Condition="'$(HelixArchitecture)' == 'x64'">
+      <TestRunName>Windows 10 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <!-- win-x86 -->
+    <!-- Windows x64 clients can run dotnet x86 natively -->
+    <HelixAvailableTargetQueue Include="windows.10.amd64.client$(QueueSuffix)"
+                               Condition="'$(HelixArchitecture)' == 'x86'">
+      <TestRunName>Windows 10 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+  </ItemGroup>
+
+  <!-- Linux gnu libc queues -->
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform(Linux)) and !$(PackageRid.Contains(musl))">
+    <!-- linux-arm64 -->
+    <HelixAvailableTargetQueue Include="ubuntu.1804.armarch$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8"
+                               Condition="'$(HelixArchitecture)' == 'arm64'">
+      <TestRunName>Debian 11 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <HelixAvailableTargetQueue Include="ubuntu.1804.armarch$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8"
+                               Condition="'$(HelixArchitecture)' == 'arm64'">
+      <TestRunName>Ubuntu 18.04 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <!-- linux-x64 -->
+    <HelixAvailableTargetQueue Include="ubuntu.1804.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64"
+                               Condition="'$(HelixArchitecture)' == 'x64'">
+      <TestRunName>Debian 11 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <HelixAvailableTargetQueue Include="ubuntu.1804.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64"
+                               Condition="'$(HelixArchitecture)' == 'x64'">
+      <TestRunName>Mariner 2.0 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <HelixAvailableTargetQueue Include="ubuntu.1804.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-amd64"
+                               Condition="'$(HelixArchitecture)' == 'x64'">
+      <TestRunName>Ubuntu 18.04 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+  </ItemGroup>
+
+  <!-- Linux musl libc queues -->
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform(Linux)) and $(PackageRid.Contains(musl))">
+    <!-- linux-musl-arm64 -->
+    <HelixAvailableTargetQueue Include="ubuntu.1804.armarch$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-helix-arm64v8"
+                               Condition="'$(HelixArchitecture)' == 'arm64'">
+      <TestRunName>Alpine 3.15 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <!-- linux-musl-x64 -->
+    <HelixAvailableTargetQueue Include="ubuntu.1804.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-helix-amd64"
+                               Condition="'$(HelixArchitecture)' == 'x64'">
+      <TestRunName>Alpine 3.15 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+  </ItemGroup>
+
+  <!-- OSX queues -->
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform(OSX))">
+    <!-- osx-arm64 -->
+    <HelixAvailableTargetQueue Include="osx.13.arm64$(QueueSuffix)"
+                               Condition="'$(HelixArchitecture)' == 'arm64'">
+      <TestRunName>OSX 13 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+    <!-- osx-x64 -->
+    <HelixAvailableTargetQueue Include="osx.13.amd64$(QueueSuffix)"
+                               Condition="'$(HelixArchitecture)' == 'x64'">
+      <TestRunName>OSX 13 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+    </HelixAvailableTargetQueue>
+  </ItemGroup>
+
+  <ItemGroup>
+    <HelixTargetQueue Include="@(HelixAvailableTargetQueue)">
+      <AdditionalProperties>%(AdditionalProperties);Configuration=$(HelixConfiguration)</AdditionalProperties>
+    </HelixTargetQueue>
+  </ItemGroup>
+
+  <!-- Correlation Payload: SDK (to use "dotnet test") -->
+  <PropertyGroup>
+    <IncludeDotNetCli>true</IncludeDotNetCli>
+    <DotNetCliPackageType>sdk</DotNetCliPackageType>
+    <DotNetCliVersion>$(MicrosoftDotnetSdkInternalVersion)</DotNetCliVersion>
+  </PropertyGroup>
+
+  <!-- Correlation Payload: AspNetCore (these packages also contain corresponding NetCoreApp version) -->
+  <ItemGroup>
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp60Version)">
+      <PackageType>aspnetcore-runtime</PackageType>
+    </AdditionalDotNetPackage>
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp70Version)">
+      <PackageType>aspnetcore-runtime</PackageType>
+    </AdditionalDotNetPackage>
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp80Version)">
+      <PackageType>aspnetcore-runtime</PackageType>
+    </AdditionalDotNetPackage>
+  </ItemGroup>
+
+  <!-- Correlation Payload: Common Helix payload -->
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(RepoRoot)eng\helix\payload" />
+  </ItemGroup>
+
+  <!-- Correlation Payload: Built binaries -->
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(ArtifactsBinDir)" />
+  </ItemGroup>
+
+  <!-- Collect HelixWorkItems from each project that participates in testing. -->
+  <Target Name="CollectHelixWorkItems"
+          BeforeTargets="BeforeTest">
+    <ItemGroup>
+      <ProjectWithHelixWorkItems Include="$(RepoRoot)src\Tests\**\*.*proj" />
+    </ItemGroup>
+    <MSBuild Projects="@(ProjectWithHelixWorkItems)"
+             Targets="CollectHelixWorkItems"
+             SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="HelixWorkItem" />
+    </MSBuild>
+  </Target>
+</Project>

--- a/eng/helix/payload/dotnettest.cmd
+++ b/eng/helix/payload/dotnettest.cmd
@@ -1,0 +1,33 @@
+@echo off
+setlocal
+
+set testAssembly=%1
+set configuration=%2
+set targetFramework=%3
+set architecture=%~4
+
+set filterArgs=
+if not "%~5" == "" (
+   set filterArgs=--filter ^"%~5^"
+)
+
+set exit_code=0
+
+echo "Start tests..."
+
+dotnet.exe test ^
+  "%HELIX_CORRELATION_PAYLOAD%\%testAssembly%\%configuration%\%targetFramework%\%testAssembly%.dll" ^
+  --logger:"console;verbosity=normal" ^
+  --logger:"trx;LogFileName=%testAssembly%_%targetFramework%_%architecture%.trx" ^
+  --logger:"html;LogFileName=%testAssembly%_%targetFramework%_%architecture%.html" ^
+  --ResultsDirectory:%HELIX_WORKITEM_UPLOAD_ROOT% ^
+  --blame "CollectHangDump;TestTimeout=15m" ^
+  %filterArgs%
+
+if not errorlevel 0 (
+    set exit_code=%errorlevel%
+)
+
+echo "Finished tests; exit code: %exit_code%"
+
+exit /b %exit_code%

--- a/eng/helix/payload/dotnettest.cmd
+++ b/eng/helix/payload/dotnettest.cmd
@@ -5,10 +5,11 @@ set testAssembly=%1
 set configuration=%2
 set targetFramework=%3
 set architecture=%~4
+set timeoutMinutes=%~5
 
 set filterArgs=
-if not "%~5" == "" (
-   set filterArgs=--filter ^"%~5^"
+if not "%~6" == "" (
+   set filterArgs=--filter ^"%~6^"
 )
 
 set exit_code=0
@@ -21,7 +22,7 @@ dotnet.exe test ^
   --logger:"trx;LogFileName=%testAssembly%_%targetFramework%_%architecture%.trx" ^
   --logger:"html;LogFileName=%testAssembly%_%targetFramework%_%architecture%.html" ^
   --ResultsDirectory:%HELIX_WORKITEM_UPLOAD_ROOT% ^
-  --blame "CollectHangDump;TestTimeout=15m" ^
+  --blame "CollectHangDump;TestTimeout=%timeoutMinutes%m" ^
   %filterArgs%
 
 if not errorlevel 0 (

--- a/eng/helix/payload/dotnettest.sh
+++ b/eng/helix/payload/dotnettest.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+testAssembly="$1"
+configuration="$2"
+targetFramework="$3"
+architecture="$4"
+
+filterArgs=""
+if [[ ! -z "$filter" ]]; then
+  filterArgs="--filter \"$5\""
+fi
+
+exit_code=0
+
+echo "Start tests..."
+
+dotnet test \
+  "$HELIX_CORRELATION_PAYLOAD/$testAssembly/$configuration/$targetFramework/$testAssembly.dll" \
+  --logger:"console;verbosity=normal" \
+  --logger:"trx;LogFileName=${testAssembly}_${targetFramework}_${architecture}.trx" \
+  --logger:"html;LogFileName=${testAssembly}_${targetFramework}_${architecture}.html" \
+  --ResultsDirectory:$HELIX_WORKITEM_UPLOAD_ROOT \
+  --blame "CollectHangDump;TestTimeout=15m" \
+  $filterArgs
+
+exit_code=$?
+
+echo "Finished tests; exit code: $exit_code"
+
+exit $exit_code

--- a/eng/helix/payload/dotnettest.sh
+++ b/eng/helix/payload/dotnettest.sh
@@ -4,10 +4,11 @@ testAssembly="$1"
 configuration="$2"
 targetFramework="$3"
 architecture="$4"
+timeoutMinutes="$5"
 
 filterArgs=""
-if [[ ! -z "$filter" ]]; then
-  filterArgs="--filter \"$5\""
+if [[ ! -z "$6" ]]; then
+  filterArgs="--filter \"$6\""
 fi
 
 exit_code=0
@@ -20,7 +21,7 @@ dotnet test \
   --logger:"trx;LogFileName=${testAssembly}_${targetFramework}_${architecture}.trx" \
   --logger:"html;LogFileName=${testAssembly}_${targetFramework}_${architecture}.html" \
   --ResultsDirectory:$HELIX_WORKITEM_UPLOAD_ROOT \
-  --blame "CollectHangDump;TestTimeout=15m" \
+  --blame "CollectHangDump;TestTimeout=${timeoutMinutes}m" \
   $filterArgs
 
 exit_code=$?

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,8 @@
   <!-- Filter tests based on specified TestGroup -->
   <PropertyGroup Condition="'$(TestGroup)' == 'PR'">
     <!-- Only run tests for .NET 8 -->
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "TargetFrameworkMoniker=Net80"</TestRunnerAdditionalArguments>
+    <TestRunnerFilterArguments>TargetFrameworkMoniker=Net80</TestRunnerFilterArguments>
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "$(TestRunnerFilterArguments)"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <ItemGroup>
@@ -62,5 +63,6 @@
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
+  <Import Project="$(RepositoryEngineeringDir)Helix.props" />
   <Import Project="$(RepositoryEngineeringDir)native\naming.props" />
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-    <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=15m"</TestRunnerAdditionalArguments>
+    <TestRunnerTestTimeoutMinutes>15</TestRunnerTestTimeoutMinutes>
+    <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=$(TestRunnerTestTimeoutMinutes)m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <!-- Filter tests based on specified TestGroup -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,8 @@
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <Import Project="$(RepositoryEngineeringDir)Helix.targets" />
+
   <!-- Work around https://github.com/dotnet/sourcelink/issues/572
   Remove once we build using an SDK that contains https://github.com/dotnet/sdk/pull/10613 -->
   <PropertyGroup>

--- a/src/Tests/Directory.Build.targets
+++ b/src/Tests/Directory.Build.targets
@@ -16,4 +16,5 @@
   <Target Name="IntegrationTest" DependsOnTargets="$(_GetTestsToRunTarget);RunTests" Condition="'$(IsIntegrationTestProject)' == 'true'" />
 
   <Import Project="$(MSBuildThisFileDirectory)CrossTargeting.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)Helix.targets" Condition="'$(IsTestProject)' == 'true'" />
 </Project>

--- a/src/Tests/Helix.targets
+++ b/src/Tests/Helix.targets
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup Condition="'$(TargetFramework)' != ''">
+    <HelixDotnetTestArgs>$(TargetName) $(Configuration) $(TargetFramework) $(Platform) $(TestRunnerFilterArguments)</HelixDotnetTestArgs>
+    <HelixDotnetTestCommand Condition="'$(IsHelixPosixShell)' != 'true'">call %HELIX_CORRELATION_PAYLOAD%\dotnettest.cmd $(HelixDotnetTestArgs)</HelixDotnetTestCommand>
+    <HelixDotnetTestCommand Condition="'$(IsHelixPosixShell)' == 'true'">$HELIX_CORRELATION_PAYLOAD/dotnettest.sh $(HelixDotnetTestArgs)</HelixDotnetTestCommand>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' != ''">
+    <!-- Helix work item that calls "dotnet test" for the test assembly. -->
+    <HelixWorkItem Include="$(MSBuildProjectName)-$(TargetFramework)-$(Platform)">
+      <PreCommands Condition="'$(HelixTargetQueue)' != ''">@(HelixWorkItemPreCommand)</PreCommands>
+      <Command Condition="'$(HelixTargetQueue)' != ''">$(HelixDotnetTestCommand)</Command>
+      <PostCommands Condition="'$(HelixTargetQueue)' != ''">@(HelixWorkItemPostCommand)</PostCommands>
+      <Timeout>00:30:00</Timeout>
+    </HelixWorkItem>
+  </ItemGroup>
+</Project>

--- a/src/Tests/Helix.targets
+++ b/src/Tests/Helix.targets
@@ -1,8 +1,10 @@
 <Project>
   <PropertyGroup Condition="'$(TargetFramework)' != ''">
-    <HelixDotnetTestArgs>$(TargetName) $(Configuration) $(TargetFramework) $(Platform) $(TestRunnerFilterArguments)</HelixDotnetTestArgs>
+    <HelixDotnetTestArgs>$(TargetName) $(Configuration) $(TargetFramework) $(Platform) $(TestRunnerTestTimeoutMinutes) $(TestRunnerFilterArguments)</HelixDotnetTestArgs>
     <HelixDotnetTestCommand Condition="'$(IsHelixPosixShell)' != 'true'">call %HELIX_CORRELATION_PAYLOAD%\dotnettest.cmd $(HelixDotnetTestArgs)</HelixDotnetTestCommand>
     <HelixDotnetTestCommand Condition="'$(IsHelixPosixShell)' == 'true'">$HELIX_CORRELATION_PAYLOAD/dotnettest.sh $(HelixDotnetTestArgs)</HelixDotnetTestCommand>
+    <!-- Add an arbitrary of time to the test timeout so that the work item has extra time to run pre and post commands. -->
+    <HelixTimeoutMinutes>$([MSBuild]::Add($(TestRunnerTestTimeoutMinutes), 10))</HelixTimeoutMinutes>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != ''">
@@ -11,7 +13,7 @@
       <PreCommands Condition="'$(HelixTargetQueue)' != ''">@(HelixWorkItemPreCommand)</PreCommands>
       <Command Condition="'$(HelixTargetQueue)' != ''">$(HelixDotnetTestCommand)</Command>
       <PostCommands Condition="'$(HelixTargetQueue)' != ''">@(HelixWorkItemPostCommand)</PostCommands>
-      <Timeout>00:30:00</Timeout>
+      <Timeout>00:$(HelixTimeoutMinutes):00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
###### Summary

These changes enable the use of Helix for executing tests on a multitude of platforms and architectures. Helix testing is enabled through the use of the `/eng/helix/Helix.proj` project and can be executed on the command line using `build.cmd/sh -projects ./eng/helix/Helix.proj -test -skipnative -skipmanaged` after a successful full build of both native and managed components.

###### Details

- The `/eng/helix/Helix.proj` project gathers the executable work item information (e.g. `dotnet test` command line) from each participating project (e.g. test projects).
- These work items (e.g. tests) are executed in a set of queues. There are several queues that are employed to get broad coverage of scenarios where .NET Monitor is used; the set of queues on which the work items are executed are determined by the build target environment e.g. a Windows x64 host can launch arm64, x64, and x86 tests on Windows queues depending on which target architecture was built.
- Test results are automatically uploaded to Azure Pipelines if this project is invoked within an Azure Pipelines build (no work was done here since this is automatically supported by the Helix SDK).
- All existing enabled tests are runnable and succeed through this project EXCEPT for the Azure blob storage tests that require Azurite to be installed; these tests are automatically skipped since Azurite is not initialized and the environment variable to indicate they should not be skipped is not applied. Enabling this is still a work in progress.
- The pipelines have not been update to use this project yet; that will come as a separate PR.

Example build where E2E testing via Helix is enabled: https://dev.azure.com/dnceng/internal/_build/results?buildId=2218286&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
