### PR TITLE
Remove unspecified variable

### DIFF
--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -101,7 +101,6 @@ jobs:
         -projects $(Build.SourcesDirectory)/eng/helix/Helix.proj
         -skipmanaged
         -skipnative
-        $(_InternalHelixArgs)
     ${{ else }}:
       buildArgs: >-
         -test


### PR DESCRIPTION
###### Summary

A value for the `_InternalHelixArgs` variable isn't specified, so it is left in the pipeline definition when expanding everything. It currently doesn't have any negative effect, although the job output does show this is not a recognized cmdlet or function, but it's good to remove it before it does cause issues.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
