### PR TITLE
Generate checksum table file

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -35,12 +35,24 @@
 
   <Target Name="GenerateChecksumsForPackages">
     <ItemGroup>
-      <GenerateChecksumItems Include="@(PackageFile)">
+      <!-- Generate checksums for non-symbols packages -->
+      <GenerateChecksumItems Include="@(PackageFile)" Condition="!$([System.String]::Copy(%(Filename)).Contains('symbols'))">
         <DestinationPath>%(FullPath).sha512</DestinationPath>
       </GenerateChecksumItems>
     </ItemGroup>
 
     <GenerateChecksums Items="@(GenerateChecksumItems)" />
+
+    <!-- Gather all checksum values of each shipping asset. -->
+    <ItemGroup>
+      <ShippingChecksums Include="@(GenerateChecksumItems)" Condition="'%(IsShipping)' == 'true'">
+        <ChecksumValue>$([System.IO.File]::ReadAllText('%(DestinationPath)').ToLowerInvariant())</ChecksumValue>
+      </ShippingChecksums>
+    </ItemGroup>
+
+    <!-- Write checksums of each shipping asset into a single file. -->
+    <WriteLinesToFile File="$(ArtifactsShippingPackagesDir)$(Version)-sha.txt"
+                      Lines="@(ShippingChecksums->'%(ChecksumValue) %(Filename)%(Extension)')"/>
   </Target>
 
   <!-- Run the CollectPackageArtifactFiles target on each PackageFile by target batching on a non-existing file.


### PR DESCRIPTION
###### Summary

- Generate a single file containing a mapping of checksums to their corresponding package name; this file will aid in generating dependency updates for .NET Monitor internal builds in the dotnet/dotnet-docker repo. While this example is not from .NET Monitor, it demonstrates the format of the file: https://dotnetcli.blob.core.windows.net/dotnet/checksums/8.0.0-sha.txt
- Generate checksums for non-symbols packages.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2312053&view=results
Corresponding dotnet/dotnet-docker utilization: https://github.com/dotnet/dotnet-docker/pull/4990

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
