### PR TITLE
Clear minor release date when promoting a preview version to RTM

### DIFF
--- a/.github/actions/update-releases-json/index.js
+++ b/.github/actions/update-releases-json/index.js
@@ -61,7 +61,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
 
     // Preserve the original minor release date and out-of-support date for RTM releases
     if (existingRelease !== undefined &&
-        actionUtils.isVersionTagRTM (existingRelease.tag) &&
+        actionUtils.isVersionTagRTM(existingRelease.tag) &&
         isRTMRelease) {
 
         newRelease.minorReleaseDate = existingRelease.minorReleaseDate;

--- a/.github/actions/update-releases-json/index.js
+++ b/.github/actions/update-releases-json/index.js
@@ -61,7 +61,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
 
     // Preserve the original minor release date and out-of-support date for RTM releases
     if (existingRelease !== undefined &&
-        actionUtils.isRTMRelease(existingRelease.tag) &&
+        actionUtils.isVersionTagRTM (existingRelease.tag) &&
         isRTMRelease) {
 
         newRelease.minorReleaseDate = existingRelease.minorReleaseDate;

--- a/.github/actions/update-releases-json/index.js
+++ b/.github/actions/update-releases-json/index.js
@@ -47,6 +47,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
 
     const [majorVersion, minorVersion, patchVersion, iteration] = actionUtils.splitVersionTag(releasePayload.tag_name);
     const releaseMajorMinorVersion = `${majorVersion}.${minorVersion}`;
+    const isRTMRelease = (iteration === undefined);
 
     // See if we're updating a release
     let existingRelease = releasesData.releases[releaseMajorMinorVersion];
@@ -59,7 +60,10 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
     };
 
     // Preserve the original minor release date and out-of-support date for RTM releases
-    if (existingRelease !== undefined && iteration === undefined) {
+    if (existingRelease !== undefined &&
+        actionUtils.isRTMRelease(existingRelease.tag) &&
+        isRTMRelease) {
+
         newRelease.minorReleaseDate = existingRelease.minorReleaseDate;
         newRelease.outOfSupportDate = existingRelease.outOfSupportDate;
     }
@@ -67,7 +71,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
     releasesData.releases[releaseMajorMinorVersion] = newRelease;
 
     // Check if we're going to be putting a version out-of-support.
-    if (minorVersion > 0 && patchVersion === 0 && iteration === undefined) {
+    if (minorVersion > 0 && patchVersion === 0 && isRTMRelease) {
         const endOfSupportDate = new Date(releaseDate.valueOf());
         endOfSupportDate.setMonth(endOfSupportDate.getMonth() + releasesData.policy.additionalMonthsOfSupportOnNewMinorRelease);
 


### PR DESCRIPTION
###### Summary

When releasing a GA build of a version that was previously in preview, we would incorrectly preserve the minor release date of the preview version.

To fix this, check if the existing version (the one that has been previously released with the same major/minor/patch version) is RTM before preserving its minor release date.

closes #5690

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
