### PR TITLE
Remove the apphost from the extensions

### DIFF
--- a/src/archives/AzureBlobStorage/ProjectsToPublish.props
+++ b/src/archives/AzureBlobStorage/ProjectsToPublish.props
@@ -9,12 +9,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
-      <AdditionalProperties>TargetFramework=$(AzureBlobStoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(AzureBlobStoragePlatformSpecificPublishPath);SelfContained=false</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(AzureBlobStoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(AzureBlobStoragePlatformSpecificPublishPath);SelfContained=false;UseAppHost=false</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
   <ItemGroup Condition="'$(SkipPlatformNeutralPublish)' != 'true'">
     <ProjectToPublish Include="$(AzureBlobStorageProjectPath)">
-      <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(AzureBlobStoragePublishRootPath)$(LatestToolTargetFramework)\any\;SelfContained=false</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(AzureBlobStoragePublishRootPath)$(LatestToolTargetFramework)\any\;SelfContained=false;UseAppHost=false</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
 </Project>

--- a/src/archives/S3Storage/ProjectsToPublish.props
+++ b/src/archives/S3Storage/ProjectsToPublish.props
@@ -9,12 +9,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectToPublish Include="$(S3StorageProjectPath)">
-      <AdditionalProperties>TargetFramework=$(S3StoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(S3StoragePlatformSpecificPublishPath);SelfContained=false</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(S3StoragePublishTargetFramework);RuntimeIdentifier=$(PackageRid);PublishDir=$(S3StoragePlatformSpecificPublishPath);SelfContained=false;UseAppHost=false</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
   <ItemGroup Condition="'$(SkipPlatformNeutralPublish)' != 'true'">
     <ProjectToPublish Include="$(S3StorageProjectPath)">
-      <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(S3StoragePublishRootPath)$(LatestToolTargetFramework)\any\;SelfContained=false</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(LatestToolTargetFramework);RuntimeIdentifier=;PublishDir=$(S3StoragePublishRootPath)$(LatestToolTargetFramework)\any\;SelfContained=false;UseAppHost=false</AdditionalProperties>
     </ProjectToPublish>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
###### Summary

The apphosts for the extensions (e.g. `dotnet-monitor-egress-azureblobstorage.exe` and `dotnet-monitor-egress-s3storage.exe`) are not necessary since the extensions are launched using the shared dotnet installation with the extensions entrypoint assembly (see the extension manifest registrations [here](https://github.com/dotnet/dotnet-monitor/blob/main/src/Extensions/AzureBlobStorage/extension.json#L3) and [here](https://github.com/dotnet/dotnet-monitor/blob/main/src/Extensions/S3Storage/extension.json#L3)).

Removing the apphosts will yield a small size savings in the packages and docker images as well as lower our compliance costs for validating them (since they won't exist anymore).

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2310976&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
