### PR TITLE
Fix Collection Rule Trigger Type Console Spew

### DIFF
--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                         triggerScope.AddCollectionRuleTrigger(Context.Options.Trigger.Type);
                         using IDisposable triggerScopeRegistration = Context.Logger.BeginScope(triggerScope);
 
-Context.Logger.CollectionRuleTriggerStarted(Context.Name, Context.Options.Trigger.Type);
+                        Context.Logger.CollectionRuleTriggerStarted(Context.Name, Context.Options.Trigger.Type);
 
                         trigger = factory.Create(
                             Context.EndpointInfo,

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRulePipeline.cs
@@ -92,9 +92,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                     {
                         KeyValueLogScope triggerScope = new();
                         triggerScope.AddCollectionRuleTrigger(Context.Options.Trigger.Type);
-                        IDisposable triggerScopeRegistration = Context.Logger.BeginScope(triggerScope);
+                        using IDisposable triggerScopeRegistration = Context.Logger.BeginScope(triggerScope);
 
-                        Context.Logger.CollectionRuleTriggerStarted(Context.Name, Context.Options.Trigger.Type);
+Context.Logger.CollectionRuleTriggerStarted(Context.Name, Context.Options.Trigger.Type);
 
                         trigger = factory.Create(
                             Context.EndpointInfo,


### PR DESCRIPTION
###### Summary

Currently, `dotnet monitor` emits the `CollectionRuleTriggerType` repeatedly in logs:

![CollectionRuleTriggerTypeDuplication](https://github.com/dotnet/dotnet-monitor/assets/85592574/3e5e0d76-efe3-475d-97e6-403be0537914)

This can lead to huge amounts of console spew as this continues to grow every time the collection rule is triggered. The issue appears to have been tied to `triggerScopeRegistration` failing to be properly disposed in a loop.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Prevent overreporting of the collection rule trigger type in console output