### PR TITLE
Fix CG pipeline: disable tests, disable CI and PR triggers, enable CG

### DIFF
--- a/eng/pipelines/dotnet-monitor-cg.yml
+++ b/eng/pipelines/dotnet-monitor-cg.yml
@@ -6,6 +6,9 @@ schedules:
     - shipped/*
   always: true
 
+trigger: none
+pr: none
+
 variables:
 - name: _TeamName
   value: DotNetCore
@@ -19,7 +22,7 @@ stages:
   jobs:
   - template: /eng/pipelines/jobs/platform-matrix.yml
     parameters:
-      jobTemplate: /eng/pipelines/jobs/build-binaries.yml
+      jobTemplate: /eng/pipelines/jobs/build.yml
       includeArm64: true
       jobParameters:
         disableComponentGovernance: false

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -22,7 +22,7 @@ parameters:
   # Sub paths under 'artifacts' folder from which files are published to artifacts location
   publishArtifactsSubPaths: []
   # Disable Component Governance injection and analysis
-  disableComponentGovernance: false
+  disableComponentGovernance: ''
   # Disable SBOM generation
   disableSbom: false
   buildArgs: ''
@@ -34,7 +34,7 @@ jobs:
     displayName: ${{ format('{0} {1} {2} {3}', parameters.prefix, parameters.osGroup, parameters.architecture, parameters.configuration) }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableTelemetry: true
-    disableComponentGovernance: ${{ or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
     ${{ if eq(parameters.disableSbom, 'true') }}:
       enableSbom: false
     helixRepo: dotnet/dotnet-monitor
@@ -97,10 +97,6 @@ jobs:
     - _InternalBuildArgs: ''
     - ${{ each variable in parameters.variables }}:
       - ${{ variable }}
-
-    # Component Governance does not work on Musl
-    - ${{ if or(eq(parameters.disableComponentGovernance, 'true'), eq(parameters.osGroup, 'Linux_Musl')) }}:
-      - skipComponentGovernanceDetection: true
     
     # Cross build for arm64 non-Windows builds
     - ${{ if and(eq(parameters.architecture, 'arm64'), ne(parameters.osGroup, 'Windows')) }}:


### PR DESCRIPTION
###### Summary

The CG pipeline fails to run and enable CG for 7.x and lower. This fixes those issues so that the pipeline runs, CG is unconditionally enabled, and tests are not run.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2225420&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
