### PR TITLE
Update `Needs-Review` Label For GitHub-Actions Bot Comments

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -531,6 +531,17 @@
                   }
                 }
               ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": "github-actions[bot]"
+                  }
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
###### Summary

Joe pointed out that the github-actions bot's comments are causing the `needs-review` label to be incorrectly removed (example [here](https://github.com/dotnet/dotnet-monitor/pull/4903)) - this should hopefully address that issue.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
