### PR TITLE
[Parameter Capturing] Filter out generic parameters earlier

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokens.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokens.cs
@@ -82,12 +82,16 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
                     methodParameterTypes.Insert(0, thisType);
                 }
             }
-             
+
             foreach (Type paramType in methodParameterTypes)
             {
                 if (paramType.IsByRef ||
                     paramType.IsByRefLike ||
                     paramType.IsPointer)
+                {
+                    boxingTokens.Add(UnsupportedParameterToken);
+                }
+                else if (paramType.IsGenericParameter)
                 {
                     boxingTokens.Add(UnsupportedParameterToken);
                 }
@@ -114,10 +118,6 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
                         // Typedef
                         boxingTokens.Add((uint)paramType.MetadataToken);
                     }
-                }
-                else if (paramType.IsGenericParameter)
-                {
-                    boxingTokens.Add(UnsupportedParameterToken);
                 }
                 else if (paramType.IsArray ||
                     paramType.IsClass ||


### PR DESCRIPTION
###### Summary

I encountered that while trying to instrument a `MethodInfo` for a constructed generic method we could incorrectly mark some generic parameters as supported if the constructed version used primitives, e.g. `MyMethod<T>(T i) , T is int`. Check for generic parameters earlier.

Note:
This isn't an expected use case of the feature (instrumenting constructed generic MethodInfos) so the problem should never show up in normal use, however in my bespoke local stress testing I am doing this.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
