### PR TITLE
Fix ExceptionsEventSource_WriteException_Event to coalesce null value

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/Eventing/ExceptionsEventSourceTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             // but in-process listener doesn't decode non-byte arrays correctly.
             Assert.Equal(Array.Empty<ulong>(), instance.InnerExceptionIds);
 
-            Assert.Equal(activityId, instance.ActivityId);
+            Assert.Equal(CoalesceNull(activityId), instance.ActivityId);
             Assert.Equal(activityIdFormat, instance.ActivityIdFormat);
         }
 


### PR DESCRIPTION
###### Summary

This test is failing with on line 99:
```
Assert.Equal() Failure
Expected: (null)
Actual:   {null}
```

The ExceptionsEventListen intentionally coalesces null to `{null}` to make sure the property is set correctly. Update the test to do the same from the test code to match behavior.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
