### PR TITLE
[Parameter Capturing] Fix native integer parameter handling

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokens.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokens.cs
@@ -93,12 +93,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
                 }
                 else if (paramType.IsPrimitive)
                 {
-                    boxingTokens.Add(GetSpecialCaseBoxingToken(Type.GetTypeCode(paramType)));
+                    boxingTokens.Add(GetSpecialCaseBoxingTokenForPrimitive(Type.GetTypeCode(paramType)));
                 }
                 else if (paramType.IsValueType)
                 {
                     // Ref structs have already been filtered out by the above IsByRefLike check.
-
                     if (paramType.IsGenericType)
                     {
                         // Typespec
@@ -134,16 +133,16 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
             return boxingTokens.ToArray();
         }
 
-        private static uint GetSpecialCaseBoxingToken(TypeCode typeCode)
+        private static uint GetSpecialCaseBoxingTokenForPrimitive(TypeCode typeCode)
         {
-            return GetSpecialCaseBoxingType(typeCode).BoxingToken();
+            return GetSpecialCaseBoxingTypeForPrimitive(typeCode).BoxingToken();
         }
 
-        private static SpecialCaseBoxingTypes GetSpecialCaseBoxingType(TypeCode typeCode)
+        private static SpecialCaseBoxingTypes GetSpecialCaseBoxingTypeForPrimitive(TypeCode typeCode)
         {
             return typeCode switch
             {
-                TypeCode.Object => SpecialCaseBoxingTypes.Object,
+                TypeCode.Object => SpecialCaseBoxingTypes.Unknown, // IntPtr, UIntPtr
                 TypeCode.Boolean => SpecialCaseBoxingTypes.Boolean,
                 TypeCode.Char => SpecialCaseBoxingTypes.Char,
                 TypeCode.SByte => SpecialCaseBoxingTypes.SByte,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/BoxingTokensTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/BoxingTokensTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.OutParam), false)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefStruct), false)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RecordStruct), true)]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.NativeIntegers), false, false)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Pointer), false)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.GenericParameters), false, false)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.TypeDef), true)]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/SampleMethods.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/SampleMethods.cs
@@ -89,6 +89,8 @@ namespace SampleMethods
             float arg11,
             double arg12) { }
 
+        public static void NativeIntegers(IntPtr intPtr, UIntPtr uintPtr) { }
+
         public static void GenericParameters<T, K>(T t, K k) { }
 
         public static void TypeRef(Uri uri) { }


### PR DESCRIPTION
###### Summary

Native integers (IntPtr,UIntPtr) were incorrectly being treated as standard boxable parameters. Fix the boxing token logic to identify these and mark them as unsupported for now.

Note:
- IntPtr and UIntPtr are marked as primitive types by .net but with a TypeCode of `Object` so use this for detection.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
