### PR TITLE
Preserve out-of-support date on new patch releases

### DIFF
--- a/.github/actions/update-releases-json/index.js
+++ b/.github/actions/update-releases-json/index.js
@@ -58,9 +58,10 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
         supportedFrameworks: supportedFrameworks.split(' ')
     };
 
-    // Preserve the original minor release date for RTM releases
+    // Preserve the original minor release date and out-of-support date for RTM releases
     if (existingRelease !== undefined && iteration === undefined) {
         newRelease.minorReleaseDate = existingRelease.minorReleaseDate;
+        newRelease.outOfSupportDate = existingRelease.outOfSupportDate;
     }
 
     releasesData.releases[releaseMajorMinorVersion] = newRelease;


### PR DESCRIPTION
###### Summary

Currently if we have a minor version set to go out-of-support this information is not preserved when we create a new patch release for that minor version.

ref: https://github.com/dotnet/dotnet-monitor/pull/4852


Example PR from this automation change: https://github.com/schmittjoseph/dotnet-monitor/pull/373

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
