### PR TITLE
Enable Helix testing in builds

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -75,9 +75,10 @@ stages:
     - template: /eng/pipelines/jobs/platform-matrix.yml
       parameters:
         jobTemplate: /eng/pipelines/jobs/test-binaries.yml
-        includeDebug: true
+        includeArm64: true
         jobParameters:
           testGroup: ${{ parameters.testGroup }}
+          useHelix: true
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Archive

--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -75,7 +75,7 @@ stages:
     - template: /eng/pipelines/jobs/platform-matrix.yml
       parameters:
         jobTemplate: /eng/pipelines/jobs/test-binaries.yml
-        includeArm64: true
+        includeArm64: ${{ ne(variables['System.TeamProject'], 'public') }}
         jobParameters:
           testGroup: ${{ parameters.testGroup }}
           useHelix: true

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -15,6 +15,7 @@
     <!-- Open queues require a creator to be set. -->
     <Creator Condition=" '$(USERNAME)' != '' ">$(USERNAME)</Creator>
     <Creator Condition=" '$(USER)' != '' ">$(USER)</Creator>
+    <Creator Condition=" '$(Creator)' == '' ">dotnet-monitor</Creator>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SYSTEM_COLLECTIONURI)' == 'https://dev.azure.com/dnceng/'">

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -95,8 +95,6 @@ jobs:
     variables:
     - JobName: ${{ parameters.prefix }}_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     - _BuildConfig: ${{ parameters.configuration }}
-    - _HelixType: build/product
-    - _HelixBuildConfig: ${{ parameters.configuration }}
     - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
     - ${{ each variable in parameters.variables }}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -123,8 +123,9 @@ jobs:
       # This is blank in public builds
       DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET: $(DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET)
       ${{ if eq(parameters.useHelix, 'true')}}:
-        HelixAccessToken: $(HelixApiAccessToken)
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        ${{ ne(variables['System.TeamProject'], 'public') }}:
+          HelixAccessToken: $(HelixApiAccessToken)
 
     postBuildSteps:
     - ${{ if ne(parameters.useHelix, 'true')}}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -19,6 +19,7 @@ parameters:
     value: .NET 7
   - key: net8.0
     value: .NET 8
+  useHelix: false
 
 jobs:
 - template: /eng/pipelines/jobs/build.yml
@@ -33,12 +34,18 @@ jobs:
     disableSbom: true
 
     # Override containers for Linux to test on real clib and architecture variants
-    ${{ if eq(parameters.osGroup, 'Linux') }}:
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
-    ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
+    ${{ if ne(parameters.useHelix, 'true')}}:
+      ${{ if eq(parameters.osGroup, 'Linux') }}:
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+      ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
 
     variables:
+    - ${{ if eq(parameters.useHelix, 'true')}}:
+      - _CrossBuildArgs: ''
+      # Cross build for all Linux builds and arm64 non-Windows builds
+      - ${{ if or(in(parameters.osGroup, 'Linux', 'Linux_Musl'), and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows'))) }}:
+        - _CrossBuildArgs: '-cross'
     # If TestGroup == 'Default', choose the test group based on the type of pipeline run
     - ${{ if eq(parameters.testGroup, 'Default') }}:
       - ${{ if in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI') }}:
@@ -63,68 +70,85 @@ jobs:
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
 
-    - ${{ if ne(parameters.osGroup, 'Windows') }}:
-      - task: NodeTool@0
-        displayName: Install Node.js
-        inputs:
-          # Version requirements:
-          # - Azurite requires 8.x or higher.
-          # - The alpine containers have their own build of Node.js of 10.x but without supplemental tooling like npm.
-          # Since the alpine containers already have a Node.js build, match it's major version for a compatible version
-          # of npm across all build environments.
-          versionSpec: '10.x'
+    - ${{ if ne(parameters.useHelix, 'true')}}:
+      - ${{ if ne(parameters.osGroup, 'Windows') }}:
+        - task: NodeTool@0
+          displayName: Install Node.js
+          inputs:
+            # Version requirements:
+            # - Azurite requires 8.x or higher.
+            # - The alpine containers have their own build of Node.js of 10.x but without supplemental tooling like npm.
+            # Since the alpine containers already have a Node.js build, match it's major version for a compatible version
+            # of npm across all build environments.
+            versionSpec: '10.x'
 
-      - task: Npm@1
-        displayName: Install Azurite
-        inputs:
-          command: custom
-          customCommand: install -g azurite
+        - task: Npm@1
+          displayName: Install Azurite
+          inputs:
+            command: custom
+            customCommand: install -g azurite
 
-    # When using the Alpine build containers, the above npm install will install to the system's
-    # node directory instead of the agent's copy.
-    # The container doesn't have the node bin directory included in PATH by default, so global npm tool installations
-    # are not discoverable by the test infrastructure.
-    #
-    # Add the azurite installation location to PATH to workaround this.
-    - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
-      - script: echo "##vso[task.prependpath]/usr/share/node/bin"
-        displayName: Add Azurite to PATH
+      # When using the Alpine build containers, the above npm install will install to the system's
+      # node directory instead of the agent's copy.
+      # The container doesn't have the node bin directory included in PATH by default, so global npm tool installations
+      # are not discoverable by the test infrastructure.
+      #
+      # Add the azurite installation location to PATH to workaround this.
+      - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
+        - script: echo "##vso[task.prependpath]/usr/share/node/bin"
+          displayName: Add Azurite to PATH
 
-    buildArgs: >-
-      -test
-      -testgroup $(_TestGroup)
-      -skipmanaged
-      -skipnative
-      /m:1
+    ${{ if eq(parameters.useHelix, 'true')}}:
+      buildArgs: >-
+        -test
+        -testgroup $(_TestGroup)
+        -projects $(Build.SourcesDirectory)/eng/helix/Helix.proj
+        -skipmanaged
+        -skipnative
+        $(_CrossBuildArgs)
+    ${{ else }}:
+      buildArgs: >-
+        -test
+        -testgroup $(_TestGroup)
+        -skipmanaged
+        -skipnative
+        /m:1
 
     buildEnv:
+      ${{ if and(eq(parameters.useHelix, 'true'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
+        # Set ROOTFS_DIR for Linux cross builds
+        ROOTFS_DIR: '/crossrootfs/${{ parameters.architecture }}'
       # Indicate that tests based on Azurite should not be skipped if it is not initialized
       TEST_AZURITE_MUST_INITIALIZE: 1
       # This is blank in public builds
       DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET: $(DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET)
+      ${{ if eq(parameters.useHelix, 'true')}}:
+        HelixAccessToken: $(HelixApiAccessToken)
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     postBuildSteps:
-    # Publish test results to Azure Pipelines
-    - ${{ each testResultTfm in parameters.testResultTfms }}:
-      - task: PublishTestResults@2
-        displayName: Publish Test Results (${{ testResultTfm.value }})
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-          failTaskOnFailedTests: true
-          testRunTitle: '${{ parameters.configuration }} ${{ parameters.osGroup }} ${{ parameters.architecture }} ${{ testResultTfm.value }}'
-          publishRunAttachments: true
-          mergeTestResults: true
-          buildConfiguration: $(JobName)
-        continueOnError: true
-        condition: succeededOrFailed()
+    - ${{ if ne(parameters.useHelix, 'true')}}:
+      # Publish test results to Azure Pipelines
+      - ${{ each testResultTfm in parameters.testResultTfms }}:
+        - task: PublishTestResults@2
+          displayName: Publish Test Results (${{ testResultTfm.value }})
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: '**/*Tests*${{ testResultTfm.key }}*.trx'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+            failTaskOnFailedTests: true
+            testRunTitle: '${{ parameters.configuration }} ${{ parameters.osGroup }} ${{ parameters.architecture }} ${{ testResultTfm.value }}'
+            publishRunAttachments: true
+            mergeTestResults: true
+            buildConfiguration: $(JobName)
+          continueOnError: true
+          condition: succeededOrFailed()
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Test Result Files
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-          ArtifactName: TestResults_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-        continueOnError: true
-        condition: succeededOrFailed()
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Test Result Files
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            ArtifactName: TestResults_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+          continueOnError: true
+          condition: succeededOrFailed()

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -122,10 +122,10 @@ jobs:
       TEST_AZURITE_MUST_INITIALIZE: 1
       # This is blank in public builds
       DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET: $(DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET)
-      ${{ if eq(parameters.useHelix, 'true')}}:
+      ${{ if eq(parameters.useHelix, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        ${{ ne(variables['System.TeamProject'], 'public') }}:
-          HelixAccessToken: $(HelixApiAccessToken)
+      ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        HelixAccessToken: $(HelixApiAccessToken)
 
     postBuildSteps:
     - ${{ if ne(parameters.useHelix, 'true')}}:


### PR DESCRIPTION
###### Summary

These changes enable the use of Helix for testing but preserve the ability to run the tests on build jobs if we need to flip back to that. If all (if there are any) Helix issues are resolved, we can then remove the ability to run tests via build jobs to simplify the pipeline.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
