### PR TITLE
Always make TestRunnerTestTimeoutMinutes available

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,7 @@
     <SignAndNotarizeRuntimeIdentifiers>osx-arm64;osx-x64</SignAndNotarizeRuntimeIdentifiers>
     <DefaultRuntimeIdentifiers>$(SignOnlyRuntimeIdentifiers);$(SignAndNotarizeRuntimeIdentifiers)</DefaultRuntimeIdentifiers>
     <DisableCustomBlobStoragePublishing Condition="'$(DisableCustomBlobStoragePublishing)' == ''">false</DisableCustomBlobStoragePublishing>
+    <TestRunnerTestTimeoutMinutes>15</TestRunnerTestTimeoutMinutes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
@@ -26,7 +27,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-    <TestRunnerTestTimeoutMinutes>15</TestRunnerTestTimeoutMinutes>
     <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=$(TestRunnerTestTimeoutMinutes)m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MockTimeProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MockTimeProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Test!
+
 using System;
 #if !NET8_0_OR_GREATER
 using Microsoft.Diagnostics.Tools.Monitor;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MockTimeProvider.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MockTimeProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Test!
-
 using System;
 #if !NET8_0_OR_GREATER
 using Microsoft.Diagnostics.Tools.Monitor;


### PR DESCRIPTION
###### Summary

Make C# linter happy by making this property always available so that the evaluation of the Helix work item timeout doesn't fail.

Failing linter run: https://github.com/dotnet/dotnet-monitor/actions/runs/5559265802/jobs/10155182618?pr=4903
Fixed linter run: https://github.com/dotnet/dotnet-monitor/actions/runs/5559414073/jobs/10155503108?pr=4918

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
