### PR TITLE
Use 8.0 RTM SDK and runtimes

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -2,6 +2,28 @@
 #! Either use the "Regenerate dependabot.yml" task in Codespaces, or run the following command:
 #! > ytt -f .github/dependabot.template.yml > .github/dependabot.yml
 
+#@ load("@ytt:struct", "struct")
+
+#! Returns a dictionary that maps the major version of .NET Monitor
+#! to the list of TFMs that the major version uses for build and test.
+#@ def getTfms():
+#@   return {
+#@     "8": [ "net8.0", "net7.0", "net6.0" ],
+#@     "7": [ "net7.0", "net6.0" ],
+#@     "6": [ "net6.0", "netcoreapp3.1" ]
+#@   }
+#@ end
+
+#! Returns an array of structs that represent a registration of the
+#! target branch and which major version of .NET Monitor it builds.
+#@ def getBranches():
+#@   return [
+#@     struct.encode({"name": "main", "majorVersion": "8"}),
+#@     struct.encode({"name": "release/7.x", "majorVersion": "7"}),
+#@     struct.encode({"name": "release/6.x", "majorVersion": "6"}),
+#@   ]
+#@ end
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -9,13 +31,13 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
-#@ for branch in ["main", "release/7.x", "release/6.x"]:
-#@ commit_prefix = "[" + branch + "] "
+#@ for branch in getBranches():
+#@ commit_prefix = "[" + branch.name + "] "
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     schedule:
       interval: "daily"
-    target-branch: #@ branch
+    target-branch: #@ branch.name
     ignore:
       - dependency-name: "Microsoft.Extensions.*"
         update-types: [ "version-update:semver-major" ]
@@ -34,15 +56,15 @@ updates:
     directory: "/eng/dependabot/nuget.org"
     schedule:
       interval: "daily"
-    target-branch: #@ branch
+    target-branch: #@ branch.name
     commit-message:
       prefix: #@ commit_prefix
-#@ for tfm in ["net7.0", "net6.0", "netcoreapp3.1"]:
+#@ for tfm in getTfms()[branch.majorVersion]:
   - package-ecosystem: "nuget"
     directory: #@ "/eng/dependabot/" + tfm
     schedule:
       interval: "daily"
-    target-branch: #@ branch
+    target-branch: #@ branch.name
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,22 @@ updates:
   commit-message:
     prefix: '[main] '
 - package-ecosystem: nuget
+  directory: /eng/dependabot/net8.0
+  schedule:
+    interval: daily
+  target-branch: main
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[main] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.App.Runtime.*
+- package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
     interval: daily
@@ -50,22 +66,6 @@ updates:
       - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
-  schedule:
-    interval: daily
-  target-branch: main
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[main] '
-  groups:
-    runtime-dependencies:
-      patterns:
-      - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
-- package-ecosystem: nuget
-  directory: /eng/dependabot/netcoreapp3.1
   schedule:
     interval: daily
   target-branch: main
@@ -140,22 +140,6 @@ updates:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
-  directory: /eng/dependabot/netcoreapp3.1
-  schedule:
-    interval: daily
-  target-branch: release/7.x
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/7.x] '
-  groups:
-    runtime-dependencies:
-      patterns:
-      - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
-- package-ecosystem: nuget
   directory: /eng/dependabot
   schedule:
     interval: daily
@@ -182,22 +166,6 @@ updates:
   target-branch: release/6.x
   commit-message:
     prefix: '[release/6.x] '
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net7.0
-  schedule:
-    interval: daily
-  target-branch: release/6.x
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/6.x] '
-  groups:
-    runtime-dependencies:
-      patterns:
-      - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -106,10 +106,10 @@
   <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp80Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions80Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging80Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions80Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole80Version)</MicrosoftExtensionsLoggingConsoleVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">
     <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,6 +4,7 @@
   <Import Project="dependabot/nuget.org/Versions.props" />
   <Import Project="dependabot/net6.0/Versions.props" />
   <Import Project="dependabot/net7.0/Versions.props" />
+  <Import Project="dependabot/net8.0/Versions.props" />
   <Import Project="dependabot/netcoreapp3.1/Versions.props" />
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
@@ -79,8 +80,7 @@
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftNETCoreApp70Version)</MicrosoftAspNetCoreApp70Version>
-    <MicrosoftNETCoreApp80Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp80Version>
-    <MicrosoftAspNetCoreApp80Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp80Version>
+    <MicrosoftAspNetCoreApp80Version>$(MicrosoftNETCoreApp80Version)</MicrosoftAspNetCoreApp80Version>
   </PropertyGroup>
   <PropertyGroup Label="Dev Workflow">
     <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow

--- a/eng/dependabot/net8.0/Directory.Build.props
+++ b/eng/dependabot/net8.0/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Dependendabot is configured to read package versions from Directory.Build.props, so just use this file as a shim. -->
+  <Import Project="Versions.props" />
+</Project>

--- a/eng/dependabot/net8.0/NuGet.config
+++ b/eng/dependabot/net8.0/NuGet.config
@@ -1,0 +1,1 @@
+../../../NuGet.config

--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -1,0 +1,12 @@
+<Project>
+  <!--
+    Packages in this file have versions updated periodically by Dependabot specifically for .NET 7.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions80Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging80Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions80Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsole80Version)" />
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreApp80Version)" />
+  </ItemGroup>
+</Project>

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -1,0 +1,15 @@
+<Project>
+  <!-- Import references updated by Dependabot. -->
+  <PropertyGroup>
+    <!-- Microsoft.Extensions.Configuration.Abstractions -->
+    <MicrosoftExtensionsConfigurationAbstractions80Version>7.0.0</MicrosoftExtensionsConfigurationAbstractions80Version>
+    <!-- Microsoft.Extensions.Logging -->
+    <MicrosoftExtensionsLogging80Version>8.0.0</MicrosoftExtensionsLogging80Version>
+    <!-- Microsoft.Extensions.Logging.Abstractions -->
+    <MicrosoftExtensionsLoggingAbstractions80Version>8.0.0</MicrosoftExtensionsLoggingAbstractions80Version>
+    <!-- Microsoft.Extensions.Logging.Console -->
+    <MicrosoftExtensionsLoggingConsole80Version>8.0.0</MicrosoftExtensionsLoggingConsole80Version>
+    <!-- Microsoft.NETCore.App -->
+    <MicrosoftNETCoreApp80Version>8.0.0</MicrosoftNETCoreApp80Version>
+  </PropertyGroup>
+</Project>

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -2,7 +2,7 @@
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
     <!-- Microsoft.Extensions.Configuration.Abstractions -->
-    <MicrosoftExtensionsConfigurationAbstractions80Version>7.0.0</MicrosoftExtensionsConfigurationAbstractions80Version>
+    <MicrosoftExtensionsConfigurationAbstractions80Version>8.0.0</MicrosoftExtensionsConfigurationAbstractions80Version>
     <!-- Microsoft.Extensions.Logging -->
     <MicrosoftExtensionsLogging80Version>8.0.0</MicrosoftExtensionsLogging80Version>
     <!-- Microsoft.Extensions.Logging.Abstractions -->

--- a/eng/dependabot/net8.0/dependabot.csproj
+++ b/eng/dependabot/net8.0/dependabot.csproj
@@ -1,0 +1,2 @@
+<!-- This isn't a real project, but Dependabot requires a project. -->
+<Project/>

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -129,7 +129,7 @@
     <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp70Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
-    <AdditionalDotNetPackage Include="$(VSRedistCommonAspNetCoreSharedFrameworkx6480Version)">
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp80Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,26 +1,26 @@
 {
   "tools": {
-    "dotnet": "8.0.100-rtm.23506.1",
+    "dotnet": "8.0.100",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(MicrosoftAspNetCoreApp70Version)",
-        "$(VSRedistCommonAspNetCoreSharedFrameworkx6480Version)"
+        "$(MicrosoftAspNetCoreApp80Version)"
       ],
       "aspnetcore/x86": [
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(MicrosoftAspNetCoreApp70Version)",
-        "$(VSRedistCommonAspNetCoreSharedFrameworkx6480Version)"
+        "$(MicrosoftAspNetCoreApp80Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp60Version)",
         "$(MicrosoftNETCoreApp70Version)",
-        "$(VSRedistCommonNetCoreSharedFrameworkx6480Version)"
+        "$(MicrosoftNETCoreApp80Version)"
       ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreApp60Version)",
         "$(MicrosoftNETCoreApp70Version)",
-        "$(VSRedistCommonNetCoreSharedFrameworkx6480Version)"
+        "$(MicrosoftNETCoreApp80Version)"
       ]
     }
   },


### PR DESCRIPTION
###### Summary

- Use the 8.0 RTM SDK for building binaries
- Switch the test runtime versions to the RTM versions
- Add net8.0 dependabot dependency updates to `main` branch.
- Refactor the dependabot configuration template to update target branches with the TFMs that exist in those branches.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
