### PR TITLE
Prevent managed messaging initialization if profiler is not loaded

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/StartupHook.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/StartupHook.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring.StartupHook.Exceptions;
 using Microsoft.Diagnostics.Monitoring.StartupHook.MonitorMessageDispatcher;
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.HostingStartup;
+using Microsoft.Diagnostics.Tools.Monitor.Profiler;
 using Microsoft.Diagnostics.Tools.Monitor.StartupHook;
 using System;
 using System.IO;
@@ -33,8 +34,12 @@ internal sealed class StartupHook
 
             try
             {
-                SharedInternals.MessageDispatcher = new MonitorMessageDispatcher(new ProfilerMessageSource());
-                ToolIdentifiers.EnableEnvVar(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.ManagedMessaging);
+                // Check that the profiler is loaded before establishing the dispatcher, which has a dependency on the existance of the profiler
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ProfilerIdentifiers.NotifyOnlyProfiler.EnvironmentVariables.ProductVersion)))
+                {
+                    SharedInternals.MessageDispatcher = new MonitorMessageDispatcher(new ProfilerMessageSource());
+                    ToolIdentifiers.EnableEnvVar(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.ManagedMessaging);
+                }
             }
             catch
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/StartupHookTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/StartupHookTests.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tools.Monitor.HostingStartup;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    public sealed class StartupHookTests
+    {
+        private ITestOutputHelper _outputHelper;
+
+        public StartupHookTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Theory]
+        [MemberData(nameof(ProfilerHelper.GetNotifyOnlyArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
+        public async Task StartupHook_WithProfiler_HasManagedMessaging(Architecture architecture, string profilerPath, ProfilerVariant variant)
+        {
+            Assert.Equal(ProfilerVariant.NotifyOnly, variant);
+
+            await using AppRunner runner = new(
+                _outputHelper,
+                Assembly.GetExecutingAssembly());
+            runner.Architecture = architecture;
+            runner.ScenarioName = TestAppScenarios.AsyncWait.Name;
+            runner.EnableMonitorStartupHook = true;
+
+            // Environment variables necessary for running the profiler + enable all logging to stderr
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarEnableNotificationProfilers, ProfilerHelper.ClrEnvVarEnabledValue);
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarEnableProfiling, ProfilerHelper.ClrEnvVarEnabledValue);
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarProfiler, ProfilerIdentifiers.NotifyOnlyProfiler.Clsid.StringWithBraces);
+            runner.Environment.Add(ProfilerHelper.ClrEnvVarProfilerPath, profilerPath);
+            runner.Environment.Add(ProfilerIdentifiers.EnvironmentVariables.RuntimeInstanceId, Guid.NewGuid().ToString("D"));
+
+            await runner.ExecuteAsync(async () =>
+            {
+                DiagnosticsClient client = new(await runner.ProcessIdTask);
+
+                Dictionary<string, string> env = client.GetProcessEnvironment();
+                Assert.True(env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.StartupHook, out string startupHookAvailableValue));
+                Assert.True(ToolIdentifiers.IsEnvVarValueEnabled(startupHookAvailableValue));
+                Assert.True(env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.ManagedMessaging, out string managedMessagingAvailableValue));
+                Assert.True(ToolIdentifiers.IsEnvVarValueEnabled(startupHookAvailableValue));
+
+                await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+            });
+        }
+
+        [Fact]
+        public async Task StartupHook_WithoutProfiler_NoManagedMessaging()
+        {
+            await using AppRunner runner = new(
+                _outputHelper,
+                Assembly.GetExecutingAssembly());
+            runner.ScenarioName = TestAppScenarios.AsyncWait.Name;
+            runner.EnableMonitorStartupHook = true;
+
+            await runner.ExecuteAsync(async () =>
+            {
+                DiagnosticsClient client = new(await runner.ProcessIdTask);
+
+                Dictionary<string, string> env = client.GetProcessEnvironment();
+                Assert.True(env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.StartupHook, out string startupHookAvailableValue));
+                Assert.True(ToolIdentifiers.IsEnvVarValueEnabled(startupHookAvailableValue));
+                Assert.False(env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.ManagedMessaging, out _));
+
+                await runner.SendCommandAsync(TestAppScenarios.AsyncWait.Commands.Continue);
+            });
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/StartupHookTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/StartupHookTests.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             _outputHelper = outputHelper;
         }
 
-        [Theory]
+        // It appears that the profiler isn't loading on musl libc distros for this tests.
+        [ConditionalTheory(typeof(TestConditions), nameof(TestConditions.IsNotAlpine))]
         [MemberData(nameof(ProfilerHelper.GetNotifyOnlyArchitectureProfilerPath), MemberType = typeof(ProfilerHelper))]
         public async Task StartupHook_WithProfiler_HasManagedMessaging(Architecture architecture, string profilerPath, ProfilerVariant variant)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/StartupHookTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/StartupHookTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Monitor.HostingStartup;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -44,6 +45,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             runner.Environment.Add(ProfilerHelper.ClrEnvVarProfiler, ProfilerIdentifiers.NotifyOnlyProfiler.Clsid.StringWithBraces);
             runner.Environment.Add(ProfilerHelper.ClrEnvVarProfilerPath, profilerPath);
             runner.Environment.Add(ProfilerIdentifiers.EnvironmentVariables.RuntimeInstanceId, Guid.NewGuid().ToString("D"));
+            runner.Environment.Add(ProfilerIdentifiers.EnvironmentVariables.StdErrLogger_Level, LogLevel.Trace.ToString("G"));
 
             await runner.ExecuteAsync(async () =>
             {


### PR DESCRIPTION
###### Summary

When parameter capturing is not enabled and no other feature is enabled that requires the profiler, the startup hook will throw a DllNotFoundException exception, which appears in the `/exceptions` history backlog. This happens because the startup hook is attempting to initialize the managed messaging dispatcher, which requires the profiler to have been loaded.

Overview of changes:
- Add an additional check of whether the profiler is loaded before attempting to initialize the dispatcher.
- Add tests to verify the availability of the dispatcher based on the existence of the profiler.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
