### PR TITLE
[release/6.x] Remove version file generation and blob publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,63 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles;CollectVersionArtifactFiles</PublishDependsOnTargets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles</PublishDependsOnTargets>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.tar.gz" IsShipping="true" />
-    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.zip" IsShipping="true" />
-    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.tar.gz" IsShipping="false" />
-    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.zip" IsShipping="false" />
-  </ItemGroup>
-
-  <Target Name="CalculateBlobGroupAndBuildVersion">
+  <Target Name="CalculateBuildVersion">
     <PropertyGroup>
-      <!--
-        These properties take a package version and transform it into a blob group name so that
-        all builds from the same product and release version are grouped together. This code has
-        to consider when the version is a release version (e.g. 7.0.0) or has a prerelease label
-        (e.g. 7.0.0-preview.1). The former is transformed into '7.0/release' whereas
-        the latter is transformed into '7.0/preview.1'. It also accounts for the
-        BlobGroupBuildQuality defined in Version.props, which determines if the prerelease information
-        should be used in the final blob group name.
-        -->
-      <_PreReleaseSeperatorIndex>$(Version.IndexOf('-'))</_PreReleaseSeperatorIndex>
-      
-      <!-- Prerelease: '7.0.0-preview.8' -> '7.0.0' and 'preview.8' -->
-      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' != '-1'">$(Version.Substring(0, $(_PreReleaseSeperatorIndex)))</_BlobGroupVersion>
-      
-      <!-- Release: take the package version as-is. -->
-      <_BlobGroupVersion Condition="'$(_PreReleaseSeperatorIndex)' == '-1'">$(Version)</_BlobGroupVersion>
-    </PropertyGroup>
-    <!-- These are the valid BlobGroupBuildQuality values. -->
-    <ItemGroup>
-      <_BlobGroupBuildQualityName Include="daily" ReleaseName="daily" />
-      <_BlobGroupBuildQualityName Include="release" ReleaseName="release" />
-    </ItemGroup>
-    <!-- Select the blob group build quality based on the specified property. -->
-    <ItemGroup>
-      <_SelectedBlobGroupQualityName Include="@(_BlobGroupBuildQualityName)" Condition="'%(Identity)' == '$(BlobGroupBuildQuality)'" />
-    </ItemGroup>
-    <PropertyGroup>
-      <!-- Extract major and minor version fields from version number. -->
-      <_BlobGroupVersionMajor>$(_BlobGroupVersion.Split('.')[0])</_BlobGroupVersionMajor>
-      <_BlobGroupVersionMinor>$(_BlobGroupVersion.Split('.')[1])</_BlobGroupVersionMinor>
-      <!-- Get release name from blob group build quality. -->
-      <_BlobGroupReleaseName>@(_SelectedBlobGroupQualityName->'%(ReleaseName)')</_BlobGroupReleaseName>
-    </PropertyGroup>
-    <!-- Validate the selected and calculated values. -->
-    <Error Text="BlobGroupBuildQuality must be set to a valid value: @(_BlobGroupBuildQualityName, ', ')" Condition="'@(_SelectedBlobGroupQualityName)' == ''" />
-    <Error Text="Unable to calculate _BlobGroupVersionMajor" Condition="'$(_BlobGroupVersionMajor)' == ''" />
-    <Error Text="Unable to calculate _BlobGroupVersionMinor" Condition="'$(_BlobGroupVersionMinor)' == ''" />
-    <Error Text="Unable to calculate _BlobGroupReleaseName" Condition="'$(_BlobGroupReleaseName)' == ''" />
-    <PropertyGroup>
-      <!--
-        Combine all parts to create blob group name.
-        Daily: '7.0.0-preview.1.12345' -> '7.0/daily'
-        Release: '7.0.0' -> '7.0/release'
-        -->
-      <_BlobGroupName>$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)/$(_BlobGroupReleaseName)</_BlobGroupName>
       <!--
         This computes the original version without considering the effect of DotNetFinalVersionKind.
         This can be used to uniquely identify a version of a specific build even if the build produces
@@ -74,16 +22,16 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="CalculatePackagesToPublish">
-    <ItemGroup>
-      <PackageToPublish Include="@(PackageFile)"
-                        Condition="$([System.IO.File]::Exists('%(PackageFile.Identity).projectpath'))" />
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.tar.gz" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**/*.zip" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.tar.gz" IsShipping="false" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**/*.zip" IsShipping="false" />
+  </ItemGroup>
 
   <Target Name="GenerateChecksumsForPackages">
     <ItemGroup>
-      <GenerateChecksumItems Include="@(PackageToPublish)">
+      <GenerateChecksumItems Include="@(PackageFile)">
         <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>
     </ItemGroup>
@@ -91,88 +39,22 @@
     <GenerateChecksums Items="@(GenerateChecksumItems)" />
   </Target>
 
-  <!-- Run the CollectPackageArtifactFiles target on each PackageToPublish by target batching on a non-existing file.
+  <!-- Run the CollectPackageArtifactFiles target on each PackageFile by target batching on a non-existing file.
        This allows using the ReadLinesFromFile task to read the blob group file, which was written with WriteLinesToFile,
        thus avoiding erroneously reading in the newline at the end of the blob group file. -->
   <Target Name="CollectPackageArtifactFiles"
-          DependsOnTargets="CalculateBlobGroupAndBuildVersion;CalculatePackagesToPublish;GenerateChecksumsForPackages"
-          Inputs="@(PackageToPublish)"
-          Outputs="%(PackageToPublish.Identity).notexist">
-
-    <!-- Read in project file name -->
-    <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectpath">
-      <Output TaskParameter="Lines" PropertyName="_RelativeProjectPath"/>
-    </ReadLinesFromFile>
-    
-    <!-- Read in project props -->
-    <ReadLinesFromFile File="%(PackageToPublish.FullPath).projectprops"
-                       Condition="Exists('%(PackageToPublish.FullPath).projectprops')">
-      <Output TaskParameter="Lines" PropertyName="_ProjectProps"/>
-    </ReadLinesFromFile>
-
-    <!-- Get package name from project as if its version was set to the build version -->
-    <ItemGroup>
-      <GetPackageFileNameProps Remove="@(GetPackageFileNameProps)" />
-      <GetPackageFileNameProps Include="Version=$(_BuildVersion)" />
-      <GetPackageFileNameProps Include="$(_ProjectProps)" />
-    </ItemGroup>
-    <MSBuild Projects="$(RepoRoot)$(_RelativeProjectPath)"
-             Targets="GetPackageFileName"
-             Properties="@(GetPackageFileNameProps)">
-      <Output ItemName="_PackageWithBuildVersionFileName" TaskParameter="TargetOutputs" />
-    </MSBuild>
-
-    <!-- Get package version from project -->
-    <ItemGroup>
-      <GetPackageVersionProps Remove="@(GetPackageVersionProps)" />
-      <GetPackageVersionProps Include="$(_ProjectProps)" />
-    </ItemGroup>
-    <MSBuild Projects="$(RepoRoot)$(_RelativeProjectPath)"
-             Targets="GetPackageVersion"
-             Properties="@(GetPackageVersionProps)">
-      <Output ItemName="_PackageVersion" TaskParameter="TargetOutputs" />
-    </MSBuild>
+          DependsOnTargets="CalculateBuildVersion;GenerateChecksumsForPackages"
+          Inputs="@(PackageFile)"
+          Outputs="%(PackageFile.Identity).notexist">
 
     <!-- Package artifact file paths -->
     <PropertyGroup>
-      <!-- Example archive file name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip -->
-      <_PackageWithBuildVersionFileName>@(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFileName>
-      <_PackageWithBuildVersionFilePath>%(PackageToPublish.RootDir)%(PackageToPublish.Directory)$(_PackageWithBuildVersionFileName)</_PackageWithBuildVersionFilePath>
-      <_ChecksumFilePath>%(PackageToPublish.FullPath).sha512</_ChecksumFilePath>
-      <_BuildVersionFilePath>$(_PackageWithBuildVersionFilePath).buildversion</_BuildVersionFilePath>
-      <_PackageVersionFilePath>$(_PackageWithBuildVersionFilePath).version</_PackageVersionFilePath>
+      <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
     </PropertyGroup>
-
-    <!--
-      A file that contains the version of the package.
-      Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.version
-      -->
-    <WriteLinesToFile File="$(_PackageVersionFilePath)"
-                      Lines="@(_PackageVersion)"
-                      Overwrite="true" />
-
-    <!--
-      A file that contains the build version of the package. The name of this file contains the build
-      version in order to avoid collisions when uploaded to blob storage.
-      Example archive name: dotnet-monitor-7.0.0-rtm.12345.6-win-x64.zip.buildversion
-      -->
-    <WriteLinesToFile File="$(_BuildVersionFilePath)"
-                      Lines="$(_BuildVersion)"
-                      Overwrite="true" />
 
     <!-- Calculate manifest artifact data for each file type. -->
     <ItemGroup>
-      <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageToPublish.IsShipping)' != 'true'" />
-    </ItemGroup>
-
-    <!-- Capture items that need to be published under the blob group. -->
-    <ItemGroup>
-      <_BlobGroupBlobItem Include="$(_BuildVersionFilePath)" Condition="Exists('$(_BuildVersionFilePath)')" >
-        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
-      </_BlobGroupBlobItem>
-      <_BlobGroupBlobItem Include="$(_PackageVersionFilePath)" Condition="Exists('$(_PackageVersionFilePath)')">
-        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
-      </_BlobGroupBlobItem>
+      <_CommonArtifactData Include="NonShipping=true" Condition="'%(PackageFile.IsShipping)' != 'true'" />
     </ItemGroup>
 
     <!-- Capture items that need to be published under the build version container. -->
@@ -180,47 +62,16 @@
       <_VersionContainerBlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_VersionContainerBlobItem>
-      <_VersionContainerBlobItem Include="%(PackageToPublish.FullPath)" Condition="Exists('%(PackageToPublish.FullPath)')" >
+      <_VersionContainerBlobItem Include="%(PackageFile.FullPath)" Condition="Exists('%(PackageFile.FullPath)')" >
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_VersionContainerBlobItem>
     </ItemGroup>
 
     <!-- Add artifact items to be pushed to blob feed -->
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(_BlobGroupBlobItem)" Condition="'$(_BlobGroupName)' != ''">
-        <!-- Place blobs into versioned container so that stable package versions do not collide. -->
-        <RelativeBlobPath>diagnostics/monitor$(_BlobGroupName)/%(_BlobGroupBlobItem.Filename)%(_BlobGroupBlobItem.Extension)</RelativeBlobPath>
-        <PublishFlatContainer>true</PublishFlatContainer>
-      </ItemsToPushToBlobFeed>
       <ItemsToPushToBlobFeed Include="@(_VersionContainerBlobItem)" Condition="'$(_BuildVersion)' != ''">
         <!-- Place blobs into versioned container so that stable package versions do not collide. -->
         <RelativeBlobPath>diagnostics/monitor/$(_BuildVersion)/%(_VersionContainerBlobItem.Filename)%(_VersionContainerBlobItem.Extension)</RelativeBlobPath>
-        <PublishFlatContainer>true</PublishFlatContainer>
-      </ItemsToPushToBlobFeed>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CollectVersionArtifactFiles"
-          DependsOnTargets="CalculateBlobGroupAndBuildVersion">
-    <PropertyGroup>
-      <VersionFileName>dotnet-monitor-$(_BuildVersion).version</VersionFileName>
-      <VersionFilePath>$(ArtifactsTmpDir)$(VersionFileName)</VersionFilePath>
-      <VersionValue Condition="'$(DotnetFinalVersionKind)' == 'release'">$(_OriginalVersionPrefix)</VersionValue>
-      <VersionValue Condition="'$(DotnetFinalVersionKind)' != 'release'">$(_BuildVersion)</VersionValue>
-    </PropertyGroup>
-
-    <!-- Write three-part version number -->
-    <WriteLinesToFile File="$(VersionFilePath)"
-                      Lines="$(VersionValue)" />
-
-    <!--
-      Place product version files into versioned container; this will cause the auto aka.ms link generation
-      to be something like aka.ms/dotnet/diagnostics/monitor{Major.Minor}/release/dotnet-monitor.version; this
-      is used to provide a stable production version file and link regardless of the actual product packages.
-      -->
-    <ItemGroup>
-      <ItemsToPushToBlobFeed Include="$(VersionFilePath)" Condition="'$(_BlobGroupName)' != ''">
-        <RelativeBlobPath>diagnostics/monitor$(_BlobGroupName)/$(VersionFileName)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPushToBlobFeed>
     </ItemGroup>

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -49,7 +49,7 @@ jobs:
         targetType: inline
         script: |
             New-Item "$(Build.ArtifactStagingDirectory)/buildInfo" -Type Directory
-            Copy-Item "$(Build.SourcesDirectory)/artifacts/packages/Release/Shipping/dotnet-monitor-*-win-x64.zip.buildversion" "$(Build.ArtifactStagingDirectory)/buildInfo/dotnet-monitor.nupkg.buildversion"
+            Copy-Item "$(Build.SourcesDirectory)/artifacts/packages/Release/Shipping/dotnet-monitor.buildversion" "$(Build.ArtifactStagingDirectory)/buildInfo/dotnet-monitor.nupkg.buildversion"
     - task: PublishPipelineArtifact@1
       displayName: Publish Build Info
       inputs:

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,52 +11,20 @@
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
 
-  <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
-  <Target Name="GenerateArchivePackageProjectFiles"
-          AfterTargets="_CreateArchive"
-          Condition="'$(DisableCustomBlobStoragePublishing)' != 'true' and '$(IsArchivable)' == 'true'">
-    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
-    <WriteLinesToFile File="$(_DestinationFileName).projectpath"
-                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
+  <Target Name="GenerateBuildVersionFile"
+          AfterTargets="Pack"
+          Condition="'$(IsPackable)' == 'true'">
+    <PropertyGroup>
+      <!--
+        This computes the original version without considering the effect of DotNetFinalVersionKind.
+        This can be used to uniquely identify a version of a specific build even if the build produces
+        stable package versions.
+        -->
+      <_BuildVersion>$(_OriginalVersionPrefix)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_BuildVersion>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(PackageOutputAbsolutePath)$(PackageId).buildversion"
+                      Lines="$(_BuildVersion)"
                       Overwrite="true" />
-    <ItemGroup>
-      <PackageProjectProps Remove="@(PackageProjectProps)" />
-      <PackageProjectProps Include="RuntimeIdentifier=$(RuntimeIdentifier)" />
-    </ItemGroup>
-    <!-- Write a props file so that the above project is invoked during publish with the specified properties. -->
-    <WriteLinesToFile File="$(_DestinationFileName).projectprops"
-                      Lines="@(PackageProjectProps)"
-                      Overwrite="true" />
-  </Target>
-  <Target Name="GenerateSymbolsArchivePackageProjectFiles"
-          AfterTargets="_CreateSymbolsArchive"
-          Condition="'$(DisableCustomBlobStoragePublishing)' != 'true' and '$(IsArchivable)' == 'true' and '$(CreateSymbolsArchive)' == 'true'">
-    <!-- The path needs to be relative to the repository root to allow for correct path rooting across platforms and build machines. -->
-    <WriteLinesToFile File="$(_DestinationFileName).projectpath"
-                      Lines="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)))"
-                      Overwrite="true" />
-    <ItemGroup>
-      <PackageProjectProps Remove="@(PackageProjectProps)" />
-      <PackageProjectProps Include="RuntimeIdentifier=$(RuntimeIdentifier)" />
-      <PackageProjectProps Include="IsSymbolsArchive=true" />
-    </ItemGroup>
-    <!-- Write a props file so that the above project is invoked during publish with the specified properties. -->
-    <WriteLinesToFile File="$(_DestinationFileName).projectprops"
-                      Lines="@(PackageProjectProps)"
-                      Overwrite="true" />
-  </Target>
-
-  <Target Name="GetPackageVersion"
-          Returns="$(PackageVersion)" />
-
-  <Target Name="GetPackageFileName"
-          Returns="@(PackageFileName)">
-    <ItemGroup>
-      <!-- The archive targets use Version instead of PackageVersion; do the same to be consistent. -->
-      <PackageFileName Include="$(ArchiveName)-$(Version)-$(RuntimeIdentifier).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' != 'true' " />
-      <!-- Symbols archive names reverse the order of the version and runtime identifier compared to the product archive. -->
-      <PackageFileName Include="$(ArchiveName)-symbols-$(RuntimeIdentifier)-$(Version).$(ArchiveFormat)" Condition="'$(IsArchivable)' == 'true' and '$(IsSymbolsArchive)' == 'true' " />
-    </ItemGroup>
   </Target>
 
   <!-- Remove native libraries from transitive dependencies -->


### PR DESCRIPTION
###### Summary

Manual backport of #5456 to release/6.x

Conflicts were due to bundle creation, which does not exist in the release/6x branch

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2282433&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
