### PR TITLE
Increase Helix job timeout

### DIFF
--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -28,7 +28,7 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     configuration: ${{ parameters.configuration }}
     architecture: ${{ parameters.architecture }}
-    timeoutInMinutes: 60
+    timeoutInMinutes: 120
     dependsOn: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     disableComponentGovernance: true
     disableSbom: true


### PR DESCRIPTION
###### Summary

Wait time in the Helix queues can be very variable. Two automated PRs that were opened today failed due to waiting for their Helix work items to be scheduled. To work around this, increase the job timeout to be generous (2 hours).

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
