### PR TITLE
Enforce editorconfig at build time

### DIFF
--- a/.github/workflows/lint-csharp.yml
+++ b/.github/workflows/lint-csharp.yml
@@ -2,7 +2,7 @@ name: 'C# linting'
 on:
   pull_request:
     paths: ['src/**.cs']
-    branches: ['main', 'release/*']
+    branches: [ 'release/7*', 'release/6*' ]
 
 permissions:
   pull-requests: read

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,8 @@
     <LangVersion>Latest</LangVersion>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -495,6 +495,7 @@
     },
     "CollectionRuleOptions": {
       "type": "object",
+      "description": "Options for describing an entire collection rule.",
       "additionalProperties": false,
       "required": [
         "Trigger"
@@ -621,6 +622,7 @@
     },
     "CollectionRuleTriggerOptions": {
       "type": "object",
+      "description": "Options for describing the type of trigger and the settings to pass to that trigger.",
       "additionalProperties": false,
       "required": [
         "Type"
@@ -750,6 +752,7 @@
     },
     "CollectionRuleActionOptions": {
       "type": "object",
+      "description": "Options for describing the type of action to execute and the settings to pass to that action.",
       "additionalProperties": false,
       "required": [
         "Type"
@@ -917,6 +920,7 @@
     },
     "CollectionRuleLimitsOptions": {
       "type": "object",
+      "description": "Options for limiting the execution of a collection rule.",
       "additionalProperties": false,
       "properties": {
         "ActionCount": {
@@ -1014,6 +1018,7 @@
     },
     "InProcessFeaturesOptions": {
       "type": "object",
+      "description": "Configuration options for in-process features, ones that execute within each target process.",
       "additionalProperties": false,
       "properties": {
         "Enabled": {
@@ -1118,6 +1123,7 @@
             "array",
             "null"
           ],
+          "description": "The list of exception configurations that determine which exceptions should be shown.\nEach configuration is a logical OR, so if any of the configurations match, the exception is shown.",
           "items": {
             "$ref": "#/definitions/ExceptionFilter"
           }
@@ -1127,6 +1133,7 @@
             "array",
             "null"
           ],
+          "description": "The list of exception configurations that determine which exceptions should be shown.\nEach configuration is a logical OR, so if any of the configurations match, the exception isn't shown.",
           "items": {
             "$ref": "#/definitions/ExceptionFilter"
           }
@@ -1296,6 +1303,7 @@
     },
     "FileSystemEgressProviderOptions": {
       "type": "object",
+      "description": "Egress provider options for file system egress.",
       "additionalProperties": false,
       "required": [
         "DirectoryPath"
@@ -1327,6 +1335,7 @@
     },
     "MetricsOptions": {
       "type": "object",
+      "description": "Configuration for prometheus metric collection and retrieval.\nTODO We may want to expose https endpoints here as well, and make port changes\nTODO How do we determine which process to scrape in multi-proc situations? How do we configure this\nfor situations where the pid is not known or ambiguous?",
       "additionalProperties": false,
       "properties": {
         "Enabled": {
@@ -1595,6 +1604,7 @@
     },
     "TemplateOptions": {
       "type": "object",
+      "description": "Options for describing custom user-defined templates.",
       "additionalProperties": false,
       "properties": {
         "CollectionRuleFilters": {
@@ -1657,6 +1667,7 @@
     },
     "CollectDumpOptions": {
       "type": "object",
+      "description": "Options for the CollectDump action.",
       "additionalProperties": false,
       "properties": {
         "Type": {
@@ -1743,6 +1754,7 @@
     },
     "CollectGCDumpOptions": {
       "type": "object",
+      "description": "Options for the CollectGCDump action.",
       "additionalProperties": false,
       "properties": {
         "Egress": {
@@ -1754,6 +1766,7 @@
     },
     "CollectLiveMetricsOptions": {
       "type": "object",
+      "description": "Options for the CollectLiveMetrics action.",
       "additionalProperties": false,
       "properties": {
         "IncludeDefaultProviders": {
@@ -1846,6 +1859,7 @@
     },
     "CollectLogsOptions": {
       "type": "object",
+      "description": "Options for the CollectLogs action.",
       "additionalProperties": false,
       "properties": {
         "DefaultLevel": {
@@ -1966,6 +1980,7 @@
     },
     "CollectTraceOptions": {
       "type": "object",
+      "description": "Options for the CollectTrace action.",
       "additionalProperties": false,
       "properties": {
         "Profile": {
@@ -2105,6 +2120,7 @@
     },
     "TraceEventFilter": {
       "type": "object",
+      "description": "A trace event filter.",
       "additionalProperties": false,
       "required": [
         "ProviderName",
@@ -2135,6 +2151,7 @@
     },
     "ExecuteOptions": {
       "type": "object",
+      "description": "Options for the Execute action.",
       "additionalProperties": false,
       "required": [
         "Path"
@@ -2163,6 +2180,7 @@
     },
     "LoadProfilerOptions": {
       "type": "object",
+      "description": "Options for the LoadProfilerAction action.",
       "additionalProperties": false,
       "required": [
         "Path",
@@ -2184,6 +2202,7 @@
     },
     "SetEnvironmentVariableOptions": {
       "type": "object",
+      "description": "Options for the SetEnvironmentVariable action.",
       "additionalProperties": false,
       "required": [
         "Name"
@@ -2205,6 +2224,7 @@
     },
     "GetEnvironmentVariableOptions": {
       "type": "object",
+      "description": "Options for the GetEnvironmentVariable action.",
       "additionalProperties": false,
       "required": [
         "Name"
@@ -2233,6 +2253,7 @@
     },
     "AspNetRequestCountOptions": {
       "type": "object",
+      "description": "Options for the AspNetRequestCount trigger.",
       "additionalProperties": false,
       "properties": {
         "RequestCount": {
@@ -2274,6 +2295,7 @@
     },
     "AspNetRequestDurationOptions": {
       "type": "object",
+      "description": "Options for the AspNetRequestDuration trigger.",
       "additionalProperties": false,
       "properties": {
         "RequestCount": {
@@ -2324,6 +2346,7 @@
     },
     "AspNetResponseStatusOptions": {
       "type": "object",
+      "description": "Options for the AspNetResponseStatus trigger.",
       "additionalProperties": false,
       "required": [
         "StatusCodes"
@@ -2377,6 +2400,7 @@
     },
     "EventCounterOptions": {
       "type": "object",
+      "description": "Options for the EventCounter trigger.",
       "additionalProperties": false,
       "required": [
         "ProviderName",
@@ -2421,6 +2445,7 @@
     },
     "CPUUsageOptions": {
       "type": "object",
+      "description": "Options for the CPUUsage trigger.",
       "additionalProperties": false,
       "properties": {
         "GreaterThan": {
@@ -2457,6 +2482,7 @@
     },
     "GCHeapSizeOptions": {
       "type": "object",
+      "description": "Options for the GCHeapSize trigger.",
       "additionalProperties": false,
       "properties": {
         "GreaterThan": {
@@ -2491,6 +2517,7 @@
     },
     "ThreadpoolQueueLengthOptions": {
       "type": "object",
+      "description": "Options for the ThreadpoolQueueLength trigger.",
       "additionalProperties": false,
       "properties": {
         "GreaterThan": {
@@ -2525,6 +2552,7 @@
     },
     "EventMeterOptions": {
       "type": "object",
+      "description": "Options for the EventMeter trigger.",
       "additionalProperties": false,
       "required": [
         "MeterName",
@@ -2722,6 +2750,7 @@
     },
     "AzureBlobEgressProviderOptions": {
       "type": "object",
+      "description": "Egress provider options for Azure blob storage.",
       "additionalProperties": false,
       "required": [
         "AccountUri",
@@ -2841,6 +2870,7 @@
     },
     "S3StorageEgressProviderOptions": {
       "type": "object",
+      "description": "Egress provider options for S3 storage.",
       "additionalProperties": false,
       "required": [
         "BucketName"

--- a/eng/release/DiagnosticsReleaseTool/Common/BlobLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/BlobLayoutWorker.cs
@@ -1,4 +1,5 @@
-using System.IO;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace ReleaseTool.Core
 {
@@ -9,6 +10,7 @@ namespace ReleaseTool.Core
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Blob),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Blob),
             stagingPath
-        ){}
+        )
+        { }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Common/ChecksumLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/ChecksumLayoutWorker.cs
@@ -1,4 +1,5 @@
-using System.IO;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace ReleaseTool.Core
 {
@@ -9,6 +10,7 @@ namespace ReleaseTool.Core
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Checksum),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Checksum),
             stagingPath
-        ){}
+        )
+        { }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Common/FileIgnoreWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/FileIgnoreWorker.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 using System.Threading;
@@ -14,11 +17,11 @@ namespace ReleaseTool.Core
             _shouldHandleFileFunc = shouldHandleFileFunc;
         }
 
-        public void Dispose() {}
+        public void Dispose() { }
 
         public ValueTask<LayoutWorkerResult> HandleFileAsync(FileInfo file, CancellationToken ct)
         {
-            LayoutResultStatus status = _shouldHandleFileFunc(file) ? 
+            LayoutResultStatus status = _shouldHandleFileFunc(file) ?
                 LayoutResultStatus.FileHandled : LayoutResultStatus.FileNotHandled;
 
             return new ValueTask<LayoutWorkerResult>(new LayoutWorkerResult(status));

--- a/eng/release/DiagnosticsReleaseTool/Common/FileSharePublisher.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/FileSharePublisher.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Buffers;
 using System.IO;

--- a/eng/release/DiagnosticsReleaseTool/Common/NugetLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/NugetLayoutWorker.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 
@@ -10,6 +13,7 @@ namespace ReleaseTool.Core
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.Nuget),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.Nuget),
             stagingPath
-        ){}
+        )
+        { }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Common/PassThroughLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/PassThroughLayoutWorker.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 using System.Threading;
@@ -28,7 +31,7 @@ namespace ReleaseTool.Core
             _stagingPath = stagingPath;
         }
 
-        public void Dispose() {}
+        public void Dispose() { }
 
         public async ValueTask<LayoutWorkerResult> HandleFileAsync(FileInfo file, CancellationToken ct)
         {

--- a/eng/release/DiagnosticsReleaseTool/Common/ReleaseToolHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/ReleaseToolHelpers.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 

--- a/eng/release/DiagnosticsReleaseTool/Common/SkipPublisher.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/SkipPublisher.cs
@@ -1,4 +1,6 @@
-﻿using ReleaseTool.Core;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/eng/release/DiagnosticsReleaseTool/Common/SymbolPackageLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/SymbolPackageLayoutWorker.cs
@@ -1,4 +1,5 @@
-using System.IO;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace ReleaseTool.Core
 {
@@ -9,6 +10,7 @@ namespace ReleaseTool.Core
             getRelativePublishPathFromFileFunc: static file => Helpers.GetDefaultPathForFileCategory(file, FileClass.SymbolPackage),
             getMetadataForFileFunc: static file => Helpers.GetDefaultFileMetadata(file, FileClass.SymbolPackage),
             stagingPath
-        ) {}
+        )
+        { }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Common/ZipLayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Common/ZipLayoutWorker.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -43,17 +46,19 @@ namespace ReleaseTool.Core
 
             DirectoryInfo unzipDirInfo = null;
 
-            try {
-                do {
+            try
+            {
+                do
+                {
                     string tempUnzipPath = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
                     unzipDirInfo = new DirectoryInfo(tempUnzipPath);
-                } while(unzipDirInfo.Exists);
+                } while (unzipDirInfo.Exists);
 
                 unzipDirInfo.Create();
                 // TODO: Do we really want to block because of unzipping. We could use ZipArchive.
                 System.IO.Compression.ZipFile.ExtractToDirectory(file.FullName, unzipDirInfo.FullName);
             }
-            catch(Exception ex) when (ex is IOException || ex is System.Security.SecurityException)
+            catch (Exception ex) when (ex is IOException || ex is System.Security.SecurityException)
             {
                 return new LayoutWorkerResult(LayoutResultStatus.Error);
             }

--- a/eng/release/DiagnosticsReleaseTool/Core/FileMapping.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/FileMapping.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace ReleaseTool.Core
 {
     public struct FileMapping

--- a/eng/release/DiagnosticsReleaseTool/Core/FileMetadata.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/FileMetadata.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 
 namespace ReleaseTool.Core
@@ -26,7 +29,7 @@ namespace ReleaseTool.Core
         // TODO: Add a metadata bag for Key,Value pairs.
 
         public FileMetadata(FileClass fileClass, string assetCategory, string sha512)
-            : this(fileClass, assetCategory, shouldPublishToCdn: false, rid: "any", sha512: sha512) {}
+            : this(fileClass, assetCategory, shouldPublishToCdn: false, rid: "any", sha512: sha512) { }
 
         public FileMetadata(FileClass fileClass, string assetCategory, bool shouldPublishToCdn, string rid, string sha512)
         {

--- a/eng/release/DiagnosticsReleaseTool/Core/FileReleaseData.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/FileReleaseData.cs
@@ -1,9 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace ReleaseTool.Core
 {
     public class FileReleaseData
     {
         public FileReleaseData(FileMapping fileMap, FileMetadata fileMetadata)
-            : this(fileMap, fileMetadata, null) {}
+            : this(fileMap, fileMetadata, null) { }
 
         private FileReleaseData(FileMapping fileMap, FileMetadata fileMetadata, string publishUri)
         {

--- a/eng/release/DiagnosticsReleaseTool/Core/FileWithCdnData.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/FileWithCdnData.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace ReleaseTool.Core
 {
     public struct FileWithCdnData

--- a/eng/release/DiagnosticsReleaseTool/Core/ILayoutWorker.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/ILayoutWorker.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 using System.Threading;

--- a/eng/release/DiagnosticsReleaseTool/Core/IManifestGenerator.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/IManifestGenerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 

--- a/eng/release/DiagnosticsReleaseTool/Core/IPublisher.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/IPublisher.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/eng/release/DiagnosticsReleaseTool/Core/IReleaseVerifier.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/IReleaseVerifier.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 

--- a/eng/release/DiagnosticsReleaseTool/Core/LayoutWorkerResult.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/LayoutWorkerResult.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Generic;
 
 namespace ReleaseTool.Core
@@ -22,6 +25,6 @@ namespace ReleaseTool.Core
                                                 ? fileLayoutDataEnumerable
                                                 : System.Linq.Enumerable.Empty<(FileMapping, FileMetadata)>();
         }
-        public LayoutWorkerResult(LayoutResultStatus status) : this(status, null) {}
+        public LayoutWorkerResult(LayoutResultStatus status) : this(status, null) { }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Core/Release.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/Release.cs
@@ -1,11 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ReleaseTool.Core
 {
@@ -22,7 +25,7 @@ namespace ReleaseTool.Core
         private readonly List<FileReleaseData> _filesToRelease;
         private ILogger _logger;
 
-        public Release(DirectoryInfo productBuildPath, 
+        public Release(DirectoryInfo productBuildPath,
             List<ILayoutWorker> layoutWorkers, List<IReleaseVerifier> verifiers,
             IPublisher publisher, IManifestGenerator manifestGenerator, string manifestSavePath)
         {
@@ -102,21 +105,21 @@ namespace ReleaseTool.Core
             }
             catch (TaskCanceledException)
             {
-               _logger.LogError("Cancellation issued.");
+                _logger.LogError("Cancellation issued.");
                 return -1;
             }
             catch (AggregateException agEx)
             {
-               _logger.LogError("Aggregate Exception");
+                _logger.LogError("Aggregate Exception");
 
                 foreach (var ex in agEx.InnerExceptions)
-                   _logger.LogError(ex, "Inner Exception");
+                    _logger.LogError(ex, "Inner Exception");
 
                 return -1;
             }
             catch (Exception ex)
             {
-               _logger.LogError(ex, "Exception");
+                _logger.LogError(ex, "Exception");
                 return -1;
             }
         }
@@ -271,10 +274,10 @@ namespace ReleaseTool.Core
 
         public void Dispose()
         {
-            foreach(ILayoutWorker lw in _layoutWorkers)
+            foreach (ILayoutWorker lw in _layoutWorkers)
                 lw.Dispose();
 
-            foreach(IReleaseVerifier rv in _verifiers)
+            foreach (IReleaseVerifier rv in _verifiers)
                 rv.Dispose();
 
             _publisher.Dispose();

--- a/eng/release/DiagnosticsReleaseTool/Core/ReleaseMetadata.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/ReleaseMetadata.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace ReleaseTool.Core
 {
     public class ReleaseMetadata

--- a/eng/release/DiagnosticsReleaseTool/Core/SingleFileResult.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/SingleFileResult.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections;
 using System.Collections.Generic;
 

--- a/eng/release/DiagnosticsReleaseTool/DarcHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DarcHelpers.cs
@@ -1,9 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ReleaseTool.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using ReleaseTool.Core;
 
 namespace DiagnosticsReleaseTool.Util
 {
@@ -47,10 +50,10 @@ namespace DiagnosticsReleaseTool.Util
 
                 // This iteration is necessary due to the public/private nature repos.
                 var repoBuilds = buildList.EnumerateArray()
-                                          .Where(build => 
+                                          .Where(build =>
                                           {
-                                            var buildUri = new Uri(build.GetProperty("repo").GetString());
-                                            return repoUrls.Any(repoUrl => buildUri == new Uri(repoUrl));
+                                              var buildUri = new Uri(build.GetProperty("repo").GetString());
+                                              return repoUrls.Any(repoUrl => buildUri == new Uri(repoUrl));
                                           });
 
                 if (repoBuilds.Count() != 1)

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
@@ -1,14 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using ReleaseTool.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
-using DiagnosticsReleaseTool.Util;
-using Microsoft.Extensions.Logging;
-using ReleaseTool.Core;
 
 namespace DiagnosticsReleaseTool.Impl
 {
@@ -83,7 +83,7 @@ namespace DiagnosticsReleaseTool.Impl
             // There's no way to obtain the json DOM for an object...
             byte[] metadataJsonObj = JsonSerializer.SerializeToUtf8Bytes<ReleaseMetadata>(_productReleaseMetadata);
             JsonDocument metadataDoc = JsonDocument.Parse(metadataJsonObj);
-            foreach(var element in metadataDoc.RootElement.EnumerateObject())
+            foreach (var element in metadataDoc.RootElement.EnumerateObject())
             {
                 element.WriteTo(writer);
             }

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLineUtil.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLineUtil.cs
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
 using System.CommandLine.Invocation;

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
@@ -1,11 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.IO;
 
 namespace DiagnosticsReleaseTool.Util
 {
     public static class DiagnosticsRepoHelpers
     {
-        public static readonly string[] ProductNames = new []{ "dotnet-monitor", "dotnet-dotnet-monitor" };
-        public static readonly string[] RepositoryUrls = new [] { "https://github.com/dotnet/dotnet-monitor", "https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor" };
+        public static readonly string[] ProductNames = new[] { "dotnet-monitor", "dotnet-dotnet-monitor" };
+        public static readonly string[] RepositoryUrls = new[] { "https://github.com/dotnet/dotnet-monitor", "https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor" };
         internal static bool IsDockerUtilityFile(FileInfo arg) =>
             arg.FullName.EndsWith(".nupkg.version")
             || arg.FullName.EndsWith(".nupkg.buildversion");

--- a/src/Extensions/Directory.Build.props
+++ b/src/Extensions/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/KeyValueLogScopeExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/KeyValueLogScopeExtensions.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Globalization;
 
 #if HOSTINGSTARTUP
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup
 #else
+using System.Globalization;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 #endif
 {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -13,7 +13,6 @@
     <IsShippingAssembly>true</IsShippingAssembly>
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             if (!string.IsNullOrEmpty(commandLine))
             {
                 // Get the process name from the command line
-                bool isWindowsProcess = false;
+                bool isWindowsProcess;
                 if (string.IsNullOrEmpty(operatingSystem))
                 {
                     // If operating system is null, the process is likely .NET Core 3.1 (which doesn't have the GetProcessInfo command).

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/TestEgressProviderOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/TestEgressProviderOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CommonTestTimeouts.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         /// </summary>
         public static readonly TimeSpan LiveMetricsTimeout = GeneralTimeout;
 
+        /// <summary>
         /// Default timeout for gcdump collection.
         /// </summary>
         /// <remarks>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Any authenticated route on the default address should 401 Unauthenticated
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
 
             // TODO: Verify other routes (e.g. /dump, /trace, /logs) also 401 Unauthenticated
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             // Any non-metrics route on the metrics address should 404 Not Found
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.NotFound, statusCodeException.StatusCode);
 
             // TODO: Verify other routes (e.g. /dump, /trace, /logs) also 404 Not Found
@@ -185,7 +185,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             }
 
             // check that the old key is now invalid
-            ApiStatusCodeException thrownEx = await Assert.ThrowsAsync<ApiStatusCodeException>(async () => await apiClient.GetProcessesAsync());
+            ApiStatusCodeException thrownEx = await Assert.ThrowsAsync<ApiStatusCodeException>(apiClient.GetProcessesAsync);
             Assert.True(HttpStatusCode.Unauthorized == thrownEx.StatusCode);
 
             _outputHelper.WriteLine("Verifying new API key.");
@@ -247,7 +247,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 }
                 else
                 {
-                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(async () => { await apiClient.GetProcessesAsync(); });
+                    ApiStatusCodeException ex = await Assert.ThrowsAsync<ApiStatusCodeException>(apiClient.GetProcessesAsync);
                     Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
                 }
             }
@@ -287,7 +287,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -315,7 +315,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -344,7 +344,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -372,7 +372,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -436,7 +436,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(expectedError, statusCodeException.StatusCode);
         }
 
@@ -533,7 +533,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Test that clearing the Authorization header will result in a 401
             httpClient.DefaultRequestHeaders.Authorization = null;
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -565,7 +565,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, apiKey);
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -608,7 +608,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
@@ -661,7 +661,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             if (EnvironmentInformation.IsElevated)
             {
                 var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                    () => client.GetProcessesAsync());
+                    client.GetProcessesAsync);
                 Assert.Equal(HttpStatusCode.Forbidden, statusCodeException.StatusCode);
             }
             else

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AzureAdIntegrationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AzureAdIntegrationTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
-                () => apiClient.GetProcessesAsync());
+                apiClient.GetProcessesAsync);
             Assert.Equal(HttpStatusCode.Forbidden, statusCodeException.StatusCode);
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DiagnosticPortTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/DiagnosticPortTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             toolRunner.ConfigurationFromEnvironment.SetDefaultSharedPath(defaultSharedTempDir.FullName);
 
             // dotnet-monitor will fail to start due to misconfigured diagnostic port
-            await Assert.ThrowsAsync<InvalidOperationException>(() => toolRunner.StartAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(toolRunner.StartAsync);
 
             AssertDefaultDiagnosticPortNotExists(defaultSharedTempDir);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// Get /process?pid={pid}&uid={uid}&name={name}
+        /// Get <![CDATA[/process?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public Task<ProcessInfo> GetProcessAsync(int? pid, Guid? uid, string name, CancellationToken token)
         {
@@ -208,7 +208,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /dump?pid={pid}&type={dumpType}
+        /// Get <![CDATA[/dump?pid={pid}&type={dumpType}]]>
         /// </summary>
         public Task<ResponseStreamHolder> CaptureDumpAsync(int pid, DumpType dumpType, CancellationToken token)
         {
@@ -216,7 +216,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /dump?uid={uid}&type={dumpType}
+        /// Get <![CDATA[/dump?uid={uid}&type={dumpType}]]>
         /// </summary>
         public Task<ResponseStreamHolder> CaptureDumpAsync(Guid uid, DumpType dumpType, CancellationToken token)
         {
@@ -254,7 +254,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// Get /collectionrules?pid={pid}&uid={uid}&name={name}
+        /// Get <![CDATA[/collectionrules?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public Task<Dictionary<string, CollectionRuleDescription>> GetCollectionRulesDescriptionAsync(int? pid, Guid? uid, string name, CancellationToken token)
         {
@@ -290,7 +290,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// GET /collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name}
+        /// GET <![CDATA[/collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public Task<CollectionRuleDetailedDescription> GetCollectionRuleDetailedDescriptionAsync(string collectionRuleName, int? pid, Guid? uid, string name, CancellationToken token)
         {
@@ -325,7 +325,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /logs?pid={pid}&level={logLevel}&durationSeconds={duration}
+        /// GET <![CDATA[/logs?pid={pid}&level={logLevel}&durationSeconds={duration}]]>
         /// </summary>
         public Task<ResponseStreamHolder> CaptureLogsAsync(int pid, TimeSpan duration, LogLevel? logLevel, LogFormat logFormat, CancellationToken token)
         {
@@ -333,7 +333,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /logs?uid={uid}&level={logLevel}&durationSeconds={duration}
+        /// GET <![CDATA[/logs?uid={uid}&level={logLevel}&durationSeconds={duration}]]>
         /// </summary>
         public Task<ResponseStreamHolder> CaptureLogsAsync(Guid uid, TimeSpan duration, LogLevel? logLevel, LogFormat logFormat, CancellationToken token)
         {
@@ -351,7 +351,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// POST /logs?pid={pid}&durationSeconds={duration}
+        /// POST <![CDATA[/logs?pid={pid}&durationSeconds={duration}]]>
         /// </summary>
         public Task<ResponseStreamHolder> CaptureLogsAsync(int pid, TimeSpan duration, LogsConfiguration configuration, LogFormat logFormat, CancellationToken token)
         {
@@ -412,7 +412,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /trace?pid={pid}&profile={profile}&durationSeconds={duration}
+        /// GET <![CDATA[/trace?pid={pid}&profile={profile}&durationSeconds={duration}]]>
         /// </summary>
         public Task<ResponseStreamHolder> CaptureTraceAsync(int pid, TimeSpan duration, TraceProfile? profile, CancellationToken token)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// Get /process?pid={pid}&uid={uid}&name={name}
+        /// Get <![CDATA[/process?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public static async Task<ProcessInfo> GetProcessAsync(this ApiClient client, int? pid, Guid? uid, string name, TimeSpan timeout)
         {
@@ -146,7 +146,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /process?pid={pid}&uid={uid}&name={name} with retry attempts.
+        /// Get <![CDATA[/process?pid={pid}&uid={uid}&name={name}]]> with retry attempts.
         /// </summary>
         public static async Task<ProcessInfo> GetProcessWithRetryAsync(this ApiClient client, ITestOutputHelper outputHelper, int? pid = null, Guid? uid = null, string name = null, int maxAttempts = 5)
         {
@@ -222,7 +222,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /dump?pid={pid}&type={dumpType}
+        /// Get <![CDATA[/dump?pid={pid}&type={dumpType}]]>
         /// </summary>
         public static Task<ResponseStreamHolder> CaptureDumpAsync(this ApiClient client, int pid, DumpType dumpType)
         {
@@ -230,7 +230,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /dump?pid={pid}&type={dumpType}
+        /// Get <![CDATA[/dump?pid={pid}&type={dumpType}]]>
         /// </summary>
         public static async Task<ResponseStreamHolder> CaptureDumpAsync(this ApiClient client, int pid, DumpType dumpType, TimeSpan timeout)
         {
@@ -239,7 +239,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /dump?uid={uid}&type={dumpType}
+        /// Get <![CDATA[/dump?uid={uid}&type={dumpType}]]>
         /// </summary>
         public static Task<ResponseStreamHolder> CaptureDumpAsync(this ApiClient client, Guid uid, DumpType dumpType)
         {
@@ -247,7 +247,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// Get /dump?uid={uid}&type={dumpType}
+        /// Get <![CDATA[/dump?uid={uid}&type={dumpType}]]>
         /// </summary>
         public static async Task<ResponseStreamHolder> CaptureDumpAsync(this ApiClient client, Guid uid, DumpType dumpType, TimeSpan timeout)
         {
@@ -256,7 +256,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /logs?pid={pid}&level={logLevel}&durationSeconds={duration}
+        /// GET <![CDATA[/logs?pid={pid}&level={logLevel}&durationSeconds={duration}]]>
         /// </summary>
         public static Task<ResponseStreamHolder> CaptureLogsAsync(this ApiClient client, int pid, TimeSpan duration, LogLevel? logLevel, LogFormat logFormat)
         {
@@ -264,7 +264,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /logs?pid={pid}&level={logLevel}&durationSeconds={duration}
+        /// GET <![CDATA[/logs?pid={pid}&level={logLevel}&durationSeconds={duration}]]>
         /// </summary>
         public static async Task<ResponseStreamHolder> CaptureLogsAsync(this ApiClient client, int pid, TimeSpan duration, LogLevel? logLevel, TimeSpan timeout, LogFormat logFormat)
         {
@@ -273,7 +273,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// POST /logs?pid={pid}&durationSeconds={duration}
+        /// POST <![CDATA[/logs?pid={pid}&durationSeconds={duration}]]>
         /// </summary>
         public static Task<ResponseStreamHolder> CaptureLogsAsync(this ApiClient client, int pid, TimeSpan duration, LogsConfiguration configuration, LogFormat logFormat)
         {
@@ -281,7 +281,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// POST /logs/{pid}?durationSeconds={duration}
+        /// POST <![CDATA[/logs/{pid}?durationSeconds={duration}]]>
         /// </summary>
         public static async Task<ResponseStreamHolder> CaptureLogsAsync(this ApiClient client, int pid, TimeSpan duration, LogsConfiguration configuration, TimeSpan timeout, LogFormat logFormat)
         {
@@ -290,7 +290,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /trace?pid={pid}&profile={profile}&durationSeconds={duration}
+        /// GET <![CDATA[/trace?pid={pid}&profile={profile}&durationSeconds={duration}]]>
         /// </summary>
         public static Task<ResponseStreamHolder> CaptureTraceAsync(this ApiClient client, int pid, TimeSpan duration, TraceProfile? profile)
         {
@@ -298,7 +298,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         }
 
         /// <summary>
-        /// GET /trace?pid={pid}&profile={profile}&durationSeconds={duration}
+        /// GET <![CDATA[/trace?pid={pid}&profile={profile}&durationSeconds={duration}]]>
         /// </summary>
         public static async Task<ResponseStreamHolder> CaptureTraceAsync(this ApiClient client, int pid, TimeSpan duration, TraceProfile? profile, TimeSpan timeout)
         {
@@ -405,7 +405,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// GET /collectionrules?pid={pid}&uid={uid}&name={name}
+        /// GET <![CDATA[/collectionrules?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public static Task<Dictionary<string, CollectionRuleDescription>> GetCollectionRulesDescriptionAsync(this ApiClient client, int? pid, Guid? uid, string name)
         {
@@ -414,7 +414,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// GET /collectionrules?pid={pid}&uid={uid}&name={name}
+        /// GET <![CDATA[/collectionrules?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public static async Task<Dictionary<string, CollectionRuleDescription>> GetCollectionRulesDescriptionAsync(this ApiClient client, int? pid, Guid? uid, string name, TimeSpan timeout)
         {
@@ -424,7 +424,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// GET /collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name}
+        /// GET <![CDATA[/collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public static Task<CollectionRuleDetailedDescription> GetCollectionRuleDetailedDescriptionAsync(this ApiClient client, string collectionRuleName, int? pid, Guid? uid, string name)
         {
@@ -433,7 +433,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
 
         /// <summary>
         /// Capable of getting every combination of process query: PID, UID, and/or Name
-        /// GET /collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name}
+        /// GET <![CDATA[/collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name}]]>
         /// </summary>
         public static async Task<CollectionRuleDetailedDescription> GetCollectionRuleDetailedDescriptionAsync(this ApiClient client, string collectionRuleName, int? pid, Guid? uid, string name, TimeSpan timeout)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -15,7 +15,9 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+#if NET7_0_OR_GREATER
 using System.Threading;
+#endif
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.Options;
-using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
@@ -132,7 +131,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             return options;
         }
 
-        internal async static Task<CollectionRuleActionResult> ExecuteAndDisposeAsync(ICollectionRuleAction action, TimeSpan timeout)
+        internal static async Task<CollectionRuleActionResult> ExecuteAndDisposeAsync(ICollectionRuleAction action, TimeSpan timeout)
         {
             using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(timeout);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestDotnetToolsFileSystem.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestDotnetToolsFileSystem.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
@@ -83,10 +83,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
                     builder.AddInMemoryCollection(configurationValues);
 
-                    if (null != overrideSource)
-                    {
-                        overrideSource.ForEach(source => builder.Sources.Add(source));
-                    }
+                    overrideSource?.ForEach(source => builder.Sources.Add(source));
                 })
                 .ConfigureLogging(loggingBuilder =>
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestOutputLogger.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestOutputLogger.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 WriteLine($"Message: {exception.Message}");
                 WriteLine("Start Stack");
                 StringReader reader = new(exception.StackTrace);
-                string line = null;
+                string line;
                 while (null != (line = reader.ReadLine()))
                 {
                     WriteLine(line);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsStoreLimitsCallbackTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ExceptionsStoreLimitsCallbackTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         }
 
         /// <summary>
-        /// Validates that a <see cref="ConfiguredExceptionsStore"/> will throw with invalid top level limit.
+        /// Validates that a <see cref="ExceptionsStoreLimitsCallback"/> will throw with invalid top level limit.
         /// </summary>
         [Fact]
         public void ExceptionsStoreLimitsCallback_LimitZero_ThrowsException()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/InProcessFeaturesOptionsBinderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/InProcessFeaturesOptionsBinderTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         }
 
         /// <summary>
-        /// Tests that a feature is enabled if InProcessFeatures:<Feature>:Enabled is true.
+        /// Tests that a feature is enabled if <![CDATA[InProcessFeatures:<Feature>:Enabled]]> is true.
         /// </summary>
         [Fact]
         public void InProcessFeaturesOptionsBinder_BindEnabled_EnabledProperty()
@@ -175,7 +175,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         }
 
         /// <summary>
-        /// Tests that a feature is disabled if InProcessFeatures:<Feature>:Enabled is true
+        /// Tests that a feature is disabled if <![CDATA[InProcessFeatures:<Feature>:Enabled]]> is true
         /// and InProcessFeatures:Enabled is false.
         /// </summary>
         [Fact]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/FunctionProbes/FunctionProbesScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/FunctionProbes/FunctionProbesScenario.cs
@@ -6,7 +6,9 @@ using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Functio
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using SampleMethods;
 using System;
+#if NET7_0_OR_GREATER
 using System.Collections.Generic;
+#endif
 using System.CommandLine;
 using System.Linq;
 using System.Reflection;

--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackAsTool>true</PackAsTool>

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerChangeTokenSource.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
         }
 
         /// <summary>
-        /// Returns Named config instance. <see cref="JwtBearerOptions>" /> expects
+        /// Returns Named config instance. <see cref="JwtBearerOptions" /> expects
         /// its configuration to be named after the AuthenticationScheme it's using, not <see cref="Options.DefaultName"/>.
         /// </summary>
         public string Name => JwtBearerDefaults.AuthenticationScheme;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {
     /// <summary>
-    /// Options for the <see cref="CollectionRules.Actions.GetEnvironmentVariableAction"/> action.
+    /// Options for the GetEnvironmentVariable action.
     /// </summary>
     [DebuggerDisplay("GetEnvironmentVariable")]
 #if SCHEMAGEN

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/LoadProfilerOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/LoadProfilerOptions.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {
     /// <summary>
-    /// Options for the <see cref="CollectionRules.Actions.LoadProfilerActionFactory.LoadProfilerAction"/> action.
+    /// Options for the LoadProfilerAction action.
     /// </summary>
     [DebuggerDisplay("LoadProfiler")]
 #if SCHEMAGEN

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 {
     /// <summary>
-    /// Options for the <see cref="CollectionRules.Actions.SetEnvironmentVariableAction"/> action.
+    /// Options for the SetEnvironmentVariable action.
     /// </summary>
     [DebuggerDisplay("SetEnvironmentVariable")]
 #if SCHEMAGEN

--- a/src/Tools/dotnet-monitor/Egress/Configuration/IEgressConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/IEgressConfigurationProvider.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
         IEnumerable<string> ProviderTypes { get; }
 
         /// <summary>
-        /// Gets the set of keys defined as a <see cref="IDictionary{string, string}"/> with values populated.
+        /// Gets the set of keys defined as a <see cref="IDictionary{TKey, TValue}"/> with values populated.
         /// </summary>
-        /// <returns><see cref="IDictionary{string, string}"/> representing the set of properties.</returns>
+        /// <returns><see cref="IDictionary{TKey, TValue}"/> representing the set of properties.</returns>
         IDictionary<string, string> GetAllProperties();
 
         /// <summary>

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         /// <summary>
         /// Accepts endpoint infos from the reversed diagnostics server.
         /// </summary>
-        /// <param name="maxConnections">The maximum number of connections the server will support.</param>
+        /// <param name="server">The reversed diagnostics server instance from which connections are accepted.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         private async Task ListenAsync(ReversedDiagnosticsServer server, CancellationToken token)
         {

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionRepository.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionRepository.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {

--- a/src/Tools/dotnet-monitor/Extensibility/IDotnetToolsFileSystem.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/IDotnetToolsFileSystem.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Extensibility
 {

--- a/src/Tools/dotnet-monitor/Swagger/Filters/BadRequestResponseDocumentFilter.cs
+++ b/src/Tools/dotnet-monitor/Swagger/Filters/BadRequestResponseDocumentFilter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger.Filters
                     {
                         Reference = new OpenApiReference()
                         {
-                            Id = typeof(ValidationProblemDetails).Name,
+                            Id = nameof(ValidationProblemDetails),
                             Type = ReferenceType.Schema
                         }
                     }

--- a/src/Tools/dotnet-monitor/Swagger/Filters/TooManyRequestsResponseDocumentFilter.cs
+++ b/src/Tools/dotnet-monitor/Swagger/Filters/TooManyRequestsResponseDocumentFilter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger.Filters
                      {
                          Reference = new OpenApiReference()
                          {
-                             Id = typeof(ProblemDetails).Name,
+                             Id = nameof(ProblemDetails),
                              Type = ReferenceType.Schema
                          }
                      }


### PR DESCRIPTION
###### Summary

- Enforce editorconfig code style at build time
- Fixup existing violations of the editorconfig
- Only have C# linting run on 7.x and lower

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
