### PR TITLE
Add mutating profiler symbols to symbols package

### DIFF
--- a/src/archives/dotnet-monitor-base/Package.props
+++ b/src/archives/dotnet-monitor-base/Package.props
@@ -70,7 +70,9 @@
     <SymbolFileToArchive Include="@(MutatingMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
       <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
     </SymbolFileToArchive>
-    <SymbolFileToArchive Include="@(CommonMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+    <!-- Symbols are not created for static libraries on non-Windows platforms -->
+    <SymbolFileToArchive Include="@(CommonMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))"
+                         Condition="$(RuntimeIdentifier.Contains(win))">
       <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
     </SymbolFileToArchive>
     <!-- Startup hook symbols -->

--- a/src/archives/dotnet-monitor-base/Package.props
+++ b/src/archives/dotnet-monitor-base/Package.props
@@ -67,6 +67,9 @@
     <SymbolFileToArchive Include="@(MonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
       <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
     </SymbolFileToArchive>
+    <SymbolFileToArchive Include="@(MutatingMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </SymbolFileToArchive>
     <!-- Startup hook symbols -->
     <SymbolFileToArchive Include="$(StartupHookSymbolsPath)">
       <PackagePath>shared\any\$(StartupHookTargetFramework)\</PackagePath>

--- a/src/archives/dotnet-monitor-base/Package.props
+++ b/src/archives/dotnet-monitor-base/Package.props
@@ -70,6 +70,9 @@
     <SymbolFileToArchive Include="@(MutatingMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
       <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
     </SymbolFileToArchive>
+    <SymbolFileToArchive Include="@(CommonMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </SymbolFileToArchive>
     <!-- Startup hook symbols -->
     <SymbolFileToArchive Include="$(StartupHookSymbolsPath)">
       <PackagePath>shared\any\$(StartupHookTargetFramework)\</PackagePath>


### PR DESCRIPTION
###### Summary

The `MutatingMonitorProfiler.pdb` symbols are missing from the symbols archive packages. Add them so they are registered when publishing symbols.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2312327&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
