### PR TITLE
Revert "update release information (#4993)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>8.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!--
       Build quality notion for blob group naming, similar to aka.ms channel build quality in Arcade:


### PR DESCRIPTION
###### Summary

This reverts commit 7553fa5d6fe4031f33653104f9deec10e13e80e2.

There's been a few dependency updates to `main` that we want in `release/8.x`. Since `release/8.x` only receives dependency updates via our `main` -> `release/8.x` merges during release cycles we need to bring over these changes manually. Rather than backporting each individual dependency update, revert this commit so we can simply do another `main` -> `release/8.x` merge without causing troubles for the next person driving releases.


Going forward if we have a release branch that gets updated via `main` merges we should avoid bumping the version in main until the release ships to avoid this situation (I'll update the release process docs separately).

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
