### PR TITLE
[release/6.x] Add GetBuildVersion.ps1 script

### DIFF
--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][string] $BarId,
+    [Parameter(Mandatory=$true)][string] $MaestroToken,
+    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
+    [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2020-02-20',
+    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+[array]$releaseData = Invoke-RestMethod `
+    -Uri "$MaestroApiEndPoint/api/assets?buildId=$BarId&api-version=$MaestroApiVersion" `
+    -Method 'GET' `
+    -Headers @{ 'accept' = 'application/json'; 'Authorization' = "Bearer $MaestroToken" }
+
+Write-Verbose 'ReleaseData:'
+$releaseDataJson = $releaseData | ConvertTo-Json
+Write-Verbose $releaseDataJson
+
+[array]$matchingData = $releaseData | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping -ieq 'true' }
+
+if ($matchingData.Length -ne 1) {
+    Write-Error 'Unable to obtain build version.'
+}
+
+$version = $matchingData[0].Version
+
+Write-Verbose "Build Version: $version"
+
+if ($TaskVariableName) {
+    & $PSScriptRoot\SetTaskVariable.ps1 `
+        -Name $TaskVariableName `
+        -Value $version
+}
+
+Write-Output $version


### PR DESCRIPTION
###### Summary

Changes in #5549 make use of the `GetBuildVersion.ps1` script in order to look up the non-final build version to use as the root of the blob storage publishing. This script didn't exist in the `release/6.x` branch. I made a copy of it from the `release/7.x` branch.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
