### PR TITLE
[Parameter Capturing] Construct log template strings with non-localizable tokens

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
@@ -71,42 +71,6 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to null.
-        /// </summary>
-        internal static string NullArgumentValue {
-            get {
-                return ResourceManager.GetString("NullArgumentValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to in.
-        /// </summary>
-        internal static string ParameterModifier_In {
-            get {
-                return ResourceManager.GetString("ParameterModifier_In", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to out.
-        /// </summary>
-        internal static string ParameterModifier_Out {
-            get {
-                return ResourceManager.GetString("ParameterModifier_Out", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ref.
-        /// </summary>
-        internal static string ParameterModifier_RefOrRefLike {
-            get {
-                return ResourceManager.GetString("ParameterModifier_RefOrRefLike", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Started parameter capturing for {duration} on {numberOfMethods} method(s)..
         /// </summary>
         internal static string StartParameterCapturingFormatString {
@@ -125,15 +89,6 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to this.
-        /// </summary>
-        internal static string ThisParameterName {
-            get {
-                return ResourceManager.GetString("ThisParameterName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Too many requests.
         /// </summary>
         internal static string TooManyRequestsErrorMessage {
@@ -143,38 +98,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to unknown.
-        /// </summary>
-        internal static string UnknownArgumentValue {
-            get {
-                return ResourceManager.GetString("UnknownArgumentValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &lt;unknown_name_at_position_{0}&gt;.
-        /// </summary>
-        internal static string UnknownParameterNameFormatString {
-            get {
-                return ResourceManager.GetString("UnknownParameterNameFormatString", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to resolve one or more methods: {0}.
         /// </summary>
         internal static string UnresolvedMethodsFormatString {
             get {
                 return ResourceManager.GetString("UnresolvedMethodsFormatString", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to unsupported.
-        /// </summary>
-        internal static string UnsupportedParameter {
-            get {
-                return ResourceManager.GetString("UnsupportedParameter", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
@@ -120,40 +120,16 @@
   <data name="FeatureUnsupported_NoLogger" xml:space="preserve">
     <value>Unable to create an ILogger instance in the target process.</value>
   </data>
-  <data name="NullArgumentValue" xml:space="preserve">
-    <value>null</value>
-  </data>
-  <data name="ParameterModifier_In" xml:space="preserve">
-    <value>in</value>
-  </data>
-  <data name="ParameterModifier_Out" xml:space="preserve">
-    <value>out</value>
-  </data>
-  <data name="ParameterModifier_RefOrRefLike" xml:space="preserve">
-    <value>ref</value>
-  </data>
   <data name="StartParameterCapturingFormatString" xml:space="preserve">
     <value>Started parameter capturing for {duration} on {numberOfMethods} method(s).</value>
   </data>
   <data name="StopParameterCapturing" xml:space="preserve">
     <value>Stopped parameter capturing.</value>
   </data>
-  <data name="ThisParameterName" xml:space="preserve">
-    <value>this</value>
-  </data>
   <data name="TooManyRequestsErrorMessage" xml:space="preserve">
     <value>Too many requests</value>
   </data>
-  <data name="UnknownArgumentValue" xml:space="preserve">
-    <value>unknown</value>
-  </data>
-  <data name="UnknownParameterNameFormatString" xml:space="preserve">
-    <value>&lt;unknown_name_at_position_{0}&gt;</value>
-  </data>
   <data name="UnresolvedMethodsFormatString" xml:space="preserve">
     <value>Unable to resolve one or more methods: {0}</value>
-  </data>
-  <data name="UnsupportedParameter" xml:space="preserve">
-    <value>unsupported</value>
   </data>
 </root>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/PrettyPrinterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/PrettyPrinterTests.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         [InlineData(typeof(TestMethodSignatures), nameof(TestMethodSignatures.ImplicitThis), "SampleMethods.TestMethodSignatures.ImplicitThis(this: {this})")]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Arrays), "SampleMethods.StaticTestMethodSignatures.Arrays(intArray: {intArray}, multidimensionalArray: {multidimensionalArray})")]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Delegate), "SampleMethods.StaticTestMethodSignatures.Delegate(func: {func})")]
-        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.InParam), "SampleMethods.StaticTestMethodSignatures.InParam(in i: {{unsupported}})")]
-        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.OutParam), "SampleMethods.StaticTestMethodSignatures.OutParam(out i: {{unsupported}})")]
-        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefParam), "SampleMethods.StaticTestMethodSignatures.RefParam(ref i: {{unsupported}})")]
-        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefStruct), "SampleMethods.StaticTestMethodSignatures.RefStruct(ref myRefStruct: {{unsupported}})")]
-        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.GenericParameters), "SampleMethods.StaticTestMethodSignatures.GenericParameters<T, K>(t: {{unsupported}}, k: {{unsupported}})")]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.InParam), "SampleMethods.StaticTestMethodSignatures.InParam(in i: <unsupported>)")]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.OutParam), "SampleMethods.StaticTestMethodSignatures.OutParam(out i: <unsupported>)")]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefParam), "SampleMethods.StaticTestMethodSignatures.RefParam(ref i: <unsupported>)")]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefStruct), "SampleMethods.StaticTestMethodSignatures.RefStruct(ref myRefStruct: <unsupported>)")]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.GenericParameters), "SampleMethods.StaticTestMethodSignatures.GenericParameters<T, K>(t: <unsupported>, k: <unsupported>)")]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.VarArgs), "SampleMethods.StaticTestMethodSignatures.VarArgs(b: {b}, myInts: {myInts})")]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Unicode_ΦΨ), "SampleMethods.StaticTestMethodSignatures.Unicode_ΦΨ(δ: {δ})")]
-        [InlineData(typeof(StaticTestMethodSignatures.SampleNestedStruct), nameof(StaticTestMethodSignatures.SampleNestedStruct.DoWork), "SampleMethods.StaticTestMethodSignatures+SampleNestedStruct.DoWork(this: {{unsupported}}, i: {i})")]
+        [InlineData(typeof(StaticTestMethodSignatures.SampleNestedStruct), nameof(StaticTestMethodSignatures.SampleNestedStruct.DoWork), "SampleMethods.StaticTestMethodSignatures+SampleNestedStruct.DoWork(this: <unsupported>, i: {i})")]
         public void MethodTemplateString(Type declaringType, string methodName, string templateString)
         {
             // Arrange


### PR DESCRIPTION
###### Summary

- Update how log template strings are constructed to use well-known tokens instead of localizable strings.
- Standardize how reserved internal values are represented e.g. `{unsupported}`->`<unsupported>`

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
