### PR TITLE
Increase stopping event test timeouts

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectTraceTests.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
     [Collection(DefaultCollectionFixture.Name)]
     public class CollectTraceTests
     {
+        TimeSpan DefaultNotStoppedCollectTraceTimeout = TimeSpan.FromSeconds(15);
+
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ITestOutputHelper _outputHelper;
 
@@ -63,7 +65,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [Fact]
         public Task StopOnEvent_DoesNotStop_WhenOpcodeDoesNotMatch()
         {
-            return StopOnEventTestCore(expectStoppingEvent: false, opcode: TraceEventOpcode.Resume);
+            return StopOnEventTestCore(expectStoppingEvent: false, opcode: TraceEventOpcode.Resume, duration: DefaultNotStoppedCollectTraceTimeout);
         }
 
         [Fact]
@@ -73,7 +75,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             {
                 { TestAppScenarios.TraceEvents.UniqueEventPayloadField, TestAppScenarios.TraceEvents.UniqueEventMessage },
                 { "foobar", "baz" }
-            });
+            },
+            duration: DefaultNotStoppedCollectTraceTimeout);
         }
 
         [Fact]
@@ -82,7 +85,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             return StopOnEventTestCore(expectStoppingEvent: false, payloadFilter: new Dictionary<string, string>()
             {
                 { TestAppScenarios.TraceEvents.UniqueEventPayloadField, TestAppScenarios.TraceEvents.UniqueEventMessage.ToUpperInvariant() }
-            });
+            },
+            duration: DefaultNotStoppedCollectTraceTimeout);
         }
 
         [Fact]
@@ -134,7 +138,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             return StopOnEventTestCore(expectStoppingEvent: false,
                 collectRundown: true,
                 opcode: TraceEventOpcode.Resume,
-                duration: TimeSpan.FromSeconds(200),
                 stopWithApi: true);
         }
 
@@ -152,7 +155,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             TimeSpan? duration = null,
             bool stopWithApi = false)
         {
-            TimeSpan DefaultCollectTraceTimeout = TimeSpan.FromSeconds(10);
             const string DefaultRuleName = "FunctionalTestRule";
             const string EgressProvider = "TmpEgressProvider";
 
@@ -200,7 +202,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                             },
                             EgressProvider, options =>
                             {
-                                options.Duration = duration ?? DefaultCollectTraceTimeout;
+                                options.Duration = duration ?? CommonTestTimeouts.GeneralTimeout;
                                 options.StoppingEvent = traceEventFilter;
                                 options.RequestRundown = collectRundown;
                             });


### PR DESCRIPTION
###### Summary

The currently stopping event timeout (10 seconds) isn't always enough in our CI pipelines. Switch to using the general timeout (3 minutes) for all stopping event tests that expect to be stopped early.

For tests that expect to not be stopped by an event (and thus take the full timeout), use a timeout of 15 seconds to avoid slowing down successful test runs.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
