### PR TITLE
Allow shared read access for file system egress

### DIFF
--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
         private async Task WriteFileAsync(Func<Stream, CancellationToken, Task> action, string filePath, CancellationToken token)
         {
             using Stream fileStream = WrapException(
-                () => new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None));
+                () => new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read));
 
             _logger?.EgressProviderInvokeStreamAction(EgressProviderTypes.FileSystem);
 


### PR DESCRIPTION
###### Summary

Allow other processes to be able to read the target file instead of using an exclusive lock while the egress provider is writing.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
