### PR TITLE
[release/7.x] Fix GetBuildVersion.ps1 to correctly look up the build version

### DIFF
--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -19,7 +19,7 @@ Write-Verbose 'ReleaseData:'
 $releaseDataJson = $releaseData | ConvertTo-Json
 Write-Verbose $releaseDataJson
 
-[array]$matchingData = $releaseData | Where-Object { $_.name -match '.nupkg.buildversion$' }
+[array]$matchingData = $releaseData | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping -ieq 'true' }
 
 if ($matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'


### PR DESCRIPTION
###### Summary

Manual backport of #3661 and #3660 to `release/7.x`

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
