### PR TITLE
[Parameter Capturing] Add debug logging for probe management 

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Diagnostics.Monitoring.StartupHook;
 using Microsoft.Diagnostics.Tools.Monitor.Profiler;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -68,11 +69,14 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
 
         public event EventHandler<InstrumentedMethod>? OnProbeFault;
 
-        public FunctionProbesManager(IFunctionProbes probes)
+        private readonly ILogger _logger;
+
+        public FunctionProbesManager(IFunctionProbes probes, ILogger logger)
         {
             ProfilerResolver.InitializeResolver<FunctionProbesManager>();
 
             _disposalToken = _disposalTokenSource.Token;
+            _logger = logger;
 
             //
             // CONSIDER:
@@ -99,6 +103,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
 
         private void OnRegistration(int hresult)
         {
+            _logger.LogDebug(ParameterCapturingStrings.ProbeManagementCallback, nameof(OnRegistration), hresult);
+
             TransitionStateFromHr(_probeRegistrationTaskSource, hresult,
                 expectedState: ProbeStateUninitialized,
                 succeededState: ProbeStateUninstalled,
@@ -107,6 +113,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
 
         private void OnInstallation(int hresult)
         {
+            _logger.LogDebug(ParameterCapturingStrings.ProbeManagementCallback, nameof(OnInstallation), hresult);
+
             TransitionStateFromHr(_installationTaskSource, hresult,
                 expectedState: ProbeStateInstalling,
                 succeededState: ProbeStateInstalled,
@@ -115,6 +123,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
 
         private void OnUninstallation(int hresult)
         {
+            _logger.LogDebug(ParameterCapturingStrings.ProbeManagementCallback, nameof(OnUninstallation), hresult);
+
             TransitionStateFromHr(_uninstallationTaskSource, hresult,
                 expectedState: ProbeStateUninstalling,
                 succeededState: ProbeStateUninstalled,

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingService.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
                     ?? throw new NotSupportedException(ParameterCapturingStrings.FeatureUnsupported_NoLogger);
 
                 _parameterCapturingLogger = new(userLogger, systemLogger);
-                FunctionProbesManager probeManager = new(new LogEmittingProbes(_parameterCapturingLogger));
+                FunctionProbesManager probeManager = new(new LogEmittingProbes(_parameterCapturingLogger), _logger);
 
                 _pipeline = new ParameterCapturingPipeline(probeManager, this, _methodDescriptionValidator);
             }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
@@ -98,6 +98,15 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {callbackName}, hr={hr}.
+        /// </summary>
+        internal static string ProbeManagementCallback {
+            get {
+                return ResourceManager.GetString("ProbeManagementCallback", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Started parameter capturing for {duration} on {numberOfMethods} method(s)..
         /// </summary>
         internal static string StartParameterCapturingFormatString {

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
@@ -129,6 +129,9 @@
   <data name="FeatureUnsupported_NoLogger" xml:space="preserve">
     <value>Unable to create an ILogger instance in the target process.</value>
   </data>
+  <data name="ProbeManagementCallback" xml:space="preserve">
+    <value>{callbackName}, hr={hr}</value>
+  </data>
   <data name="StartParameterCapturingFormatString" xml:space="preserve">
     <value>Started parameter capturing for {duration} on {numberOfMethods} method(s).</value>
   </data>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/FunctionProbes/FunctionProbesScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/FunctionProbes/FunctionProbesScenario.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.FunctionProbes
                     return ScenarioHelpers.RunScenarioAsync(async logger =>
                     {
                         PerFunctionProbeProxy probeProxy = new PerFunctionProbeProxy();
-                        using FunctionProbesManager probeManager = new(probeProxy);
+                        using FunctionProbesManager probeManager = new(probeProxy, logger);
 
                         await testCase(probeManager, probeProxy, token);
 
@@ -335,7 +335,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.FunctionProbes
             return ScenarioHelpers.RunScenarioAsync(logger =>
             {
                 PerFunctionProbeProxy probeProxy = new PerFunctionProbeProxy();
-                Assert.Throws<DllNotFoundException>(() => new FunctionProbesManager(probeProxy));
+                Assert.Throws<DllNotFoundException>(() => new FunctionProbesManager(probeProxy, logger));
 
                 return Task.FromResult(0);
             }, token);


### PR DESCRIPTION
###### Summary

I'm currently investigating a hard-to-repro issue that seems to occur during probe installation and need to gather more information. This PR introduces logging to `FunctionProbesManager`, leveraging an ILogger instance (thus logging during our tests). When running in a user's app, `FunctionProbesManager` will use the logging category `DotnetMonitor.ParameterCapture.Service` per our [docs](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/api/parameters.md#logger-categories). 

This also has the added benefit of the user being able to easily increase logging if we need to gather additional info about a problem they are encountering. e.g.
```json
{
  "Logging": {
    "LogLevel": {
      "DotnetMonitor": "Debug"
    }
}

```

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
