### PR TITLE
Add missing livemetrics HTTP 200 OK result

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1131,6 +1131,16 @@
           "429": {
             "$ref": "#/components/responses/TooManyRequestsResponse"
           },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json-seq": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "202": {
             "description": "Accepted"
           }
@@ -1228,6 +1238,16 @@
           },
           "429": {
             "$ref": "#/components/responses/TooManyRequestsResponse"
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json-seq": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "202": {
             "description": "Accepted"

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         [HttpGet("livemetrics", Name = nameof(CaptureMetrics))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJsonSequence)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status202Accepted)]
         [EgressValidation]
         public Task<ActionResult> CaptureMetrics(
@@ -71,6 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         [HttpPost("livemetrics", Name = nameof(CaptureMetricsCustom))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJsonSequence)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status202Accepted)]
         [EgressValidation]
         public Task<ActionResult> CaptureMetricsCustom(


### PR DESCRIPTION
###### Summary

The HTTP 200 OK result for livemetrics was missing from the OpenAPI. Add it to the route handler and regenerate the OpenAPI document.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
