### PR TITLE
Allow Helix tests to use internal assets

### DIFF
--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -113,6 +113,14 @@
     <HelixTargetQueue Include="@(HelixAvailableTargetQueue)" />
   </ItemGroup>
 
+  <!-- Additional package feeds -->
+  <ItemGroup>
+    <AdditionalDotNetPackageFeed Include="https://dotnetbuilds.blob.core.windows.net/internal"
+                                 Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
+      <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalContainerReadToken'))</SasToken>
+    </AdditionalDotNetPackageFeed>
+  </ItemGroup>
+
   <!-- Correlation Payload: SDK (to use "dotnet test") -->
   <PropertyGroup>
     <IncludeDotNetCli>true</IncludeDotNetCli>

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -101,6 +101,7 @@ jobs:
         -projects $(Build.SourcesDirectory)/eng/helix/Helix.proj
         -skipmanaged
         -skipnative
+        /p:DotNetBuildsInternalContainerReadToken=$(dotnetbuilds-internal-container-read-token-base64)
     ${{ else }}:
       buildArgs: >-
         -test

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -58,6 +58,10 @@ jobs:
       # Provide blank versions of the secrets so we don't have to conditionally create
       # internal vs public versions of tasks.
       - DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET: ''
+    - _InternalHelixArgs: ''
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - _InternalHelixArgs: >-
+          /p:DotNetBuildsInternalContainerReadToken=$(dotnetbuilds-internal-container-read-token-base64)
 
     preBuildSteps:
     - task: DownloadPipelineArtifact@2
@@ -101,7 +105,7 @@ jobs:
         -projects $(Build.SourcesDirectory)/eng/helix/Helix.proj
         -skipmanaged
         -skipnative
-        /p:DotNetBuildsInternalContainerReadToken=$(dotnetbuilds-internal-container-read-token-base64)
+        $(_InternalHelixArgs)
     ${{ else }}:
       buildArgs: >-
         -test


### PR DESCRIPTION
###### Summary

Allow Helix test setup to get the blob storage internal container token to read packages and files from the container.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
