### PR TITLE
Add compliance pipeline and scripts

### DIFF
--- a/eng/pipelines/dotnet-monitor-compliance.yml
+++ b/eng/pipelines/dotnet-monitor-compliance.yml
@@ -1,0 +1,118 @@
+resources:
+  pipelines:
+  - pipeline: Build
+    source: dotnet-dotnet-monitor
+
+trigger: none
+pr: none
+
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml
+- group: DotNet-ApiScan
+- group: DotNetBuilds storage account read tokens
+- group: Release-Pipeline
+- name: _TeamName
+  value: DotNetCore
+  readonly: true
+
+stages:
+- stage: Compliance
+
+  pool:
+    name: $(DncEngInternalBuildPool)
+    demands: ImageOverride -equals 1es-windows-2019
+
+  jobs:
+  - job: Validate
+    timeoutInMinutes: 180
+
+    workspace:
+      clean: all
+
+    steps:    
+    - task: PowerShell@2
+      displayName: Get BAR ID
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBarId.ps1
+        arguments: >-
+          -BuildId $(resources.pipeline.Build.runID)
+          -TaskVariableName 'BuildBarId'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    
+    - task: PowerShell@2
+      displayName: 'Get Build Version'
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+        arguments: >-
+          -BarId $(BuildBarId)
+          -MaestroToken $(MaestroAccessToken)
+          -TaskVariableName 'BuildVersion'
+    
+    # Only scan the files that are being shipped; use the same gathering procedure
+    # that the asset staging process uses.
+    - task: PowerShell@2
+      displayName: 'Download Build Assets'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
+        arguments: >-
+          -BarBuildId "$(BuildBarId)"
+          -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
+          -MaestroToken "$(MaestroAccessToken)"
+          -GitHubToken "$(BotAccount-dotnet-bot-repo-PAT)"
+          -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
+          -SasSuffixes "$(dotnetbuilds-internal-checksums-container-read-token),$(dotnetbuilds-internal-container-read-token)"
+          -ReleaseVersion "$(BuildVersion)"
+          -Separated $False
+        workingDirectory: '$(Build.Repository.LocalPath)'
+      continueOnError: true
+    
+    # All of the relevant assets are packages, which must be extracted before scanning
+    - task: PowerShell@2
+      displayName: 'Extract Package Assets'
+      inputs:
+        targetType: filePath
+        filePath: '$(Build.Repository.LocalPath)/eng/pipelines/scripts/Extract-Assets.ps1'
+        arguments: >-
+          -SourcePath '$(System.ArtifactsDirectory)\BuildAssets'
+          -TargetPath '$(System.ArtifactsDirectory)\UnpackedAssets'
+
+    # Copy eligible files to be scanned
+    - task: PowerShell@2
+      displayName: 'Copy Eligible Assets'
+      inputs:
+        pwsh: true
+        targetType: filePath
+        filePath: '$(Build.Repository.LocalPath)/eng/pipelines/scripts/Copy-ApiScanEligible.ps1'
+        arguments: >-
+          -SourcePath '$(System.ArtifactsDirectory)\UnpackedAssets'
+          -TargetPath '$(System.ArtifactsDirectory)\ApiScan'
+
+    - task: APIScan@2
+      displayName: Run APIScan
+      inputs:
+        softwareFolder: '$(System.ArtifactsDirectory)\ApiScan'
+        softwareName: 'Dotnet-Monitor'
+        softwareVersionNum: '$(BuildVersion)'
+        softwareBuildNum: '$(resources.pipeline.Build.runID)'
+        symbolsFolder: 'SRV*http://symweb'
+      env:
+        AzureServicesAuthConnectionString: runAs=App;AppId=$(apiscan-service-principal-app-id);TenantId=72f988bf-86f1-41af-91ab-2d7cd011db47;AppKey=$(apiscan-service-principal-app-secret)
+      continueOnError: true
+
+    - task: PublishSecurityAnalysisLogs@3
+      displayName: Publish Analysis
+      inputs:
+        ArtifactName: 'CodeAnalysisLogs'
+        ArtifactType: 'Container'
+        AllTools: false
+        ApiScan: true
+        ToolLogsNotFoundAction: 'Standard'
+    
+    - task: PostAnalysis@2
+      displayName: Fail if Issues are Detected
+      condition: succeededOrFailed()
+      inputs:
+        GdnBreakAllTools: true
+        GdnBreakGdnToolApiScanSeverity: Warning

--- a/eng/pipelines/scripts/Copy-ApiScanEligible.ps1
+++ b/eng/pipelines/scripts/Copy-ApiScanEligible.ps1
@@ -1,0 +1,97 @@
+param(
+  [Parameter(Mandatory=$true)][string] $SourcePath,
+  [Parameter(Mandatory=$true)][string] $TargetPath,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+if ($null -ne $properties) {
+  Write-Host "Unexpected extra parameters: $properties."
+  exit 1
+}
+
+$copyCount = 0
+$skipCount = 0
+
+# Copy files from source to target directory while preserving the relative directory structure
+function Copy-File() {
+  param(
+    [System.IO.FileInfo] $FileInfo
+  )
+  Write-Host "Copying $($FileInfo.FullName)"
+  $relativePath = [System.IO.Path]::GetRelativePath($SourcePath, $FileInfo.FullName)
+  $fileTargetPath = Join-Path -Path $TargetPath -ChildPath $relativePath
+  $fileTargetDir = [System.IO.Path]::GetDirectoryName($fileTargetPath)
+  [System.IO.Directory]::CreateDirectory($fileTargetDir) | Out-Null
+  Copy-Item -Path $FileInfo.FullName -Destination $fileTargetPath
+  $script:copyCount++
+}
+
+# Check if the file is a ARM64 PE file
+function Test-PeArm64() {
+  param(
+    [System.IO.FileInfo] $FileInfo
+  )
+  $stream = [System.IO.File]::OpenRead($FileInfo.FullName)
+  $reader = [System.IO.BinaryReader]($stream)
+  # https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
+  # MS DOS Magic Number
+  if (0x5A4D -ne $reader.ReadUInt16()) {
+    $reader.Dispose()
+    return $false
+  }
+  $stream.Position = 0x3C # NT Header offset, 4 bytes
+  $ntHeaderOffset = $reader.ReadUInt32()
+  $stream.Position = $ntHeaderOffset
+  # PE Magic Number, 4 bytes
+  if (0x00004550 -ne $reader.ReadUInt32()) {
+    $reader.Dispose()
+    return $false;
+  }
+  # Machine type, 2 bytes
+  # 0xAA64 is ARM64
+  $isArm64 = 0xAA64 -eq $reader.ReadUInt16();
+  $reader.Dispose()
+  return $isArm64
+}
+
+function Copy-Executable() {
+  param(
+    [System.IO.FileInfo] $FileInfo
+  )
+  if (Test-PeArm64 -FileInfo $fileInfo) {
+    Skip-File -FileInfo $fileInfo -Reason "ARM64 PE" # ARM64 is not supported by ApiScan
+  } else {
+    Copy-File -FileInfo $fileInfo
+  }
+}
+
+function Skip-File() {
+  param(
+    [System.IO.FileInfo] $FileInfo,
+    [string] $Reason
+  )
+  Write-Host "Skipping $($FileInfo.FullName): $Reason"
+  $script:skipCount++
+}
+
+New-Item -ItemType Directory -Force -Path $TargetPath | Out-Null
+
+foreach ($fileInfo in (Get-ChildItem $SourcePath -Recurse -Attributes !Directory)) {
+  if ($fileInfo.Directory.FullName.Contains('symbols')) { # Skip symbols packages
+    Skip-File -FileInfo $fileInfo -Reason "Symbols"
+  } elseif ($fileInfo.Extension -eq ".dll") { # Library
+    Copy-Executable -FileInfo $fileInfo
+  } elseif ($fileInfo.Extension -eq ".exe") { # Executable
+    Copy-Executable -FileInfo $fileInfo
+  } elseif ($fileInfo.Extension -eq ".pdb") { # Program database
+    Copy-File -FileInfo $fileInfo
+  } else {
+    Skip-File -FileInfo $fileInfo -Reason "Unsupported" # Skip remaining files
+  }
+}
+
+Write-Host "Copied $copyCount files."
+Write-Host "Skipped $skipCount files."

--- a/eng/pipelines/scripts/Extract-Assets.ps1
+++ b/eng/pipelines/scripts/Extract-Assets.ps1
@@ -38,7 +38,7 @@ function Extract-TarGz() {
   )
   $extractionPath = Create-PackageDir -FileName $FileInfo.Name
   Write-Host "Extracting $($FileInfo.Name)"
-  tar -xf $FileInfo.FullName -C $extractionPath
+  tar -xzf $FileInfo.FullName -C $extractionPath
 }
 
 function Copy-File() {

--- a/eng/pipelines/scripts/Extract-Assets.ps1
+++ b/eng/pipelines/scripts/Extract-Assets.ps1
@@ -1,0 +1,66 @@
+param(
+  [Parameter(Mandatory=$true)][string] $SourcePath,
+  [Parameter(Mandatory=$true)][string] $TargetPath,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+if ($null -ne $properties) {
+  Write-Host "Unexpected extra parameters: $properties."
+  exit 1
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Create-PackageDir() {
+  param( 
+    [string] $FileName
+  )
+  $extractionPath = Join-Path -Path $TargetPath -ChildPath ($FileName + "_dir")
+  New-Item -ItemType Directory -Force -Path $extractionPath | Out-Null
+  return $extractionPath
+}
+
+function Extract-Zip() {
+  param(
+    [System.IO.FileInfo] $FileInfo
+  )
+  $extractionPath = Create-PackageDir -FileName $FileInfo.Name
+  Write-Host "Extracting $($FileInfo.Name)"
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($FileInfo.FullName, $extractionPath)
+}
+
+function Extract-TarGz() {
+  param(
+    [System.IO.FileInfo] $FileInfo
+  )
+  $extractionPath = Create-PackageDir -FileName $FileInfo.Name
+  Write-Host "Extracting $($FileInfo.Name)"
+  tar -xf $FileInfo.FullName -C $extractionPath
+}
+
+function Copy-File() {
+  param(
+    [System.IO.FileInfo] $FileInfo
+  )
+  Write-Host "Copying $($FileInfo.Name)"
+  Copy-Item -Path $FileInfo.FullName -Destination $TargetPath
+}
+
+New-Item -ItemType Directory -Force -Path $TargetPath | Out-Null
+
+foreach ($fileInfo in (Get-ChildItem $SourcePath -Recurse -Attributes !Directory)) {
+  if ($fileInfo.Name.EndsWith('symbols.nupkg')) {
+    Extract-Zip -FileInfo $fileInfo
+  } elseif ($fileInfo.Name.EndsWith('nupkg')) {
+    Extract-Zip -FileInfo $fileInfo
+  } elseif ($fileInfo.Name.EndsWith('zip')) {
+    Extract-Zip -FileInfo $fileInfo
+  } elseif ($fileInfo.Name.EndsWith('tar.gz')) {
+    Extract-TarGz -FileInfo $fileInfo
+  } else {
+    Copy-File -FileInfo $fileInfo
+  }
+}

--- a/eng/release/Scripts/AcquireBuild.ps1
+++ b/eng/release/Scripts/AcquireBuild.ps1
@@ -8,6 +8,7 @@ param(
   [Parameter(Mandatory=$true)][string] $GitHubToken,
   [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
   [Parameter(Mandatory=$false)][string] $DarcVersion = $null,
+  [Parameter(Mandatory=$false)][bool] $Separated = $true,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
@@ -19,8 +20,9 @@ function Write-Help() {
     Write-Host "  -SasSuffixes <value>              Comma separated list of potential uri suffixes that can be used if anonymous access to a blob uri fails. Appended directly to the end of the URI. Use full SAS syntax with ?."
     Write-Host "  -AzdoToken <value>                Azure DevOps token to use for builds queries"
     Write-Host "  -MaestroToken <value>             Maestro token to use for querying BAR"
-    Write-Host "  -GitHubToken <value>             GitHub token to use for querying repository information"
+    Write-Host "  -GitHubToken <value>              GitHub token to use for querying repository information"
     Write-Host "  -MaestroApiEndPoint <value>       BAR endpoint to use for build queries."
+    Write-Host "  -Separated <`$true|`$false>       Download files to their repo separated locations."
     Write-Host ""
 }
 
@@ -49,6 +51,11 @@ try {
         $darc = Get-Darc $DarcVersion
     }
 
+    $separatedArgs = ""
+    if ($Separated) {
+        $separatedArgs = "--separated"
+    }
+
     & $darc gather-drop `
         --id $BarBuildId `
         --release-name $ReleaseVersion `
@@ -59,9 +66,9 @@ try {
         --azdev-pat $AzdoToken `
         --bar-uri $MaestroApiEndPoint `
         --password $MaestroToken `
-        --separated `
         --verbose `
-        --continue-on-error
+        --continue-on-error `
+        $separatedArgs
 
     if ($LastExitCode -ne 0) {
         Write-Host "Error: unable to gather the assets from build $BarBuildId to $DownloadTargetPath using darc."


### PR DESCRIPTION
###### Summary

Add a pipeline for running ApiScan on the shipping assets. Shipping assets are downloaded, unpacked, and filtered to what is applicable to ApiScan. All results are uploaded as an artifact on the pipeline. This pipeline requires manual invocation at this time.

Example run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2318464&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
