### PR TITLE
Use dotnetbuilds SAS tokens for drop acquisition and continue on error

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -24,6 +24,7 @@ stages:
       - group: DotNet-Diagnostics-Storage
       - group: DotNet-DotNetStage-Storage
       - group: Release-Pipeline
+      - group: DotNetBuilds storage account read tokens
     steps:
     - task: UseDotNet@2
       displayName: 'Use .NET 6'
@@ -50,9 +51,10 @@ stages:
             -MaestroToken "$(MaestroAccessToken)"
             -GitHubToken "$(BotAccount-dotnet-bot-repo-PAT)"
             -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
-            -SasSuffixes "$(dotnetclichecksumsmsrc-dotnet-read-list-sas-token),$(dotnetclimsrc-read-sas-token)"
+            -SasSuffixes "$(dotnetbuilds-internal-checksums-container-read-token),$(dotnetbuilds-internal-container-read-token)"
             -ReleaseVersion "$(Build.BuildNumber)"
           workingDirectory: '$(Build.Repository.LocalPath)'
+        continueOnError: true
       - script: >-
           $(Build.SourcesDirectory)\dotnet.cmd run --project $(Build.Repository.LocalPath)\eng\release\DiagnosticsReleaseTool\DiagnosticsReleaseTool.csproj -c Release
           --

--- a/eng/release/Scripts/AcquireBuild.ps1
+++ b/eng/release/Scripts/AcquireBuild.ps1
@@ -60,7 +60,8 @@ try {
         --bar-uri $MaestroApiEndPoint `
         --password $MaestroToken `
         --separated `
-        --verbose
+        --verbose `
+        --continue-on-error
 
     if ($LastExitCode -ne 0) {
         Write-Host "Error: unable to gather the assets from build $BarBuildId to $DownloadTargetPath using darc."


### PR DESCRIPTION
###### Summary

- Update the release preparation stage to use the dotnetbuilds internal container SAS tokens.
- Add "continue on error" switches. Even though the correct tokens are used and the expected set of files are gathered, the `darc gather-drop` command will error many errors and exit with a non-zero code when acquiring files from locations that require SAS tokens.

I used [this build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2262628&view=results) to test these changes with additional changes to skip all other parts of the building the product and to use the darc drop from [this nearly successful build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2262256&view=results).

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2262651&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
