### PR TITLE
[DO NOT REVIEW] Investigate Eclipsing Exceptions Issue

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string ArrayException = nameof(ArrayException);
                 public const string InnerUnthrownException = nameof(InnerUnthrownException);
                 public const string InnerThrownException = nameof(InnerThrownException);
+                public const string EclipsingException = nameof(EclipsingException);
                 public const string AggregateException = nameof(AggregateException);
                 public const string ReflectionTypeLoadException = nameof(ReflectionTypeLoadException);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -316,6 +316,40 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         }
 
         /// <summary>
+        /// Tests that wrapped exceptions thrown within a catch block are detectable
+        /// (and that the outer exception's callstack is present).
+        /// </summary>
+        [Fact]
+        public Task EventExceptionsPipeline_EclipsingException()
+        {
+            const int ExpectedInstanceCount = 2;
+
+            return Execute(
+                TestAppScenarios.Exceptions.SubScenarios.EclipsingException,
+                ExpectedInstanceCount,
+                validate: instances =>
+                {
+                    Assert.Equal(ExpectedInstanceCount, instances.Count());
+
+                    IExceptionInstance innerInstance = instances.First();
+                    Assert.NotNull(innerInstance);
+
+                    Assert.NotEqual(0UL, innerInstance.Id);
+                    Assert.Equal(typeof(FormatException).FullName, innerInstance.TypeName);
+                    Assert.Empty(innerInstance.InnerExceptionIds);
+                    Assert.NotEmpty(innerInstance.CallStack.Frames); // Indicates this exception was thrown
+
+                    IExceptionInstance outerInstance = instances.Skip(1).Single();
+                    Assert.NotNull(outerInstance);
+
+                    Assert.NotEqual(0UL, outerInstance.Id);
+                    Assert.Equal(typeof(InvalidOperationException).FullName, outerInstance.TypeName);
+                    Assert.Equal(innerInstance.Id, Assert.Single(outerInstance.InnerExceptionIds));
+                    Assert.NotEmpty(outerInstance.CallStack.Frames); // Indicates this exception was thrown
+                });
+        }
+
+        /// <summary>
         /// Tests that inner exceptions from AggregateException are detectable.
         /// </summary>
         [Fact]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             CliCommand innerThrownExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.InnerThrownException);
             innerThrownExceptionCommand.SetAction(InnerThrownExceptionAsync);
 
+            CliCommand eclipsingExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.EclipsingException);
+            eclipsingExceptionCommand.SetAction(EclipsingExceptionAsync);
+
             CliCommand aggregateExceptionCommand = new(TestAppScenarios.Exceptions.SubScenarios.AggregateException);
             aggregateExceptionCommand.SetAction(AggregateExceptionAsync);
 
@@ -68,6 +71,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             scenarioCommand.Subcommands.Add(arrayExceptionCommand);
             scenarioCommand.Subcommands.Add(innerUnthrownExceptionCommand);
             scenarioCommand.Subcommands.Add(innerThrownExceptionCommand);
+            scenarioCommand.Subcommands.Add(eclipsingExceptionCommand);
             scenarioCommand.Subcommands.Add(aggregateExceptionCommand);
             scenarioCommand.Subcommands.Add(reflectionTypeLoadExceptionCommand);
             return scenarioCommand;
@@ -276,6 +280,20 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             }, token);
         }
 
+        public static Task<int> EclipsingExceptionAsync(ParseResult result, CancellationToken token)
+        {
+            return ScenarioHelpers.RunScenarioAsync(async logger =>
+            {
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
+
+                EclipsingInvalidOperationException();
+
+                await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.End, logger);
+
+                return 0;
+            }, token);
+        }
+
         public static Task<int> AggregateExceptionAsync(ParseResult result, CancellationToken token)
         {
             return ScenarioHelpers.RunScenarioAsync(async logger =>
@@ -358,6 +376,25 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                 }
 
                 throw new InvalidOperationException(null, innerException);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void EclipsingInvalidOperationException()
+        {
+            try
+            {
+                try
+                {
+                    throw new FormatException();
+                }
+                catch (Exception innerException)
+                {
+                    throw new InvalidOperationException(null, innerException);
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
###### Summary

Observed an issue locally where eclipsing exceptions (catching, wrapping, throwing within a catch block) don't have their callstacks. Creating a test to see how it behaves.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
