### PR TITLE
Invoke callbacks in reverse order on diagnostic disconnect

### DIFF
--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                 if (isServiceScopeValid)
                 {
-                    foreach (IDiagnosticLifetimeService lifetimeService in serviceScope.ServiceProvider.GetServices<IDiagnosticLifetimeService>())
+                    foreach (IDiagnosticLifetimeService lifetimeService in serviceScope.ServiceProvider.GetServices<IDiagnosticLifetimeService>().Reverse())
                     {
                         try
                         {
@@ -342,7 +342,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     }
                 }
 
-                foreach (IEndpointInfoSourceCallbacks callback in _callbacks)
+                foreach (IEndpointInfoSourceCallbacks callback in _callbacks.Reverse())
                 {
                     try
                     {


### PR DESCRIPTION
###### Summary

The callbacks should be invoked in reverse order during diagnostic disconnect so that services that were started later will be the first ones to stop. This allows for proper ordering of detach/disconnect/event handler removing types of operations.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
