### PR TITLE
[Exceptions] Fix Bug For Missing Callstacks With Eclipsing Exceptions

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string ArrayException = nameof(ArrayException);
                 public const string InnerUnthrownException = nameof(InnerUnthrownException);
                 public const string InnerThrownException = nameof(InnerThrownException);
+                public const string EclipsingException = nameof(EclipsingException);
                 public const string AggregateException = nameof(AggregateException);
                 public const string ReflectionTypeLoadException = nameof(ReflectionTypeLoadException);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string InnerUnthrownException = nameof(InnerUnthrownException);
                 public const string InnerThrownException = nameof(InnerThrownException);
                 public const string EclipsingException = nameof(EclipsingException);
+                public const string EclipsingExceptionFromMethodCall = nameof(EclipsingExceptionFromMethodCall);
                 public const string AggregateException = nameof(AggregateException);
                 public const string ReflectionTypeLoadException = nameof(ReflectionTypeLoadException);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsPipelineTests.cs
@@ -356,6 +356,36 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         }
 
         /// <summary>
+        /// Tests that wrapped exceptions thrown within a catch block are detectable
+        /// (and that the outer exception's callstack is present).
+        /// </summary>
+        [Fact]
+        public Task EventExceptionsPipeline_EclipsingException()
+        {
+            const int ExpectedInstanceCount = 2;
+
+            return Execute(
+                TestAppScenarios.Exceptions.SubScenarios.EclipsingException,
+                ExpectedInstanceCount,
+                validate: instances =>
+                {
+                    Assert.Equal(ExpectedInstanceCount, instances.Count());
+                    IExceptionInstance innerInstance = instances.First();
+                    Assert.NotNull(innerInstance);
+                    Assert.NotEqual(0UL, innerInstance.Id);
+                    Assert.Equal(typeof(FormatException).FullName, innerInstance.TypeName);
+                    Assert.Empty(innerInstance.InnerExceptionIds);
+                    Assert.NotEmpty(innerInstance.CallStack.Frames); // Indicates this exception was thrown
+                    IExceptionInstance outerInstance = instances.Skip(1).Single();
+                    Assert.NotNull(outerInstance);
+                    Assert.NotEqual(0UL, outerInstance.Id);
+                    Assert.Equal(typeof(InvalidOperationException).FullName, outerInstance.TypeName);
+                    Assert.Equal(innerInstance.Id, Assert.Single(outerInstance.InnerExceptionIds));
+                    Assert.NotEmpty(outerInstance.CallStack.Frames); // Indicates this exception was thrown
+                });
+        }
+
+        /// <summary>
         /// Tests that inner exceptions from AggregateException are detectable.
         /// </summary>
         [Fact]


### PR DESCRIPTION
###### Summary

For context: https://github.com/dotnet/runtime/issues/91125

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
