### PR TITLE
Use native offset instead of IL offset

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             {
                 StackFrame threadStackFrame = threadStackFrames[index];
                 if (throwingFrame.GetMethod() == threadStackFrame.GetMethod() &&
-                    throwingFrame.GetILOffset() == threadStackFrame.GetILOffset())
+                    throwingFrame.GetNativeOffset() == threadStackFrame.GetNativeOffset())
                 {
                     break;
                 }


### PR DESCRIPTION
###### Summary

Starting in #4970, the throwing frame from the `StackTrace` of the exception seems to be reporting a bogus IL offset, which means it fails to find the match stack frame from the thread's `StackTrace`. Change the exception reporting to compare the native offsets instead, which seem to be correct or at least be the same value for the same frame.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
