### PR TITLE
[Parameter Capturing] Remove static reference to function probes on cleanup

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
@@ -321,6 +321,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
             if (!DisposableHelper.CanDispose(ref _disposedState))
                 return;
 
+            FunctionProbesStub.Instance = null;
+
             try
             {
                 _disposalTokenSource.Cancel();


### PR DESCRIPTION
###### Summary

If/when parameter capturing is being cleaned up, the actual function probes being used wouldn't be cleaned up since a static reference to it would still be held.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
