### PR TITLE
[Parameter Capturing] Add dedicated service logging category

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/FunctionProbeCategories.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/FunctionProbeCategories.cs
@@ -15,6 +15,10 @@ namespace DotnetMonitor.ParameterCapture
     internal sealed class SystemCode
     {
     }
+
+    internal sealed class Service
+    {
+    }
 }
 
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingService.cs
@@ -82,16 +82,19 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
                     IpcCommand.StopCapturingParameters,
                     OnStopMessage);
 
-                ILogger logger = services.GetService<ILogger<DotnetMonitor.ParameterCapture.UserCode>>()
+                ILogger serviceLogger = services.GetService<ILogger<DotnetMonitor.ParameterCapture.Service>>()
+                    ?? throw new NotSupportedException(ParameterCapturingStrings.FeatureUnsupported_NoLogger);
+
+                ILogger userLogger = services.GetService<ILogger<DotnetMonitor.ParameterCapture.UserCode>>()
                     ?? throw new NotSupportedException(ParameterCapturingStrings.FeatureUnsupported_NoLogger);
 
                 ILogger systemLogger = services.GetService<ILogger<DotnetMonitor.ParameterCapture.SystemCode>>()
                     ?? throw new NotSupportedException(ParameterCapturingStrings.FeatureUnsupported_NoLogger);
 
-                _parameterCapturingLogger = new(logger, systemLogger);
+                _parameterCapturingLogger = new(userLogger, systemLogger);
                 FunctionProbesManager probeManager = new(new LogEmittingProbes(_parameterCapturingLogger));
 
-                ParameterCapturingCallbacks callbacks = new(logger, _eventSource);
+                ParameterCapturingCallbacks callbacks = new(serviceLogger, _eventSource);
                 _pipeline = new ParameterCapturingPipeline(probeManager, callbacks);
             }
             catch (NotSupportedException ex)


### PR DESCRIPTION
###### Summary

Add a dedicated `DotnetMonitor.ParameterCapture.Service` logging category. Currently the `DotnetMonitor.ParameterCapture.UserCode` category is being used for service-level log statements, such as starting/stopping parameter capturing.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
