### PR TITLE
Fix flaky `ProcessTests.SingleProcessIdentificationTest` test

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ProcessTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
-using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
###### Summary
`Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.ProcessTests.SingleProcessIdentificationTest` was resulting in all of our CI test failures due to a race condition in it. 

The test launches a test app, waits for `dotnet-monitor` to track it (with retry) and then terminates the test app and sees if `dotnet-monitor` is no longer tracking it. However there's no waiting or retry on the termination part, so it's common for the test to fail here since `dotnet-monitor` hasn't had enough time to react. Add a simple retry. If this ends up not being enough we can extend the retry's wait.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
