### PR TITLE
Ignore architecture if TEST_DOTNET_ROOT is specified

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs
@@ -57,16 +57,17 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         {
             // e.g. <TEST_DOTNET_ROOT>/dotnet
             string dotnetDirPath = Environment.GetEnvironmentVariable("TEST_DOTNET_ROOT");
+
             if (string.IsNullOrEmpty(dotnetDirPath))
             {
                 // e.g. <repoPath>/.dotnet
                 dotnetDirPath = Path.Combine("..", "..", "..", "..", "..", ".dotnet");
-            }
 
-            if (arch.HasValue && arch.Value != RuntimeInformation.OSArchitecture)
-            {
-                // e.g. Append "\x86" to the path
-                dotnetDirPath = Path.Combine(dotnetDirPath, arch.Value.ToString("G").ToLowerInvariant());
+                if (arch.HasValue && arch.Value != RuntimeInformation.OSArchitecture)
+                {
+                    // e.g. Append "\x86" to the path
+                    dotnetDirPath = Path.Combine(dotnetDirPath, arch.Value.ToString("G").ToLowerInvariant());
+                }
             }
 
             return Path.GetFullPath(Path.Combine(dotnetDirPath, ExeName));


### PR DESCRIPTION
###### Summary

The Windows x86 Helix tests are failing due to the incorrect calculation of the `dotnet` installation directory. The problem is that it is appending the target architecture to the path, even though the path fully specifies the correct installation path. Update the code to only append the architecture path in the case that the fallback path is used (e.g. the in-repository installation) since only that will contain a separate non-OS-architecture installation of `dotnet`.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
