### PR TITLE
Compatibility with 6/7 Runtimes For Multiple `System.Diagnostics.Metrics` Sessions

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     using IDisposable monitorListener = _optionsMonitor.OnChange((_, _) => optionsTokenSource.SafeCancel());
 
                     MetricsPipelineSettings counterSettings = MetricsSettingsFactory.CreateSettings(counterOptions, options);
+                    counterSettings.UseSharedSession = pi.EndpointInfo.RuntimeVersion.Major >= 8;
 
                     _counterPipeline = new MetricsPipeline(client, counterSettings, loggers: new[] { new MetricsLogger(_store.MetricsStore) });
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     using IDisposable monitorListener = _optionsMonitor.OnChange((_, _) => optionsTokenSource.SafeCancel());
 
                     MetricsPipelineSettings counterSettings = MetricsSettingsFactory.CreateSettings(counterOptions, options);
-                    counterSettings.UseSharedSession = pi.EndpointInfo.RuntimeVersion.Major >= 8;
+                    counterSettings.UseSharedSession = pi.EndpointInfo.RuntimeVersion?.Major >= 8;
 
                     _counterPipeline = new MetricsPipeline(client, counterSettings, loggers: new[] { new MetricsLogger(_store.MetricsStore) });
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
@@ -44,7 +44,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
                 SlidingWindowDuration = options.SlidingWindowDuration.GetValueOrDefault(TimeSpan.Parse(EventMeterOptionsDefaults.SlidingWindowDuration)),
                 MaxHistograms = _counterOptions.CurrentValue.GetMaxHistograms(),
                 MaxTimeSeries = _counterOptions.CurrentValue.GetMaxTimeSeries(),
+                RuntimeVersion = endpointInfo.RuntimeVersion
             };
+
+            
 
             return EventPipeTriggerFactory.Create(
                 endpointInfo,

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
@@ -47,8 +47,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
                 RuntimeVersion = endpointInfo.RuntimeVersion
             };
 
-            
-
             return EventPipeTriggerFactory.Create(
                 endpointInfo,
                 SystemDiagnosticsMetricsTrigger.CreateConfiguration(settings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
                 SlidingWindowDuration = options.SlidingWindowDuration.GetValueOrDefault(TimeSpan.Parse(EventMeterOptionsDefaults.SlidingWindowDuration)),
                 MaxHistograms = _counterOptions.CurrentValue.GetMaxHistograms(),
                 MaxTimeSeries = _counterOptions.CurrentValue.GetMaxTimeSeries(),
-                RuntimeVersion = endpointInfo.RuntimeVersion
+                UseSharedSession = endpointInfo.RuntimeVersion.Major >= 8
             };
 
             return EventPipeTriggerFactory.Create(

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/EventMeterTriggerFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
                 SlidingWindowDuration = options.SlidingWindowDuration.GetValueOrDefault(TimeSpan.Parse(EventMeterOptionsDefaults.SlidingWindowDuration)),
                 MaxHistograms = _counterOptions.CurrentValue.GetMaxHistograms(),
                 MaxTimeSeries = _counterOptions.CurrentValue.GetMaxTimeSeries(),
-                UseSharedSession = endpointInfo.RuntimeVersion.Major >= 8
+                UseSharedSession = endpointInfo.RuntimeVersion?.Major >= 8
             };
 
             return EventPipeTriggerFactory.Create(

--- a/src/Tools/dotnet-monitor/Metrics/MetricsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Metrics/MetricsOperationFactory.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public IArtifactOperation Create(IEndpointInfo endpointInfo, MetricsPipelineSettings settings)
         {
+            settings.UseSharedSession = endpointInfo.RuntimeVersion.Major >= 8;
             return new MetricsOperation(endpointInfo, settings, _operationTrackerService, _logger);
         }
     }

--- a/src/Tools/dotnet-monitor/Metrics/MetricsOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Metrics/MetricsOperationFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public IArtifactOperation Create(IEndpointInfo endpointInfo, MetricsPipelineSettings settings)
         {
-            settings.UseSharedSession = endpointInfo.RuntimeVersion.Major >= 8;
+            settings.UseSharedSession = endpointInfo.RuntimeVersion?.Major >= 8;
             return new MetricsOperation(endpointInfo, settings, _operationTrackerService, _logger);
         }
     }


### PR DESCRIPTION
###### Summary

The core change is [here](https://github.com/dotnet/diagnostics/pull/3889) - this is the only piece that requires a change to the `dotnet monitor` repo for now, but the changes in the diagnostics repo do apply for Metrics/LiveMetrics/Triggers. For more context on the problem this is trying to solve, see [here](https://github.com/dotnet/diagnostics/pull/3889#issuecomment-1629262044).


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
