### PR TITLE
[Parameter Capturing] Refactor probe management API to accept more detailed boxing instructions

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -20,7 +20,7 @@
         "arity",
         "armv",
         "Bldr",
-        "Blittable",
+        "blittable",
         "Brotli",
         "Browsable",
         "callstacks",

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
         "arity",
         "armv",
         "Bldr",
+        "Blittable",
         "Brotli",
         "Browsable",
         "callstacks",

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingInstructions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
             //
             // A signature decoder will used to determine boxing tokens for parameter types that cannot be determined from standard
             // reflection alone. The boxing tokens generated from this decoder should only be used to fill in these gaps
-            // as it is not a comprehensive decoder and will produce an unsupport boxing instruction for any types not explicitly mentioned
+            // as it is not a comprehensive decoder and will produce an unsupported boxing instruction for any types not explicitly mentioned
             // in BoxingTokensSignatureProvider's summary.
             // 
             Lazy<ParameterBoxingInstructions[]?> ancillaryInstructions = new(() => GetAncillaryBoxingInstructionsFromMethodSignature(method));

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokensSignatureProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokensSignatureProvider.cs
@@ -13,28 +13,28 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
     ///
     /// The results of this decoder should not be used for any types not listed above.
     /// </summary>
-    internal sealed class BoxingTokensSignatureProvider : ISignatureTypeProvider<uint, object?>
+    internal sealed class BoxingTokensSignatureProvider : ISignatureTypeProvider<uint?, object?>
     {
         //
         // Supported
         //
-        public uint GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => (uint)MetadataTokens.GetToken(handle);
+        public uint? GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => (uint)MetadataTokens.GetToken(handle);
 
         //
         // Unsupported
         //
-        public uint GetArrayType(uint elementType, ArrayShape shape) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetByReferenceType(uint elementType) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetFunctionPointerType(MethodSignature<uint> signature) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetGenericInstantiation(uint genericType, ImmutableArray<uint> typeArguments) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetGenericMethodParameter(object? genericContext, int index) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetGenericTypeParameter(object? genericContext, int index) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetModifiedType(uint modifier, uint unmodifiedType, bool isRequired) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetPinnedType(uint elementType) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetPointerType(uint elementType) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetPrimitiveType(PrimitiveTypeCode typeCode) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetSZArrayType(uint elementType) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => BoxingTokens.UnsupportedParameterToken;
-        public uint GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => BoxingTokens.UnsupportedParameterToken;
+        public uint? GetArrayType(uint? elementType, ArrayShape shape) => null;
+        public uint? GetByReferenceType(uint? elementType) => null;
+        public uint? GetFunctionPointerType(MethodSignature<uint?> signature) => null;
+        public uint? GetGenericInstantiation(uint? genericType, ImmutableArray<uint?> typeArguments) => null;
+        public uint? GetGenericMethodParameter(object? genericContext, int index) => null;
+        public uint? GetGenericTypeParameter(object? genericContext, int index) => null;
+        public uint? GetModifiedType(uint? modifier, uint? unmodifiedType, bool isRequired) => null;
+        public uint? GetPinnedType(uint? elementType) => null;
+        public uint? GetPointerType(uint? elementType) => null;
+        public uint? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
+        public uint? GetSZArrayType(uint? elementType) => null;
+        public uint? GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => null;
+        public uint? GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => null;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokensSignatureProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/BoxingTokensSignatureProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -13,28 +14,28 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
     ///
     /// The results of this decoder should not be used for any types not listed above.
     /// </summary>
-    internal sealed class BoxingTokensSignatureProvider : ISignatureTypeProvider<uint?, object?>
+    internal sealed class BoxingTokensSignatureProvider : ISignatureTypeProvider<ParameterBoxingInstructions, object?>
     {
         //
         // Supported
         //
-        public uint? GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => (uint)MetadataTokens.GetToken(handle);
+        public ParameterBoxingInstructions GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => (uint)MetadataTokens.GetToken(handle);
 
         //
         // Unsupported
         //
-        public uint? GetArrayType(uint? elementType, ArrayShape shape) => null;
-        public uint? GetByReferenceType(uint? elementType) => null;
-        public uint? GetFunctionPointerType(MethodSignature<uint?> signature) => null;
-        public uint? GetGenericInstantiation(uint? genericType, ImmutableArray<uint?> typeArguments) => null;
-        public uint? GetGenericMethodParameter(object? genericContext, int index) => null;
-        public uint? GetGenericTypeParameter(object? genericContext, int index) => null;
-        public uint? GetModifiedType(uint? modifier, uint? unmodifiedType, bool isRequired) => null;
-        public uint? GetPinnedType(uint? elementType) => null;
-        public uint? GetPointerType(uint? elementType) => null;
-        public uint? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
-        public uint? GetSZArrayType(uint? elementType) => null;
-        public uint? GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => null;
-        public uint? GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => null;
+        public ParameterBoxingInstructions GetArrayType(ParameterBoxingInstructions elementType, ArrayShape shape) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetByReferenceType(ParameterBoxingInstructions elementType) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetFunctionPointerType(MethodSignature<ParameterBoxingInstructions> signature) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetGenericInstantiation(ParameterBoxingInstructions genericType, ImmutableArray<ParameterBoxingInstructions> typeArguments) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetGenericMethodParameter(object? genericContext, int index) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetGenericTypeParameter(object? genericContext, int index) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetModifiedType(ParameterBoxingInstructions modifier, ParameterBoxingInstructions unmodifiedType, bool isRequired) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetPinnedType(ParameterBoxingInstructions elementType) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetPointerType(ParameterBoxingInstructions elementType) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetPrimitiveType(PrimitiveTypeCode typeCode) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetSZArrayType(ParameterBoxingInstructions elementType) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => SpecialCaseBoxingTypes.Unknown;
+        public ParameterBoxingInstructions GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => SpecialCaseBoxingTypes.Unknown;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/InstrumentedMethod.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/InstrumentedMethod.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
     {
         private static readonly string[] SystemTypePrefixes = { nameof(System), nameof(Microsoft) };
 
-        public InstrumentedMethod(MethodInfo method, uint[] boxingTokens)
+        public InstrumentedMethod(MethodInfo method, ParameterBoxingInstructions[] boxingInstructions)
         {
             FunctionId = method.GetFunctionId();
-            SupportedParameters = BoxingTokens.AreParametersSupported(boxingTokens);
+            SupportedParameters = BoxingInstructions.AreParametersSupported(boxingInstructions);
             MethodTemplateString = new MethodTemplateString(method);
             foreach (bool isParameterSupported in SupportedParameters)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+//
+// !!IMPORTANT!!
+// All types in this file are also used by the mutating profiler during PINVOKEs and so **need** to be kept in sync
+// with the profiler's version (found in src\Profilers\MutatingMonitorProfiler\ProbeInstrumentation\ProbeInjector.h).
+//
+
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes
 {
     internal enum SpecialCaseBoxingTypes : uint

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes
+{
+    public enum SpecialCaseBoxingTypes : uint
+    {
+        Unknown = 0,
+        Object,
+        Boolean,
+        Char,
+        SByte,
+        Byte,
+        Int16,
+        UInt16,
+        Int32,
+        UInt32,
+        Int64,
+        UInt64,
+        IntPtr,
+        UIntPtr,
+        Single,
+        Double,
+    };
+
+    internal enum InstructionType : ushort
+    {
+        Unknown = 0,
+        SpecialCaseToken,
+        MetadataToken
+    }
+
+    internal struct ParameterBoxingInstructions
+    {
+        public InstructionType InstructionType;
+
+        public uint Token;
+
+        public static implicit operator ParameterBoxingInstructions(uint mdToken)
+        {
+            return new ParameterBoxingInstructions()
+            {
+                InstructionType = InstructionType.MetadataToken,
+                Token = mdToken
+            };
+        }
+
+        public static implicit operator ParameterBoxingInstructions(SpecialCaseBoxingTypes token)
+        {
+            return new ParameterBoxingInstructions()
+            {
+                InstructionType = InstructionType.SpecialCaseToken,
+                Token = (uint)token
+            };
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
@@ -7,6 +7,8 @@
 // with the profiler's version (found in src\Profilers\MutatingMonitorProfiler\ProbeInstrumentation\ProbeInjector.h).
 //
 
+using System.Runtime.InteropServices;
+
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes
 {
     internal enum SpecialCaseBoxingTypes : uint
@@ -36,6 +38,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
         MetadataToken
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     internal struct ParameterBoxingInstructions
     {
         public InstructionType InstructionType;

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes
 {
-    public enum SpecialCaseBoxingTypes : uint
+    internal enum SpecialCaseBoxingTypes : uint
     {
         Unknown = 0,
         Object,

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/ProfilerAbi.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
     {
         public InstructionType InstructionType;
 
+        //
+        // NOTE: The profiler represents this Token field as a union for easier type handling.
+        // However it takes extra steps (static asserts) to ensure that the union is the same
+        // size as a uint so it won't impact the size of the struct or field offsets.
+        //
         public uint Token;
 
         public static implicit operator ParameterBoxingInstructions(uint mdToken)

--- a/src/Profilers/MutatingMonitorProfiler/ProbeInstrumentation/ProbeInjector.h
+++ b/src/Profilers/MutatingMonitorProfiler/ProbeInstrumentation/ProbeInjector.h
@@ -38,17 +38,22 @@ enum class SpecialCaseBoxingTypes : ULONG32
     TYPE_DOUBLE
 };
 
+typedef union _BOXING_INSTRUCTION_TOKEN_UNION
+{
+    ULONG32 mdToken;
+    SpecialCaseBoxingTypes specialCaseToken;
+} BOXING_INSTRUCTION_TOKEN_UNION;
+
 // Ensure that the size of SpecialCaseBoxingTypes is the same size as ULONG32
 // so that the union used below for easy type access doesn't alter the size of the struct.
 static_assert(sizeof(SpecialCaseBoxingTypes) == sizeof(ULONG32), "SpecialCaseBoxingTypes should be same size as ULONG32");
+// Also make sure the union is the expected size.
+static_assert(sizeof(BOXING_INSTRUCTION_TOKEN_UNION) == sizeof(ULONG32), "BOXING_INSTRUCTION_TOKEN_UNION should be same size as ULONG32");
 
 typedef struct _PARAMETER_BOXING_INSTRUCTIONS
 {
     InstructionType instructionType;
-    union {
-        ULONG32 mdToken;
-        SpecialCaseBoxingTypes specialCaseToken;
-    } token;
+    BOXING_INSTRUCTION_TOKEN_UNION token;
 } PARAMETER_BOXING_INSTRUCTIONS;
 
 typedef struct _INSTRUMENTATION_REQUEST

--- a/src/Profilers/MutatingMonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.cpp
+++ b/src/Profilers/MutatingMonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.cpp
@@ -235,19 +235,18 @@ void STDMETHODCALLTYPE ProbeInstrumentation::OnFunctionProbeFault(ULONG64 uniqui
 STDAPI DLLEXPORT RequestFunctionProbeInstallation(
     ULONG64 functionIds[],
     ULONG32 count,
-    ULONG32 argumentBoxingTypes[],
-    ULONG32 argumentCounts[])
+    PARAMETER_BOXING_INSTRUCTIONS boxingInstructions[],
+    ULONG32 parameterCounts[])
 {
     HRESULT hr;
 
     //
     // This method receives N (where n is "count") function IDs that probes should be installed into.
     //
-    // Along with this, boxing types are provided for every argument in all of the functions, and the number of 
-    // arguments for each function can be found using argumentCounts.
+    // Along with this, boxing instructions are provided for every parameter in every requested function,
+    // and the number of parameters for each function can be found using parameterCounts.
     //
-    // The boxing types are passed in as a flattened multidimensional array (argumentBoxingTypes).
-    //
+    // The boxing types are passed in as a flattened multidimensional array (boxingInstructions).
     //
 
     //
@@ -263,22 +262,22 @@ STDAPI DLLEXPORT RequestFunctionProbeInstallation(
     ULONG32 offset = 0;
     for (ULONG32 i = 0; i < count; i++)
     {
-        if (UINT32_MAX - offset < argumentCounts[i])
+        if (UINT32_MAX - offset < parameterCounts[i])
         {
             return E_INVALIDARG;
         }
 
-        vector<ULONG32> tokens;
-        tokens.reserve(argumentCounts[i]);
-        for (ULONG32 j = 0; j < argumentCounts[i]; j++)
+        vector<PARAMETER_BOXING_INSTRUCTIONS> instructions;
+        instructions.reserve(parameterCounts[i]);
+        for (ULONG32 j = 0; j < parameterCounts[i]; j++)
         {
-            tokens.push_back(argumentBoxingTypes[offset+j]);
+            instructions.push_back(boxingInstructions[offset+j]);
         }
-        offset += argumentCounts[i];
+        offset += parameterCounts[i];
 
         UNPROCESSED_INSTRUMENTATION_REQUEST request;
         request.functionId = static_cast<FunctionID>(functionIds[i]);
-        request.boxingTypes = tokens;
+        request.boxingInstructions = instructions;
 
         requests.push_back(request);
     }
@@ -357,7 +356,7 @@ HRESULT ProbeInstrumentation::InstallProbes(vector<UNPROCESSED_INSTRUMENTATION_R
         // For now just use the function id as the uniquifier.
         // Consider allowing the caller to specify one.
         processedRequest.uniquifier = static_cast<ULONG64>(req.functionId);
-        processedRequest.boxingTypes = req.boxingTypes;
+        processedRequest.boxingInstructions = req.boxingInstructions;
 
         IfFailLogRet(m_pCorProfilerInfo->GetFunctionInfo2(
             req.functionId,
@@ -523,7 +522,7 @@ STDAPI DLLEXPORT RegisterFunctionProbeCallbacks(
     {
         return E_FAIL;
     }
-   
+
     g_probeManagementCallbacks.pProbeRegistrationCallback = pRegistrationCallback;
     g_probeManagementCallbacks.pProbeInstallationCallback = pInstallationCallback;
     g_probeManagementCallbacks.pProbeUninstallationCallback = pUninstallationCallback;

--- a/src/Profilers/MutatingMonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.h
+++ b/src/Profilers/MutatingMonitorProfiler/ProbeInstrumentation/ProbeInstrumentation.h
@@ -22,7 +22,7 @@
 typedef struct _UNPROCESSED_INSTRUMENTATION_REQUEST
 {
     FunctionID functionId;
-    std::vector<ULONG32> boxingTypes;
+    std::vector<PARAMETER_BOXING_INSTRUCTIONS> boxingInstructions;
 } UNPROCESSED_INSTRUMENTATION_REQUEST;
 
 enum class ProbeWorkerInstruction

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/BoxingInstructionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/BoxingInstructionsTests.cs
@@ -2,22 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing;
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using SampleMethods;
 using System;
 using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.BoxingTokens;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing
 {
     [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
-    public class BoxingTokensTests
+    public class BoxingInstructionsTests
     {
         private readonly ITestOutputHelper _outputHelper;
 
-        public BoxingTokensTests(ITestOutputHelper outputHelper)
+        public BoxingInstructionsTests(ITestOutputHelper outputHelper)
         {
             _outputHelper = outputHelper;
         }
@@ -46,75 +46,75 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.ValueType_TypeSpec), false)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.VarArgs), true, true)]
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Unicode_ΦΨ), true)]
-        public void GetBoxingTokens_Detects_UnsupportedParameters(Type declaringType, string methodName, params bool[] supported)
+        public void GetBoxingInstructions_Detects_UnsupportedParameters(Type declaringType, string methodName, params bool[] supported)
         {
             // Arrange
             MethodInfo method = declaringType.GetMethod(methodName);
 
             // Act
-            bool[] supportedParameters = BoxingTokens.AreParametersSupported(BoxingTokens.GetBoxingTokens(method));
+            bool[] supportedParameters = BoxingInstructions.AreParametersSupported(BoxingInstructions.GetBoxingInstructions(method));
 
             // Assert
             Assert.Equal(supported, supportedParameters);
         }
 
         [Fact]
-        public void GetBoxingTokens_Detects_UnsupportedGenericParameters()
+        public void GetBoxingInstructions_Detects_UnsupportedGenericParameters()
         {
             // Arrange
             MethodInfo method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2").GetMethod("GenericParameters");
             bool[] supported = new bool[] { true, false, false, false };
 
             // Act
-            bool[] supportedParameters = BoxingTokens.AreParametersSupported(BoxingTokens.GetBoxingTokens(method));
+            bool[] supportedParameters = BoxingInstructions.AreParametersSupported(BoxingInstructions.GetBoxingInstructions(method));
 
             // Assert
             Assert.Equal(supported, supportedParameters);
         }
 
         [Fact]
-        public void GetBoxingTokens_Handles_Primitives()
+        public void GetBoxingInstructions_Handles_Primitives()
         {
             // Arrange
-            uint[] expectedBoxingTokens = new uint[] {
-                SpecialCaseBoxingTypes.Boolean.BoxingToken(),
-                SpecialCaseBoxingTypes.Char.BoxingToken(),
-                SpecialCaseBoxingTypes.SByte.BoxingToken(),
-                SpecialCaseBoxingTypes.Byte.BoxingToken(),
-                SpecialCaseBoxingTypes.Int16.BoxingToken(),
-                SpecialCaseBoxingTypes.UInt16.BoxingToken(),
-                SpecialCaseBoxingTypes.Int32.BoxingToken(),
-                SpecialCaseBoxingTypes.UInt32.BoxingToken(),
-                SpecialCaseBoxingTypes.Int64.BoxingToken(),
-                SpecialCaseBoxingTypes.UInt64.BoxingToken(),
-                SpecialCaseBoxingTypes.Single.BoxingToken(),
-                SpecialCaseBoxingTypes.Double.BoxingToken()
-            };
+            ParameterBoxingInstructions[] expectedInstructions = [
+                SpecialCaseBoxingTypes.Boolean,
+                SpecialCaseBoxingTypes.Char,
+                SpecialCaseBoxingTypes.SByte,
+                SpecialCaseBoxingTypes.Byte,
+                SpecialCaseBoxingTypes.Int16,
+                SpecialCaseBoxingTypes.UInt16,
+                SpecialCaseBoxingTypes.Int32,
+                SpecialCaseBoxingTypes.UInt32,
+                SpecialCaseBoxingTypes.Int64,
+                SpecialCaseBoxingTypes.UInt64,
+                SpecialCaseBoxingTypes.Single,
+                SpecialCaseBoxingTypes.Double,
+            ];
             MethodInfo method = typeof(StaticTestMethodSignatures).GetMethod(nameof(StaticTestMethodSignatures.Primitives));
 
             // Act
-            uint[] actualBoxingTokens = BoxingTokens.GetBoxingTokens(method);
+            ParameterBoxingInstructions[] actualInstructions = BoxingInstructions.GetBoxingInstructions(method);
 
             // Assert
-            Assert.Equal(expectedBoxingTokens, actualBoxingTokens);
+            Assert.Equal(expectedInstructions, actualInstructions);
         }
 
         [Fact]
-        public void GetBoxingTokens_Handles_BuiltInReferenceTypes()
+        public void GetBoxingInstructions_Handles_BuiltInReferenceTypes()
         {
             // Arrange
-            uint[] expectedBoxingTokens = new uint[] {
-                SpecialCaseBoxingTypes.Object.BoxingToken(),
-                SpecialCaseBoxingTypes.Object.BoxingToken(),
-                SpecialCaseBoxingTypes.Object.BoxingToken()
-            };
+            ParameterBoxingInstructions[] expectedInstructions = [
+                SpecialCaseBoxingTypes.Object,
+                SpecialCaseBoxingTypes.Object,
+                SpecialCaseBoxingTypes.Object,
+            ];
             MethodInfo method = typeof(StaticTestMethodSignatures).GetMethod(nameof(StaticTestMethodSignatures.BuiltInReferenceTypes));
 
             // Act
-            uint[] actualBoxingTokens = BoxingTokens.GetBoxingTokens(method);
+            ParameterBoxingInstructions[] actualInstructions = BoxingInstructions.GetBoxingInstructions(method);
 
             // Assert
-            Assert.Equal(expectedBoxingTokens, actualBoxingTokens);
+            Assert.Equal(expectedInstructions, actualInstructions);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/FunctionProbes/ProfilerAbiTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/FunctionProbes/ProfilerAbiTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         {
             // The above unmanaged constraint will ensure that T doesn't contain any GC references at build time.
             // However bool and char are both unmanaged types but are not blittable so we need to check for those.
-            FieldInfo[] fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            FieldInfo[] fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
             foreach (FieldInfo field in fields)
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/FunctionProbes/ProfilerAbiTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/FunctionProbes/ProfilerAbiTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing.FunctionProbes
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    public class ProfilerAbiTests
+    {
+        [Fact]
+        public void ParameterBoxingInstructions_IsBlittable()
+        {
+            EnsureIsBlittable<ParameterBoxingInstructions>();
+        }
+
+        private static void EnsureIsBlittable<T>() where T : unmanaged
+        {
+            // The above unmanaged constraint will ensure that T doesn't contain any GC references at build time.
+            // However bool and char are both unmanaged types but are not blittable so we need to check for those.
+            FieldInfo[] fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+            foreach (FieldInfo field in fields)
+            {
+                if (field.FieldType == typeof(bool) ||
+                    field.FieldType == typeof(char))
+                {
+                    Assert.Fail($"Field '{field.Name}' is not blittable");
+                }
+            }
+        }
+    }
+    
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodResolverTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodResolverTests.cs
@@ -137,11 +137,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             // Arrange
             AssemblyLoadContext customContext = new("Custom context", isCollectible: false);
             // Load an assembly that's already loaded (but not our own assembly as that'll impact other tests in this class).
-            Assembly duplicateHostingStartupAssembly = customContext.LoadFromAssemblyPath(typeof(BoxingTokens).Assembly.Location);
+            Assembly duplicateHostingStartupAssembly = customContext.LoadFromAssemblyPath(typeof(BoxingInstructions).Assembly.Location);
             Assert.NotNull(duplicateHostingStartupAssembly);
 
             MethodResolver resolver = new();
-            MethodDescription description = GetMethodDescription(typeof(BoxingTokens), nameof(BoxingTokens.GetBoxingTokens));
+            MethodDescription description = GetMethodDescription(typeof(BoxingInstructions), nameof(BoxingInstructions.GetBoxingInstructions));
 
             // Act
             List<MethodInfo> methods = resolver.ResolveMethodDescription(description);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
         public void TriggerFault(MethodInfo method)
         {
-            InstrumentedMethod faultingMethod = new(method, BoxingTokens.GetBoxingTokens(method));
+            InstrumentedMethod faultingMethod = new(method, BoxingInstructions.GetBoxingInstructions(method));
             OnProbeFault?.Invoke(this, faultingMethod);
         }
 


### PR DESCRIPTION
###### Summary

Currently the probe management API's managed layer precomputes all boxing tokens and passes only those to the profiler. This has the restriction of not allowing us to send additional information to the profiler for special boxing instruction. e.g.:
- What parameters need an indirect load.
- What parameters are typespecs and need a new metadata token emitted by the profiler.

This PR refactors those APIs, extending the ABI to accept a c-style array of structs (type: `PARAMETER_BOXING_INSTRUCTIONS`). This struct contains a discriminator telling the profiler the type of boxing instruction followed by a fixed-size set of data (to be expanded on in the future).

As an added benefit we can replace the current mechanism for specifying primitive tokens (where we create a fake metadata table with an id of `0x7f000000`  and fill it with our own enum) with an easier-to-understand system that doesn't overload the metadata token format. 

> [!IMPORTANT]
> There are **no** functional differences in this PR, follow up PRs will build upon this to add support for more parameter types.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
