### PR TITLE
Represent TimeSpan as formatted string in OpenAPI

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1443,21 +1443,21 @@
             "description": "The sliding window duration in which the actionCountLimit is the maximum number of occurrences (as defined by Limits).",
             "format": "time-span",
             "nullable": true,
-            "example": "00:00:00"
+            "example": "00:00:30"
           },
           "slidingWindowDurationCountdown": {
             "type": "string",
             "description": "The amount of time that needs to pass before the slidingWindowOccurrences drops below the actionCountLimit",
             "format": "time-span",
             "nullable": true,
-            "example": "00:00:00"
+            "example": "00:00:30"
           },
           "ruleFinishedCountdown": {
             "type": "string",
             "description": "The amount of time that needs to pass before the rule is finished",
             "format": "time-span",
             "nullable": true,
-            "example": "00:00:00"
+            "example": "00:00:30"
           }
         },
         "additionalProperties": false

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1439,13 +1439,25 @@
             "format": "int32"
           },
           "actionCountSlidingWindowDurationLimit": {
-            "$ref": "#/components/schemas/TimeSpan"
+            "type": "string",
+            "description": "The sliding window duration in which the actionCountLimit is the maximum number of occurrences (as defined by Limits).",
+            "format": "time-span",
+            "nullable": true,
+            "example": "00:00:00"
           },
           "slidingWindowDurationCountdown": {
-            "$ref": "#/components/schemas/TimeSpan"
+            "type": "string",
+            "description": "The amount of time that needs to pass before the slidingWindowOccurrences drops below the actionCountLimit",
+            "format": "time-span",
+            "nullable": true,
+            "example": "00:00:00"
           },
           "ruleFinishedCountdown": {
-            "$ref": "#/components/schemas/TimeSpan"
+            "type": "string",
+            "description": "The amount of time that needs to pass before the rule is finished",
+            "format": "time-span",
+            "nullable": true,
+            "example": "00:00:00"
           }
         },
         "additionalProperties": false
@@ -1857,66 +1869,6 @@
           "processArchitecture": {
             "type": "string",
             "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "TimeSpan": {
-        "type": "object",
-        "properties": {
-          "ticks": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "days": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "hours": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "milliseconds": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "minutes": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "seconds": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
-          "totalDays": {
-            "type": "number",
-            "format": "double",
-            "readOnly": true
-          },
-          "totalHours": {
-            "type": "number",
-            "format": "double",
-            "readOnly": true
-          },
-          "totalMilliseconds": {
-            "type": "number",
-            "format": "double",
-            "readOnly": true
-          },
-          "totalMinutes": {
-            "type": "number",
-            "format": "double",
-            "readOnly": true
-          },
-          "totalSeconds": {
-            "type": "number",
-            "format": "double",
-            "readOnly": true
           }
         },
         "additionalProperties": false

--- a/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger
             options.IncludeXmlComments(() => new XPathDocument(Assembly.GetExecutingAssembly().GetManifestResourceStream(documentationFile)));
 
             // Make sure TimeSpan is represented as a string instead of a full object type
-            options.MapType<TimeSpan>(() => new OpenApiSchema() { Type = "string", Format = "time-span", Example = new OpenApiString("00:00:00") });
+            options.MapType<TimeSpan>(() => new OpenApiSchema() { Type = "string", Format = "time-span", Example = new OpenApiString("00:00:30") });
         }
 
         public static void AddBearerTokenAuthOption(this SwaggerGenOptions options, string securityDefinitionName)

--- a/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
@@ -6,10 +6,10 @@ using Microsoft.Diagnostics.Monitoring.WebApi.Controllers;
 using Microsoft.Diagnostics.Tools.Monitor.Swagger.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
-using System.IO;
 using System.Reflection;
 using System.Xml.XPath;
 
@@ -30,6 +30,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger
 
             string documentationFile = $"{typeof(DiagController).Assembly.GetName().Name}.xml";
             options.IncludeXmlComments(() => new XPathDocument(Assembly.GetExecutingAssembly().GetManifestResourceStream(documentationFile)));
+
+            // Make sure TimeSpan is represented as a string instead of a full object type
+            options.MapType<TimeSpan>(() => new OpenApiSchema() { Type = "string", Format = "time-span", Example = new OpenApiString("00:00:00") });
         }
 
         public static void AddBearerTokenAuthOption(this SwaggerGenOptions options, string securityDefinitionName)


### PR DESCRIPTION
###### Summary

These changes make sure that `TimeSpan` is represented as a formatted string in the OpenAPI; this better describes the expected output (see collection rule details example: https://github.com/dotnet/dotnet-monitor/blob/main/documentation/api/collectionrules-get.md#sample-response) as well as leads to better code generation for generating HTTP clients so that the built-in `TimeSpan` is used rather than generating a new type.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
