### PR TITLE
Use final stable version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,8 +9,7 @@
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>8.0.0</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
-    <!-- Disable final version kind until merged into release branch. -->
-    <!--<DotnetFinalVersionKind>release</DotnetFinalVersionKind>-->
+    <DotnetFinalVersionKind>release</DotnetFinalVersionKind>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!--
       Build quality notion for blob group naming, similar to aka.ms channel build quality in Arcade:


### PR DESCRIPTION
###### Summary

Change `release/8.x` to produce stable versions.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
