### PR TITLE
Use non-base64 token for Helix additional feed

### DIFF
--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -61,7 +61,7 @@ jobs:
     - _InternalHelixArgs: ''
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - _InternalHelixArgs: >-
-          /p:DotNetBuildsInternalContainerReadToken=$(dotnetbuilds-internal-container-read-token-base64)
+          /p:DotNetBuildsInternalContainerReadToken=$(dotnetbuilds-internal-container-read-token)
 
     preBuildSteps:
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
###### Summary

Use the non-base64 encoded token for Helix testing as opposed to the base64 encoded token for acquiring installers as part of restore operations.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2260802&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
