### PR TITLE
[Parameter Capturing] Improve unknown declaring type representation

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
@@ -152,6 +152,15 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;unknown_type&gt;.
+        /// </summary>
+        internal static string UnknownDeclaringType {
+            get {
+                return ResourceManager.GetString("UnknownDeclaringType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;unknown_name_at_position_{0}&gt;.
         /// </summary>
         internal static string UnknownParameterNameFormatString {

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
@@ -147,6 +147,9 @@
   <data name="UnknownArgumentValue" xml:space="preserve">
     <value>unknown</value>
   </data>
+  <data name="UnknownDeclaringType" xml:space="preserve">
+    <value>&lt;unknown_type&gt;</value>
+  </data>
   <data name="UnknownParameterNameFormatString" xml:space="preserve">
     <value>&lt;unknown_name_at_position_{0}&gt;</value>
   </data>

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/PrettyPrinter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/PrettyPrinter.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
             // Declaring type name
             // For a generic declaring type, trim the arity information and replace it with the known generic argument names.
             const char arityDelimiter = '`';
-            string declaringTypeName = method.DeclaringType?.FullName?.Split(arityDelimiter)?[0] ?? string.Empty;
+            string declaringTypeName = method.DeclaringType?.FullName?.Split(arityDelimiter)?[0] ?? ParameterCapturingStrings.UnknownDeclaringType;
             fmtStringBuilder.Append(declaringTypeName);
             EmitGenericArguments(fmtStringBuilder, method.DeclaringType?.GetGenericArguments());
 


### PR DESCRIPTION
###### Summary

When constructing the template string for logging in function probes, represent unknown declaring types as `<unknown_type>` instead of an empty string.

This is a follow up on earlier parameter capturing feedback: https://github.com/dotnet/dotnet-monitor/pull/4474#discussion_r1213500057

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
