### PR TITLE
[Parameter Capturing] Cancel initializing profilers on unsupported runtimes

### DIFF
--- a/src/Profilers/CommonMonitorProfiler/ProfilerBase.cpp
+++ b/src/Profilers/CommonMonitorProfiler/ProfilerBase.cpp
@@ -10,16 +10,14 @@ ProfilerBase::ProfilerBase() :
 {
 }
 
-HRESULT ProfilerBase::IsRuntimeSupported(ICorProfilerInfo12* pCorProfilerInfo, bool& supported)
+HRESULT ProfilerBase::IsRuntimeSupported(bool& supported)
 {
     HRESULT hr;
 
     supported = false;
 
-    ExpectedPtr(pCorProfilerInfo);
-
     COR_PRF_RUNTIME_TYPE runtimeType;
-    IfFailRet(pCorProfilerInfo->GetRuntimeInformation(
+    IfFailRet(m_pCorProfilerInfo->GetRuntimeInformation(
         nullptr, // instance id
         &runtimeType,
         nullptr, nullptr, nullptr, nullptr, // version info

--- a/src/Profilers/CommonMonitorProfiler/ProfilerBase.h
+++ b/src/Profilers/CommonMonitorProfiler/ProfilerBase.h
@@ -16,7 +16,7 @@ protected:
     ComPtr<ICorProfilerInfo12> m_pCorProfilerInfo;
 
 protected:
-    HRESULT IsRuntimeSupported(ICorProfilerInfo12* pCorProfilerInfo, bool& supported);
+    HRESULT IsRuntimeSupported(bool& supported);
 
 public:
     ProfilerBase();

--- a/src/Profilers/MonitorProfiler/MainProfiler/MainProfiler.cpp
+++ b/src/Profilers/MonitorProfiler/MainProfiler/MainProfiler.cpp
@@ -164,7 +164,7 @@ HRESULT MainProfiler::InitializeCommon()
 
     // Logging is initialized and can now be used
     bool supported;
-    IfFailLogRet(ProfilerBase::IsRuntimeSupported(m_pCorProfilerInfo, supported));
+    IfFailLogRet(ProfilerBase::IsRuntimeSupported(supported));
     if (!supported)
     {
         m_pLogger->Log(LogLevel::Debug, _LS("Unsupported runtime."));

--- a/src/Profilers/MutatingMonitorProfiler/MutatingMonitorProfiler.cpp
+++ b/src/Profilers/MutatingMonitorProfiler/MutatingMonitorProfiler.cpp
@@ -80,7 +80,7 @@ HRESULT MutatingMonitorProfiler::InitializeCommon()
 
     // Logging is initialized and can now be used
     bool supported;
-    IfFailLogRet(ProfilerBase::IsRuntimeSupported(m_pCorProfilerInfo, supported));
+    IfFailLogRet(ProfilerBase::IsRuntimeSupported(supported));
     if (!supported)
     {
         m_pLogger->Log(LogLevel::Debug, _LS("Unsupported runtime."));


### PR DESCRIPTION
###### Summary

Ensure that our profilers only initialize on supported runtimes (.net core, and not desktop). This is to help avoid problems where our profilers are loaded into a process with both the desktop and core CLRs and they attempt to act on global objects (e.g. the parameter-capturing request queue).

This is a follow-up on earlier parameter capturing feedback:  https://github.com/dotnet/dotnet-monitor/pull/4428#discussion_r1197002931

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
