### PR TITLE
Fix Helix test filter args

### DIFF
--- a/eng/helix/payload/dotnettest.sh
+++ b/eng/helix/payload/dotnettest.sh
@@ -8,7 +8,7 @@ timeoutMinutes="$5"
 
 filterArgs=""
 if [[ ! -z "$6" ]]; then
-  filterArgs="--filter \"$6\""
+  filterArgs="--filter $6"
 fi
 
 exit_code=0

--- a/src/Tests/Helix.targets
+++ b/src/Tests/Helix.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(TargetFramework)' != ''">
-    <HelixDotnetTestArgs>$(TargetName) $(Configuration) $(TargetFramework) $(Platform) $(TestRunnerTestTimeoutMinutes) $(TestRunnerFilterArguments)</HelixDotnetTestArgs>
+    <HelixDotnetTestArgs>$(TargetName) $(Configuration) $(TargetFramework) $(Platform) $(TestRunnerTestTimeoutMinutes)</HelixDotnetTestArgs>
+    <HelixDotnetTestArgs Condition=" '$(TestRunnerFilterArguments)' != ''">$(HelixDotnetTestArgs) &quot;$(TestRunnerFilterArguments)&quot;</HelixDotnetTestArgs>
     <HelixDotnetTestCommand Condition="'$(IsHelixPosixShell)' != 'true'">call %HELIX_CORRELATION_PAYLOAD%\dotnettest.cmd $(HelixDotnetTestArgs)</HelixDotnetTestCommand>
     <HelixDotnetTestCommand Condition="'$(IsHelixPosixShell)' == 'true'">$HELIX_CORRELATION_PAYLOAD/dotnettest.sh $(HelixDotnetTestArgs)</HelixDotnetTestCommand>
     <!-- Add an arbitrary of time to the test timeout so that the work item has extra time to run pre and post commands. -->


### PR DESCRIPTION
###### Summary

The Helix runs were not filtering tests for PR builds correctly causing all tests to be skipped!

For example, on non-Windows machines, it would state the following:

```
No test matches the given testcase filter `"TargetFrameworkMoniker=Net80"` in /root/helix/work/correlation/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Release/net6.0/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.dll
```

I've removed the double quotes around the filter argument in the dotnettest.sh script.

On Windows, it would state the following:

```
No test matches the given testcase filter `TargetFrameworkMoniker` in C:\h\w\C20409DE\p\Microsoft.Diagnostics.Monitoring.Tool.UnitTests\Release\net6.0\Microsoft.Diagnostics.Monitoring.Tool.UnitTests.dll
```

I added double quotes to the entire filter argument that is passed into dotnettest.sh/cmd script.

With these two changes, the tests are now being filtered correctly:
- Example build running as PR build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2223983&view=results
- Example build running as CI build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2224061&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
