### PR TITLE
[Parameter Capturing] Fix race conditions when cancelling probe management methods

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
@@ -207,11 +207,12 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
             }
 
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(_disposalToken, token);
+            CancellationToken linkedCancellationToken = cts.Token;
             try
             {
-                using IDisposable _ = cts.Token.Register(() =>
+                using IDisposable _ = linkedCancellationToken.Register(() =>
                 {
-                    _uninstallationTaskSource.TrySetCanceled(cts.Token);
+                    _uninstallationTaskSource?.TrySetCanceled(linkedCancellationToken);
                 });
                 await _uninstallationTaskSource.Task.ConfigureAwait(false);
             }
@@ -306,7 +307,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
                 using IDisposable _ = linkedCancellationToken.Register(() =>
                 {
                     _logger.LogDebug(ParameterCapturingStrings.CancellationRequestedDuringProbeInstallation, token.IsCancellationRequested, _disposalToken.IsCancellationRequested);
-                    _installationTaskSource.TrySetCanceled(linkedCancellationToken);
+                    _installationTaskSource?.TrySetCanceled(linkedCancellationToken);
 
                     //
                     // We need to uninstall the probes ourselves here if dispose has happened  otherwise the probes could be left in an installed state.


### PR DESCRIPTION
###### Summary

There existed two possible race conditions during cancellation on `StartCapturingAsync` and `StopCapturingAsync`:
1. Use-after-dispose could happen on the linked cancellation token in `StopCapturingAsync`:
   - During `StopCapturingAsync` a cancellation token gets signaled, and our registered delegate on `cts` is started, but not yet run to completion.
   - Concurrently the outstanding probe uninstallation completes and we receive a callback, completing the task completion source we are waiting on. When this happens,we return from `StopCapturingAsync`, exiting the scope that `cts` belongs to and causing it to be disposed.
   - Our delegate runs to completion and tries to transition the now completed task completion source to a cancelled state. Doing so accesses the now disposed `cts` object via `cts.Token`, throwing an exception.
  
2. Null reference exceptions could occur on the task completion sources in `StartCapturingAsync` and `StopCapturingAsync`
   - During `[Start/Stop]CapturingAsync` a cancellation token gets signaled, and our registered delegate on `cts` is started, but not yet run to completion.
   - Concurrently the outstanding probe [un]installation completes and we receive a callback, completing the task completion source we are waiting on. When this happens, we set the task completion source to null.
   - Our delegate runs to completion and tries to transition the completed task completion source to a cancelled state. Doing so tries to access the now-null task completion source, throwing an exception.
 
<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
