### PR TITLE
[Parameter Capturing] Disallow when the process is using Hot Reload

### DIFF
--- a/documentation/api/parameters.md
+++ b/documentation/api/parameters.md
@@ -149,6 +149,7 @@ info: DotnetMonitor.ParameterCapture.SystemCode[0]
 ## Additional Requirements
 
 - The target application must use ASP.NET Core.
+- The target application cannot have [Hot Reload](https://learn.microsoft.com/visualstudio/debugger/hot-reload) enabled.
 - `dotnet-monitor` must be set to `Listen` mode, and the target application must start suspended. See [diagnostic port configuration](../configuration/diagnostic-port-configuration.md) for information on how to do this.
 - The target application must have [`ILogger`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger) available via [ASP.NET Core's dependency injection](https://learn.microsoft.com/aspnet/core/fundamentals/dependency-injection).
 - This feature relies on a hosting startup assembly. If the target application [disabled automatic loading](https://learn.microsoft.com/aspnet/core/fundamentals/host/platform-specific-configuration#disable-automatic-loading-of-hosting-startup-assemblies) of these, this feature will not be available.

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -87,6 +87,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             {
                 throw getNotAvailableException(Strings.ParameterCapturingNotAvailable_Reason_HostingStartupDidNotLoad);
             }
+
+            const string EditAndContinueEnvName = "COMPLUS_ForceEnc";
+            if (env.TryGetValue(EditAndContinueEnvName, out string editAndContinueEnvValue) &&
+                ToolIdentifiers.IsEnvVarValueEnabled(editAndContinueEnvValue))
+            {
+                // Having Enc enabled results in methods belonging to debug modules to silently fail being instrumented.
+                // ref: https://github.com/dotnet/runtime/issues/91963
+                throw getNotAvailableException(Strings.ParameterCapturingNotAvailable_Reason_HotReload);
+            }
         }
 
         public async Task ExecuteAsync(CancellationToken token)

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1700,6 +1700,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The process has Hot Reload enabled..
+        /// </summary>
+        internal static string ParameterCapturingNotAvailable_Reason_HotReload {
+            get {
+                return ResourceManager.GetString("ParameterCapturingNotAvailable_Reason_HotReload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An internal error occurred that has prevented communication with the process..
         /// </summary>
         internal static string ParameterCapturingNotAvailable_Reason_ManagedMessagingDidNotLoad {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -959,4 +959,7 @@
   <data name="ParameterCapturingNotAvailable_Reason_UnsupportedRuntime" xml:space="preserve">
     <value>The process needs to be using .NET 7 or newer.</value>
   </data>
+  <data name="ParameterCapturingNotAvailable_Reason_HotReload" xml:space="preserve">
+    <value>The process has Hot Reload enabled.</value>
+  </data>
 </root>


### PR DESCRIPTION
###### Summary

While not fatal, having Hot Reload enabled will result in instrumentation requests to methods belonging to debug modules to silently fail. I've opted to disallow parameter capturing altogether if we detect Hot Reload is being used rather than giving a partially-usable state to the user.

ref: https://github.com/dotnet/runtime/issues/91963


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
