### PR TITLE
Use call to keep batch interpreter running

### DIFF
--- a/eng/helix/payload/installazurite.cmd
+++ b/eng/helix/payload/installazurite.cmd
@@ -1,3 +1,3 @@
-npm install -g azurite
+call npm install -g azurite
 if %ERRORLEVEL% neq 0 exit %ERRORLEVEL%
 set TEST_AZURITE_MUST_INITIALIZE=1

--- a/eng/helix/payload/setupnode.cmd
+++ b/eng/helix/payload/setupnode.cmd
@@ -1,4 +1,4 @@
 set PATH=%HELIX_CORRELATION_PAYLOAD%\nodejs\%1;%PATH%
-npm config set prefix %HELIX_WORKITEM_ROOT%\.npm
+call npm config set prefix %HELIX_WORKITEM_ROOT%\.npm
 if %ERRORLEVEL% neq 0 exit %ERRORLEVEL%
 set PATH=%HELIX_WORKITEM_ROOT%\.npm;%PATH%


### PR DESCRIPTION
###### Summary

The batch scripts would immediately exit after invoking `npm`; fix this by using `call` to invoke `npm` in order to keep the batch interpreter executing.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
