### PR TITLE
Add Check For Existing Key For `ApplyStartupHook`

### DIFF
--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookEndpointInfoSourceCallback.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookEndpointInfoSourceCallback.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
 
         async Task IEndpointInfoSourceCallbacks.OnBeforeResumeAsync(IEndpointInfo endpointInfo, CancellationToken cancellationToken)
         {
-            if (_inProcessFeatures.IsStartupHookRequired)
+            if (_inProcessFeatures.IsStartupHookRequired && !ApplyStartupState.ContainsKey(endpointInfo.RuntimeInstanceCookie))
             {
                 if (await _startupHookValidator.CheckEnvironmentAsync(endpointInfo, cancellationToken))
                 {
@@ -39,13 +39,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
                     return;
                 }
 
-                if (!ApplyStartupState.ContainsKey(endpointInfo.RuntimeInstanceCookie))
+                if (await _startupHookValidator.ApplyStartupHook(endpointInfo, cancellationToken))
                 {
-                    if (await _startupHookValidator.ApplyStartupHook(endpointInfo, cancellationToken))
-                    {
-                        ApplyStartupState[endpointInfo.RuntimeInstanceCookie] = true;
-                        return;
-                    }
+                    ApplyStartupState[endpointInfo.RuntimeInstanceCookie] = true;
+                    return;
                 }
 
                 ApplyStartupState[endpointInfo.RuntimeInstanceCookie] = false;

--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookEndpointInfoSourceCallback.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookEndpointInfoSourceCallback.cs
@@ -39,10 +39,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
                     return;
                 }
 
-                if (await _startupHookValidator.ApplyStartupHook(endpointInfo, cancellationToken))
+                if (!ApplyStartupState.ContainsKey(endpointInfo.RuntimeInstanceCookie))
                 {
-                    ApplyStartupState[endpointInfo.RuntimeInstanceCookie] = true;
-                    return;
+                    if (await _startupHookValidator.ApplyStartupHook(endpointInfo, cancellationToken))
+                    {
+                        ApplyStartupState[endpointInfo.RuntimeInstanceCookie] = true;
+                        return;
+                    }
                 }
 
                 ApplyStartupState[endpointInfo.RuntimeInstanceCookie] = false;


### PR DESCRIPTION
###### Summary

After talking to @schmittjoseph , `OnBeforeResumeAsync` could be called multiple times for the same endpoint. Without this check, it'll repeatedly try to apply the startup hook, even if it already applied (or failed) earlier.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
