### PR TITLE
Update GET livemetrics route to use metrics configuration

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -126,7 +126,7 @@ Describes custom metrics.
 |---|---|---|
 | `includeDefaultProviders` | bool | Determines if the default counter providers should be used (such as System.Runtime). |
 | `providers` | [EventMetricsProvider](#eventmetricsprovider)[] | Array of counter providers for metrics to collect. |
-| `meters` | [EventMetricsMeter](#eventmetricsmeter)[] | Array of meters for metrics to collect. |
+| `meters` | [EventMetricsMeter](#eventmetricsmeter)[] | (7.1+) Array of meters for metrics to collect. |
 
 ## EventMetricsMeter
 

--- a/documentation/api/livemetrics-get.md
+++ b/documentation/api/livemetrics-get.md
@@ -3,7 +3,9 @@
 
 # Livemetrics - Get
 
-Captures metrics for a chosen process.
+Captures metrics for a chosen process for a duration of time.
+
+> **Note**: Starting in 8.0, the [metrics configuration](../configuration/metrics-configuration.md#metrics-configuration) is used as the collection specification. Prior to 8.0, the collection specification only included the [default providers](../configuration/metrics-configuration.md#default-providers) and could not be changed.
 
 > **Note**: For Prometheus style metrics, use the [metrics](./metrics.md) endpoint.
 

--- a/documentation/configuration/collection-rule-configuration.md
+++ b/documentation/configuration/collection-rule-configuration.md
@@ -762,12 +762,15 @@ Usage that collects a CPU trace for 30 seconds and egresses it to a provider nam
 
 An action that collects live metrics for the process that the collection rule is targeting.
 
+> **NOTE: (8.0+)** If none of `IncludeDefaultProviders`, `Provider`, or `Meters` are specified, then the [metrics configuration](<metrics-configuration.md#metrics-configuration>) is used as the collection specification.
+
 #### Properties
 
 | Name | Type | Required | Description | Default Value | Min Value | Max Value |
 |---|---|---|---|---|---|---|
 | `IncludeDefaultProviders` | bool | false | Determines if the default counter providers should be used. | `true` | | |
 | `Providers` | [EventMetricsProvider](../api/definitions.md#eventmetricsprovider)[] | false | The array of providers for metrics to collect. | | | |
+| `Meters` | [EventMetricsMeter](../api/definitions.md#eventmetricsmeter)[] | false | (7.1+) The array of meters for metrics to collect. | | | |
 | `Duration` | TimeSpan? | false | The duration of the live metrics operation. | `"00:00:30"` (30 seconds) | `"00:00:01"` (1 second) | `"1.00:00:00"` (1 day) |
 | `Egress` | string | true | The named [egress provider](../egress.md) for egressing the collected live metrics. | | | |
 

--- a/documentation/configuration/metrics-configuration.md
+++ b/documentation/configuration/metrics-configuration.md
@@ -3,12 +3,21 @@
 
 # Metrics Configuration
 
+## Default Providers
+
+The `/metrics` route (and starting in 8.0, the `/livemetrics` route and `CollectLiveMetrics` actions) will collect metrics from the default providers. The default providers are:
+- `System.Runtime`
+- `Microsoft.AspNetCore.Hosting`
+- `Grpc.AspNetCore.Server`
+
+These providers are collected by default for the above mentioned features, even when specifiying [custom metrics](#custom-metrics) collection. The default providers can be excluded by [disabling](#disable-default-providers) them.
+
 ## Global Counter Interval
 
 Due to limitations in event counters, `dotnet monitor` supports only **one** refresh interval when collecting metrics. This interval is used for
 Prometheus metrics, livemetrics, triggers, traces, and trigger actions that collect traces. The default interval is 5 seconds, but can be changed in configuration.
 
-[8.0+] For EventCounter providers, is possible to specify a different interval for each provider. See [Per provider intervals](#per-provider-intervals-71).
+[7.1+] For EventCounter providers, is possible to specify a different interval for each provider. See [Per provider intervals](#per-provider-intervals).
 
 <details>
   <summary>JSON</summary>
@@ -39,7 +48,9 @@ Prometheus metrics, livemetrics, triggers, traces, and trigger actions that coll
   ```
 </details>
 
-## Per provider intervals (8.0+)
+## Per Provider Intervals
+
+First Available: 7.1
 
 It is possible to override the global interval on a per provider basis. Note this forces all scenarios (triggers, live metrics, prometheus metrics, traces) that use a particular provider to use that interval. Metrics that are `System.Diagnostics.Metrics` based always use global interval.
 
@@ -334,7 +345,7 @@ For System.Diagnostics.Metrics, `dotnet monitor` allows you to set the maximum n
   ```
 </details>
 
-## Disable default providers
+## Disable Default Providers
 
 In addition to enabling custom providers, `dotnet monitor` also allows you to disable collection of the default providers. You can do so via the following configuration:
 

--- a/documentation/configuration/metrics-configuration.md
+++ b/documentation/configuration/metrics-configuration.md
@@ -10,7 +10,7 @@ The `/metrics` route (and starting in 8.0, the `/livemetrics` route and `Collect
 - `Microsoft.AspNetCore.Hosting`
 - `Grpc.AspNetCore.Server`
 
-These providers are collected by default for the above mentioned features, even when specifiying [custom metrics](#custom-metrics) collection. The default providers can be excluded by [disabling](#disable-default-providers) them.
+These providers are collected by default for the above mentioned features, even when specifying [custom metrics](#custom-metrics) collection. The default providers can be excluded by [disabling](#disable-default-providers) them.
 
 ## Global Counter Interval
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 
             MetricsPipelineSettings settings = MetricsSettingsFactory.CreateSettings(
                 _counterOptions.CurrentValue,
-                includeDefaults: true,
-                durationSeconds: durationSeconds);
+                durationSeconds,
+                _metricsOptions.CurrentValue);
 
             return InvokeForProcess(
                 processInfo => Result(

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         private readonly IOptions<CallStacksOptions> _callStacksOptions;
         private readonly IOptions<ParameterCapturingOptions> _parameterCapturingOptions;
         private readonly IOptionsMonitor<GlobalCounterOptions> _counterOptions;
+        private readonly IOptionsMonitor<MetricsOptions> _metricsOptions;
         private readonly ICollectionRuleService _collectionRuleService;
         private readonly IDumpOperationFactory _dumpOperationFactory;
         private readonly ILogsOperationFactory _logsOperationFactory;
@@ -55,6 +56,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             _callStacksOptions = serviceProvider.GetRequiredService<IOptions<CallStacksOptions>>();
             _parameterCapturingOptions = serviceProvider.GetRequiredService<IOptions<ParameterCapturingOptions>>();
             _counterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
+            _metricsOptions = serviceProvider.GetRequiredService<IOptionsMonitor<MetricsOptions>>();
             _collectionRuleService = serviceProvider.GetRequiredService<ICollectionRuleService>();
             _dumpOperationFactory = serviceProvider.GetRequiredService<IDumpOperationFactory>();
             _logsOperationFactory = serviceProvider.GetRequiredService<ILogsOperationFactory>();

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     //If metric options change, we need to cancel the existing metrics pipeline and restart with the new settings.
                     using IDisposable monitorListener = _optionsMonitor.OnChange((_, _) => optionsTokenSource.SafeCancel());
 
-                    MetricsPipelineSettings counterSettings = MetricsSettingsFactory.CreateSettings(counterOptions, options);
+                    MetricsPipelineSettings counterSettings = MetricsSettingsFactory.CreateSettings(counterOptions, Timeout.Infinite, options);
                     counterSettings.UseSharedSession = pi.EndpointInfo.RuntimeVersion?.Major >= 8;
 
                     _counterPipeline = new MetricsPipeline(client, counterSettings, loggers: new[] { new MetricsLogger(_store.MetricsStore) });

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsSettingsFactory.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
@@ -27,10 +26,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 () => new List<EventPipeCounterGroup>(0));
         }
 
-        public static MetricsPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, MetricsOptions options)
+        public static MetricsPipelineSettings CreateSettings(GlobalCounterOptions counterOptions, int durationSeconds,
+            MetricsOptions options)
         {
-            return CreateSettings(options.IncludeDefaultProviders.GetValueOrDefault(MetricsOptionsDefaults.IncludeDefaultProviders),
-                Timeout.Infinite, counterOptions.GetIntervalSeconds(),
+            return CreateSettings(
+                options.IncludeDefaultProviders.GetValueOrDefault(MetricsOptionsDefaults.IncludeDefaultProviders),
+                durationSeconds,
+                counterOptions.GetIntervalSeconds(),
                 counterOptions.Providers,
                 counterOptions.GetMaxHistograms(),
                 counterOptions.GetMaxTimeSeries(),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsSettingsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsSettingsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -106,7 +107,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
             var options = host.Services.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
 
-            var settings = MetricsSettingsFactory.CreateSettings(options.CurrentValue, new MetricsOptions
+            var settings = MetricsSettingsFactory.CreateSettings(options.CurrentValue, Timeout.Infinite, new MetricsOptions
             {
                 IncludeDefaultProviders = false,
                 Providers = new List<MetricProvider> { new MetricProvider { ProviderName = CustomProvider1 }, new MetricProvider { ProviderName = CustomProvider2 } }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptionsExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
+{
+    internal static class CollectLiveMetricsOptionsExtensions
+    {
+        public static bool HasCustomConfiguration(this CollectLiveMetricsOptions options)
+        {
+            return options.Providers?.Length > 0 ||
+                options.Meters?.Length > 0 ||
+                options.IncludeDefaultProviders.HasValue;
+        }
+
+        public static bool GetIncludeDefaultProviders(this CollectLiveMetricsOptions options)
+        {
+            return options.IncludeDefaultProviders.GetValueOrDefault(CollectLiveMetricsOptionsDefaults.IncludeDefaultProviders);
+        }
+
+        public static TimeSpan GetDuration(this CollectLiveMetricsOptions options)
+        {
+            return options.Duration.GetValueOrDefault(TimeSpan.Parse(CollectLiveMetricsOptionsDefaults.Duration, CultureInfo.InvariantCulture));
+        }
+    }
+}


### PR DESCRIPTION
###### Summary

This changes the pipeline settings of the `GET /livemetrics` route to use the Metrics configuration instead of using the default event counters providers. Reasons for change:
- Both `GET /metrics` and `GET /livemetrics` now collect the same providers/counters/meters/instruments/etc. Customers "fall into the pit of success" more easily and don't need to wonder why `/livemetrics` collected a different data specification than `/metrics`.
- Customers are not required to respecify their metrics configuration via `POST /livemetrics` for something they already configured and naturally applies to all metrics scenarios.
- External tooling can now collect live metrics with the same specification that was already configured without having to dig through configuration sources, if has access to those sources. Customers do not need to tell those external tools how to replicate that configuration.

**This is a breaking change** If a customer wants to revert to the prior behavior, they can invoke `POST /livemetrics` with a request body of `{"includeDefaultProviders": "true"}`

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Update `GET /livemetrics` route to use configuration from Metrics section instead of only using the default event counters providers. Update `CollectLiveMetrics` action to use configuration from Metrics section by default.

TODO

- [x] Update `CollectLiveMetrics` action to have same behavior
- [x] Update documentation with behavioral differences

closes #5393 