### PR TITLE
[Parameter Capturing] Refactor reflection-only boxing logic into new method

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             {
                 ParameterInfo paramInfo = formalParameters[i];
 
-                ParameterBoxingInstructions paramBoxingInstructions = GetBoxingInstructionFromReflection(method, paramInfo.ParameterType, out bool canUseSignatureDecoder);
+                ParameterBoxingInstructions paramBoxingInstructions = GetBoxingInstructionsFromReflection(method, paramInfo.ParameterType, out bool canUseSignatureDecoder);
                 if (canUseSignatureDecoder &&
                     !IsParameterSupported(paramBoxingInstructions) &&
                     signatureDecoderInstructions.Value != null)
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             return instructions;
         }
 
-        private static ParameterBoxingInstructions GetBoxingInstructionFromReflection(MethodInfo method, Type paramType, out bool canUseSignatureDecoder)
+        private static ParameterBoxingInstructions GetBoxingInstructionsFromReflection(MethodInfo method, Type paramType, out bool canUseSignatureDecoder)
         {
             canUseSignatureDecoder = false;
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
                 }
                 else
                 {
-                    thisBoxingInstructions = GetBoxingInstructionFromReflection(method, thisType, out _);
+                    thisBoxingInstructions = GetBoxingInstructionsFromReflection(method, thisType, out _);
                 }
 
                 instructions[index++] = thisBoxingInstructions;

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -3,14 +3,12 @@
 
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
-namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing
 {
     internal static class BoxingInstructions
     {
@@ -32,26 +30,25 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
 
         public static ParameterBoxingInstructions[] GetBoxingInstructions(MethodInfo method)
         {
-            List<Type> methodParameterTypes = method.GetParameters().Select(p => p.ParameterType).ToList();
-            List<ParameterBoxingInstructions> instructions = new(methodParameterTypes.Count + (method.HasImplicitThis() ? 1 : 0));
-            //
-            // A signature decoder will used to determine boxing tokens for parameter types that cannot be determined from standard
-            // reflection alone. The boxing tokens generated from this decoder should only be used to fill in these gaps
-            // as it is not a comprehensive decoder and will produce an unsupported boxing instruction for any types not explicitly mentioned
-            // in BoxingTokensSignatureProvider's summary.
-            // 
-            Lazy<ParameterBoxingInstructions[]?> ancillaryInstructions = new(() => GetAncillaryBoxingInstructionsFromMethodSignature(method));
+            ParameterInfo[] formalParameters = method.GetParameters();
+            int numberOfParameters = formalParameters.Length + (method.HasImplicitThis() ? 1 : 0);
+            if (numberOfParameters == 0)
+            {
+                return Array.Empty<ParameterBoxingInstructions>();
+            }
 
-            int formalParameterPosition = 0;
+            ParameterBoxingInstructions[] instructions = new ParameterBoxingInstructions[numberOfParameters];
+            int index = 0;
 
             // Handle implicit this
             if (method.HasImplicitThis())
             {
                 Debug.Assert(!method.IsStatic);
 
+                ParameterBoxingInstructions thisBoxingInstructions;
+
                 Type? thisType = method.DeclaringType;
-                if (thisType == null ||
-                    thisType.IsValueType)
+                if (thisType == null || thisType.IsValueType)
                 {
                     //
                     // Implicit this pointers for value types can **sometimes** be passed as an address to the value.
@@ -60,74 +57,98 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
                     // To enable it in the future add a new special case token and when rewriting IL
                     // emit a ldobj instruction for it.
                     //
-                    instructions.Add(SpecialCaseBoxingTypes.Unknown);
+                    thisBoxingInstructions = SpecialCaseBoxingTypes.Unknown;
                 }
                 else
                 {
-                    methodParameterTypes.Insert(0, thisType);
-                    // Implicit this isn't a formal parameter, so offset by one.
-                    formalParameterPosition = -1;
+                    thisBoxingInstructions = GetBoxingInstructionFromReflection(method, thisType, out _);
                 }
+
+                instructions[index++] = thisBoxingInstructions;
             }
 
-            foreach (Type paramType in methodParameterTypes)
+            //
+            // A signature decoder will used to determine boxing tokens for formal parameter types that cannot be determined from standard
+            // reflection alone. The boxing tokens generated from this decoder should only be used to fill in these gaps
+            // as it is not a comprehensive decoder and will produce an unsupported boxing instruction for any types not explicitly mentioned
+            // in BoxingTokensSignatureProvider's summary.
+            // 
+            Lazy<ParameterBoxingInstructions[]?> signatureDecodingInstructions = new(() =>
             {
-                if (paramType.IsByRef ||
-                    paramType.IsByRefLike ||
-                    paramType.IsPointer)
+                ParameterBoxingInstructions[]? instructions = GetAncillaryBoxingInstructionsFromMethodSignature(method);
+                if (instructions != null &&
+                    instructions.Length != formalParameters.Length)
                 {
-                    instructions.Add(SpecialCaseBoxingTypes.Unknown);
+                    Debug.Fail("Signature decoder results have unexpected number of formal parameters");
+                    return null;
                 }
-                else if (paramType.IsGenericParameter)
+                return instructions;
+            });
+
+            for (int i = 0; i < formalParameters.Length; i++)
+            {
+                ParameterInfo paramInfo = formalParameters[i];
+
+                ParameterBoxingInstructions paramBoxingInstructions = GetBoxingInstructionFromReflection(method, paramInfo.ParameterType, out bool canUseSignatureDecoder);
+                if (canUseSignatureDecoder &&
+                    !IsParameterSupported(paramBoxingInstructions) &&
+                    signatureDecodingInstructions.Value != null)
                 {
-                    instructions.Add(SpecialCaseBoxingTypes.Unknown);
+                    paramBoxingInstructions = signatureDecodingInstructions.Value[i];
                 }
-                else if (paramType.IsPrimitive)
+
+                instructions[index++] = paramBoxingInstructions;
+            }
+
+            return instructions;
+        }
+
+        private static ParameterBoxingInstructions GetBoxingInstructionFromReflection(MethodInfo method, Type paramType, out bool canUseSignatureDecoder)
+        {
+            canUseSignatureDecoder = false;
+
+            if (paramType.IsByRef ||
+                paramType.IsByRefLike ||
+                paramType.IsPointer)
+            {
+                return SpecialCaseBoxingTypes.Unknown;
+            }
+
+            if (paramType.IsGenericParameter)
+            {
+                return SpecialCaseBoxingTypes.Unknown;
+            }
+
+            if (paramType.IsPrimitive)
+            {
+                return GetSpecialCaseBoxingTokenForPrimitive(paramType);
+            }
+
+            if (paramType.IsValueType)
+            {
+                // Ref structs have already been filtered out by the above IsByRefLike check.
+                if (paramType.IsGenericType ||
+                    paramType.Assembly != method.Module.Assembly)
                 {
-                    instructions.Add(GetSpecialCaseBoxingTokenForPrimitive(paramType));
-                }
-                else if (paramType.IsValueType)
-                {
-                    // Ref structs have already been filtered out by the above IsByRefLike check.
-                    if (paramType.IsGenericType)
-                    {
-                        // Typespec
-                        instructions.Add(SpecialCaseBoxingTypes.Unknown);
-                    }
-                    else if (paramType.Assembly != method.Module.Assembly)
-                    {
-                        // Typeref
-                        if (formalParameterPosition >= 0)
-                        {
-                            // value-type type refs are supported by the signature decoder
-                            instructions.Add(ancillaryInstructions.Value?[formalParameterPosition] ?? SpecialCaseBoxingTypes.Unknown);
-                        }
-                        else
-                        {
-                            instructions.Add(SpecialCaseBoxingTypes.Unknown);
-                        }
-                    }
-                    else
-                    {
-                        // Typedef
-                        instructions.Add((uint)paramType.MetadataToken);
-                    }
-                }
-                else if (paramType.IsArray ||
-                    paramType.IsClass ||
-                    paramType.IsInterface)
-                {
-                    instructions.Add(SpecialCaseBoxingTypes.Object);
+                    // Typeref or Typespec
+                    canUseSignatureDecoder = true;
+                    return SpecialCaseBoxingTypes.Unknown;
                 }
                 else
                 {
-                    instructions.Add(SpecialCaseBoxingTypes.Unknown);
+                    // Typedef
+                    return (uint)paramType.MetadataToken;
                 }
-
-                formalParameterPosition++;
             }
 
-            return instructions.ToArray();
+            if (paramType.IsArray ||
+                paramType.IsClass ||
+                paramType.IsInterface)
+            {
+                return SpecialCaseBoxingTypes.Object;
+            }
+
+            return SpecialCaseBoxingTypes.Unknown;
         }
 
         private static unsafe ParameterBoxingInstructions[]? GetAncillaryBoxingInstructionsFromMethodSignature(MethodInfo method)

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -127,10 +127,14 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             if (paramType.IsValueType)
             {
                 // Ref structs have already been filtered out by the above IsByRefLike check.
-                if (paramType.IsGenericType ||
-                    paramType.Assembly != method.Module.Assembly)
+                if (paramType.IsGenericType)
                 {
-                    // Typeref or Typespec
+                    // Typespec
+                    return SpecialCaseBoxingTypes.Unknown;
+                }
+                else if (paramType.Assembly != method.Module.Assembly)
+                {
+                    // Typeref
                     canUseSignatureDecoder = true;
                     return SpecialCaseBoxingTypes.Unknown;
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             // as it is not a comprehensive decoder and will produce an unsupported boxing instruction for any types not explicitly mentioned
             // in BoxingTokensSignatureProvider's summary.
             // 
-            Lazy<ParameterBoxingInstructions[]?> signatureDecodingInstructions = new(() =>
+            Lazy<ParameterBoxingInstructions[]?> signatureDecoderInstructions = new(() =>
             {
                 ParameterBoxingInstructions[]? instructions = GetAncillaryBoxingInstructionsFromMethodSignature(method);
                 if (instructions != null &&
                     instructions.Length != formalParameters.Length)
                 {
-                    Debug.Fail("Signature decoder results have unexpected number of formal parameters");
+                    Debug.Fail("Signature decoder results have an unexpected number of formal parameters");
                     return null;
                 }
                 return instructions;
@@ -92,9 +92,9 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
                 ParameterBoxingInstructions paramBoxingInstructions = GetBoxingInstructionFromReflection(method, paramInfo.ParameterType, out bool canUseSignatureDecoder);
                 if (canUseSignatureDecoder &&
                     !IsParameterSupported(paramBoxingInstructions) &&
-                    signatureDecodingInstructions.Value != null)
+                    signatureDecoderInstructions.Value != null)
                 {
-                    paramBoxingInstructions = signatureDecodingInstructions.Value[i];
+                    paramBoxingInstructions = signatureDecoderInstructions.Value[i];
                 }
 
                 instructions[index++] = paramBoxingInstructions;

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -172,8 +172,9 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
                 MethodSignature<ParameterBoxingInstructions> methodSignature = methodDef.DecodeSignature(new BoxingTokensSignatureProvider(), genericContext: null);
                 return [.. methodSignature.ParameterTypes];
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Debug.Fail($"Unable to decode method '{method.Name}' signature", ex.Message);
                 return null;
             }
         }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             }
 
             //
-            // A signature decoder will used to determine boxing tokens for formal parameter types that cannot be determined from standard
+            // A signature decoder will be used to determine boxing tokens for formal parameter types that cannot be determined from standard
             // reflection alone. The boxing tokens generated from this decoder should only be used to fill in these gaps
             // as it is not a comprehensive decoder and will produce an unsupported boxing instruction for any types not explicitly mentioned
             // in BoxingTokensSignatureProvider's summary.

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingInstructions.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             return instructions;
         }
 
-        private static ParameterBoxingInstructions GetBoxingInstructionsFromReflection(MethodInfo method, Type paramType, out bool canUseSignatureDecoder)
+        // Internal for testing, do not use outside of unit tests.
+        internal static ParameterBoxingInstructions GetBoxingInstructionsFromReflection(MethodInfo method, Type paramType, out bool canUseSignatureDecoder)
         {
             canUseSignatureDecoder = false;
 
@@ -155,7 +156,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Box
             return SpecialCaseBoxingTypes.Unknown;
         }
 
-        private static unsafe ParameterBoxingInstructions[]? GetAncillaryBoxingInstructionsFromMethodSignature(MethodInfo method)
+        // Internal for testing, do not use outside of unit tests.
+        internal static unsafe ParameterBoxingInstructions[]? GetAncillaryBoxingInstructionsFromMethodSignature(MethodInfo method)
         {
             try
             {

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingTokensSignatureProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Boxing/BoxingTokensSignatureProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
-namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing
 {
     /// <summary>
     /// This decoder is made specifically for parameters of the following types:

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesManager.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing;
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting;
 using Microsoft.Diagnostics.Monitoring.StartupHook;
 using Microsoft.Diagnostics.Tools.Monitor.Profiler;

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/InstrumentedMethod.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/InstrumentedMethod.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing;
 using System.Reflection;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/BoxingInstructionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/BoxingInstructionsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing;
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing;
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using SampleMethods;
@@ -10,7 +10,7 @@ using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing.Boxing
 {
     [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     public class BoxingInstructionsTests

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/BoxingInstructionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/BoxingInstructionsTests.cs
@@ -116,5 +116,73 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             // Assert
             Assert.Equal(expectedInstructions, actualInstructions);
         }
+
+        [Theory]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Primitives))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Arrays))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.BuiltInReferenceTypes))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Delegate))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.ExplicitThis))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.InParam))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefParam))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.OutParam))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RefStruct))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.RecordStruct))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.NativeIntegers))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.Pointer))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.GenericParameters))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.TypeDef))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.TypeRef))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.TypeSpec))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.ValueType_TypeDef))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.ValueType_TypeRef))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.ValueType_TypeSpec))]
+        [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.VarArgs))]
+        public void ReflectionAndSignatureDecoder_Contract_InSync(Type declaringType, string methodName)
+        {
+            MethodInfo method = declaringType.GetMethod(methodName);
+            ReflectionAndSignatureDecoder_Contract_InSyncCore(method);
+        }
+
+        [Fact]
+        public void ReflectionAndSignatureDecoder_Contract_Generics_InSync()
+        {
+            MethodInfo method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2").GetMethod("GenericParameters");
+            ReflectionAndSignatureDecoder_Contract_InSyncCore(method);
+        }
+
+        /// <summary>
+        /// Tests if GetBoxingInstructionsFromReflection is in sync with the signature decoder support for a given method's parameters.
+        /// </summary>
+        /// <param name="method">The method whose parameters to test.</param>
+        private static void ReflectionAndSignatureDecoder_Contract_InSyncCore(MethodInfo method)
+        {
+            Assert.NotNull(method);
+
+            ParameterInfo[] parameters = method.GetParameters();
+
+            ParameterBoxingInstructions[] signatureDecoderInstructions = BoxingInstructions.GetAncillaryBoxingInstructionsFromMethodSignature(method); ;
+            Assert.NotNull(signatureDecoderInstructions);
+            Assert.Equal(parameters.Length, signatureDecoderInstructions.Length);
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                //
+                // If GetBoxingInstructionsFromReflection sets canUseSignatureDecoder then the following must be true:
+                // - GetBoxingInstructionsFromReflection was unable to get boxing instructions for the parameter.
+                // - The signature decoder is able to get boxing instructions for the parameter.
+                //
+                //
+                // NOTE: The signature decoder may produce a superset of boxing instructions compared to what GetBoxingInstructionsFromReflection needs.
+                // This is okay as GetBoxingInstructionsFromReflection determines when to leverage the signature decoder. 
+                //
+                ParameterBoxingInstructions reflectionInstructions = BoxingInstructions.GetBoxingInstructionsFromReflection(method, parameters[i].ParameterType, out bool canUseSignatureDecoder);
+                if (canUseSignatureDecoder)
+                {
+                    Assert.False(BoxingInstructions.IsParameterSupported(reflectionInstructions));
+                    Assert.True(BoxingInstructions.IsParameterSupported(signatureDecoderInstructions[i]));
+                }
+            }
+        }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodResolverTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodResolverTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing;
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing;
 using Microsoft.Diagnostics.Monitoring.StartupHook.MonitorMessageDispatcher.Models;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using SampleMethods;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing;
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Boxing;
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline;
 using Microsoft.Diagnostics.Monitoring.StartupHook.MonitorMessageDispatcher.Models;


### PR DESCRIPTION
###### Summary

With the upcoming support for typespec related parameters, the current `GetBoxingInstructions` method becomes responsible for too much and will be difficult to read.

To address this, move reflection-only boxing logic into a new method (`GetBoxingInstructionsFromReflection`). Also reorganizes the boxing-related files into a subfolder to help group things together.

There are **no** functional changes in this PR.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
