### PR TITLE
Add script to update `shipped/*` branches

### DIFF
--- a/eng/release/Scripts/UpdateShippedBranch.ps1
+++ b/eng/release/Scripts/UpdateShippedBranch.ps1
@@ -1,0 +1,20 @@
+param(
+  [Parameter(Mandatory=$true)][string] $ReleaseVersion,
+  [Parameter(Mandatory=$true)][string] $ReleaseCommit
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+
+# Calculate branch name
+if ($ReleaseVersion -notmatch '^(?<majorMinorVersion>v[0-9]+\.[0-9]+)\.+')
+{
+    Write-Host "Error: unexpected release version: $ReleaseVersion"
+    exit 1
+}
+
+$majorMinorVersion = $Matches.majorMinorVersion
+$branchName = "shipped/$majorMinorVersion"
+
+git push --force origin "$ReleaseCommit`:refs/heads/$branchName"

--- a/eng/release/Scripts/UpdateShippedBranch.ps1
+++ b/eng/release/Scripts/UpdateShippedBranch.ps1
@@ -7,8 +7,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
 
-if ($ReleaseVersion -notmatch '^(?<majorMinorVersion>v[0-9]+\.[0-9]+)\.+')
-{
+if ($ReleaseVersion -notmatch '^(?<majorMinorVersion>v[0-9]+\.[0-9]+)\.+') {
     Write-Host "Error: unexpected release version: $ReleaseVersion"
     exit 1
 }

--- a/eng/release/Scripts/UpdateShippedBranch.ps1
+++ b/eng/release/Scripts/UpdateShippedBranch.ps1
@@ -7,7 +7,6 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
 
-# Calculate branch name
 if ($ReleaseVersion -notmatch '^(?<majorMinorVersion>v[0-9]+\.[0-9]+)\.+')
 {
     Write-Host "Error: unexpected release version: $ReleaseVersion"


### PR DESCRIPTION
###### Summary

Add a new script that force updates/creates the `shipped/*` branch that corresponds to a given release. Once merged in, I'll update our release definition to call it.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
