### PR TITLE
Return HTTP 400 for disabled features

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ControllerExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ControllerExtensions.cs
@@ -17,6 +17,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 {
     internal static class ControllerExtensions
     {
+        public static ActionResult FeatureNotEnabled(this ControllerBase controller, string featureName)
+        {
+            return new BadRequestObjectResult(new ProblemDetails()
+            {
+                Detail = string.Format(Strings.Message_FeatureNotEnabled, featureName),
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
         public static ActionResult NotAcceptable(this ControllerBase controller)
         {
             return new StatusCodeResult((int)HttpStatusCode.NotAcceptable);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -584,7 +584,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             if (!_parameterCapturingOptions.Value.GetEnabled())
             {
-                return NotFound();
+                return this.FeatureNotEnabled(Strings.FeatureName_ParameterCapturing);
             }
 
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
@@ -617,7 +617,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             if (!_callStacksOptions.Value.GetEnabled())
             {
-                return Task.FromResult<ActionResult>(NotFound());
+                return Task.FromResult<ActionResult>(this.FeatureNotEnabled(Strings.FeatureName_CallStacks));
             }
 
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi.Exceptions;
-using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -64,7 +63,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             if (!_options.Value.GetEnabled())
             {
-                return Task.FromResult<ActionResult>(NotFound());
+                return Task.FromResult<ActionResult>(this.FeatureNotEnabled(Strings.FeatureName_Exceptions));
             }
 
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -520,7 +520,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The {0} feature is not enabled..
+        ///   Looks up a localized string similar to The &apos;{0}&apos; feature is not enabled..
         /// </summary>
         internal static string Message_FeatureNotEnabled {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.Designer.cs
@@ -277,6 +277,33 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Call Stacks.
+        /// </summary>
+        internal static string FeatureName_CallStacks {
+            get {
+                return ResourceManager.GetString("FeatureName_CallStacks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exceptions.
+        /// </summary>
+        internal static string FeatureName_Exceptions {
+            get {
+                return ResourceManager.GetString("FeatureName_Exceptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter Capturing.
+        /// </summary>
+        internal static string FeatureName_ParameterCapturing {
+            get {
+                return ResourceManager.GetString("FeatureName_ParameterCapturing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The counter {0} ended and is no longer receiving metrics..
         /// </summary>
         internal static string LogFormatString_CounterEndedPayload {
@@ -489,6 +516,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         internal static string Message_CollectionRuleStateReason_Throttled {
             get {
                 return ResourceManager.GetString("Message_CollectionRuleStateReason_Throttled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} feature is not enabled..
+        /// </summary>
+        internal static string Message_FeatureNotEnabled {
+            get {
+                return ResourceManager.GetString("Message_FeatureNotEnabled", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -324,7 +324,7 @@
     <value>This collection rule is temporarily throttled because the ActionCountLimit has been reached within the ActionCountSlidingWindowDuration.</value>
   </data>
   <data name="Message_FeatureNotEnabled" xml:space="preserve">
-    <value>The {0} feature is not enabled.</value>
+    <value>The '{0}' feature is not enabled.</value>
   </data>
   <data name="Message_GeneratedInProcessArtifact" xml:space="preserve">
     <value>Finished generating in-process artifact</value>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Strings.resx
@@ -213,6 +213,15 @@
     <value>Value must be of type string.</value>
     <comment>Gets a string similar to "Value must be of type string.".</comment>
   </data>
+  <data name="FeatureName_CallStacks" xml:space="preserve">
+    <value>Call Stacks</value>
+  </data>
+  <data name="FeatureName_Exceptions" xml:space="preserve">
+    <value>Exceptions</value>
+  </data>
+  <data name="FeatureName_ParameterCapturing" xml:space="preserve">
+    <value>Parameter Capturing</value>
+  </data>
   <data name="LogFormatString_CounterEndedPayload" xml:space="preserve">
     <value>The counter {0} ended and is no longer receiving metrics.</value>
   </data>
@@ -313,6 +322,9 @@
   </data>
   <data name="Message_CollectionRuleStateReason_Throttled" xml:space="preserve">
     <value>This collection rule is temporarily throttled because the ActionCountLimit has been reached within the ActionCountSlidingWindowDuration.</value>
+  </data>
+  <data name="Message_FeatureNotEnabled" xml:space="preserve">
+    <value>The {0} feature is not enabled.</value>
   </data>
   <data name="Message_GeneratedInProcessArtifact" xml:space="preserve">
     <value>Finished generating in-process artifact</value>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -247,8 +247,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 {
                     int processId = await runner.ProcessIdTask;
 
-                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
-                    Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
+                    ValidationProblemDetailsException ex = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
+                    Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
 
                     await runner.SendCommandAsync(TestAppScenarios.Stacks.Commands.Continue);
                 },
@@ -279,8 +279,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 {
                     int processId = await runner.ProcessIdTask;
 
-                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
-                    Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
+                    ValidationProblemDetailsException ex = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => client.CaptureStacksAsync(processId, WebApi.StackFormat.Json));
+                    Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
 
                     await runner.SendCommandAsync(TestAppScenarios.Stacks.Commands.Continue);
                 },

--- a/src/Tools/dotnet-monitor/Experimental/ExperimentalStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/Experimental/ExperimentalStartupLogger.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             if (_parameterCapturingOptions.GetEnabled())
             {
-                _logger.ExperimentalFeatureEnabled(Strings.FeatureName_ParameterCapturing);
+                _logger.ExperimentalFeatureEnabled(Microsoft.Diagnostics.Monitoring.WebApi.Strings.FeatureName_ParameterCapturing);
             }
 
             // Experimental features should log a warning when they are activated e.g.

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -593,33 +593,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Call Stacks.
-        /// </summary>
-        internal static string FeatureName_CallStacks {
-            get {
-                return ResourceManager.GetString("FeatureName_CallStacks", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Exceptions.
-        /// </summary>
-        internal static string FeatureName_Exceptions {
-            get {
-                return ResourceManager.GetString("FeatureName_Exceptions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Parameter Capturing.
-        /// </summary>
-        internal static string FeatureName_ParameterCapturing {
-            get {
-                return ResourceManager.GetString("FeatureName_ParameterCapturing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Monitor logs and metrics in a .NET application send the results to a chosen destination..
         /// </summary>
         internal static string HelpDescription_CommandCollect {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -377,12 +377,6 @@
     <value>'{0}' is not a known trigger type.</value>
     <comment>{0} = The type of trigger that is unknown.</comment>
   </data>
-  <data name="FeatureName_CallStacks" xml:space="preserve">
-    <value>Call Stacks</value>
-  </data>
-  <data name="FeatureName_Exceptions" xml:space="preserve">
-    <value>Exceptions</value>
-  </data>
   <data name="HelpDescription_CommandCollect" xml:space="preserve">
     <value>Monitor logs and metrics in a .NET application send the results to a chosen destination.</value>
     <comment>Gets the string to display in help that explains what the 'collect' command does.</comment>
@@ -912,9 +906,6 @@
 2 Format Parameters:
 0. providerName: The name of the provider that failed validation.
 1. errorMessage: The validation failure message</comment>
-  </data>
-  <data name="FeatureName_ParameterCapturing" xml:space="preserve">
-    <value>Parameter Capturing</value>
   </data>
   <data name="ErrorMessage_UnableToFindHostingStartupAssembly" xml:space="preserve">
     <value>Unable to find hosting startup assembly at determined path.</value>


### PR DESCRIPTION
###### Summary

Instead of returning HTTP 404 for routes that correspond to disabled feature, return HTTP 400 with a detail message:

```bash
curl -k https://localhost:52323/stacks
{"status":400,"detail":"The Call Stacks feature is not enabled."}
```

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Disabled features with HTTP routes will return HTTP 400