### PR TITLE
Fix build and test infra to support internal release builds

### DIFF
--- a/eng/Helix.Common.props
+++ b/eng/Helix.Common.props
@@ -7,5 +7,15 @@
     <HelixNodeRuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform(Linux))">linux-$(HelixArchitecture)</HelixNodeRuntimeIdentifier>
     <HelixNodeRuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform(OSX))">darwin-$(HelixArchitecture)</HelixNodeRuntimeIdentifier>
     <HelixNodeName>node-v$(HelixNodeVersion)-$(HelixNodeRuntimeIdentifier)</HelixNodeName>
+    <!--
+      Helix SDK docs state that this type of information can be attached to individual queues
+      as AdditionalProperties metadata, but the AzurePipleines.MultiQueue.targets overwrites it
+      when calcuating and assigning the TestRunId. Calculate this information per-project using
+      available information e.g. PackageRid contains OS, libc, and architecture information.
+    -->
+    <IsHelixPosixShell>true</IsHelixPosixShell>
+    <IsHelixPosixShell Condition="$(PackageRid.Contains(win))">false</IsHelixPosixShell>
+    <IsHelixMuslLibc>false</IsHelixMuslLibc>
+    <IsHelixMuslLibc Condition="$(PackageRid.Contains(musl))">true</IsHelixMuslLibc>
   </PropertyGroup>
 </Project>

--- a/eng/Helix.props
+++ b/eng/Helix.props
@@ -1,15 +1,3 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)Helix.Common.props" />
-  <PropertyGroup>
-    <!--
-      Helix SDK docs state that this type of information can be attached to individual queues
-      as AdditionalProperties metadata, but the AzurePipleines.MultiQueue.targets overwrites it
-      when calcuating and assigning the TestRunId. Calculate this information per-project using
-      available information e.g. PackageRid contains OS, libc, and architecture information.
-    -->
-    <IsHelixPosixShell>true</IsHelixPosixShell>
-    <IsHelixPosixShell Condition="$(PackageRid.Contains(win))">false</IsHelixPosixShell>
-    <IsHelixMuslLibc>false</IsHelixMuslLibc>
-    <IsHelixMuslLibc Condition="$(PackageRid.Contains(musl))">true</IsHelixMuslLibc>
-  </PropertyGroup>
 </Project>

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -117,15 +117,31 @@
   <ItemGroup>
     <AdditionalDotNetPackageFeed Include="https://dotnetbuilds.blob.core.windows.net/internal"
                                  Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
-      <SasToken>$(DotNetBuildsInternalContainerReadToken)</SasToken>
+      <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalContainerReadToken'))</SasToken>
     </AdditionalDotNetPackageFeed>
   </ItemGroup>
 
   <!-- Correlation Payload: SDK (to use "dotnet test") -->
+  <ItemGroup>
+    <AdditionalDotNetPackage Include="$(MicrosoftDotnetSdkInternalVersion)">
+      <PackageType>sdk</PackageType>
+    </AdditionalDotNetPackage>
+  </ItemGroup>
+
+  <!--
+    Replicate the "IncludeDotNetCli" notion since we are specifying the SDK as an additoional package.
+    Replicated from https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+    These commands are shared by all work items.
+    -->
   <PropertyGroup>
-    <IncludeDotNetCli>true</IncludeDotNetCli>
-    <DotNetCliPackageType>sdk</DotNetCliPackageType>
-    <DotNetCliVersion>$(MicrosoftDotnetSdkInternalVersion)</DotNetCliVersion>
+    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination):$PATH</HelixPreCommands>
+    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination)%3B%PATH%</HelixPreCommands> <!-- %3B is an escaped ; -->
+    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination);export DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
+    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination);set DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
+    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export DOTNET_CLI_HOME=$HELIX_WORKITEM_ROOT/.dotnet</HelixPreCommands>
+    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set DOTNET_CLI_HOME=%HELIX_WORKITEM_ROOT%\.dotnet</HelixPreCommands>
+    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export NUGET_PACKAGES=$HELIX_WORKITEM_ROOT/.nuget</HelixPreCommands>
+    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set NUGET_PACKAGES=%HELIX_WORKITEM_ROOT%\.nuget</HelixPreCommands>
   </PropertyGroup>
 
   <!-- Correlation Payload: AspNetCore (these packages also contain corresponding NetCoreApp version) -->

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -121,29 +121,6 @@
     </AdditionalDotNetPackageFeed>
   </ItemGroup>
 
-  <!-- Correlation Payload: SDK (to use "dotnet test") -->
-  <ItemGroup>
-    <AdditionalDotNetPackage Include="$(MicrosoftDotnetSdkInternalVersion)">
-      <PackageType>sdk</PackageType>
-    </AdditionalDotNetPackage>
-  </ItemGroup>
-
-  <!--
-    Replicate the "IncludeDotNetCli" notion since we are specifying the SDK as an additoional package.
-    Replicated from https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
-    These commands are shared by all work items.
-    -->
-  <PropertyGroup>
-    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination):$PATH</HelixPreCommands>
-    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination)%3B%PATH%</HelixPreCommands> <!-- %3B is an escaped ; -->
-    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination);export DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
-    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination);set DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
-    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export DOTNET_CLI_HOME=$HELIX_WORKITEM_ROOT/.dotnet</HelixPreCommands>
-    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set DOTNET_CLI_HOME=%HELIX_WORKITEM_ROOT%\.dotnet</HelixPreCommands>
-    <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export NUGET_PACKAGES=$HELIX_WORKITEM_ROOT/.nuget</HelixPreCommands>
-    <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set NUGET_PACKAGES=%HELIX_WORKITEM_ROOT%\.nuget</HelixPreCommands>
-  </PropertyGroup>
-
   <!-- Correlation Payload: AspNetCore (these packages also contain corresponding NetCoreApp version) -->
   <ItemGroup>
     <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp60Version)">
@@ -174,6 +151,36 @@
   <ItemGroup>
     <HelixCorrelationPayload Include="$(ArtifactsBinDir)" />
   </ItemGroup>
+
+  <!--
+    Replicate the "IncludeDotNetCli" notion since we are specifying the SDK as an additoional package.
+    Adapted from https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+    -->
+  <Target Name="AddDotNetSdkAsAdditionalPackage"
+          BeforeTargets="AddAdditionalRuntimes">
+    <!-- Correlation Payload: SDK (to use "dotnet test") -->
+    <ItemGroup>
+      <AdditionalDotNetPackage Include="$(MicrosoftDotnetSdkInternalVersion)">
+        <PackageType>sdk</PackageType>
+      </AdditionalDotNetPackage>
+    </ItemGroup>
+
+    <!--
+      These commands are shared by all work items.
+      These are created within a target to allow access to the DotNetCliDestination property
+      that is included in targets near the end of project evaluation.
+      -->
+    <PropertyGroup>
+      <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination):$PATH</HelixPreCommands>
+      <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination)%3B%PATH%</HelixPreCommands> <!-- %3B is an escaped ; -->
+      <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination);export DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
+      <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination);set DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
+      <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export DOTNET_CLI_HOME=$HELIX_WORKITEM_ROOT/.dotnet</HelixPreCommands>
+      <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set DOTNET_CLI_HOME=%HELIX_WORKITEM_ROOT%\.dotnet</HelixPreCommands>
+      <HelixPreCommands Condition="$(IsHelixPosixShell)">$(HelixPreCommands);export NUGET_PACKAGES=$HELIX_WORKITEM_ROOT/.nuget</HelixPreCommands>
+      <HelixPreCommands Condition="!$(IsHelixPosixShell)">$(HelixPreCommands);set NUGET_PACKAGES=%HELIX_WORKITEM_ROOT%\.nuget</HelixPreCommands>
+    </PropertyGroup>
+  </Target>
 
   <!-- Collect HelixWorkItems from each project that participates in testing. -->
   <Target Name="CollectHelixWorkItems"

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -58,10 +58,6 @@ jobs:
       # Provide blank versions of the secrets so we don't have to conditionally create
       # internal vs public versions of tasks.
       - DOTNET_MONITOR_AZURE_AD_TESTS_PIPELINE_CLIENT_SECRET: ''
-    - _InternalHelixArgs: ''
-    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      - _InternalHelixArgs: >-
-          /p:DotNetBuildsInternalContainerReadToken=$(dotnetbuilds-internal-container-read-token-base64)
 
     preBuildSteps:
     - task: DownloadPipelineArtifact@2
@@ -123,6 +119,7 @@ jobs:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         HelixAccessToken: $(HelixApiAccessToken)
+        DotNetBuildsInternalContainerReadToken: $(dotnetbuilds-internal-container-read-token)
 
     postBuildSteps:
     - ${{ if ne(parameters.useHelix, 'true')}}:

--- a/eng/pipelines/jobs/tpn.yml
+++ b/eng/pipelines/jobs/tpn.yml
@@ -16,6 +16,13 @@ jobs:
           /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
           /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
     steps:
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+      env:
+        Token: $(dn-bot-dnceng-artifact-feeds-rw)
     # Only restore the projects that are shipped so only packages we ship get included in the below CG scan
     - script: >-
         $(Build.SourcesDirectory)/restore.cmd -ci


### PR DESCRIPTION
###### Summary

- Setup private feed usage in the TPN job so it can acquire internal build builds
- Change `dotnetbuilds` internal container token to be passed via environment to avoid escaping/splitting and use the non-based64 encoded variant
- Convert the `IncludeDotnetCli` convenience to an `AdditionalDotNetPackage` so that it may consume the `AdditionalDotNetPackageFeed` list.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2261376&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
