### PR TITLE
Replace tagBuildOrRelease with Powershell inline script

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -85,20 +85,20 @@ stages:
           artifact: 'StagingToolAssetsLayout'
       # Only tag build from real release branches
       - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/')) }}:
-        - task: tagBuildOrRelease@0
+        - task: Powershell@2
           displayName: 'Tag Build with MonitorRelease'
           inputs:
-            type: 'Build'
-            tags: 'MonitorRelease'
+            targetType: inline
+            script: Write-Host "##vso[build.addbuildtag]MonitorRelease"
     - task: PublishPipelineArtifact@1
       displayName: 'Upload Staging Tool Logs'
       inputs:
         targetPath: '$(System.ArtifactsDirectory)\StagingToolLogs'
         artifact: 'StagingToolLogs'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: tagBuildOrRelease@0
+      - task: Powershell@2
         displayName: 'Tag Build with update-docker'
         condition: ${{ parameters.updateDockerCondition }}
         inputs:
-          type: 'Build'
-          tags: 'update-docker'
+          targetType: inline
+          script: Write-Host "##vso[build.addbuildtag]update-docker"


### PR DESCRIPTION
###### Summary

The `tagBuildOrRelease` task has been disabled/removed from the Azure DevOps organization. Replace with built-in support for tagging builds via Powershell inline script and logging commands.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
