### PR TITLE
Add pipeline for component governance scan on shipped code

### DIFF
--- a/eng/pipelines/dotnet-monitor-cg.yml
+++ b/eng/pipelines/dotnet-monitor-cg.yml
@@ -1,0 +1,26 @@
+schedules:
+- cron: "0 9 * * Mon-Fri"
+  displayName: Shipped Component Governance Scan
+  branches:
+    include:
+    - shipped/*
+  always: true
+
+variables:
+- name: _TeamName
+  value: DotNetCore
+# These branches represent shipped assets, thus use Svc build pool
+- name: DncEngInternalBuildPool
+  value: NetCore1ESPool-Svc-Internal
+
+stages:
+- stage: Build
+  displayName: Build and Scan
+  jobs:
+  - template: /eng/pipelines/jobs/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/jobs/build-binaries.yml
+      includeArm64: true
+      jobParameters:
+        disableComponentGovernance: false
+        disableSbom: true


### PR DESCRIPTION
###### Summary

Create a daily scheduled pipeline that checks the shipped branches for component governance issues. This is needed since we frequently update release branches with newer package versions and will not get an accurate picture of if the latest shipped binaries have a component governance issue.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
