### PR TITLE
Report unhandled exceptions through ExceptionsEventSource

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainExceptionProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing;
 using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline;
 using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps;
 
@@ -8,28 +9,44 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
     internal sealed class CurrentAppDomainExceptionProcessor
     {
-        private readonly ExceptionPipeline _pipeline;
-        private readonly CurrentAppDomainExceptionSource _source;
+        private readonly ExceptionsEventSource _eventSource = new();
+        private readonly ExceptionIdSource _idSource = new();
+
+        private readonly CurrentAppDomainFirstChanceExceptionSource _firstChanceSource;
+        private readonly ExceptionPipeline _firstChancePipeline;
+
+        private readonly CurrentAppDomainUnhandledExceptionSource _unhandledSource;
+        private readonly ExceptionPipeline _unhandledPipeline;
 
         public CurrentAppDomainExceptionProcessor()
         {
-            _source = new();
-            _pipeline = new(_source, ConfigurePipeline);
+            _firstChanceSource = new();
+            _firstChancePipeline = new(_firstChanceSource, ConfigureFirstChancePipeline);
+
+            _unhandledSource = new();
+            _unhandledPipeline = new(_unhandledSource, ConfigureUnhandledPipeline);
         }
 
         public void Start()
         {
-            _pipeline.Start();
+            _firstChancePipeline.Start();
+            _unhandledPipeline.Start();
         }
 
-        private static void ConfigurePipeline(ExceptionPipelineBuilder builder)
+        private void ConfigureFirstChancePipeline(ExceptionPipelineBuilder builder)
         {
             // Process current exception and its inner exceptions
             builder.Add(next => new ExceptionDemultiplexerPipelineStep(next).Invoke);
             // Prevent rethrows from being evaluated; only care about origination of exceptions.
             builder.Add(next => new FilterRepeatExceptionPipelineStep(next).Invoke);
             // Report exception through event source
-            builder.Add(next => new ExceptionEventsPipelineStep(next).Invoke);
+            builder.Add(next => new ExceptionEventsPipelineStep(next, _eventSource, _idSource).Invoke);
+        }
+
+        private void ConfigureUnhandledPipeline(ExceptionPipelineBuilder builder)
+        {
+            // Report exception through event source
+            builder.Add(next => new UnhandledExceptionEventsPipelineStep(next, _eventSource, _idSource).Invoke);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainFirstChanceExceptionSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainFirstChanceExceptionSource.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.ExceptionServices;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    /// <summary>
+    /// Produces first chance exceptions from the current app domain.
+    /// </summary>
+    internal sealed class CurrentAppDomainFirstChanceExceptionSource :
+        GuardedExceptionSourceBase,
+        IDisposable
+    {
+        private long _disposedState;
+
+        public CurrentAppDomainFirstChanceExceptionSource()
+        {
+            AppDomain.CurrentDomain.FirstChanceException += CurrentDomain_FirstChanceException;
+        }
+
+        private void CurrentDomain_FirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
+        {
+            RaiseExceptionGuarded(e.Exception);
+        }
+
+        public void Dispose()
+        {
+            if (!DisposableHelper.CanDispose(ref _disposedState))
+                return;
+
+            AppDomain.CurrentDomain.FirstChanceException -= CurrentDomain_FirstChanceException;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainUnhandledExceptionSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/CurrentAppDomainUnhandledExceptionSource.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
+{
+    /// <summary>
+    /// Produces the unhandled exceptions from the current app domain.
+    /// </summary>
+    internal sealed class CurrentAppDomainUnhandledExceptionSource :
+        GuardedExceptionSourceBase,
+        IDisposable
+    {
+        private long _disposedState;
+
+        public CurrentAppDomainUnhandledExceptionSource()
+        {
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        }
+
+        private void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception exception)
+            {
+                RaiseExceptionGuarded(exception);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!DisposableHelper.CanDispose(ref _disposedState))
+                return;
+
+            AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Eventing/ExceptionsEventSource.cs
@@ -62,6 +62,17 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing
             WriteEventWithFlushing(ExceptionEvents.EventIds.ExceptionInstance, data);
         }
 
+        [Event(ExceptionEvents.EventIds.ExceptionInstanceUnhandled)]
+        public void ExceptionInstanceUnhandled(
+            ulong ExceptionId)
+        {
+            Span<EventData> data = stackalloc EventData[1];
+
+            SetValue(ref data[ExceptionEvents.ExceptionInstanceUnhandledPayloads.ExceptionId], ExceptionId);
+
+            WriteEventWithFlushing(ExceptionEvents.EventIds.ExceptionInstanceUnhandled, data);
+        }
+
         [Event(ExceptionEvents.EventIds.ClassDescription)]
         public void ClassDescription(
             ulong ClassId,

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionAvailableEventArgs.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionAvailableEventArgs.cs
@@ -6,9 +6,9 @@ using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
-    internal sealed class ExceptionEventArgs : EventArgs
+    internal sealed class ExceptionAvailableEventArgs : EventArgs
     {
-        public ExceptionEventArgs(Exception exception, DateTime timestamp, string? activityId, ActivityIdFormat activityIdFormat)
+        public ExceptionAvailableEventArgs(Exception exception, DateTime timestamp, string? activityId, ActivityIdFormat activityIdFormat)
         {
             Exception = exception;
             Timestamp = timestamp;

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
@@ -7,18 +7,18 @@ using System.Diagnostics;
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
     /// <summary>
-    /// Represents a source of thrown exceptions.
+    /// Represents a source of exceptions.
     /// </summary>
     internal abstract class ExceptionSourceBase
     {
-        protected void RaiseExceptionThrown(Exception ex, DateTime timestamp, string? activityId, ActivityIdFormat format)
+        protected void RaiseException(Exception ex, DateTime timestamp, string? activityId, ActivityIdFormat format)
         {
-            ExceptionThrown?.Invoke(this, new ExceptionEventArgs(ex, timestamp, activityId, format));
+            Exception?.Invoke(this, new ExceptionEventArgs(ex, timestamp, activityId, format));
         }
 
         /// <summary>
-        /// Event that is raised each time an exception is thrown.
+        /// Event that is raised each time an exception is made available.
         /// </summary>
-        public event EventHandler<ExceptionEventArgs>? ExceptionThrown;
+        public event EventHandler<ExceptionEventArgs>? Exception;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/ExceptionSourceBase.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
     {
         protected void RaiseException(Exception ex, DateTime timestamp, string? activityId, ActivityIdFormat format)
         {
-            Exception?.Invoke(this, new ExceptionEventArgs(ex, timestamp, activityId, format));
+            ExceptionAvailable?.Invoke(this, new ExceptionAvailableEventArgs(ex, timestamp, activityId, format));
         }
 
         /// <summary>
         /// Event that is raised each time an exception is made available.
         /// </summary>
-        public event EventHandler<ExceptionEventArgs>? Exception;
+        public event EventHandler<ExceptionAvailableEventArgs>? ExceptionAvailable;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/GuardedExceptionSourceBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/GuardedExceptionSourceBase.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/GuardedExceptionSourceBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/GuardedExceptionSourceBase.cs
@@ -1,30 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using System.Runtime.ExceptionServices;
+using System;
 using System.Threading;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
-    /// <summary>
-    /// Produces first chance exceptions from the current app domain.
-    /// </summary>
-    internal sealed class CurrentAppDomainExceptionSource :
-        ExceptionSourceBase,
-        IDisposable
+    internal abstract class GuardedExceptionSourceBase :
+        ExceptionSourceBase
     {
         private readonly ThreadLocal<bool> _handlingException = new();
 
-        private long _disposedState;
-
-        public CurrentAppDomainExceptionSource()
-        {
-            AppDomain.CurrentDomain.FirstChanceException += CurrentDomain_FirstChanceException;
-        }
-
-        private void CurrentDomain_FirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
+        protected void RaiseExceptionGuarded(Exception exception)
         {
             DateTime timestamp = DateTime.UtcNow;
 
@@ -41,7 +29,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             {
                 _handlingException.Value = true;
 
-                RaiseExceptionThrown(e.Exception,
+                RaiseException(
+                    exception,
                     timestamp,
                     Activity.Current?.Id,
                     Activity.Current?.IdFormat ?? ActivityIdFormat.Unknown);
@@ -54,14 +43,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             {
                 _handlingException.Value = false;
             }
-        }
-
-        public void Dispose()
-        {
-            if (!DisposableHelper.CanDispose(ref _disposedState))
-                return;
-
-            AppDomain.CurrentDomain.FirstChanceException -= CurrentDomain_FirstChanceException;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
         {
             DisposableHelper.ThrowIfDisposed<ExceptionPipeline>(ref _disposedState);
 
-            _exceptionSource.Exception += ExceptionSource_Exception;
+            _exceptionSource.ExceptionAvailable += ExceptionSource_ExceptionAvailable;
         }
 
-        private void ExceptionSource_Exception(object? sender, ExceptionEventArgs args)
+        private void ExceptionSource_ExceptionAvailable(object? sender, ExceptionAvailableEventArgs args)
         {
             // DESIGN: While async patterns are typically favored over synchronous patterns,
             // this is intentionally synchronous. Use cases for making this asynchronous typically
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
             if (!DisposableHelper.CanDispose(ref _disposedState))
                 return;
 
-            _exceptionSource.Exception -= ExceptionSource_Exception;
+            _exceptionSource.ExceptionAvailable -= ExceptionSource_ExceptionAvailable;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/ExceptionPipeline.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
         {
             DisposableHelper.ThrowIfDisposed<ExceptionPipeline>(ref _disposedState);
 
-            _exceptionSource.ExceptionThrown += ExceptionSource_ExceptionThrown;
+            _exceptionSource.Exception += ExceptionSource_Exception;
         }
 
-        private void ExceptionSource_ExceptionThrown(object? sender, ExceptionEventArgs args)
+        private void ExceptionSource_Exception(object? sender, ExceptionEventArgs args)
         {
             // DESIGN: While async patterns are typically favored over synchronous patterns,
             // this is intentionally synchronous. Use cases for making this asynchronous typically
@@ -40,15 +40,21 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline
             // (e.g. EventSource provides events but diagnostic pipe events are queued and asynchronously emitted).
             // Synchronous execution is required for scenarios where the exception needs to be held
             // at the site of where it is thrown before allowing it to unwind (e.g. capturing a dump of the exception).
-            _exceptionHandler.Invoke(args.Exception, new ExceptionPipelineExceptionContext(args.Timestamp, args.ActivityId, args.ActivityIdFormat));
+            _exceptionHandler.Invoke(
+                args.Exception,
+                new ExceptionPipelineExceptionContext(
+                    args.Timestamp,
+                    args.ActivityId,
+                    args.ActivityIdFormat));
         }
+
 
         public void Dispose()
         {
             if (!DisposableHelper.CanDispose(ref _disposedState))
                 return;
 
-            _exceptionSource.ExceptionThrown -= ExceptionSource_ExceptionThrown;
+            _exceptionSource.Exception -= ExceptionSource_Exception;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionEventsPipelineStep.cs
@@ -8,30 +8,30 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
 {
     internal sealed class ExceptionEventsPipelineStep
     {
-        private static readonly object ExceptionIdKey = new object();
-
-        private readonly ExceptionsEventSource _eventSource = new();
+        private readonly ExceptionsEventSource _eventSource;
         private readonly ExceptionGroupIdentifierCache _identifierCache;
+        private readonly ExceptionIdSource _idSource;
         private readonly ExceptionPipelineDelegate _next;
 
-        private ulong _nextExceptionId = 1;
-
-        public ExceptionEventsPipelineStep(ExceptionPipelineDelegate next)
+        public ExceptionEventsPipelineStep(ExceptionPipelineDelegate next, ExceptionsEventSource eventSource, ExceptionIdSource idSource)
         {
             ArgumentNullException.ThrowIfNull(next);
+            ArgumentNullException.ThrowIfNull(eventSource);
+            ArgumentNullException.ThrowIfNull(idSource);
 
             List<ExceptionGroupIdentifierCacheCallback> callbacks = new(1)
             {
-                new ExceptionsEventSourceIdentifierCacheCallback(_eventSource)
+                new ExceptionsEventSourceIdentifierCacheCallback(eventSource)
             };
 
+            _eventSource = eventSource;
             _identifierCache = new ExceptionGroupIdentifierCache(callbacks);
+            _idSource = idSource;
             _next = next;
         }
 
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                 ulong[] frameIds = _identifierCache.GetOrAdd(stackFrames);
 
                 _eventSource.ExceptionInstance(
-                    GetExceptionId(exception),
+                    _idSource.GetId(exception),
                     groupId,
                     exception.Message,
                     frameIds,
@@ -82,7 +82,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             // stack. In the case of observing the exception from the FirstChanceException event,
             // there is only one frame on the stack (the throwing frame). In order to get the
             // full call stack of the exception, get the current call stack of the thread and
-            // filter out the call frames that are "above" the exceptions's throwing frame.
+            // filter out the call frames that are "above" the exception's throwing frame.
             StackFrame? throwingFrame = null;
             foreach (StackFrame stackFrame in exceptionStackTrace.GetFrames())
             {
@@ -137,43 +137,6 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
             }
         }
 
-        private ulong GetExceptionId(Exception? exception)
-        {
-            if (null == exception)
-                return 0;
-
-            if (TryGetExceptionId(exception, out ulong exceptionId))
-                return exceptionId;
-
-            lock (exception.Data)
-            {
-                if (TryGetExceptionId(exception, out exceptionId))
-                    return exceptionId;
-
-                exceptionId = Interlocked.Increment(ref _nextExceptionId);
-
-                exception.Data[ExceptionIdKey] = exceptionId;
-            }
-
-            return exceptionId;
-
-            static bool TryGetExceptionId(Exception exception, out ulong exceptionId)
-            {
-                if (exception.Data.Contains(ExceptionIdKey))
-                {
-                    // The ExceptionIdKey data should only ever have a ulong
-                    if (exception.Data[ExceptionIdKey] is ulong exceptionIdCandidate)
-                    {
-                        exceptionId = exceptionIdCandidate;
-                        return true;
-                    }
-                }
-
-                exceptionId = default;
-                return false;
-            }
-        }
-
         private ulong[] GetInnerExceptionsIds(Exception exception)
         {
             if (exception is AggregateException aggregateException)
@@ -183,7 +146,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                 ulong[] exceptionIds = new ulong[aggregateException.InnerExceptions.Count];
                 for (int i = 0; i < aggregateException.InnerExceptions.Count; i++)
                 {
-                    exceptionIds[i] = GetExceptionId(aggregateException.InnerExceptions[i]);
+                    exceptionIds[i] = _idSource.GetId(aggregateException.InnerExceptions[i]);
                 }
                 return exceptionIds;
             }
@@ -196,14 +159,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
                     Exception? loaderException = reflectionTypeLoadException.LoaderExceptions[i];
                     if (null != loaderException)
                     {
-                        exceptionIds[i] = GetExceptionId(loaderException);
+                        exceptionIds[i] = _idSource.GetId(loaderException);
                     }
                 }
                 return exceptionIds;
             }
             else if (null != exception.InnerException)
             {
-                return new ulong[] { GetExceptionId(exception.InnerException) };
+                return new ulong[] { _idSource.GetId(exception.InnerException) };
             }
             return Array.Empty<ulong>();
         }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionIdSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/ExceptionIdSource.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    internal sealed class ExceptionIdSource
+    {
+        private readonly object _exceptionIdKey = new object();
+
+        private ulong _nextExceptionId = 1;
+
+        public ulong GetId(Exception? exception)
+        {
+            if (null == exception)
+                return 0;
+
+            if (TryGetExceptionId(exception, out ulong exceptionId))
+                return exceptionId;
+
+            lock (exception.Data)
+            {
+                if (TryGetExceptionId(exception, out exceptionId))
+                    return exceptionId;
+
+                exceptionId = Interlocked.Increment(ref _nextExceptionId);
+
+                exception.Data[_exceptionIdKey] = exceptionId;
+            }
+
+            return exceptionId;
+
+            bool TryGetExceptionId(Exception exception, out ulong exceptionId)
+            {
+                if (exception.Data.Contains(_exceptionIdKey))
+                {
+                    // The ExceptionIdKey data should only ever have a ulong
+                    if (exception.Data[_exceptionIdKey] is ulong exceptionIdCandidate)
+                    {
+                        exceptionId = exceptionIdCandidate;
+                        return true;
+                    }
+                }
+
+                exceptionId = default;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/UnhandledExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/UnhandledExceptionEventsPipelineStep.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Eventing;
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
+{
+    internal sealed class UnhandledExceptionEventsPipelineStep
+    {
+        private readonly ExceptionsEventSource _eventSource;
+        private readonly ExceptionIdSource _idSource;
+        private readonly ExceptionPipelineDelegate _next;
+
+        public UnhandledExceptionEventsPipelineStep(ExceptionPipelineDelegate next, ExceptionsEventSource eventSource, ExceptionIdSource idSource)
+        {
+            ArgumentNullException.ThrowIfNull(next);
+            ArgumentNullException.ThrowIfNull(eventSource);
+            ArgumentNullException.ThrowIfNull(idSource);
+
+            _eventSource = eventSource;
+            _idSource = idSource;
+            _next = next;
+        }
+
+        public void Invoke(Exception exception, ExceptionPipelineExceptionContext context)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            // Do not send via the EventSource unless an listener is active.
+            if (_eventSource.IsEnabled())
+            {
+                _eventSource.ExceptionInstanceUnhandled(_idSource.GetId(exception));
+            }
+
+            _next(exception, context);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/UnhandledExceptionEventsPipelineStep.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/Exceptions/Pipeline/Steps/UnhandledExceptionEventsPipelineStep.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions.Pipeline.Steps
         {
             ArgumentNullException.ThrowIfNull(exception);
 
-            // Do not send via the EventSource unless an listener is active.
+            // Do not send via the EventSource unless a listener is active.
             if (_eventSource.IsEnabled())
             {
                 _eventSource.ExceptionInstanceUnhandled(_idSource.GetId(exception));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainFirstChanceExceptionSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainFirstChanceExceptionSourceTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 {
     [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
-    public sealed class CurrentAppDomainExceptionSourceTests
+    public sealed class CurrentAppDomainFirstChanceExceptionSourceTests
     {
         private readonly Thread _thisThread = Thread.CurrentThread;
 
@@ -26,14 +26,14 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
         }
 
         [Fact]
-        public void CurrentAppDomainExceptionSource_ReportsExceptionInsideLifetime()
+        public void CurrentAppDomainFirstChanceExceptionSource_ReportsExceptionInsideLifetime()
         {
             List<Exception> reportedExceptions = new();
 
             Exception thrownException = new();
-            using (CurrentAppDomainExceptionSource source = new())
+            using (CurrentAppDomainFirstChanceExceptionSource source = new())
             {
-                source.ExceptionThrown += CreateHandler(reportedExceptions);
+                source.Exception += CreateHandler(reportedExceptions);
                 try
                 {
                     throw thrownException;
@@ -48,13 +48,13 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
         }
 
         [Fact]
-        public void CurrentAppDomainExceptionSource_NoExceptionsOutsideLifetime()
+        public void CurrentAppDomainFirstChanceExceptionSource_NoExceptionsOutsideLifetime()
         {
             List<Exception> reportedExceptions = new();
 
-            using (CurrentAppDomainExceptionSource source = new())
+            using (CurrentAppDomainFirstChanceExceptionSource source = new())
             {
-                source.ExceptionThrown += CreateHandler(reportedExceptions);
+                source.Exception += CreateHandler(reportedExceptions);
             }
 
             try
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
         }
 
         [Fact]
-        public void CurrentAppDomainExceptionSource_ReentrancyPrevented()
+        public void CurrentAppDomainFirstChanceExceptionSource_ReentrancyPrevented()
         {
             bool handled = false;
             EventHandler<ExceptionEventArgs> handler = (sender, args) =>
@@ -84,9 +84,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             };
 
             Exception thrownException = new();
-            using (CurrentAppDomainExceptionSource source = new())
+            using (CurrentAppDomainFirstChanceExceptionSource source = new())
             {
-                source.ExceptionThrown += handler;
+                source.Exception += handler;
                 try
                 {
                     throw thrownException;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainFirstChanceExceptionSourceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/CurrentAppDomainFirstChanceExceptionSourceTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
     {
         private readonly Thread _thisThread = Thread.CurrentThread;
 
-        private EventHandler<ExceptionEventArgs> CreateHandler(List<Exception> reportedExceptions)
+        private EventHandler<ExceptionAvailableEventArgs> CreateHandler(List<Exception> reportedExceptions)
         {
             return (sender, args) =>
             {
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             Exception thrownException = new();
             using (CurrentAppDomainFirstChanceExceptionSource source = new())
             {
-                source.Exception += CreateHandler(reportedExceptions);
+                source.ExceptionAvailable += CreateHandler(reportedExceptions);
                 try
                 {
                     throw thrownException;
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 
             using (CurrentAppDomainFirstChanceExceptionSource source = new())
             {
-                source.Exception += CreateHandler(reportedExceptions);
+                source.ExceptionAvailable += CreateHandler(reportedExceptions);
             }
 
             try
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
         public void CurrentAppDomainFirstChanceExceptionSource_ReentrancyPrevented()
         {
             bool handled = false;
-            EventHandler<ExceptionEventArgs> handler = (sender, args) =>
+            EventHandler<ExceptionAvailableEventArgs> handler = (sender, args) =>
             {
                 if (Thread.CurrentThread == _thisThread)
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
             Exception thrownException = new();
             using (CurrentAppDomainFirstChanceExceptionSource source = new())
             {
-                source.Exception += handler;
+                source.ExceptionAvailable += handler;
                 try
                 {
                     throw thrownException;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/Exceptions/MockExceptionSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions
 
         public void ProvideException(Exception exception)
         {
-            RaiseExceptionThrown(exception, DateTime.UtcNow, Guid.Empty.ToString(), ActivityIdFormat.Unknown);
+            RaiseException(exception, DateTime.UtcNow, Guid.Empty.ToString(), ActivityIdFormat.Unknown);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -87,6 +87,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         traceEvent.GetPayload<string>(ExceptionEvents.ExceptionInstancePayloads.ActivityId),
                         traceEvent.GetPayload<ActivityIdFormat>(ExceptionEvents.ExceptionInstancePayloads.ActivityIdFormat));
                     break;
+                case "ExceptionInstanceUnhandled":
+                    // TODO: Advertise unhandled exception as necessary
+                    ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId);
+                    break;
                 case "FunctionDescription":
                     _cache.AddFunction(
                         traceEvent.GetPayload<ulong>(NameIdentificationEvents.FunctionDescPayloads.FunctionId),

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipeline.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                     break;
                 case "ExceptionInstanceUnhandled":
                     // TODO: Advertise unhandled exception as necessary
-                    ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstancePayloads.ExceptionId);
+                    ulong exceptionId = traceEvent.GetPayload<ulong>(ExceptionEvents.ExceptionInstanceUnhandledPayloads.ExceptionId);
                     break;
                 case "FunctionDescription":
                     _cache.AddFunction(

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionEvents.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public const int TokenDescription = 6;
             public const int Flush = 7;
             public const int StackFrameDescription = 8;
+            public const int ExceptionInstanceUnhandled = 9;
         }
 
         public static class ExceptionInstancePayloads
@@ -33,6 +34,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             public const int InnerExceptionIds = 5;
             public const int ActivityId = 6;
             public const int ActivityIdFormat = 7;
+        }
+
+        public static class ExceptionInstanceUnhandledPayloads
+        {
+            public const int ExceptionId = 0;
         }
 
         public static class ExceptionGroupPayloads


### PR DESCRIPTION
###### Summary

Refactor exception source, pipeline, and event source to allow for processing unhandled exceptions through a separate pipeline instance but reporting them through the same event source instance used for first chance exceptions. This was done by:
- Refactoring `ExceptionSourceBase` to be agnostic of the source of the exception. Add `GuardedExceptionSourceBase` to shared between the first chance and unhandled sources.
- Move ownership of the `ExceptionsEventSource` and exception ID generation to the processor so that it can be shared between the first chance pipeline and the unhandled pipeline.
- Add new `ExceptionInstanceUnhandled` event to `ExceptionsEventSource`.

I've left the handling of the `ExceptionInstanceUnhandled` event in the `EventExceptionsPipeline` alone for now in order to keep this PR focused on providing the infrastructure to react to unhandled exceptions.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
