### PR TITLE
Exclude internal release branches from SourceLink validation

### DIFF
--- a/dotnet-monitor.yml
+++ b/dotnet-monitor.yml
@@ -128,7 +128,7 @@ stages:
       validateDependsOn:
       - PackSignPublish
       publishingInfraVersion: 3
-      enableSourceLinkValidation: true
+      enableSourceLinkValidation: ${{ not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}
       enableSigningValidation: true
       enableSymbolValidation: false
       enableNugetValidation: true


### PR DESCRIPTION
###### Summary

If changes are made in the internal branches that are not yet publicly on GitHub, the SourceLink validation will fail. Skip this validation for the internal release branches.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2262105&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
