### PR TITLE
Lower CPU threshold in collection rule integration tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
@@ -195,10 +195,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(NonStartupRuleName)
                         .SetEventCounterTrigger(options =>
                         {
-                            // cpu usage greater that 5% for 2 seconds
+                            // cpu usage greater than 1% for 2 seconds
                             options.ProviderName = "System.Runtime";
                             options.CounterName = "cpu-usage";
-                            options.GreaterThan = 5;
+                            options.GreaterThan = 1;
                             options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
                         })
                         .AddExecuteActionAppAction(Assembly.GetExecutingAssembly(), "TextFileOutput", ExpectedFilePath, ExpectedFileContent)
@@ -329,10 +329,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(NonStartupRuleName)
                         .SetEventCounterTrigger(options =>
                         {
-                            // cpu usage greater that 5% for 2 seconds
+                            // cpu usage greater than 1% for 2 seconds
                             options.ProviderName = "System.Runtime";
                             options.CounterName = "cpu-usage";
-                            options.GreaterThan = 5;
+                            options.GreaterThan = 1;
                             options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
                         })
                         .AddExecuteActionAppAction(Assembly.GetExecutingAssembly(), "TextFileOutput", ExpectedFilePath, ExpectedFileContent)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleDescriptionTests.cs
@@ -195,11 +195,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(NonStartupRuleName)
                         .SetEventCounterTrigger(options =>
                         {
-                            // cpu usage greater than 1% for 2 seconds
+                            // cpu usage greater than 1% for 1 second
                             options.ProviderName = "System.Runtime";
                             options.CounterName = "cpu-usage";
                             options.GreaterThan = 1;
-                            options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
+                            options.SlidingWindowDuration = TimeSpan.FromSeconds(1);
                         })
                         .AddExecuteActionAppAction(Assembly.GetExecutingAssembly(), "TextFileOutput", ExpectedFilePath, ExpectedFileContent)
                         .SetActionLimits(count: ExpectedActionCountLimit);
@@ -329,11 +329,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(NonStartupRuleName)
                         .SetEventCounterTrigger(options =>
                         {
-                            // cpu usage greater than 1% for 2 seconds
+                            // cpu usage greater than 1% for 1 second
                             options.ProviderName = "System.Runtime";
                             options.CounterName = "cpu-usage";
                             options.GreaterThan = 1;
-                            options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
+                            options.SlidingWindowDuration = TimeSpan.FromSeconds(1);
                         })
                         .AddExecuteActionAppAction(Assembly.GetExecutingAssembly(), "TextFileOutput", ExpectedFilePath, ExpectedFileContent)
                         .SetActionLimits(count: ExpectedActionCountLimit);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -107,10 +107,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
                         .SetEventCounterTrigger(options =>
                         {
-                            // cpu usage greater that 5% for 2 seconds
+                            // cpu usage greater than 1% for 2 seconds
                             options.ProviderName = "System.Runtime";
                             options.CounterName = "cpu-usage";
-                            options.GreaterThan = 5;
+                            options.GreaterThan = 1;
                             options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
                         })
                         .AddExecuteActionAppAction(Assembly.GetExecutingAssembly(), "TextFileOutput", ExpectedFilePath, ExpectedFileContent)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -107,11 +107,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     runner.ConfigurationFromEnvironment.CreateCollectionRule(DefaultRuleName)
                         .SetEventCounterTrigger(options =>
                         {
-                            // cpu usage greater than 1% for 2 seconds
+                            // cpu usage greater than 1% for 1 second
                             options.ProviderName = "System.Runtime";
                             options.CounterName = "cpu-usage";
                             options.GreaterThan = 1;
-                            options.SlidingWindowDuration = TimeSpan.FromSeconds(2);
+                            options.SlidingWindowDuration = TimeSpan.FromSeconds(1);
                         })
                         .AddExecuteActionAppAction(Assembly.GetExecutingAssembly(), "TextFileOutput", ExpectedFilePath, ExpectedFileContent)
                         .SetActionLimits(count: 1);


### PR DESCRIPTION
###### Summary

The collection rule tests that use a CPU usage trigger are have sporadically not completion, which causes the test to wait for a long time and eventually timeout. Attempt to mitigate by lowering the CPU threshold for these tests.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
