### PR TITLE
Use portable runtime identifier for profiler enablement when available

### DIFF
--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -494,8 +494,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_EgressProviderTypeNotExist);
 
-        private static readonly Action<ILogger, string, Exception> _profilerRuntimeIdentifier =
-            LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, string, Exception> _profilerRuntimeIdentifier =
+            LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.ProfilerRuntimeIdentifier.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ProfilerRuntimeIdentifier);
@@ -915,9 +915,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _egressProviderTypeNotExist(logger, providerType, null);
         }
 
-        public static void ProfilerRuntimeIdentifier(this ILogger logger, string runtimeIdentifier)
+        public static void ProfilerRuntimeIdentifier(this ILogger logger, string runtimeIdentifier, string source)
         {
-            _profilerRuntimeIdentifier(logger, runtimeIdentifier, null);
+            _profilerRuntimeIdentifier(logger, runtimeIdentifier, source, null);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1385,7 +1385,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Using &apos;{runtimeIdentifier}&apos; runtime identifier for profiler enablement..
+        ///   Looks up a localized string similar to Using &apos;{runtimeIdentifier}&apos; profiler runtime identifier. Source: {source}.
         /// </summary>
         internal static string LogFormatString_ProfilerRuntimeIdentifier {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -907,6 +907,6 @@
 1. errorMessage: The validation failure message</comment>
   </data>
   <data name="LogFormatString_ProfilerRuntimeIdentifier" xml:space="preserve">
-    <value>Using '{runtimeIdentifier}' runtime identifier for profiler enablement.</value>
+    <value>Using '{runtimeIdentifier}' profiler runtime identifier. Source: {source}</value>
   </data>
 </root>


### PR DESCRIPTION
###### Summary

If the process host reports a portable runtime identifier, use that value to determine which profiler variant to use. Additionally, log how the profiler runtime identifier was determined (`ProcessEnvironment`, `ProcessHost`, `ProcessImplicit`).

With these changes, the .NET 8 test applications have their profiler variant determined by the portable runtime identifier (since they respond to the `ProcessInfo3` command) and thus report as `ProcessHost` whereas the lower .NET versions fallback to the `ProcessImplicit` determination.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
