### PR TITLE
Add per-process service support

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoSource.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         string ProcessArchitecture { get; }
 
         Version RuntimeVersion { get; }
+
+        IServiceProvider ServiceProvider { get; }
     }
 
     /// <summary>
@@ -45,6 +47,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public abstract string ProcessArchitecture { get; protected set; }
 
         public abstract Version RuntimeVersion { get; protected set; }
+
+        public abstract IServiceProvider ServiceProvider { get; protected set; }
     }
 
     public interface IEndpointInfoSource

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj
@@ -9,6 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.WebApi\Microsoft.Diagnostics.Monitoring.WebApi.csproj" />
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.Options\Microsoft.Diagnostics.Monitoring.Options.csproj" />
     <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj" />

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             public string ProcessName => ProcessInfoImpl.GetProcessName(CommandLine, OperatingSystem);
         }
 
-        private sealed class TestEndpointInfo : WebApi.EndpointInfoBase
+        private sealed class TestEndpointInfo : EndpointInfoBase
         {
             public TestEndpointInfo(Guid runtimeInstanceCookie, int processId, string commandLine, string operatingSystem, string processArchitecture)
             {
@@ -54,6 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 CommandLine = commandLine;
                 OperatingSystem = operatingSystem;
                 ProcessArchitecture = processArchitecture;
+                ServiceProvider = new NotSupportedServiceProvider();
             }
 
             public override int ProcessId { get; protected set; }
@@ -63,6 +64,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             public override string ProcessArchitecture { get; protected set; }
 
             public override Version RuntimeVersion { get; protected set; }
+            public override IServiceProvider ServiceProvider { get; protected set; }
         }
 
         private readonly ITestOutputHelper _outputHelper;

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -138,6 +138,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 services.AddSingleton<ILogsOperationFactory, LogsOperationFactory>();
                 services.AddSingleton<IMetricsOperationFactory, MetricsOperationFactory>();
                 services.AddSingleton<ITraceOperationFactory, TraceOperationFactory>();
+
+                // Per-process services must be scoped
+                services.AddScoped<ScopedEndpointInfo>();
+                services.AddScopedForwarder<IEndpointInfo, ScopedEndpointInfo>();
             })
             .ConfigureContainer((HostBuilderContext context, IServiceCollection services) =>
             {

--- a/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     try
                     {
-                        return await EndpointInfo.FromProcessIdAsync(pid, linkedToken);
+                        return await EndpointInfo.FromProcessIdAsync(pid, new NotSupportedServiceProvider(), linkedToken);
                     }
                     // Catch when timeout on waiting for EndpointInfo creation. Some runtime instances may be
                     // in a bad state and not respond to any requests on their diagnostic pipe; gracefully abandon

--- a/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class EndpointInfo : EndpointInfoBase
     {
-        public static async Task<EndpointInfo> FromProcessIdAsync(int processId, CancellationToken token)
+        public static async Task<EndpointInfo> FromProcessIdAsync(int processId, IServiceProvider serviceProvider, CancellationToken token)
         {
             var client = new DiagnosticsClient(processId);
 
@@ -50,11 +50,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 CommandLine = processInfo?.CommandLine,
                 OperatingSystem = processInfo?.OperatingSystem,
                 ProcessArchitecture = processInfo?.ProcessArchitecture,
-                RuntimeVersion = runtimeVersion
+                RuntimeVersion = runtimeVersion,
+                ServiceProvider = serviceProvider
             };
         }
 
-        public static async Task<EndpointInfo> FromIpcEndpointInfoAsync(IpcEndpointInfo info, CancellationToken token)
+        public static async Task<EndpointInfo> FromIpcEndpointInfoAsync(IpcEndpointInfo info, IServiceProvider serviceProvider, CancellationToken token)
         {
             var client = new DiagnosticsClient(info.Endpoint);
 
@@ -88,7 +89,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 CommandLine = processInfo?.CommandLine,
                 OperatingSystem = processInfo?.OperatingSystem,
                 ProcessArchitecture = processInfo?.ProcessArchitecture,
-                RuntimeVersion = runtimeVersion
+                RuntimeVersion = runtimeVersion,
+                ServiceProvider = serviceProvider
             };
         }
 
@@ -133,6 +135,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public override string ProcessArchitecture { get; protected set; }
 
         public override Version RuntimeVersion { get; protected set; }
+
+        public override IServiceProvider ServiceProvider { get; protected set; }
 
         internal string DebuggerDisplay => FormattableString.Invariant($"PID={ProcessId}, Cookie={RuntimeInstanceCookie}");
     }

--- a/src/Tools/dotnet-monitor/EndpointInfo/ScopedEndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ScopedEndpointInfo.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.NETCore.Client;
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class ScopedEndpointInfo : IEndpointInfo
+    {
+        private IEndpointInfo _endpointInfo;
+
+        public void Set(IEndpointInfo endpointInfo)
+        {
+            _endpointInfo = endpointInfo;
+        }
+
+        public int ProcessId => _endpointInfo.ProcessId;
+
+        public Guid RuntimeInstanceCookie => _endpointInfo.RuntimeInstanceCookie;
+
+        public string CommandLine => _endpointInfo.CommandLine;
+
+        public string OperatingSystem => _endpointInfo.OperatingSystem;
+
+        public string ProcessArchitecture => _endpointInfo.ProcessArchitecture;
+
+        public Version RuntimeVersion => _endpointInfo.RuntimeVersion;
+
+        IpcEndpoint IEndpointInfo.Endpoint => _endpointInfo.Endpoint;
+
+        public IServiceProvider ServiceProvider => _endpointInfo.ServiceProvider;
+    }
+}

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -36,6 +37,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private readonly List<EndpointInfo> _activeEndpoints = new();
         private readonly SemaphoreSlim _activeEndpointsSemaphore = new(1);
+        private readonly Dictionary<Guid, AsyncServiceScope> _activeEndpointServiceScopes = new();
+        private readonly IServiceProvider _serviceProvider;
 
         private readonly ChannelReader<IEndpointInfo> _pendingRemovalReader;
         private readonly ChannelWriter<IEndpointInfo> _pendingRemovalWriter;
@@ -55,12 +58,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IOptions<DiagnosticPortOptions> portOptions,
             IEnumerable<IEndpointInfoSourceCallbacks> callbacks = null,
             OperationTrackerService operationTrackerService = null,
-            ILogger<ServerEndpointInfoSource> logger = null)
+            ILogger<ServerEndpointInfoSource> logger = null,
+            IServiceProvider serviceProvider = null)
         {
             _callbacks = callbacks ?? Enumerable.Empty<IEndpointInfoSourceCallbacks>();
             _operationTrackerService = operationTrackerService;
             _portOptions = portOptions.Value;
             _logger = logger;
+            _serviceProvider = serviceProvider;
 
             BoundedChannelOptions channelOptions = new(PendingRemovalChannelCapacity)
             {
@@ -172,12 +177,32 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             List<Exception> exceptions = new();
             try
             {
-                EndpointInfo endpointInfo = await EndpointInfo.FromIpcEndpointInfoAsync(info, token);
+                // Create the process service scope
+                AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+
+                EndpointInfo endpointInfo = await EndpointInfo.FromIpcEndpointInfoAsync(info, scope.ServiceProvider, token);
+                _activeEndpointServiceScopes.Add(endpointInfo.RuntimeInstanceCookie, scope);
+
+                // Initialize endpoint information within the service scope
+                endpointInfo.ServiceProvider.GetRequiredService<ScopedEndpointInfo>().Set(endpointInfo);
+
                 foreach (IEndpointInfoSourceCallbacks callback in _callbacks)
                 {
                     try
                     {
                         await callback.OnBeforeResumeAsync(endpointInfo, token).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+
+                foreach (IDiagnosticLifetimeService lifetimeService in endpointInfo.ServiceProvider.GetServices<IDiagnosticLifetimeService>())
+                {
+                    try
+                    {
+                        await lifetimeService.StartAsync(token);
                     }
                     catch (Exception ex)
                     {
@@ -249,11 +274,39 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 IEndpointInfo endpoint = await _pendingRemovalReader.ReadAsync(token);
 
                 List<Exception> exceptions = new();
+
+                if (_activeEndpointServiceScopes.TryGetValue(endpoint.RuntimeInstanceCookie, out AsyncServiceScope stopScope))
+                {
+                    foreach (IDiagnosticLifetimeService lifetimeService in stopScope.ServiceProvider.GetServices<IDiagnosticLifetimeService>())
+                    {
+                        try
+                        {
+                            await lifetimeService.StopAsync(token);
+                        }
+                        catch (Exception ex)
+                        {
+                            exceptions.Add(ex);
+                        }
+                    }
+                }
+
                 foreach (IEndpointInfoSourceCallbacks callback in _callbacks)
                 {
                     try
                     {
                         await callback.OnRemovedEndpointInfoAsync(endpoint, token).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+
+                if (_activeEndpointServiceScopes.Remove(endpoint.RuntimeInstanceCookie, out AsyncServiceScope disposeScope))
+                {
+                    try
+                    {
+                        await disposeScope.DisposeAsync();
                     }
                     catch (Exception ex)
                     {

--- a/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;

--- a/src/Tools/dotnet-monitor/IDiagnosticLifetimeService.cs
+++ b/src/Tools/dotnet-monitor/IDiagnosticLifetimeService.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Callbacks for the lifetime events related to the diagnostic connection.
+    /// </summary>
+    public interface IDiagnosticLifetimeService
+    {
+        /// <summary>
+        /// Invoked just as the target process is discovered and is available for diagnostics.
+        /// </summary>
+        /// <remarks>
+        /// This is called just before the ResumeRuntime command is invoked.
+        /// </remarks>
+        ValueTask StartAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Invoke just after the target process is no longer available for diagnostics.
+        /// </summary>
+        /// <remarks>
+        /// The target process may have terminated or is no longer responding to diagnostic requests.
+        /// </remarks>
+        ValueTask StopAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/dotnet-monitor/IDiagnosticLifetimeService.cs
+++ b/src/Tools/dotnet-monitor/IDiagnosticLifetimeService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     /// <summary>
     /// Callbacks for the lifetime events related to the diagnostic connection.
     /// </summary>
-    public interface IDiagnosticLifetimeService
+    internal interface IDiagnosticLifetimeService
     {
         /// <summary>
         /// Invoked just as the target process is discovered and is available for diagnostics.

--- a/src/Tools/dotnet-monitor/NotSupportedServiceProvider.cs
+++ b/src/Tools/dotnet-monitor/NotSupportedServiceProvider.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class NotSupportedServiceProvider : IServiceProvider
+    {
+        public object GetService(Type serviceType)
+        {
+            throw new NotSupportedException("Pre-process services are not supported.");
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -369,6 +369,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return services;
         }
 
+        public static void AddScopedForwarder<TService, TImplementation>(this IServiceCollection services) where TImplementation : class, TService where TService : class
+        {
+            services.AddScoped<TService, TImplementation>(sp => sp.GetRequiredService<TImplementation>());
+        }
+
         private static void AddSingletonForwarder<TService, TImplementation>(this IServiceCollection services) where TImplementation : class, TService where TService : class
         {
             services.AddSingleton<TService, TImplementation>(sp => sp.GetRequiredService<TImplementation>());


### PR DESCRIPTION
###### Summary

These changes allow establishing services in a per-process scope; the benefit is that features can easily establish per-process state at any point in the lifetime of the diagnostic capability of the target process. Note that this is current only support for listen mode as connect mode does NOT have stable endpoint instances and tracking over the lifetime of the target process.

Example usage of this is in https://github.com/jander-msft/dotnet-monitor/pull/104, where the exception history feature has been converted to make use of the per-process services facility; note that the exceptions service and startup hooks service are greatly simplified. Because exceptions are tracked per-process, the HTTP API can allow reporting of exception history for any target process.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
