### PR TITLE
Verify shared library files integrity

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private sealed class AutoDeleteFileStream : FileStream
         {
             public AutoDeleteFileStream(string path) : base(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete,
-                bufferSize: 4096, FileOptions.DeleteOnClose)
+                StreamDefaults.BufferSize, FileOptions.DeleteOnClose)
             {
             }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamDefaults.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    internal static class StreamDefaults
+    {
+        // Matches FileStream.DefaultBufferSize
+        public const int BufferSize = 4096;
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/BuildOutputSharedLibraryInitializer.cs
@@ -5,6 +5,8 @@ using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
 {
@@ -17,11 +19,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup
             _logger = logger;
         }
 
-        public IFileProviderFactory Initialize()
+        public Task<IFileProviderFactory> InitializeAsync(CancellationToken cancellationToken)
         {
             _logger.SharedLibraryPath(BuildOutput.RootPath);
 
-            return new Factory();
+            return Task.FromResult<IFileProviderFactory>(new Factory());
         }
 
         private sealed class Factory : IFileProviderFactory

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestOutputLogger.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestOutputLogger.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
     internal sealed class TestOutputLogger<T> : TestOutputLogger, ILogger<T>
     {
-        public TestOutputLogger(ITestOutputHelper outputHelper) : base(outputHelper, nameof(T))
+        public TestOutputLogger(ITestOutputHelper outputHelper) : base(outputHelper, typeof(T).Name)
         {
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public sealed class DefaultSharedLibraryInitializerTests : IDisposable
     {
         private const string ManagedTargetFramework = "custom";

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
 using Microsoft.Extensions.FileProviders;
 using System;
@@ -213,6 +214,37 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             // Arrange
             string SourceFileName = "source.txt";
             CreateSourceManagedFile(SourceFileName);
+
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                await initializer.InitializeAsync(CancellationToken.None);
+            }
+
+            // Assert
+            Assert.True(File.Exists(TargetFilePath));
+
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                await initializer.InitializeAsync(CancellationToken.None);
+            }
+        }
+
+        /// <summary>
+        /// Validate that initialization will succeed if size of file in target directory is a multiple
+        /// of the default buffer size.
+        /// </summary>
+        [Fact]
+        public async Task DefaultSharedLibraryInitializer_SourceAndTarget_TargetIsMultipleOfBufferSize()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            string SourceFilePath = CreateSourceManagedFile(SourceFileName);
+            File.WriteAllText(SourceFilePath, new string('a', 2 * StreamDefaults.BufferSize));
 
             string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
@@ -1,0 +1,250 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Tools.Monitor.LibrarySharing;
+using Microsoft.Extensions.FileProviders;
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    public sealed class DefaultSharedLibraryInitializerTests : IDisposable
+    {
+        private const string ManagedTargetFramework = "custom";
+
+        private readonly TestOutputLogger<DefaultSharedLibraryInitializer> _logger;
+        private readonly TemporaryDirectory _sourceDir;
+        private readonly TemporaryDirectory _targetDir;
+
+        public DefaultSharedLibraryInitializerTests(ITestOutputHelper outputHelper)
+        {
+            _logger = new TestOutputLogger<DefaultSharedLibraryInitializer>(outputHelper);
+            _sourceDir = new TemporaryDirectory(outputHelper);
+            _targetDir = new TemporaryDirectory(outputHelper);
+        }
+
+        public void Dispose()
+        {
+            _targetDir.Dispose();
+            _sourceDir.Dispose();
+        }
+
+        /// <summary>
+        /// Validate that initialization fails if the source directory does not exist.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceNotExist_InitializeThrows()
+        {
+            DefaultSharedLibraryPathProvider provider = new(
+                Path.Combine(_sourceDir.FullName, "doesNotExist"),
+                _targetDir.FullName);
+
+            using DefaultSharedLibraryInitializer initializer = new(provider, _logger);
+
+            Assert.Throws<DirectoryNotFoundException>(initializer.Initialize);
+        }
+
+        /// <summary>
+        /// Validate that initialization succeeds when there is not target directory.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceNoTarget_ReturnsSourcePath()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            string ExpectedFilePath = CreateSourceManagedFile(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, null);
+
+            // Act
+            using DefaultSharedLibraryInitializer initializer = new(provider, _logger);
+
+            IFileProviderFactory factory = initializer.Initialize();
+
+            // Assert
+            Assert.NotNull(factory);
+
+            IFileProvider managedProvider = factory.CreateManaged(ManagedTargetFramework);
+            Assert.NotNull(managedProvider);
+
+            IFileInfo managedDirInfo = managedProvider.GetFileInfo(SourceFileName);
+            Assert.NotNull(managedDirInfo);
+
+            Assert.Equal(ExpectedFilePath, managedDirInfo.PhysicalPath);
+        }
+
+        /// <summary>
+        /// Validate that files copied to the target directory are readable.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceAndTarget_TargetReadAllowed()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            string SourceFilePath = CreateSourceManagedFile(SourceFileName);
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using DefaultSharedLibraryInitializer initializer = new(provider, _logger);
+
+            IFileProviderFactory factory = initializer.Initialize();
+
+            // Assert
+            Assert.NotNull(factory);
+
+            IFileProvider managedProvider = factory.CreateManaged(ManagedTargetFramework);
+            Assert.NotNull(managedProvider);
+
+            IFileInfo managedDirInfo = managedProvider.GetFileInfo(SourceFileName);
+            Assert.NotNull(managedDirInfo);
+
+            Assert.Equal(TargetFilePath, managedDirInfo.PhysicalPath);
+            Assert.True(File.Exists(TargetFilePath));
+
+            using StreamReader reader = CreateTargetFileReader(TargetFilePath);
+
+            Assert.Equal(File.ReadAllText(SourceFilePath), reader.ReadToEnd());
+        }
+
+
+        /// <summary>
+        /// Validate that files copied to the target directory cannot be edited or deleted
+        /// during the user of the initializer.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceAndTarget_TargetModifyDenied()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            CreateSourceManagedFile(SourceFileName);
+
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using DefaultSharedLibraryInitializer initializer = new(provider, _logger);
+
+            initializer.Initialize();
+
+            // Assert
+            Assert.True(File.Exists(TargetFilePath));
+            Assert.Throws<IOException>(() => CreateTargetFileWriter(TargetFilePath));
+            Assert.Throws<IOException>(() => File.Delete(TargetFilePath));
+            Assert.True(File.Exists(TargetFilePath));
+        }
+
+        /// <summary>
+        /// Validate that files copied to the target directory can be edited after release of the initializer.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceAndTarget_TargetAllowWriteAfterRelease()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            CreateSourceManagedFile(SourceFileName);
+
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                initializer.Initialize();
+
+                // Assert
+                Assert.Throws<IOException>(() => CreateTargetFileWriter(TargetFilePath));
+            }
+
+            CreateTargetFileWriter(TargetFilePath).Dispose();
+        }
+
+        /// <summary>
+        /// Validate that files copied to the target directory can be deleted after release of the initializer.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceAndTarget_TargetAllowDeleteAfterRelease()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            CreateSourceManagedFile(SourceFileName);
+
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                initializer.Initialize();
+
+                // Assert
+                Assert.Throws<IOException>(() => File.Delete(TargetFilePath));
+            }
+
+            File.Delete(TargetFilePath);
+        }
+
+        /// <summary>
+        /// Validate that initialization will fail if the target directory already has the files cached
+        /// but the files have been modified to be different.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceModifiedTarget_InitializeThrows()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            CreateSourceManagedFile(SourceFileName);
+
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                initializer.Initialize();
+            }
+
+            using (StreamWriter writer = CreateTargetFileWriter(TargetFilePath))
+            {
+                writer.Write("target.txt");
+            }
+
+            // Assert
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                Assert.Throws<InvalidOperationException>(initializer.Initialize);
+            }
+        }
+
+        private string CreateSourceManagedFile(string fileName)
+        {
+            string path = Path.Combine(_sourceDir.FullName, "any", ManagedTargetFramework, fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, fileName);
+            return path;
+        }
+
+        private string CreateTargetManagedFilePath(string fileName)
+        {
+            return Path.Combine(_targetDir.FullName, "any", ManagedTargetFramework, fileName);
+        }
+
+        private static StreamReader CreateTargetFileReader(string filePath)
+        {
+            return new StreamReader(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+        }
+
+        private static StreamWriter CreateTargetFileWriter(string filePath)
+        {
+            return new StreamWriter(new FileStream(filePath, FileMode.Open, FileAccess.Write, FileShare.ReadWrite));
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/DefaultSharedLibraryInitializerTests.cs
@@ -192,6 +192,35 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         }
 
         /// <summary>
+        /// Validate that initialization will succeed if that target directory already has the files cached.
+        /// </summary>
+        [Fact]
+        public void DefaultSharedLibraryInitializer_SourceAndTarget_TargetAlreadyCached()
+        {
+            // Arrange
+            string SourceFileName = "source.txt";
+            CreateSourceManagedFile(SourceFileName);
+
+            string TargetFilePath = CreateTargetManagedFilePath(SourceFileName);
+
+            DefaultSharedLibraryPathProvider provider = new(_sourceDir.FullName, _targetDir.FullName);
+
+            // Act
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                initializer.Initialize();
+            }
+
+            // Assert
+            Assert.True(File.Exists(TargetFilePath));
+
+            using (DefaultSharedLibraryInitializer initializer = new(provider, _logger))
+            {
+                initializer.Initialize();
+            }
+        }
+
+        /// <summary>
         /// Validate that initialization will fail if the target directory already has the files cached
         /// but the files have been modified to be different.
         /// </summary>

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
@@ -5,20 +5,28 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Win32.SafeHandles;
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Security.Cryptography;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     internal sealed class DefaultSharedLibraryInitializer :
-        ISharedLibraryInitializer
+        ISharedLibraryInitializer,
+        IDisposable
     {
         private static readonly string SharedLibrarySourcePath = Path.Combine(AppContext.BaseDirectory, "shared");
 
+        private readonly List<SafeFileHandle> _sharedFileHandles = new();
         private readonly ILogger<DefaultSharedLibraryInitializer> _logger;
         private readonly string _sharedLibraryTargetPath;
+
+        private long _disposeState;
 
         public DefaultSharedLibraryInitializer(
             IOptions<StorageOptions> _storageOptions,
@@ -26,6 +34,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
         {
             _logger = logger;
             _sharedLibraryTargetPath = _storageOptions.Value.SharedLibraryPath;
+        }
+
+        public void Dispose()
+        {
+            if (!DisposableHelper.CanDispose(ref _disposeState))
+                return;
+
+            // Release locks on shared file handles
+            foreach (SafeFileHandle handle in _sharedFileHandles)
+            {
+                handle.Dispose();
+            }
+            _sharedFileHandles.Clear();
         }
 
         public IFileProviderFactory Initialize()
@@ -67,15 +88,60 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
                 // do not assume that the prior versions are deletable due to possible file locks.
                 string versionedSharedLibraryTargetPath = Path.Combine(_sharedLibraryTargetPath, expectedVersion);
 
-                // Check that the sentinel file exists (which would indicate this version of the libraries was staged correctly).
-                string sentinelPath = Path.Combine(versionedSharedLibraryTargetPath, "completed");
-                if (!File.Exists(sentinelPath))
-                {
-                    sharedLibrarySourceDir.CopyContentsTo(Directory.CreateDirectory(versionedSharedLibraryTargetPath), overwrite: true);
+                Queue<string> subDirectories = new();
+                subDirectories.Enqueue(string.Empty); // The root of the shared library source directory
+                using SHA256 hasher = SHA256.Create();
+                Span<byte> sourceHash = stackalloc byte[32];
+                Span<byte> targetHash = stackalloc byte[32];
 
-                    // Write a sentinel file to signal that staging of the directory completed. The lack of
-                    // this file signals that directory was partially staged and must be restaged.
-                    File.Create(sentinelPath).Dispose();
+                // Go through each directory and validate the existing files are exactly the same as expected
+                // or create new files if they do not exist. Hold onto the file handles to prevent modification
+                // of the shared files while they are being offered for use in target applications.
+                while (subDirectories.TryDequeue(out string subDirectory))
+                {
+                    DirectoryInfo sourceDir = new(Path.Combine(sharedLibrarySourceDir.FullName, subDirectory));
+                    DirectoryInfo targetDir = Directory.CreateDirectory(Path.Combine(versionedSharedLibraryTargetPath, subDirectory));
+
+                    FileInfo[] sourceFiles = sourceDir.GetFiles();
+                    for (int i = 0; i < sourceFiles.Length; i++)
+                    {
+                        string targetFilePath = Path.Combine(targetDir.FullName, sourceFiles[i].Name);
+                        if (File.Exists(targetFilePath))
+                        {
+                            string sourceFilePath = sourceFiles[i].FullName;
+                            using SafeFileHandle sourceHandle = File.OpenHandle(sourceFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                            int sourceLength = ComputeHashAndLength(sourceHandle, sourceHash);
+
+                            // Open target file handle for reading and only allow read sharing to prevent modification of file while in use
+                            SafeFileHandle targetHandle = File.OpenHandle(targetFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                            _sharedFileHandles.Add(targetHandle);
+                            int targetLength = ComputeHashAndLength(targetHandle, targetHash);
+
+                            // Check that they are the same
+                            if (targetLength != sourceLength || !sourceHash.SequenceEqual(targetHash))
+                            {
+                                throw new InvalidOperationException(
+                                    string.Format(
+                                        CultureInfo.InvariantCulture,
+                                        Strings.ErrorMessage_SharedFileDiffersFromSource,
+                                        targetFilePath,
+                                        sourceFilePath));
+                            }
+                        }
+                        else
+                        {
+                            // Open target file handle for writing and only allow read sharing to prevent modification of file while in use
+                            SafeFileHandle targetHandle = File.OpenHandle(targetFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read, FileOptions.WriteThrough);
+                            _sharedFileHandles.Add(targetHandle);
+                            RandomAccess.Write(targetHandle, File.ReadAllBytes(sourceFiles[i].FullName), 0);
+                        }
+                    }
+
+                    DirectoryInfo[] childDirs = sourceDir.GetDirectories();
+                    for (int i = 0; i < childDirs.Length; i++)
+                    {
+                        subDirectories.Enqueue(Path.Combine(subDirectory, childDirs[i].Name));
+                    }
                 }
 
                 sharedLibraryPath = versionedSharedLibraryTargetPath;
@@ -84,6 +150,22 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
             _logger.SharedLibraryPath(sharedLibraryPath);
 
             return new Factory(sharedLibraryPath);
+        }
+
+        private static int ComputeHashAndLength(SafeFileHandle handle, Span<byte> destination)
+        {
+            int length = (int)RandomAccess.GetLength(handle);
+            byte[] content = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                RandomAccess.Read(handle, content, 0);
+                SHA256.HashData(content, destination);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(content);
+            }
+            return length;
         }
 
         private sealed class Factory : IFileProviderFactory

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Reflection.Metadata;
 using System.Security.Cryptography;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32.SafeHandles;
@@ -116,8 +117,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
                             }
 
                             // Check that they have the same content
-                            using FileStream sourceStream = new(sourceHandle, FileAccess.Read);
-                            using FileStream targetStream = new(targetHandle, FileAccess.Read);
+                            using FileStream sourceStream = new(sourceHandle, FileAccess.Read, StreamDefaults.BufferSize, isAsync: true);
+                            using FileStream targetStream = new(targetHandle, FileAccess.Read, StreamDefaults.BufferSize, isAsync: true);
 
                             if (!await sourceStream.HasSameContentAsync(targetStream, cancellationToken))
                             {

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryPathProvider.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryPathProvider.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Extensions.Options;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
+{
+    internal sealed class DefaultSharedLibraryPathProvider
+    {
+        /// <summary>
+        /// Provides libraries from the 'shared' folder under the .NET Monitor installation.
+        /// </summary>
+        public DefaultSharedLibraryPathProvider(IOptions<StorageOptions> _storageOptions)
+            : this(Path.Combine(AppContext.BaseDirectory, "shared"), ComputeTargetPath(_storageOptions))
+        {
+        }
+
+        public DefaultSharedLibraryPathProvider(string sourcePath, string targetPath)
+        {
+            SourcePath = sourcePath ?? throw new ArgumentNullException(nameof(sourcePath));
+            TargetPath = targetPath;
+        }
+
+        private static string ComputeTargetPath(IOptions<StorageOptions> options)
+        {
+            string rootPath = options.Value.SharedLibraryPath;
+            if (string.IsNullOrEmpty(rootPath))
+                return null;
+
+            string expectedVersion = Assembly.GetExecutingAssembly().GetInformationalVersionString();
+            // Remove '+' and commit hash from version string
+            int hashSeparatorIndex = expectedVersion.IndexOf('+');
+            if (hashSeparatorIndex > 0)
+            {
+                expectedVersion = expectedVersion.Substring(0, hashSeparatorIndex);
+            }
+
+            // If the user specified '/diag/libs' for Storage:SharedLibraryPath, this path may look like '/diag/libs/7.0.0'
+            // This path includes the .NET Monitor version in order to avoid collisions when performing rolling updates
+            // in containerized environments; newer .NET Monitor versions must repopulate the shared library directory, but
+            // do not assume that the prior versions are removable due to possible file locks.
+            return Path.Combine(rootPath, expectedVersion);
+        }
+
+        public string SourcePath { get; }
+
+        public string TargetPath { get; }
+    }
+}

--- a/src/Tools/dotnet-monitor/LibrarySharing/ISharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/ISharedLibraryInitializer.cs
@@ -1,10 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 {
     internal interface ISharedLibraryInitializer
     {
-        IFileProviderFactory Initialize();
+        Task<IFileProviderFactory> InitializeAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/dotnet-monitor/LibrarySharing/SharedLibraryService.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/SharedLibraryService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
 
             try
             {
-                _fileProviderFactorySource.SetResult(_sharedLibraryInitializer.Initialize());
+                _fileProviderFactorySource.SetResult(await _sharedLibraryInitializer.InitializeAsync(stoppingToken));
             }
             catch (Exception ex)
             {

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -323,6 +323,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             services.AddSingletonForwarder<ISharedLibraryService, SharedLibraryService>();
             services.AddHostedServiceForwarder<SharedLibraryService>();
             services.TryAddSingleton<ISharedLibraryInitializer, DefaultSharedLibraryInitializer>();
+            services.AddSingleton<DefaultSharedLibraryPathProvider>();
             return services;
         }
 

--- a/src/Tools/dotnet-monitor/StreamExtensions.cs
+++ b/src/Tools/dotnet-monitor/StreamExtensions.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private const int DefaultBufferSize = 4096;
 
         public static async Task<bool> HasSameContentAsync(
-            this FileStream thisStream,
-            FileStream otherStream,
+            this Stream thisStream,
+            Stream otherStream,
             CancellationToken cancellationToken)
         {
             byte[] thisBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);

--- a/src/Tools/dotnet-monitor/StreamExtensions.cs
+++ b/src/Tools/dotnet-monitor/StreamExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-using System.Threading;
 using System;
-using System.IO;
 using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {

--- a/src/Tools/dotnet-monitor/StreamExtensions.cs
+++ b/src/Tools/dotnet-monitor/StreamExtensions.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using System.IO;
+using System.Buffers;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static class StreamExtensions
+    {
+        private const int DefaultBufferSize = 4096;
+
+        public static async Task<bool> HasSameContentAsync(
+            this FileStream thisStream,
+            FileStream otherStream,
+            CancellationToken cancellationToken)
+        {
+            byte[] thisBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            Array.Fill<byte>(thisBuffer, 0);
+
+            byte[] otherBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            Array.Fill<byte>(otherBuffer, 0);
+
+            try
+            {
+                Memory<byte> thisMemory = thisBuffer;
+                Memory<byte> otherMemory = otherBuffer;
+
+                while (true)
+                {
+                    // Fill buffer; read will only be less than buffer size
+                    // if encounter end of stream.
+                    int thisRead = await thisStream.ReadAtLeastAsync(
+                        thisMemory,
+                        thisMemory.Length,
+                        throwOnEndOfStream: false,
+                        cancellationToken);
+
+                    // Fill buffer; read will only be less than buffer size
+                    // if encounter end of stream.
+                    int otherRead = await otherStream.ReadAtLeastAsync(
+                        otherMemory,
+                        otherMemory.Length,
+                        throwOnEndOfStream: false,
+                        cancellationToken);
+
+                    if (thisRead != otherRead || !thisMemory.Span.SequenceEqual(otherMemory.Span))
+                    {
+                        return false;
+                    }
+
+                    // If read is less than buffer size, then end of streams
+                    // were encountered. Since the last segment of the stream
+                    // content were the same, the entire stream contents were
+                    // the same.
+                    if (thisRead < thisMemory.Length)
+                    {
+                        return true;
+                    }
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(thisBuffer);
+                ArrayPool<byte>.Shared.Return(otherBuffer);
+            }
+        }
+
+#if !NET7_0_OR_GREATER
+        public static async ValueTask<int> ReadAtLeastAsync(
+            this Stream stream,
+            Memory<byte> buffer,
+            int minimumBytes,
+            bool throwOnEndOfStream = true,
+            CancellationToken cancellationToken = default)
+        {
+            int totalRead = 0;
+            while (totalRead < minimumBytes)
+            {
+                int read = await stream.ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    if (throwOnEndOfStream)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    return totalRead;
+                }
+
+                totalRead += read;
+            }
+
+            return totalRead;
+        }
+#endif
+    }
+}

--- a/src/Tools/dotnet-monitor/StreamExtensions.cs
+++ b/src/Tools/dotnet-monitor/StreamExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using System;
 using System.Buffers;
 using System.IO;
@@ -11,17 +12,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class StreamExtensions
     {
-        private const int DefaultBufferSize = 4096;
-
         public static async Task<bool> HasSameContentAsync(
             this Stream thisStream,
             Stream otherStream,
             CancellationToken cancellationToken)
         {
-            byte[] thisBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            byte[] thisBuffer = ArrayPool<byte>.Shared.Rent(StreamDefaults.BufferSize);
             Array.Fill<byte>(thisBuffer, 0);
 
-            byte[] otherBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            byte[] otherBuffer = ArrayPool<byte>.Shared.Rent(StreamDefaults.BufferSize);
             Array.Fill<byte>(otherBuffer, 0);
 
             try

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -448,6 +448,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The shared file &apos;{0}&apos; is different from source file &apos;{1}&apos;..
+        /// </summary>
+        internal static string ErrorMessage_SharedFileDiffersFromSource {
+            get {
+                return ResourceManager.GetString("ErrorMessage_SharedFileDiffersFromSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The following unrecoverable validation issues were found with the &apos;{0}&apos; configuration:
         ///{1}.
         /// </summary>
@@ -1286,7 +1295,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to initialize shared library storage..
+        ///   Looks up a localized string similar to Failed to initialize shared library storage. Some monitoring features may be unavailable..
         /// </summary>
         internal static string LogFormatString_FailedInitializeSharedLibraryStorage {
             get {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -724,7 +724,7 @@
     <value>Experimental feature '{name}' is enabled.</value>
   </data>
   <data name="LogFormatString_FailedInitializeSharedLibraryStorage" xml:space="preserve">
-    <value>Failed to initialize shared library storage.</value>
+    <value>Failed to initialize shared library storage. Some monitoring features may be unavailable.</value>
   </data>
   <data name="LogFormatString_GetEnvironmentVariable" xml:space="preserve">
     <value>Getting the environment variable {variableName} from process {processId}.</value>
@@ -914,5 +914,8 @@
   </data>
   <data name="LogFormatString_EndpointRemovalFailed" xml:space="preserve">
     <value>Unable to fully remove endpoint for process {processId}.</value>
+  </data>
+  <data name="ErrorMessage_SharedFileDiffersFromSource" xml:space="preserve">
+    <value>The shared file '{0}' is different from source file '{1}'.</value>
   </data>
 </root>


### PR DESCRIPTION
###### Summary

Change the shared library initializer to validate the files in the existing shared directory or write new files instead of relying on a sentinel file and keep the file handles open with read-only shared access. This allows .NET Monitor to confidently share libraries that will be loaded into target applications and know that they have not been tampered with between runs of .NET Monitor. If any file is different than expected, shared library initialization will fail and any feature that is dependent on it will not work.

Example console output:
```
16:58:51 info: Microsoft.Diagnostics.Tools.Monitor.Startup[60]
      Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey
16:58:51 info: Microsoft.Diagnostics.Tools.Monitor.Startup[77]
      Connection mode: Listen at '\\.\pipe\diagport'
16:58:51 warn: Microsoft.Diagnostics.Tools.Monitor.Startup[13]
      WARNING: Authentication has been disabled. This can pose a security risk and is not intended for production environments.
16:58:52 info: Microsoft.Hosting.Lifetime[14]
      Now listening on: https://localhost:49260
16:58:52 info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://localhost:49261
16:58:52 fail: Microsoft.Diagnostics.Tools.Monitor.LibrarySharing.SharedLibraryService[73]
      Failed to initialize shared library storage. Some monitoring features may be unavailable.
      System.InvalidOperationException: The shared file 'C:\Users\jander\dnmshared\libs\8.0.0-dev.23363.1\any\net6.0\Microsoft.Diagnostics.Monitoring.StartupHook.dll' is different from source file 'C:\src\dotnet\dotnet-monitor\artifacts\bin\dotnet-monitor\Debug\net6.0\shared\any\net6.0\Microsoft.Diagnostics.Monitoring.StartupHook.dll'.
         at Microsoft.Diagnostics.Tools.Monitor.LibrarySharing.DefaultSharedLibraryInitializer.Initialize() in C:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\LibrarySharing\DefaultSharedLibraryInitializer.cs:line 123
         at Microsoft.Diagnostics.Tools.Monitor.LibrarySharing.SharedLibraryService.ExecuteAsync(CancellationToken stoppingToken) in C:\src\dotnet\dotnet-monitor\src\Tools\dotnet-monitor\LibrarySharing\SharedLibraryService.cs:line 47
16:58:52 info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
```

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
