### PR TITLE
Disable extension response tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -70,10 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.NotNull(extension);
         }
 
-        // Conditionally disable on Alpine and ARM64. The apphost for the extension is currently built for glibc x64
-        // in CI builds. Need to publish the test extension for different RIDs and dynamically select which
-        // variant with which tests are run.
-        [ConditionalFact(nameof(IsNotAlpineAndNotArm64))]
+        [Fact(Skip = "https://github.com/dotnet/dotnet-monitor/issues/4983")]
         public async Task ExtensionResponse_Success()
         {
             EgressArtifactResult result = await GetExtensionResponse(true);
@@ -82,10 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.Equal(EgressExtensibilityTestsConstants.SampleArtifactPath, result.ArtifactPath);
         }
 
-        // Conditionally disable on Alpine and ARM64. The apphost for the extension is currently built for glibc x64
-        // in CI builds. Need to publish the test extension for different RIDs and dynamically select which
-        // variant with which tests are run.
-        [ConditionalFact(nameof(IsNotAlpineAndNotArm64))]
+        [Fact(Skip = "https://github.com/dotnet/dotnet-monitor/issues/4983")]
         public async Task ExtensionResponse_Failure()
         {
             EgressArtifactResult result = await GetExtensionResponse(false);


### PR DESCRIPTION
###### Summary

The ExtensionResponse_Success and ExtensionResponse_Failure tests frequently fail on non-x64 (and non-glibc Linux) platforms due to the apphost being built for x64 but the installed runtime is not necessarily x64. Disable the tests for now until the app and the corresponding tests can better handle different architectures and libc implementations.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
