### PR TITLE
Remove net6.0 TFM build and packaging

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -2203,8 +2203,7 @@
                 "type": "string"
               }
             },
-            "nullable": true,
-            "readOnly": true
+            "nullable": true
           }
         },
         "additionalProperties": { }

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -2624,6 +2624,10 @@
         "Indented": {
           "type": "boolean"
         },
+        "MaxDepth": {
+          "type": "integer",
+          "format": "int32"
+        },
         "SkipValidation": {
           "type": "boolean"
         }

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <LatestTargetFramework>net8.0</LatestTargetFramework>
     <LatestToolTargetFramework>$(LatestTargetFramework)</LatestToolTargetFramework>
-    <OlderToolTargetFramework>net6.0</OlderToolTargetFramework>
     <ArtifactsNonShippingBundlesDir>$(ArtifactsDir)bundles\$(Configuration)\NonShipping\</ArtifactsNonShippingBundlesDir>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,19 +28,12 @@
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)Common.props" />
   <PropertyGroup Label="TargetFrameworks">
-    <!-- Conditionally exclude when building in Visual Studio until stable SDK is available. -->
-    <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == '' and '$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework>
-    <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == ''">false</ExcludeLatestTargetFramework>
     <!-- The TFMs of the dotnet-monitor tool.  -->
-    <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
-    <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);$(LatestTargetFramework)</ToolTargetFrameworks>
+    <ToolTargetFrameworks>$(LatestTargetFramework)</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
-    <TestTargetFrameworks>net6.0;net7.0</TestTargetFrameworks>
-    <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);$(LatestTargetFramework)</TestTargetFrameworks>
+    <TestTargetFrameworks>net6.0;net7.0;$(LatestTargetFramework)</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
-    <SchemaTargetFramework>net6.0</SchemaTargetFramework>
-    <!-- Defines for including the next .NET version -->
-    <DefineConstants Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(DefineConstants);INCLUDE_NEXT_DOTNET</DefineConstants>
+    <SchemaTargetFramework>net8.0</SchemaTargetFramework>
   </PropertyGroup>
   <PropertyGroup Label="Arcade">
     <UsingToolXliff>false</UsingToolXliff>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 SchemaGeneratorName,
-                TargetFrameworkMoniker.Net60);
+                TargetFrameworkMoniker.Net80);
 
         public SchemaGenerationTests(ITestOutputHelper outputHelper)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
             Path.Combine(Path.GetDirectoryName(CurrentExecutingAssemblyPath), OpenApiBaselineName);
 
         private static readonly string OpenApiGenPath =
-            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), OpenApiGenName, TargetFrameworkMoniker.Net60);
+            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), OpenApiGenName, TargetFrameworkMoniker.Net80);
 
         private readonly ITestOutputHelper _outputHelper;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -51,11 +51,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
 
-#if NET7_0_OR_GREATER
                     Version currentAspNetVersion = TargetFrameworkMoniker.Net80.GetAspNetCoreFrameworkVersion();
-#else
-                    Version currentAspNetVersion = TargetFrameworkMoniker.Net60.GetAspNetCoreFrameworkVersion();
-#endif
                     Assert.Equal(currentAspNetVersion.Major, runtimeVersion.Major);
                     Assert.Equal(currentAspNetVersion.Minor, runtimeVersion.Minor);
                     Assert.Equal(currentAspNetVersion.Revision, runtimeVersion.Revision);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -92,7 +92,7 @@
     <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -68,22 +68,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
-#if NET7_0_OR_GREATER
                 TargetFrameworkMoniker.Net80
-#else
-                TargetFrameworkMoniker.Net60
-#endif
                 );
 
         private static string TestStartupHookPath =>
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 TestStartupHookAssemblyName,
-#if NET7_0_OR_GREATER
                 TargetFrameworkMoniker.Net80
-#else
-                TargetFrameworkMoniker.Net60
-#endif
                 );
 
         private string SharedConfigDirectoryPath =>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
@@ -25,17 +25,13 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         {
             TargetFrameworkMoniker.Net60,
             TargetFrameworkMoniker.Net70,
-#if INCLUDE_NEXT_DOTNET
             TargetFrameworkMoniker.Net80
-#endif
         };
         public static TargetFrameworkMoniker[] tfms6PlusToTest = new TargetFrameworkMoniker[]
         {
             TargetFrameworkMoniker.Net60,
             TargetFrameworkMoniker.Net70,
-#if INCLUDE_NEXT_DOTNET
             TargetFrameworkMoniker.Net80
-#endif
         };
 
         public static IEnumerable<object[]> GetTfms()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -576,18 +576,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         {
             yield return new object[] { TargetFrameworkMoniker.Net60 };
             yield return new object[] { TargetFrameworkMoniker.Net70 };
-#if INCLUDE_NEXT_DOTNET
             yield return new object[] { TargetFrameworkMoniker.Net80 };
-#endif
         }
 
         public static IEnumerable<object[]> GetCurrentTfm()
         {
-#if INCLUDE_NEXT_DOTNET
             yield return new object[] { TargetFrameworkMoniker.Net80 };
-#else
-            yield return new object[] { TargetFrameworkMoniker.Net70 };
-#endif
         }
     }
 }

--- a/src/archives/AzureBlobStorage/ProjectsToPublish.props
+++ b/src/archives/AzureBlobStorage/ProjectsToPublish.props
@@ -16,8 +16,5 @@
     <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
       <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(AzureBlobStoragePublishRootPath)$(LatestToolTargetFramework)\any\;SelfContained=false</AdditionalProperties>
     </ProjectToPublish>
-    <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
-      <AdditionalProperties>TargetFramework=$(OlderToolTargetFramework);RuntimeIdentifier=;PublishDir=$(AzureBlobStoragePublishRootPath)$(OlderToolTargetFramework)\any\;SelfContained=false</AdditionalProperties>
-    </ProjectToPublish>
   </ItemGroup>
 </Project>

--- a/src/archives/S3Storage/ProjectsToPublish.props
+++ b/src/archives/S3Storage/ProjectsToPublish.props
@@ -16,8 +16,5 @@
     <ProjectToPublish Include="$(S3StorageProjectPath)">
       <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(S3StoragePublishRootPath)$(LatestToolTargetFramework)\any\;SelfContained=false</AdditionalProperties>
     </ProjectToPublish>
-    <ProjectToPublish Include="$(S3StorageProjectPath)">
-      <AdditionalProperties>TargetFramework=$(OlderToolTargetFramework);RuntimeIdentifier=;PublishDir=$(S3StoragePublishRootPath)$(OlderToolTargetFramework)\any\;SelfContained=false</AdditionalProperties>
-    </ProjectToPublish>
   </ItemGroup>
 </Project>

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -14,9 +14,6 @@ SET DOTNET_MULTILEVEL_LOOKUP=0
 :: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
 SET PATH=%DOTNET_ROOT%;%PATH%
 
-:: Allow building of the latest target framework because SDK from the repository will be used to build
-SET ExcludeLatestTargetFramework=false
-
 SET sln=%~1
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (


### PR DESCRIPTION
###### Summary

These changes remove the net6.0 TFM build of the .NET Monitor binaries such that only net8.0 TFM is built and packaged. The effect is that .NET Monitor 8.0 will only be runnable on systems with .NET 8 installed. This change does not impact the diagnosability of applications that are running on other .NET versions.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2285523&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Remove `net6.0` TFM build and packaging. There is no impact on the ability to monitor .NET 6 (or any other version) applications.