### PR TITLE
Pin Az.Storage module version

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -163,8 +163,8 @@ stages:
           - powershell: Install-PackageProvider -Name NuGet -Force -Scope CurrentUser
             displayName: Install NuGet PowerShell Package Provider
 
-          - powershell: Install-Module Az.Storage -Force -Scope CurrentUser -AllowClobber -Verbose
-            displayName: Install Az.Storage Module
+          - powershell: Install-Module Az.Storage -Force -Scope CurrentUser -AllowClobber -Verbose -RequiredVersion 5.10.1
+            displayName: Install Az.Storage Module 5.10.1
 
           - powershell: |
               Write-Host "##vso[task.setvariable variable=DestinationAccountName]$env:DESTINATION_ACCOUNT_NAME"


### PR DESCRIPTION
###### Summary

The `Az.Storage` PowerShell module released a new version today that has breaking changes regarding the generation of SAS tokens. This change initially blocked the ability to copy between blob storage accounts that are secured with SAS tokens. To mitigate this, pin the module version until changes can be made to adapt to the breaking change.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
