### PR TITLE
[Parameter Capturing] Use pinned thunk for `ProfilerMessageCallback`

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/MonitorMessageDispatcher/ProfilerMessageSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/MonitorMessageDispatcher/ProfilerMessageSource.cs
@@ -20,12 +20,15 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.MonitorMessageDispatcher
         [DllImport(ProfilerIdentifiers.NotifyOnlyProfiler.LibraryRootFileName, CallingConvention = CallingConvention.StdCall, PreserveSig = false)]
         private static extern void UnregisterMonitorMessageCallback();
 
+        private readonly ProfilerMessageCallback _messageCallbackDelegate;
+
         private long _disposedState;
 
         public ProfilerMessageSource()
         {
             ProfilerResolver.InitializeResolver<ProfilerMessageSource>();
-            RegisterMonitorMessageCallback(Marshal.GetFunctionPointerForDelegate(OnProfilerMessage));
+            _messageCallbackDelegate = OnProfilerMessage;
+            RegisterMonitorMessageCallback(Marshal.GetFunctionPointerForDelegate(_messageCallbackDelegate));
         }
 
         private void RaiseMonitorMessage(MonitorMessageArgs e)


### PR DESCRIPTION
###### Summary

Fix an issue where the provided managed callback for profiler messages can be relocated.  Use `GetFunctionPointerForDelegate` to create a pinned thunk that'll be given to the profiler instead.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
