### PR TITLE
Push cross build into base build job

### DIFF
--- a/eng/pipelines/jobs/build-archive.yml
+++ b/eng/pipelines/jobs/build-archive.yml
@@ -15,6 +15,7 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
+    enableCrossBuild: true
     dependsOn:
     - Sign_Binaries
 

--- a/eng/pipelines/jobs/build-binaries.yml
+++ b/eng/pipelines/jobs/build-binaries.yml
@@ -35,15 +35,11 @@ jobs:
     architecture: ${{ parameters.architecture }}
     disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
     disableSbom: ${{ parameters.disableSbom }}
+    enableCrossBuild: true
     variables:
-    - _CrossBuildArgs: ''
     - _PublishProjectsArgs: ''
     - ${{ each variable in parameters.variables }}:
       - ${{ variable }}
-
-    # Cross build for all Linux builds and arm64 non-Windows builds
-    - ${{ if or(in(parameters.osGroup, 'Linux', 'Linux_Musl'), and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows'))) }}:
-      - _CrossBuildArgs: '-cross'
 
     - ${{ if and(eq(parameters.targetRid, 'win-x64'), eq(parameters.configuration, 'Release')) }}:
       - _PublishProjectsArgs: '/p:PublishProjectsAfterBuild=true'
@@ -54,14 +50,7 @@ jobs:
     - ${{ each step in parameters.preBuildSteps }}:
       - ${{ step }}
 
-    buildArgs: >-
-      $(_CrossBuildArgs)
-      $(_PublishProjectsArgs)
-
-    # Set ROOTFS_DIR for Linux cross builds
-    ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:
-      buildEnv:
-        ROOTFS_DIR: '/crossrootfs/${{ parameters.architecture }}'
+    buildArgs: $(_PublishProjectsArgs)
 
     postBuildSteps:
     - ${{ each step in parameters.postBuildSteps }}:

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -9,6 +9,8 @@ parameters:
   configuration: Release
   # Build architecture (arm64, x64, x86, etc)
   architecture: x64
+  # Enables cross build from host target libraries and architectures
+  enableCrossBuild: true
   # Docker container in which job steps shall be run (leave empty to choose default build container).
   # This should be empty unless exclusively testing on a specific container image.
   container: ''
@@ -95,10 +97,15 @@ jobs:
     variables:
     - JobName: ${{ parameters.prefix }}_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     - _BuildConfig: ${{ parameters.configuration }}
+    - _CrossBuildArgs: ''
     - _InternalInstallArgs: ''
     - _InternalBuildArgs: ''
     - ${{ each variable in parameters.variables }}:
       - ${{ variable }}
+    
+    # Cross build for all Linux builds and arm64 non-Windows builds
+    - ${{ if and(eq(parameters.enableCrossBuild, 'true'), or(in(parameters.osGroup, 'Linux', 'Linux_Musl'), and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows')))) }}:
+      - _CrossBuildArgs: '-cross'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-MSRC-Storage
@@ -151,11 +158,15 @@ jobs:
         -configuration ${{ parameters.configuration }}
         -architecture ${{ parameters.architecture }}
         ${{ parameters.buildArgs }}
+        $(_CrossBuildArgs)
         $(_InternalInstallArgs)
         $(_InternalBuildArgs)
       displayName: Build
       env:
         ${{ insert }}: ${{ parameters.buildEnv }}
+        # Set ROOTFS_DIR for Linux cross builds
+        ${{ if and(eq(parameters.enableCrossBuild, 'true'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
+          ROOTFS_DIR: '/crossrootfs/${{ parameters.architecture }}'
 
     - ${{ each step in parameters.postBuildSteps }}:
       - ${{ step }}

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -28,6 +28,7 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
+    enableCrossBuild: ${{ parameters.useHelix }}
     timeoutInMinutes: 60
     dependsOn: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     disableComponentGovernance: true
@@ -41,11 +42,6 @@ jobs:
         container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
 
     variables:
-    - ${{ if eq(parameters.useHelix, 'true')}}:
-      - _CrossBuildArgs: ''
-      # Cross build for all Linux builds and arm64 non-Windows builds
-      - ${{ if or(in(parameters.osGroup, 'Linux', 'Linux_Musl'), and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows'))) }}:
-        - _CrossBuildArgs: '-cross'
     # If TestGroup == 'Default', choose the test group based on the type of pipeline run
     - ${{ if eq(parameters.testGroup, 'Default') }}:
       - ${{ if in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI') }}:
@@ -105,7 +101,6 @@ jobs:
         -projects $(Build.SourcesDirectory)/eng/helix/Helix.proj
         -skipmanaged
         -skipnative
-        $(_CrossBuildArgs)
     ${{ else }}:
       buildArgs: >-
         -test
@@ -115,9 +110,6 @@ jobs:
         /m:1
 
     buildEnv:
-      ${{ if and(eq(parameters.useHelix, 'true'), in(parameters.osGroup, 'Linux', 'Linux_Musl')) }}:
-        # Set ROOTFS_DIR for Linux cross builds
-        ROOTFS_DIR: '/crossrootfs/${{ parameters.architecture }}'
       # Indicate that tests based on Azurite should not be skipped if it is not initialized
       TEST_AZURITE_MUST_INITIALIZE: 1
       # This is blank in public builds


### PR DESCRIPTION
###### Summary

In the 8.0 offering, the musl libc packages are actually packing the glibc variants of the binaries AND publishing with glibc naming (e.g. https://dev.azure.com/dnceng/internal/_build/results?buildId=2222464&view=logs&j=d5728782-5d7f-5e51-ea2d-92c117e26b20&t=93b29a1b-9d48-5ac0-d339-4d509d35665f&l=103). This was likely a regression that occurred when switching to using cross builds, where the build jobs would cross build but the archive jobs did not; the root of the issue is that the target RID for these builds are `linux-x64` and `linux-arm64` instead of `linux-musl-x64` and `linux-musl-arm64` due to the lack of cross build. This has the effect that we have not been publishing musl libc packages since that change occurred.

This change pushes all of the cross build support back into the base build job so that build and archive can unconditionally use it and test jobs can use it when running Helix tests.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2223688&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry