### PR TITLE
Unify stacks property naming convention

### DIFF
--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 }
                 writer.WriteEndArray();
 
-                writer.WriteStartObject("callStack");
+                writer.WriteStartObject("stack");
                 writer.WriteNumber("threadId", instance.CallStack.ThreadId);
                 writer.WriteString("threadName", instance.CallStack.ThreadName);
 


### PR DESCRIPTION
###### Summary

Rename the call stack property on exceptions from `callStack` to `stack` to be more consistent with the call stacks feature (which reports this property as `stacks` since its an array of call stacks) as well with other tools that have a JSON representation of call stacks.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
