### PR TITLE
Update release pipeline to use SAS tokens

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -110,6 +110,8 @@ stages:
     variables:
     - ${{ if eq(parameters.IsTestRun, 'true') }}:
       - group: DotNet-Diagnostics-Storage-Test
+    - ${{ else }}:
+      - group: DotNetCli storage account tokens
     - group: DotNet-DotNetStage-Storage
 
     workspace:
@@ -157,24 +159,24 @@ stages:
 
           - powershell: |
               Write-Host "##vso[task.setvariable variable=DestinationAccountName]$env:DESTINATION_ACCOUNT_NAME"
-              Write-Host "##vso[task.setvariable variable=DestinationAccountKey;issecret=true]$env:DESTINATION_ACCOUNT_KEY"
+              Write-Host "##vso[task.setvariable variable=DestinationSasTokenBase64;issecret=true]$env:DESTINATION_SAS_TOKEN_BASE64"
               Write-Host "##vso[task.setvariable variable=ChecksumsAccountName]$env:CHECKSUMS_ACCOUNT_NAME"
-              Write-Host "##vso[task.setvariable variable=ChecksumsAccountKey;issecret=true]$env:CHECKSUMS_ACCOUNT_KEY"
+              Write-Host "##vso[task.setvariable variable=ChecksumsSasTokenBase64;issecret=true]$env:CHECKSUMS_SAS_TOKEN_BASE64"
             displayName: Set Storage Accounts
             ${{ if eq(parameters.IsTestRun, 'true') }}:
               env:
                 # Variables provided by DotNet-Diagnostics-Storage-Test group
                 DESTINATION_ACCOUNT_NAME: $(dotnet-monitor-test-storage-accountname)
-                DESTINATION_ACCOUNT_KEY: $(dotnet-monitor-test-storage-accountkey)
+                DESTINATION_SAS_TOKEN_BASE64: $(dotnet-monitor-test-blob-write-token-base64)
                 CHECKSUMS_ACCOUNT_NAME: $(dotnet-monitor-checksums-test-storage-accountname)
-                CHECKSUMS_ACCOUNT_KEY: $(dotnet-monitor-checksums-test-storage-accountkey)
+                CHECKSUMS_SAS_TOKEN_BASE64: $(dotnet-monitor-checksums-test-blob-write-token-base64)
             ${{ else }}:
               env:
-                # Variables provided by Release-Pipeline group
+                # Variables provided by "DotNetCli storage account tokens" group
                 DESTINATION_ACCOUNT_NAME: dotnetcli
-                DESTINATION_ACCOUNT_KEY: $(dotnetcli-storage-key)
+                DESTINATION_SAS_TOKEN_BASE64: $(dotnetcli-account-blob-write-token-base64)
                 CHECKSUMS_ACCOUNT_NAME: dotnetclichecksums
-                CHECKSUMS_ACCOUNT_KEY: $(dotnetclichecksums-storage-key)
+                CHECKSUMS_SAS_TOKEN_BASE64: $(dotnetclichecksums-account-blob-write-token-base64)
 
           - task: PowerShell@2
             displayName: Publish Assets
@@ -186,9 +188,9 @@ stages:
                 -ReleaseVersion $(ReleaseVersion)
                 -DotnetStageAccountKey $(dotnetstage-storage-key)
                 -DestinationAccountName $(DestinationAccountName)
-                -DestinationAccountKey $(DestinationAccountKey)
+                -DestinationSasTokenBase64 $(DestinationSasTokenBase64)
                 -ChecksumsAccountName $(ChecksumsAccountName)
-                -ChecksumsAccountKey $(ChecksumsAccountKey)
+                -ChecksumsSasTokenBase64 $(ChecksumsSasTokenBase64)
                 -WhatIf:${{ format('${0}', parameters.IsDryRun) }}
           
           - task: PublishBuildArtifacts@1

--- a/eng/release/Scripts/PublishToBlobAccounts.ps1
+++ b/eng/release/Scripts/PublishToBlobAccounts.ps1
@@ -5,9 +5,9 @@ Param(
     [Parameter(Mandatory=$true)][string]$ReleaseVersion,
     [Parameter(Mandatory=$true)][string]$DotnetStageAccountKey,
     [Parameter(Mandatory=$true)][string]$DestinationAccountName,
-    [Parameter(Mandatory=$true)][string]$DestinationAccountKey,
+    [Parameter(Mandatory=$true)][string]$DestinationSasTokenBase64,
     [Parameter(Mandatory=$true)][string]$ChecksumsAccountName,
-    [Parameter(Mandatory=$true)][string]$ChecksumsAccountKey
+    [Parameter(Mandatory=$true)][string]$ChecksumsSasTokenBase64
 )
 
 $ErrorActionPreference = 'Stop'
@@ -16,6 +16,9 @@ Set-StrictMode -Version 2.0
 $sourceAccountName = 'dotnetstage'
 $sourceContainerName = 'dotnet-monitor'
 $destinationContainerName = 'dotnet'
+
+$destinationSasToken = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($DestinationSasTokenBase64))
+$checksumsSasToken = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($ChecksumsSasTokenBase64))
 
 function Generate-Source-Uri{
     [CmdletBinding()]
@@ -65,13 +68,13 @@ function Transfer-File{
         [Parameter(Mandatory=$true)][string]$ToToken
     )
 
-    Write-Verbose "Copy $From -> $To"
+    Write-Host "Copy $From -> $To"
 
     if ($From -eq $to) {
-        Write-Verbose 'Skipping copy because source and destination are the same.'
+        Write-Host 'Skipping copy because source and destination are the same.'
     } else {
-        [array]$azCopyArgs = "$from$fromToken"
-        $azCopyArgs += "$to$toToken"
+        [array]$azCopyArgs = "$From$FromToken"
+        $azCopyArgs += "$To$ToToken"
         $azCopyArgs += "--s2s-preserve-properties"
         $azCopyArgs += "--s2s-preserve-access-tier=false"
         if ($WhatIfPreference) {
@@ -90,14 +93,9 @@ $soureSasToken = Generate-Sas-Token `
     -AccountKey $DotnetStageAccountKey `
     -Permissions 'rl'
 
-# Create destination URI and SAS token
+# Create destination URI
 $destinationUri = Generate-Destination-Uri `
     -AccountName $DestinationAccountName
-$destinationSasToken = Generate-Sas-Token `
-    -StorageAccountName $DestinationAccountName `
-    -ContainerName $destinationContainerName `
-    -AccountKey $DestinationAccountKey `
-    -Permissions 'rlw'
 
 # Copy files to destination account
 Transfer-File `
@@ -111,19 +109,14 @@ Transfer-File `
 $checksumsSourceUri = Generate-Source-Uri `
     -AssetType 'Checksum'
 
-# Create checksums destination URI and SAS token
+# Create checksums destination URI
 $checksumsDestinationUri = Generate-Destination-Uri `
     -AccountName $ChecksumsAccountName
-$checksumsDestinationSasToken = Generate-Sas-Token `
-    -StorageAccountName $ChecksumsAccountName `
-    -ContainerName $destinationContainerName `
-    -AccountKey $ChecksumsAccountKey `
-    -Permissions 'rlw'
 
 # Copy checksums to checksum account
 Transfer-File `
     -From $checksumsSourceUri `
     -FromToken $soureSasToken `
     -To $checksumsDestinationUri `
-    -ToToken $checksumsDestinationSasToken `
+    -ToToken $checksumsSasToken `
     -WhatIf:$WhatIfPreference


### PR DESCRIPTION
###### Summary

Update the release pipeline to use storage account container SAS tokens instead of using the account keys directly.

close #4645

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
