### PR TITLE
Update docs to use final GitHub alert syntax

### DIFF
--- a/documentation/api-key-format.md
+++ b/documentation/api-key-format.md
@@ -3,7 +3,8 @@
 
 # API Key Format
 API Keys or MonitorApiKeys used in `dotnet monitor` are JSON Web Tokens or JWTs as defined by [RFC 7519: JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519).
-> **Note**: Because the API Key is a `Bearer` token, it should be treated as a secret and always transmitted over `TLS` or another protected protocol.
+> [!IMPORTANT]
+> Because the API Key is a `Bearer` token, it should be treated as a secret and always transmitted over `TLS` or another protected protocol.
 
 It is possible to make your own API Keys for `dotnet monitor` by following the format as defined below. Although, it is recommended to use the `generatekey` command unless you have a specific reason to make your own key.
 
@@ -14,7 +15,8 @@ For this example, let's consider the API Key given on the [Authentication page](
 ```yaml
 eyJhbGciOiJFUffffffffffffCI6IkpXVCJ9.eyJhdWQiOiJodffffffffffffGh1Yi5jb20vZG90bmV0L2RvdG5ldC1tb25pdG9yIiwiaXNzIjoiaHR0cHM6Ly9naXRodWIuY29tL2RvdG5ldC9kb3RuZXQtbW9uaXRvci9nZW5lcmF0ZWtleStNb25pdG9yQXBpS2V5Iiwic3ViIjoiYWU1NDczYjYtOGRhZC00OThkLWI5MTUtNTNiOWM2ODQwMDBlIn0.RZffffffffffff_yIyApvFKcxFpDJ65HJZek1_dt7jCTCMEEEffffffffffffR08OyhZZHs46PopwAsf_6fdTLKB1UGvLr95volwEwIFnHjdvMfTJ9ffffffffffffAU
 ```
->**Note**: While all values provided in this document are the correct length and format, the raw values have been edited to prevent this public example being used as a dotnet-monitor configuration.
+> [!NOTE]
+> While all values provided in this document are the correct length and format, the raw values have been edited to prevent this public example being used as a dotnet-monitor configuration.
 
 ### Header
 The header (decoded from the token above) must contain at least 2 elements: `alg` (or [Algorithm](https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1)), and `typ` (or [Type](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1)). `dotnet monitor` expects the `typ` to always be `JWT` for a JSON Web Token. `dotnet monitor` supports 6 `alg` values: `ES256`, `ES384`, `ES512`, `RS256`, `RS384`, and `RS512`.
@@ -25,10 +27,11 @@ The header (decoded from the token above) must contain at least 2 elements: `alg
   "typ": "JWT"
 }
 ```
->**Note**: The `alg` requirement is designed to enforce `dotnet monitor` to use public/private key signed tokens. This allows the key that is stored in configuration (as `Authentication__MonitorApiKey__PublicKey`) to only contain public key information and thus does not need to be kept secret.
+> [!NOTE]
+> The `alg` requirement is designed to enforce `dotnet monitor` to use public/private key signed tokens. This allows the key that is stored in configuration (as `Authentication__MonitorApiKey__PublicKey`) to only contain public key information and thus does not need to be kept secret.
 
 ### Payload
-The payload (also decoded from the token above) must contain at least 2 elements: `aud` (or [Audience](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)), and `sub` (or [Subject](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)). `dotnet monitor` expects the `aud` to always be `https://github.com/dotnet/dotnet-monitor` which signals that the token is intended for dotnet-monitor. The `sub` field is any non-empty string defined in `Authentication__MonitorApiKey__Subject`, this is used to validate that the token provided is for the expected instance and is user-defined in configuration. 
+The payload (also decoded from the token above) must contain at least 2 elements: `aud` (or [Audience](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)), and `sub` (or [Subject](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)). `dotnet monitor` expects the `aud` to always be `https://github.com/dotnet/dotnet-monitor` which signals that the token is intended for dotnet-monitor. The `sub` field is any non-empty string defined in `Authentication__MonitorApiKey__Subject`, this is used to validate that the token provided is for the expected instance and is user-defined in configuration.
 
 When using the `generatekey` command, the `sub` field will be a randomly-generated `Guid` but the `sub` field may be any non-empty string that matches the configuration. The `iss` (or [Issuer](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1)) field will be set to `https://github.com/dotnet/dotnet-monitor/generatekey+MonitorApiKey` to specify the source of the token, however `dotnet monitor` will accept any `iss` field value, and does not need to be present.
 ```json

--- a/documentation/api-key-setup.md
+++ b/documentation/api-key-setup.md
@@ -15,7 +15,8 @@ Run the command:
 
 The output from this command will display the API key (a bearer JWT token) formatted as an `Authorization` header along with its corresponding configuration for `dotnet monitor`. You will need to store the `Subject` and `PublicKey` in the configuration for `dotnet monitor` and use the `Authorization` header value when making requests to the `dotnet monitor` HTTPS endpoint.
 
->**Note**: The `Authorization` header value is the string `Bearer` (representing the type) + the JWT, separated by a space. In some applications (like Postman), you fill in the `Authorization` header type in a separate field from the JWT.
+> [!NOTE]
+> The `Authorization` header value is the string `Bearer` (representing the type) + the JWT, separated by a space. In some applications (like Postman), you fill in the `Authorization` header type in a separate field from the JWT.
 
 ```yaml
 Tell us about your experience with dotnet monitor: https://aka.ms/dotnet-monitor-survey
@@ -35,7 +36,8 @@ Settings in Json format:
 }
 ```
 
->**Note**: The actual values provided in this document will never work as valid configuration. All values provided in this document are the correct length and format, but the raw values have been edited to prevent this public example being used to configure authentication for a dotnet-monitor installation.
+> [!NOTE]
+> The actual values provided in this document will never work as valid configuration. All values provided in this document are the correct length and format, but the raw values have been edited to prevent this public example being used to configure authentication for a dotnet-monitor installation.
 
 The `generatekey` command supports 1 parameter `--output`/`-o` to specify the configuration format. By default, `dotnet monitor generatekey` will use the `--output json` format. Currently, the values in the list below are supported values for `--output`.
 
@@ -59,7 +61,8 @@ The easiest way to configure `dotnet-monitor` on a local dev box is by using the
   - If `XDG_CONFIG_HOME` is defined: `$XDG_CONFIG_HOME/dotnet-monitor/settings.json`
   - Otherwise: `$HOME/.config/dotnet-monitor/settings.json`
 
-> **Note**: You probably need to create the directory and `settings.json` file within.
+> [!NOTE]
+> You probably need to create the directory and `settings.json` file within.
 
   or
 
@@ -79,7 +82,8 @@ Run the command `dotnet monitor generatekey --output json` and copy the json blo
 }
 ```
 
->**Note**: The example above is not valid configuration, use the provided command to get a unique authentication key.
+> [!NOTE]
+> The example above is not valid configuration, use the provided command to get a unique authentication key.
 
 ### Docker
 
@@ -89,13 +93,15 @@ The easiest way to configure `docker` is to pass environment variables for the r
 > docker run --rm --entrypoint dotnet-monitor mcr.microsoft.com/dotnet/monitor generatekey --output Text
 ```
 
->**Note**: You'll need 3 parameters from the above execution. Grab the value in `Subject` and `PublicKey` and fill in `<Subject>` and `<PublicKey>` in the command below; save the value in `Authorization` for [step 3](#3-using-an-api-key-to-access-the-http-api).
+> [!NOTE]
+> You'll need 3 parameters from the above execution. Grab the value in `Subject` and `PublicKey` and fill in `<Subject>` and `<PublicKey>` in the command below; save the value in `Authorization` for [step 3](#3-using-an-api-key-to-access-the-http-api).
 
 ```bash
 > docker run --rm -p 127.0.0.1:52323:52323/tcp --entrypoint dotnet-monitor --env DOTNETMONITOR_Authentication__MonitorApiKey__Subject=<Subject> --env DOTNETMONITOR_Authentication__MonitorApiKey__PublicKey=<PublicKey> mcr.microsoft.com/dotnet/monitor collect --urls http://+:52323 --metricUrls http://+:52325
 ```
 
->**Note**: This command disables TLS, and should only be used for testing.
+> [!WARNING]
+> This command disables TLS, and should only be used for testing.
 
 ### Configuring an API Key in a Kubernetes Cluster
 
@@ -126,7 +132,8 @@ spec:
 
 ```
 
-> **Note**: For a complete example of running dotnet-monitor in Kubernetes, see [Running in a Kubernetes Cluster](./kubernetes.md)
+> [!NOTE]
+> For a complete example of running dotnet-monitor in Kubernetes, see [Running in a Kubernetes Cluster](./kubernetes.md)
 
 ## 3. Using an API Key to access the HTTP API
 

--- a/documentation/api/README.md
+++ b/documentation/api/README.md
@@ -5,7 +5,8 @@
 
 The HTTP API enables on-demand extraction of diagnostic information and artifacts from discoverable processes.
 
->**Note**: Some features are [experimental](./../experimental.md) and are denoted as `**[Experimental]**` in this document.
+> [!NOTE]
+> Some features are [experimental](./../experimental.md) and are denoted as `**[Experimental]**` in this document.
 
 The following are the root routes on the HTTP API surface.
 

--- a/documentation/api/collectionrules-get.md
+++ b/documentation/api/collectionrules-get.md
@@ -13,7 +13,8 @@ Get the detailed state of the specified collection rule for all processes or for
 GET /collectionrules/{collectionrulename}?pid={pid}&uid={uid}&name={name} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/collectionrules-list.md
+++ b/documentation/api/collectionrules-list.md
@@ -13,7 +13,8 @@ Get the basic state of all collection rules for all processes or for the specifi
 GET /collectionrules?pid={pid}&uid={uid}&name={name} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/collectionrules.md
+++ b/documentation/api/collectionrules.md
@@ -7,7 +7,8 @@ First Available: 6.3
 
 The `/collectionrules` route reports the state of configured collection rules.
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 | Operation | Description |
 |---|---|

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -3,7 +3,8 @@
 
 # Definitions
 
->**Note**: Some features are [experimental](./../experimental.md) and are denoted as `**[Experimental]**` in this document.
+> [!NOTE]
+> Some features are [experimental](./../experimental.md) and are denoted as `**[Experimental]**` in this document.
 
 ## CallStack
 

--- a/documentation/api/dump.md
+++ b/documentation/api/dump.md
@@ -13,7 +13,8 @@ Captures a managed dump of a specified process without using a debugger.
 GET /dump?pid={pid}&uid={uid}&name={name}&type={type}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -52,7 +53,8 @@ Allowed schemes:
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many dump requests at this time. Try to request a dump at a later time. | |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 
@@ -91,7 +93,8 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
 | Linux | .NET Core 3.1, .NET 5+ |
 | MacOS | .NET 5+ |
 
-> **Note**: For .NET 5, only ELF core dumps are supported on MacOS and require setting an environment variable in the application. Starting in .NET 6, dumps will be in the MachO format, and this environment variable is deprecated. See [Minidump Generation on OS X](https://github.com/dotnet/runtime/blob/main/docs/design/coreclr/botr/xplat-minidump-generation.md#os-x) for further details.
+> [!NOTE]
+> For .NET 5, only ELF core dumps are supported on MacOS and require setting an environment variable in the application. Starting in .NET 6, dumps will be in the MachO format, and this environment variable is deprecated. See [Minidump Generation on OS X](https://github.com/dotnet/runtime/blob/main/docs/design/coreclr/botr/xplat-minidump-generation.md#os-x) for further details.
 
 ## Additional Notes
 

--- a/documentation/api/exceptions-custom.md
+++ b/documentation/api/exceptions-custom.md
@@ -4,7 +4,8 @@
 
 Captures a history of first chance exceptions that were thrown in the specified process, with the ability to filter which exceptions are included in the response.
 
->**Note**: This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the exceptions history feature uses shared libraries loaded into the target application for collecting the exception information.
+> [!NOTE]
+> This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the exceptions history feature uses shared libraries loaded into the target application for collecting the exception information.
 
 ## HTTP Route
 

--- a/documentation/api/exceptions.md
+++ b/documentation/api/exceptions.md
@@ -5,7 +5,8 @@
 
 Captures a history of first chance exceptions that were thrown in the specified process.
 
->**Note**: This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the exceptions history feature uses shared libraries loaded into the target application for collecting the exception information.
+> [!NOTE]
+> This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the exceptions history feature uses shared libraries loaded into the target application for collecting the exception information.
 
 ## HTTP Route
 
@@ -13,7 +14,8 @@ Captures a history of first chance exceptions that were thrown in the specified 
 GET /exceptions?pid={pid}&uid={uid}&name={name}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/gcdump.md
+++ b/documentation/api/gcdump.md
@@ -17,7 +17,8 @@ Captures a GC dump of a specified process. These dumps are useful for several sc
 GET /gcdump?pid={pid}&uid={uid}&name={name}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -55,7 +56,8 @@ Allowed schemes:
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many GC dump requests at this time. Try to request a GC dump at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 

--- a/documentation/api/livemetrics-custom.md
+++ b/documentation/api/livemetrics-custom.md
@@ -11,7 +11,8 @@ Captures metrics for a process, with the ability to specify custom metrics.
 POST /livemetrics?pid={pid}&uid={uid}&name={name}&durationSeconds={durationSeconds}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -56,7 +57,8 @@ The expected content type is `application/json`.
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many requests at this time. Try to request metrics at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 

--- a/documentation/api/livemetrics-get.md
+++ b/documentation/api/livemetrics-get.md
@@ -5,9 +5,11 @@
 
 Captures metrics for a chosen process for a duration of time.
 
-> **Note**: Starting in 8.0, the [metrics configuration](../configuration/metrics-configuration.md#metrics-configuration) is used as the collection specification. Prior to 8.0, the collection specification only included the [default providers](../configuration/metrics-configuration.md#default-providers) and could not be changed.
+> [!NOTE]
+> Starting in 8.0, the [metrics configuration](../configuration/metrics-configuration.md#metrics-configuration) is used as the collection specification. Prior to 8.0, the collection specification only included the [default providers](../configuration/metrics-configuration.md#default-providers) and could not be changed.
 
-> **Note**: For Prometheus style metrics, use the [metrics](./metrics.md) endpoint.
+> [!NOTE]
+> For Prometheus style metrics, use the [metrics](./metrics.md) endpoint.
 
 ## HTTP Route
 
@@ -15,7 +17,8 @@ Captures metrics for a chosen process for a duration of time.
 GET /livemetrics?pid={pid}&uid={uid}&name={name}&durationSeconds={durationSeconds}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -54,7 +57,8 @@ Allowed schemes:
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many requests at this time. Try to request metrics at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 

--- a/documentation/api/logs-custom.md
+++ b/documentation/api/logs-custom.md
@@ -5,7 +5,8 @@
 
 Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process, as described in the settings specified in the request body. By default, logs are collected at the levels as specified by the [application-defined configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging).
 
-> **Note**: The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
+> [!NOTE]
+> The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
 
 ## HTTP Route
 
@@ -13,7 +14,8 @@ Captures log statements that are logged to the [ILogger<> infrastructure](https:
 POST /logs?pid={pid}&uid={uid}&name={name}&durationSeconds={durationSeconds}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -59,7 +61,8 @@ The expected content type is `application/json`.
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many logs requests at this time. Try to request logs at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 
@@ -105,7 +108,7 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
 
 2021-05-13 18:06:41Z info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
       => RequestId:0HM8M726ENU3K:0000002B, RequestPath:/, SpanId:|4791a4a7-433aa59a9e362743., TraceId:4791a4a7-433aa59a9e362743, ParentId:
-      Request starting HTTP/1.1 GET http://localhost:5000/  
+      Request starting HTTP/1.1 GET http://localhost:5000/
 
 2021-05-13 18:06:41Z info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
       => RequestId:0HM8M726ENU3K:0000002B, RequestPath:/, SpanId:|4791a4a7-433aa59a9e362743., TraceId:4791a4a7-433aa59a9e362743, ParentId:

--- a/documentation/api/logs-get.md
+++ b/documentation/api/logs-get.md
@@ -5,7 +5,8 @@
 
 Captures log statements that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process. By default, logs are collected at the levels as specified by the [application-defined configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/#configure-logging).
 
-> **Note**: The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
+> [!IMPORTANT]
+> The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
 
 ## HTTP Route
 
@@ -13,7 +14,8 @@ Captures log statements that are logged to the [ILogger<> infrastructure](https:
 GET /logs?pid={pid}&uid={uid}&name={name}&level={level}&durationSeconds={durationSeconds}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -54,7 +56,8 @@ Allowed schemes:
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many logs requests at this time. Try to request logs at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 

--- a/documentation/api/logs.md
+++ b/documentation/api/logs.md
@@ -5,9 +5,11 @@
 
 The Logs API enables collecting logs that are logged to the [ILogger<> infrastructure](https://docs.microsoft.com/aspnet/core/fundamentals/logging) within a specified process.
 
-> **Note**: The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
+> [!IMPORTANT]
+> The [`LoggingEventSource`](https://docs.microsoft.com/aspnet/core/fundamentals/logging#event-source) provider must be enabled in the process in order to capture logs.
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 | Operation | Description |
 |---|---|

--- a/documentation/api/metrics.md
+++ b/documentation/api/metrics.md
@@ -12,7 +12,8 @@ The metrics are collected from the following providers by default:
 
 All of the counters for each of these providers are collected by default.
 
-> **Note**: This route collects metrics only from a single process. If there are no processes or more than one process, the endpoint will not return information. In order to facilitate observing a single process, the tool can be configured to listen for connections from a target process; see [Default Process Configuration](<../configuration/default-process-configuration.md#default-process-configuration>) and [Diagnostic Port Configuration](<../configuration/diagnostic-port-configuration.md#diagnostic-port-configuration>) for more details.
+> [!NOTE]
+> This route collects metrics only from a single process. If there are no processes or more than one process, the endpoint will not return information. In order to facilitate observing a single process, the tool can be configured to listen for connections from a target process; see [Default Process Configuration](<../configuration/default-process-configuration.md#default-process-configuration>) and [Diagnostic Port Configuration](<../configuration/diagnostic-port-configuration.md#diagnostic-port-configuration>) for more details.
 
 ## HTTP Route
 
@@ -20,7 +21,8 @@ All of the counters for each of these providers are collected by default.
 GET /metrics HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/operations-list.md
+++ b/documentation/api/operations-list.md
@@ -28,9 +28,11 @@ See [ProcessIdentifier](definitions.md#processidentifier) for more details about
 
 If none of `pid`, `uid`, or `name` are specified, all operations will be listed.
 
-> **Note**: If multiple processes match the provided parameters (e.g., two processes named "MyProcess"), the operations for all matching processes will be listed.
+> [!NOTE]
+> If multiple processes match the provided parameters (e.g., two processes named "MyProcess"), the operations for all matching processes will be listed.
 
-> **Note**: An operation must include all of the provided tags to be shown in the results (e.g., tags=tag1,tag2 only includes operations with tag1 and tag2, not one or the other). 
+> [!NOTE]
+> An operation must include all of the provided tags to be shown in the results (e.g., tags=tag1,tag2 only includes operations with tag1 and tag2, not one or the other).
 
 ## Authentication
 

--- a/documentation/api/parameters.md
+++ b/documentation/api/parameters.md
@@ -5,9 +5,11 @@
 
 Captures parameters for one or more methods each time they are called. Parameters are logged inside the target application using its [`ILogger`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger).
 
->**Note**: Unlike other artifacts, parameters do **not** support being sent to an egress provider.
+> [!NOTE]
+> Unlike other artifacts, parameters do **not** support being sent to an egress provider.
 
->**Note**: This feature is not enabled by default and requires configuration to be enabled. See [Enabling](#enabling) for more information.
+> [!IMPORTANT]
+> This feature is not enabled by default and requires configuration to be enabled. See [Enabling](#enabling) for more information.
 
 ## Enabling
 
@@ -27,7 +29,8 @@ This feature is currently marked as experimental and so needs to be explicitly e
 POST /parameters?pid={pid}&uid={uid}&name={name}&durationSeconds={durationSeconds}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/process-env.md
+++ b/documentation/api/process-env.md
@@ -11,7 +11,8 @@ Gets the environment block of a specified process.
 GET /env?pid={pid}&uid={uid}&name={name} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/process-get.md
+++ b/documentation/api/process-get.md
@@ -11,7 +11,8 @@ Gets detailed information about a specified process.
 GET /process?pid={pid}&uid={uid}&name={name} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/processes-list.md
+++ b/documentation/api/processes-list.md
@@ -11,7 +11,8 @@ Lists the processes that are available from which diagnostic information can be 
 GET /processes HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 

--- a/documentation/api/processes.md
+++ b/documentation/api/processes.md
@@ -5,7 +5,8 @@
 
 The Processes API enables enumeration of the processes that `dotnet monitor` can detect and allows for obtaining their metadata (such as their names and environment variables).
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 | Operation | Description |
 |---|---|

--- a/documentation/api/stacks.md
+++ b/documentation/api/stacks.md
@@ -5,7 +5,8 @@
 
 Captures the call stacks of a target process. Note that only managed frames are collected.
 
->**Note**: This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
+> [!NOTE]
+> This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
 
 ## HTTP Route
 
@@ -13,7 +14,8 @@ Captures the call stacks of a target process. Note that only managed frames are 
 GET /stacks?pid={pid}&uid={uid}&name={name}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -52,7 +54,8 @@ Allowed schemes:
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many stack requests at this time. Try to request a stack at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
 ## Examples
 

--- a/documentation/api/trace-custom.md
+++ b/documentation/api/trace-custom.md
@@ -11,7 +11,8 @@ Captures a diagnostic trace of a process using the given set of event providers 
 POST /trace?pid={pid}&uid={uid}&name={name}&durationSeconds={durationSeconds}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -56,9 +57,11 @@ The expected content type is `application/json`.
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many trace requests at this time. Try to request a trace at a later time. | `application/problem+json` |
 
-> **NOTE: (7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)** Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
-> **Note**: After the expiration of the trace duration, completing the request may take a long time (up to several minutes) for large applications if `EventProvidersConfiguration.RequestRundown` is set to `true`. The runtime needs to send over the type cache for all managed code that was captured in the trace, known as rundown events. Thus, the length of time of the request may take significantly longer than the requested duration.
+> [!NOTE]
+> After the expiration of the trace duration, completing the request may take a long time (up to several minutes) for large applications if `EventProvidersConfiguration.RequestRundown` is set to `true`. The runtime needs to send over the type cache for all managed code that was captured in the trace, known as rundown events. Thus, the length of time of the request may take significantly longer than the requested duration.
 
 ## Examples
 
@@ -131,7 +134,7 @@ See [Process ID `pid` vs Unique ID `uid`](pidvsuid.md) for clarification on when
 
 ### View the collected `.nettrace` file
 
-On Windows, `.nettrace` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio. 
+On Windows, `.nettrace` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio.
 
 A `.nettrace` files can be converted to another format (e.g. SpeedScope or Chromium) using the [dotnet-trace](https://docs.microsoft.com/dotnet/core/diagnostics/dotnet-trace) tool.
 

--- a/documentation/api/trace-get.md
+++ b/documentation/api/trace-get.md
@@ -11,7 +11,8 @@ Captures a diagnostic trace of a process based on a predefined set of trace prof
 GET /trace?pid={pid}&uid={uid}&name={name}&profile={profile}&durationSeconds={durationSeconds}&egressProvider={egressProvider}&tags={tags} HTTP/1.1
 ```
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 ## Host Address
 
@@ -51,9 +52,11 @@ Allowed schemes:
 | 401 Unauthorized | | Authentication is required to complete the request. See [Authentication](./../authentication.md) for further information. | |
 | 429 Too Many Requests | | There are too many trace requests at this time. Try to request a trace at a later time. | `application/problem+json` |
 
-> **Note: (7.1+)**: Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
+> [!NOTE]
+> **(7.1+)**: Regardless if an egress provider is specified if the request was successful (response codes 200 or 202), the Location header contains the URI of the operation. This can be used to query the status of the operation or change its state.
 
-> **Note**: After the expiration of the trace duration, completing the request may take a long time (up to several minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured in the trace, known as rundown events. Thus, the length of time of the request may take significantly longer than the requested duration.
+> [!NOTE]
+> After the expiration of the trace duration, completing the request may take a long time (up to several minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured in the trace, known as rundown events. Thus, the length of time of the request may take significantly longer than the requested duration.
 
 ## Examples
 
@@ -100,7 +103,7 @@ See [Process ID `pid` vs Unique ID `uid`](pidvsuid.md) for clarification on when
 
 ### View the collected `.nettrace` file
 
-On Windows, `.nettrace` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio. 
+On Windows, `.nettrace` files can be viewed in [PerfView](https://github.com/microsoft/perfview) for analysis or in Visual Studio.
 
 A `.nettrace` files can be converted to another format (e.g. SpeedScope or Chromium) using the [dotnet-trace](https://docs.microsoft.com/dotnet/core/diagnostics/dotnet-trace) tool.
 

--- a/documentation/api/trace.md
+++ b/documentation/api/trace.md
@@ -5,7 +5,8 @@
 
 The Traces API enables collecting `.nettrace` formatted traces without using a profiler.
 
-> **Note**: Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
+> [!NOTE]
+> Process information (IDs, names, environment, etc) may change between invocations of these APIs. Processes may start or stop between API invocations, causing this information to change.
 
 | Operation | Description |
 |---|---|

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -10,7 +10,8 @@ Authenticated requests to `dotnet monitor` help protect sensitive diagnostic art
 
 It is also possible, although strongly not recommended, to [disable authentication](#disabling-authentication).
 
-> **Note**: Authentication is not performed on requests to the metrics endpoint (by default, http://localhost:52325).
+> [!NOTE]
+> Authentication is not performed on requests to the metrics endpoint (by default, http://localhost:52325).
 
 The recommended configuration for `dotnet monitor` is to use [Azure Active Directory Authentication](#azure-active-directory-authentication) over a channel secured with TLS.
 
@@ -25,7 +26,8 @@ Azure Active Directory integration (referred to as Azure AD) is the recommended 
 - [Assign user to role](https://learn.microsoft.com/azure/active-directory/develop/howto-add-app-roles-in-apps#assign-users-and-groups-to-roles) via the Enterprise Applications section of AAD.
 - [Configure Azure AD in dotnet monitor](./configuration/azure-ad-authentication-configuration.md).
 
-> **Note**: Azure AD B2C is currently not supported.
+> [!NOTE]
+> Azure AD B2C is currently not supported.
 
 ### Authenticating with a Managed Identity
 
@@ -58,7 +60,8 @@ If you want Azure AD users to be able to interactively authenticate with your `d
 - [Add a redirect URI to the App Registration](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app#add-a-redirect-uri).
   1. Select `Single-page application` as the platform.
   1. For the redirect URI, enter `{dotnet monitor address}/swagger/oauth2-redirect.html`, where `{dotnet monitor address}` is the address of your `dotnet monitor` instance.
-  > **Note**: If using `localhost` for the address, you do **not** need to specify the port number. Example: `https://localhost/swagger/oauth2-redirect.html`
+> [!NOTE]
+> If using `localhost` for the address, you do **not** need to specify the port number. Example: `https://localhost/swagger/oauth2-redirect.html`
 
 ## Windows Authentication
 
@@ -66,7 +69,8 @@ We only recommend using Windows Authentication if you're running `dotnet monitor
 
 Windows authentication doesn't require explicit configuration and is enabled automatically when running `dotnet monitor` on Windows. When available, `dotnet monitor` will authorize any user authenticated as the same user that started the `dotnet monitor` process. It is not possible to disable Windows authentication.
 
-> **Note**: Windows authentication will not be attempted if you are running `dotnet monitor` as an Administrator
+> [!NOTE]
+> Windows authentication will not be attempted if you are running `dotnet monitor` as an Administrator
 
 ## API Key Authentication
 
@@ -78,13 +82,15 @@ API Keys are referred to as `MonitorApiKey` in configuration and source code but
 
 - Use the `--temp-apikey` command line option to generate a one-time API key for that instantiation of dotnet-monitor. The API key will be reported back as part of log output during the startup of the process.
 
-> **Note**: API Key Authentication should only be used when TLS is enabled to protect the key while in transit. `dotnet monitor` will emit a warning if authentication is enabled over an insecure transport medium.
+> [!IMPORTANT]
+> API Key Authentication should only be used when TLS is enabled to protect the key while in transit. `dotnet monitor` will emit a warning if authentication is enabled over an insecure transport medium.
 
 ## Authenticating requests
 
 ### Windows authentication
 
-> **Note**: Windows authentication is only supported when also using API Key authentication and not running elevated.
+> [!NOTE]
+> Windows authentication is only supported when also using API Key authentication and not running elevated.
 
 - When using a web browser, it will automatically handle the Windows authentication challenge.
 

--- a/documentation/collectionrules/collectionrules.md
+++ b/documentation/collectionrules/collectionrules.md
@@ -5,7 +5,8 @@
 
 `dotnet monitor` can be [configured](../configuration/collection-rule-configuration.md#collection-rule-configuration) to automatically collect diagnostic artifacts based on conditions within the discovered processes.
 
->**Note**: Collection rules are only enabled when running dotnet-monitor in `Listen` mode. See [Connection Mode](../configuration/collection-rule-configuration.md#connection-mode) configuration for details.
+> [!NOTE]
+> Collection rules are only enabled when running dotnet-monitor in `Listen` mode. See [Connection Mode](../configuration/collection-rule-configuration.md#connection-mode) configuration for details.
 
 A collection rule is composed of four key aspects:
 - [Filters](#filters): Describes for which processes the rule is applied. Can filter on aspects such as process name, ID, and command line.
@@ -27,7 +28,8 @@ Once a trigger is satisfied, the [action](#actions) list is executed. Each actio
 
 A rule can describe for which processes that the rule is applied. If a discovered process does not match the filters, then the rule is not applied to the process. If filters are not configured, the rule is applied to the process.
 
->**Note**: `dotnet monitor` is capable of observing multiple processes simultaneously. The filter mechanism for collection rules allows the user to specify which subset of the observed processes that each individual rule should be applied.
+> [!NOTE]
+> `dotnet monitor` is capable of observing multiple processes simultaneously. The filter mechanism for collection rules allows the user to specify which subset of the observed processes that each individual rule should be applied.
 
 The filter criteria are the same as those used for the [default process](../configuration/collection-rule-configuration.md#default-process-configuration) configuration.
 
@@ -110,7 +112,7 @@ For example, if action `A` has an output named `EgressPath`, and action `B` has 
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Name: "A"
   CollectionRules__RuleName__Actions__0__Type: "CollectTrace"
@@ -125,7 +127,7 @@ For example, if action `A` has an output named `EgressPath`, and action `B` has 
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Name
     value: "A"

--- a/documentation/compatibility/7.0/README.md
+++ b/documentation/compatibility/7.0/README.md
@@ -51,4 +51,5 @@ When egressing an artifact to Azure blob storage, several metadata keys and valu
 - `ArtifactSource_ProcessId` -> `DotnetMonitor_ArtifactSource_ProcessId`
 - `ArtifactSource_RuntimeInstanceCookie` -> `DotnetMonitor_ArtifactSource_RuntimeInstanceCookie`
 
-> **Note**: The custom metadata keys as specified in the [Azure blob storage](../../configuration/egress-configuration.md#azure-blob-storage-egress-provider) egress provider are not prefixed.
+> [!NOTE]
+> The custom metadata keys as specified in the [Azure blob storage](../../configuration/egress-configuration.md#azure-blob-storage-egress-provider) egress provider are not prefixed.

--- a/documentation/configuration/README.md
+++ b/documentation/configuration/README.md
@@ -5,11 +5,12 @@
 
 `dotnet monitor` has extensive configuration to control various aspects of its behavior. Ordinarily, you are not required to specify most of this configuration and only exists if you wish to change the default behavior in `dotnet monitor`.
 
->**Note**: Some features are [experimental](../experimental.md) and are denoted as `**[Experimental]**` in these documents.
+> [!NOTE]
+> Some features are [experimental](../experimental.md) and are denoted as `**[Experimental]**` in these documents.
 
 ## Configuration Reference
 
-- **[Configuration Sources](./configuration-sources.md)** - How to use JSON configuration files, Environment variables or Kubernetes for configuration 
+- **[Configuration Sources](./configuration-sources.md)** - How to use JSON configuration files, Environment variables or Kubernetes for configuration
 - **[Configuration Schema](#configuration-schema)** - How to get schema completion in supported editors
 - **[View Merged Configuration](./view-merged-configuration.md)** - How to use a diagnostic command to show the merged configuration that will be applied
 - **[Diagnostic Port Configuration](diagnostic-port-configuration.md)** - `dotnet monitor` communicates via .NET processes through their diagnostic port which can be changed if necessary

--- a/documentation/configuration/collection-rule-configuration.md
+++ b/documentation/configuration/collection-rule-configuration.md
@@ -13,7 +13,7 @@ Collection rules are specified in configuration as a named item under the `Colle
   - [AspNetResponseStatus](#aspnetresponsestatus-trigger)
   - [EventCounter](#eventcounter-trigger)
   - [EventMeter](#eventmeter-trigger-80)
-  - [Trigger shortcuts](../collectionrules/triggershortcuts.md) 
+  - [Trigger shortcuts](../collectionrules/triggershortcuts.md)
 - [`Actions`](#actions) - The action to be be performed
   - [CollectDump](#collectdump-action)
   - [CollectExceptions](#collectexceptions-action)
@@ -74,7 +74,7 @@ The following is a collection rule that collects a 1 minute CPU trace and egress
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__HighCpuRule__Filters__0__Key: "ProcessName"
   CollectionRules__HighCpuRule__Filters__0__Value: "dotnet"
@@ -95,7 +95,7 @@ The following is a collection rule that collects a 1 minute CPU trace and egress
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__HighCpuRule__Filters__0__Key
     value: "ProcessName"
@@ -155,7 +155,7 @@ The following example shows the `Filters` portion of a collection rule that has 
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Filters__0__Key: "ProcessName"
   CollectionRules__RuleName__Filters__0__Value: "dotnet"
@@ -167,7 +167,7 @@ The following example shows the `Filters` portion of a collection rule that has 
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Filters__0__Key
     value: "ProcessName"
@@ -219,7 +219,7 @@ Usage that is satisfied when request count is higher than 500 requests during a 
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Trigger__Settings__RequestCount: "500"
   CollectionRules__RuleName__Trigger__Settings__SlidingWindowDuration: "00:01:00"
@@ -229,7 +229,7 @@ Usage that is satisfied when request count is higher than 500 requests during a 
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Trigger__Settings__RequestCount
     value: "500"
@@ -275,7 +275,7 @@ Usage that is satisfied when 10 requests take longer than 3 seconds during a 1 m
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Trigger__Settings__RequestCount: "10"
   CollectionRules__RuleName__Trigger__Settings__RequestDuration: "00:00:03"
@@ -286,7 +286,7 @@ Usage that is satisfied when 10 requests take longer than 3 seconds during a 1 m
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Trigger__Settings__RequestCount
     value: "10"
@@ -334,7 +334,7 @@ Usage that is satisfied when 10 requests respond with a 5XX status code during a
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Trigger__Settings__StatusCodes__0: "500-599"
   CollectionRules__RuleName__Trigger__Settings__RequestCount: "10"
@@ -345,7 +345,7 @@ Usage that is satisfied when 10 requests respond with a 5XX status code during a
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Trigger__Settings__StatusCodes__0
     value: "500-599"
@@ -393,7 +393,7 @@ Usage that is satisfied when the CPU usage of the application is higher than 70%
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Trigger__Settings__ProviderName: "System.Runtime"
   CollectionRules__RuleName__Trigger__Settings__CounterName: "cpu-usage"
@@ -404,7 +404,7 @@ Usage that is satisfied when the CPU usage of the application is higher than 70%
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Trigger__Settings__ProviderName
     value: "System.Runtime"
@@ -581,7 +581,7 @@ Usage that collects a full dump and egresses it to a provider named "AzureBlobDu
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Type: "Full"
   CollectionRules__RuleName__Actions__0__Settings__Egress: "AzureBlobDumps"
@@ -590,7 +590,7 @@ Usage that collects a full dump and egresses it to a provider named "AzureBlobDu
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Type
     value: "Full"
@@ -636,7 +636,7 @@ Usage that collects exceptions as newline-delimited JSON and egresses it to a pr
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Egress: "AzureBlobExceptions"
   CollectionRules__RuleName__Actions__0__Settings__Format: "NewlineDelimitedJson"
@@ -645,7 +645,7 @@ Usage that collects exceptions as newline-delimited JSON and egresses it to a pr
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Egress
     value: "AzureBlobExceptions"
@@ -686,7 +686,7 @@ Usage that collects a gcdump and egresses it to a provider named "AzureBlobGCDum
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Egress: "AzureBlobGCDumps"
   ```
@@ -694,7 +694,7 @@ Usage that collects a gcdump and egresses it to a provider named "AzureBlobGCDum
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Egress
     value: "AzureBlobGCDumps"
@@ -740,7 +740,7 @@ Usage that collects a CPU trace for 30 seconds and egresses it to a provider nam
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Profile: "Cpu"
   CollectionRules__RuleName__Actions__0__Settings__Egress: "TmpDir"
@@ -749,7 +749,7 @@ Usage that collects a CPU trace for 30 seconds and egresses it to a provider nam
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Profile
     value: "Cpu"
@@ -762,7 +762,8 @@ Usage that collects a CPU trace for 30 seconds and egresses it to a provider nam
 
 An action that collects live metrics for the process that the collection rule is targeting.
 
-> **NOTE: (8.0+)** If none of `IncludeDefaultProviders`, `Provider`, or `Meters` are specified, then the [metrics configuration](<metrics-configuration.md#metrics-configuration>) is used as the collection specification.
+> [!NOTE]
+> **(8.0+)** If none of `IncludeDefaultProviders`, `Provider`, or `Meters` are specified, then the [metrics configuration](<metrics-configuration.md#metrics-configuration>) is used as the collection specification.
 
 #### Properties
 
@@ -796,7 +797,7 @@ Usage that collects live metrics with the default providers for 30 seconds and e
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Egress: "TmpDir"
   ```
@@ -804,7 +805,7 @@ Usage that collects live metrics with the default providers for 30 seconds and e
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Egress
     value: "TmpDir"
@@ -834,7 +835,7 @@ Usage that collects live metrics for the `cpu-usage` counter on `System.Runtime`
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__UseDefaultProviders: "false"
   CollectionRules__RuleName__Actions__0__Settings__Providers__0__ProviderName: "System.Runtime"
@@ -845,7 +846,7 @@ Usage that collects live metrics for the `cpu-usage` counter on `System.Runtime`
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__UseDefaultProviders
     value: "false"
@@ -897,7 +898,7 @@ Usage that collects logs at the Information level for 30 seconds and egresses it
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__DefaultLevel: "Information"
   CollectionRules__RuleName__Actions__0__Settings__UseAppFilters: "false"
@@ -907,7 +908,7 @@ Usage that collects logs at the Information level for 30 seconds and egresses it
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__DefaultLevel
     value: "Information"
@@ -953,7 +954,7 @@ Usage that executes a .NET executable named `myapp.dll` using `dotnet`.
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Path: "C:\\Program Files\\dotnet\\dotnet.exe"
   CollectionRules__RuleName__Actions__0__Settings__Arguments: "C:\\Program Files\\MyApp\\myapp.dll"
@@ -962,7 +963,7 @@ Usage that executes a .NET executable named `myapp.dll` using `dotnet`.
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Path
     value: "C:\\Program Files\\dotnet\\dotnet.exe"
@@ -977,7 +978,8 @@ First Available: 8.0 Preview 7
 
 Collect call stacks from the target process.
 
->**Note**: This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
+> [!NOTE]
+> This feature is not enabled by default and requires configuration to be enabled. The [in-process features](./../configuration/in-process-features-configuration.md) must be enabled since the call stacks feature uses shared libraries loaded into the target application for collecting the call stack information.
 
 #### Properties
 
@@ -1018,7 +1020,7 @@ Usage that loads one of the sample profilers from [`dotnet/runtime: src/tests/pr
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Path: "Profilers\\Profiler.dll"
   CollectionRules__RuleName__Actions__0__Settings__Clsid: "55b9554d-6115-45a2-be1e-c80f7fa35369"
@@ -1027,7 +1029,7 @@ Usage that loads one of the sample profilers from [`dotnet/runtime: src/tests/pr
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Path
     value: "Profilers\\Profiler.dll"
@@ -1068,7 +1070,7 @@ Usage that sets a parameter to the profiler you loaded. In this case, your profi
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Settings__Name: "MyProfiler_AccountId"
   CollectionRules__RuleName__Actions__0__Settings__Value: "8fb138d2c44e4aea8545cc2df541ed4c"
@@ -1077,7 +1079,7 @@ Usage that sets a parameter to the profiler you loaded. In this case, your profi
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Settings__Name
     value: "MyProfiler_AccountId"
@@ -1106,7 +1108,8 @@ An action that gets an environment variable from the target process. Its value i
 
 Usage that gets a token your app has access to and uses it to send a trace.
 
-> **Note**: the example below is of an entire action list to provide context, only the second json entry represents the `GetEnvironmentVariable` Action.
+> [!NOTE]
+> The example below is of an entire action list to provide context, only the second json entry represents the `GetEnvironmentVariable` Action.
 
 <details>
   <summary>JSON</summary>
@@ -1138,7 +1141,7 @@ Usage that gets a token your app has access to and uses it to send a trace.
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Actions__0__Name: "A"
   CollectionRules__RuleName__Actions__0__Type: "CollectTrace"
@@ -1156,7 +1159,7 @@ Usage that gets a token your app has access to and uses it to send a trace.
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Actions__0__Name
     value: "A"
@@ -1212,7 +1215,7 @@ The following example shows the `Limits` portion of a collection rule that has t
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   CollectionRules__RuleName__Limits__ActionCount: "3"
   CollectionRules__RuleName__Limits__ActionCountSlidingWindowDuration: "01:00:00"
@@ -1221,7 +1224,7 @@ The following example shows the `Limits` portion of a collection rule that has t
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_CollectionRules__RuleName__Limits__ActionCount
     value: "3"
@@ -1274,7 +1277,7 @@ The following example includes a default egress provider that corresponds to the
     },
     "CollectionRuleDefaults": {
       "Actions": {
-        "Egress": "artifacts"    
+        "Egress": "artifacts"
       }
     },
     "CollectionRules": {
@@ -1305,7 +1308,7 @@ The following example includes a default egress provider that corresponds to the
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Egress__AzureBlobStorage__monitorBlob__accountUri: "https://exampleaccount.blob.core.windows.net"
   Egress__AzureBlobStorage__monitorBlob__containerName: "dotnet-monitor"
@@ -1325,7 +1328,7 @@ The following example includes a default egress provider that corresponds to the
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Egress__AzureBlobStorage__monitorBlob__accountUri
     value: "https://exampleaccount.blob.core.windows.net"

--- a/documentation/configuration/egress-configuration.md
+++ b/documentation/configuration/egress-configuration.md
@@ -24,7 +24,8 @@ When `dotnet-monitor` is used to produce artifacts such as dumps or traces, an e
 | queueSharedAccessSignatureName | string | false | (6.3+) Name of the property in the Properties section that will contain the queue SAS token; if using SAS, must be specified if `queueSharedAccessSignature` is not specified.|
 | metadata | Dictionary<string, string> | false | A mapping of metadata keys to environment variable names. The values of the environment variables will be added as metadata for egressed artifacts.|
 
-> **Note**: Starting with `dotnet monitor` 7.0, all built-in metadata keys are prefixed with `DotnetMonitor_`; to avoid metadata naming conflicts, avoid prefixing your metadata keys with `DotnetMonitor_`.
+> [!NOTE]
+> Starting with `dotnet monitor` 7.0, all built-in metadata keys are prefixed with `DotnetMonitor_`; to avoid metadata naming conflicts, avoid prefixing your metadata keys with `DotnetMonitor_`.
 
 ### Example azureBlobStorage provider
 
@@ -52,7 +53,7 @@ When `dotnet-monitor` is used to produce artifacts such as dumps or traces, an e
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Egress__AzureBlobStorage__monitorBlob__accountUri: "https://exampleaccount.blob.core.windows.net"
   Egress__AzureBlobStorage__monitorBlob__containerName: "dotnet-monitor"
@@ -64,7 +65,7 @@ When `dotnet-monitor` is used to produce artifacts such as dumps or traces, an e
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Egress__AzureBlobStorage__monitorBlob__accountUri
     value: "https://exampleaccount.blob.core.windows.net"
@@ -107,7 +108,7 @@ When `dotnet-monitor` is used to produce artifacts such as dumps or traces, an e
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Egress__AzureBlobStorage__monitorBlob__accountUri: "https://exampleaccount.blob.core.windows.net"
   Egress__AzureBlobStorage__monitorBlob__containerName: "dotnet-monitor"
@@ -121,7 +122,7 @@ When `dotnet-monitor` is used to produce artifacts such as dumps or traces, an e
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Egress__AzureBlobStorage__monitorBlob__accountUri
     value: "https://exampleaccount.blob.core.windows.net"
@@ -185,7 +186,7 @@ The Queue Message's payload will be the blob name (`<BlobPrefix>/<ArtifactName>`
 
 <details>
   <summary>Kubernetes Secret</summary>
-  
+
   ```sh
   #!/bin/sh
   kubectl create secret generic my-s3-secrets \
@@ -225,7 +226,7 @@ The Queue Message's payload will be the blob name (`<BlobPrefix>/<ArtifactName>`
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Egress__FileSystem__monitorFile__directoryPath: "/artifacts"
   Egress__FileSystem__monitorFile__intermediateDirectoryPath: "/intermediateArtifacts"
@@ -234,7 +235,7 @@ The Queue Message's payload will be the blob name (`<BlobPrefix>/<ArtifactName>`
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Egress__FileSystem__monitorFile__directoryPath
     value: "/artifacts"

--- a/documentation/configuration/storage-configuration.md
+++ b/documentation/configuration/storage-configuration.md
@@ -28,7 +28,7 @@ The default shared path option (`DefaultSharedPath`) can be set, which allows ar
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Storage__DefaultSharedPath: "/diag"
   ```
@@ -36,7 +36,7 @@ The default shared path option (`DefaultSharedPath`) can be set, which allows ar
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Storage__DefaultSharedPath
     value: "/diag"
@@ -47,7 +47,8 @@ The default shared path option (`DefaultSharedPath`) can be set, which allows ar
 
 Unlike the other diagnostic artifacts (for example, traces), memory dumps aren't streamed back from the target process to `dotnet monitor`. Instead, they are written directly to disk by the runtime. After successful collection of a process dump, `dotnet monitor` will read the process dump directly from disk. In the default configuration, the directory that the runtime writes its process dump to is the temp directory (`%TMP%` on Windows, `/tmp` on \*nix). It is possible to change to the ephemeral directory that these dump files get written to via the following configuration:
 
->**Note**: This option is optional if `dotnet monitor` is running in the same process namespace as the target processes or if `DefaultSharedPath` is specified.
+> [!NOTE]
+> This option is optional if `dotnet monitor` is running in the same process namespace as the target processes or if `DefaultSharedPath` is specified.
 
 <details>
   <summary>JSON</summary>
@@ -63,7 +64,7 @@ Unlike the other diagnostic artifacts (for example, traces), memory dumps aren't
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Storage__DumpTempFolder: "/diag/dumps/"
   ```
@@ -71,7 +72,7 @@ Unlike the other diagnostic artifacts (for example, traces), memory dumps aren't
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Storage__DumpTempFolder
     value: "/diag/dumps/"
@@ -84,7 +85,8 @@ First Available: 8.0 Preview 7
 
 The shared library path option (`SharedLibraryPath`) allows specifying the path to where shared libraries are copied from the `dotnet monitor` installation to make them available to target applications for in-process diagnostics scenarios, such as call stack collection.
 
->**Note**: This option is not required if `DefaultSharedPath` is specified. This option provides an alternative directory path compared to the behavior of specifying `DefaultSharedPath`.
+> [!NOTE]
+> This option is not required if `DefaultSharedPath` is specified. This option provides an alternative directory path compared to the behavior of specifying `DefaultSharedPath`.
 
 <details>
   <summary>JSON</summary>
@@ -100,7 +102,7 @@ The shared library path option (`SharedLibraryPath`) allows specifying the path 
 
 <details>
   <summary>Kubernetes ConfigMap</summary>
-  
+
   ```yaml
   Storage__SharedLibraryPath: "/diag/libs/"
   ```
@@ -108,7 +110,7 @@ The shared library path option (`SharedLibraryPath`) allows specifying the path 
 
 <details>
   <summary>Kubernetes Environment Variables</summary>
-  
+
   ```yaml
   - name: DotnetMonitor_Storage__SharedLibraryPath
     value: "/diag/libs/"

--- a/documentation/egress.md
+++ b/documentation/egress.md
@@ -3,13 +3,14 @@
 
 # Egress Providers
 
-`dotnet monitor` supports configuration of [egress providers](./configuration/egress-configuration.md) that can be used to egress artifacts externally, instead of to the client. This is supported for dumps, gcdumps, traces, logs, and live metrics. Currently supported providers are Azure blob storage and filesystem. 
+`dotnet monitor` supports configuration of [egress providers](./configuration/egress-configuration.md) that can be used to egress artifacts externally, instead of to the client. This is supported for dumps, gcdumps, traces, logs, and live metrics. Currently supported providers are Azure blob storage and filesystem.
 
 Egress providers must first be named and configured in `dotnet monitor` configuration. They can then be referenced from a request, and will cause an egress based on the provider configuration, rather than directly back to the client.
 
 Egress providers use [operations](./api/operations.md) to provide status.
 
-> **Note**: The filesystem provider can be used to egress to [kubernetes volumes](https://kubernetes.io/docs/concepts/storage/volumes/).
+> [!NOTE]
+> The filesystem provider can be used to egress to [kubernetes volumes](https://kubernetes.io/docs/concepts/storage/volumes/).
 
 ### Disabling HTTP Egress
 
@@ -40,7 +41,9 @@ Users using the `monitor-base` image can manually install supported extensions v
 
 For an example of using Multi-Stage Docker Builds, see the [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) that the `dotnet monitor` team uses to construct the `amd64` `monitor` image.
 
-To directly access archives for one of `dotnet monitor`'s supported extensions, these are available using the following link (this example is specifically for the `linux-x64` archive): `https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz`. Note: the versions in this link will change in response to new `dotnet monitor` releases; as a result, the link will need to be changed to reflect the most recent version when updating your extensions.
+To directly access archives for one of `dotnet monitor`'s supported extensions, these are available using the following link (this example is specifically for the `linux-x64` archive): `https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz`.
+> [!NOTE]
+> The versions in this link will change in response to new `dotnet monitor` releases; as a result, the link will need to be changed to reflect the most recent version when updating your extensions.
 
 #### Example Of Manually Installing AzureBlobStorage Extension Locally (Version Numbers May Vary)
 

--- a/documentation/learningPath/README.md
+++ b/documentation/learningPath/README.md
@@ -1,7 +1,8 @@
 
 ### Was this documentation helpful? [Share feedback](https://www.research.net/r/DGDQWXH?src=documentation%2FlearningPath%2FREADME)
 
->**Note**:  All documents in this directory are a work in progress.
+> [!NOTE]
+> All documents in this directory are a work in progress.
 
 # Overview
 

--- a/documentation/learningPath/aks.md
+++ b/documentation/learningPath/aks.md
@@ -11,10 +11,11 @@ This workflow takes your local development copy of `dotnet-monitor`, patches it 
 
 1. Open `pwsh` and run the [generate-dev-sln script](https://github.com/dotnet/dotnet-monitor/blob/main/generate-dev-sln.ps1), providing a path to your local copy of the diagnostics repo.
 
->**Note**: If your changes do not involve the [.NET Core Diagnostics Repo](https://github.com/dotnet/diagnostics#net-core-diagnostics-repo), you don't need to complete this step.
+> [!NOTE]
+> If your changes do not involve the [.NET Core Diagnostics Repo](https://github.com/dotnet/diagnostics#net-core-diagnostics-repo), you don't need to complete this step.
 
 ```ps1
-cd C:\your-path\dotnet-monitor 
+cd C:\your-path\dotnet-monitor
 .\generate-dev-sln.ps1 C:\your-path\diagnostics
 ```
 

--- a/documentation/release-process.md
+++ b/documentation/release-process.md
@@ -29,7 +29,8 @@
 ## Updating dependencies
 
 If necessary, update dependencies in the release branch.
->**Note**: This is typically not needed for the diagnostics packages. They are kept up-to-date by dependabot if `UseMicrosoftDiagnosticsMonitoringShippedVersion` in [../eng/Versions.props](../eng/Versions.props) is set to `true`. It might be set to `false` if feature development requiring unreleased diagnostics libraries was merged into the branch. Official releases should use the released diagnostics libraries per agreed upon policy.
+> [!NOTE]
+> This is typically not needed for the diagnostics packages. They are kept up-to-date by dependabot if `UseMicrosoftDiagnosticsMonitoringShippedVersion` in [../eng/Versions.props](../eng/Versions.props) is set to `true`. It might be set to `false` if feature development requiring unreleased diagnostics libraries was merged into the branch. Official releases should use the released diagnostics libraries per agreed upon policy.
 
 1. For new branches only, you need to setup a subscription using darc: `darc add-subscription --channel ".NET Core Tooling Release" --source-repo https://github.com/dotnet/diagnostics --target-repo https://github.com/dotnet/dotnet-monitor --target-branch release/8.x --update-frequency None --standard-automerge`
 1. Use `darc get-subscriptions --target-repo monitor` to see existing subscriptions.
@@ -56,7 +57,8 @@ The official build will not automatically trigger for release branches. Each tim
 1. Wait for changes to be mirrored from [GitHub repository](https://github.com/dotnet/dotnet-monitor) to the [internal repository](https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor).
 1. Invoke the [internal pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=954) for the release branch. Make sure the `Update dotnet-docker?` parameter is set to true. Setting this will cause a successful build to trigger an update in the `dotnet-docker` repository.
 
-> **Note**: If the release is part of security servicing, build the `internal/release/*` branch instead of the `release/*` branch and set `Update dotnet-docker?` parameter to false. Ensure that all public changes have been mirrored into the release branch before starting the build.
+> [!NOTE]
+> If the release is part of security servicing, build the `internal/release/*` branch instead of the `release/*` branch and set `Update dotnet-docker?` parameter to false. Ensure that all public changes have been mirrored into the release branch before starting the build.
 
 ## Update Nightly Docker Ingestion
 
@@ -70,7 +72,8 @@ If you are releasing a new minor version, you may need to update the current/pre
 
 ### Manually updating docker versions
 
-> **Note**: This only applies for public releases e.g. ones from a `release/*` branch.
+> [!NOTE]
+> This only applies for public releases e.g. ones from a `release/*` branch.
 
 1. Run `\eng\Set-DotnetVersions.ps1`. Example:
 ``` powershell
@@ -97,7 +100,9 @@ The nightly image is `mcr.microsoft.com/dotnet/nightly/monitor`. The tag list is
 1. Run the [Generate release notes](https://github.com/dotnet/dotnet-monitor/actions/workflows/generate-release-notes.yml) workflow, setting `Use workflow from` to the release branch. Review and merge in the PR created by this workflow.
 1. Start [release pipeline](https://dev.azure.com/dnceng/internal/_release?_a=releases&view=mine&definitionId=105). Allow the stages to trigger automatically (do not check the boxes in the associated dropdown). During creation of the release you must select the dotnet-monitor build to release from the list of available builds. This must be a build with the tag `MonitorRelease` and the associated `MonitorRelease` artifact (set `dotnet-monitor_build` to the pipeline run of `dotnet monitor` that is being released; set `dotnet-monitor_source` to the latest commit from `main`).
 1. The release will start the stage "Pre-Release Verification"; this will check that the above steps were done as expected. The name of the release will be updated automatically.
-1. Approve the sign-off step the day before the release after 8:15 AM PT, when ready to publish. **Note**: After sign-off of the "Pre-Release Verification" environment the NuGet and GitHub release steps will automatically wait until 8:15 AM PT the next day.
+1. Approve the sign-off step the day before the release after 8:15 AM PT, when ready to publish.
+> [!NOTE]
+> After sign-off of the "Pre-Release Verification" environment the NuGet and GitHub release steps will automatically wait until 8:15 AM PT the next day.
 
 The remainder of the release will automatically push NuGet packages to nuget.org, [tag](https://github.com/dotnet/dotnet-monitor/tags) the commit from the build with the release version, and add a new [GitHub release](https://github.com/dotnet/dotnet-monitor/releases).
 


### PR DESCRIPTION
###### Summary

The markdown docs are currently used the beta syntax for GitHub alerts. This syntax is deprecated and no longer supported, so switch to the new syntax instead. As part of this PR, a couple notes were upgraded to `important` alerts.

Examples of alerts in docs:

> [!IMPORTANT]
> This is really important.

> [!WARNING]
> This is a warning.

> [!NOTE]
> This is a note.

ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
