### PR TITLE
[releases.json] Clear original date when promoting a preview release to rtm

### DIFF
--- a/.github/actions/update-releases-json/index.js
+++ b/.github/actions/update-releases-json/index.js
@@ -61,7 +61,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
 
     // Preserve the original minor release date and out-of-support date for RTM releases
     if (existingRelease !== undefined &&
-        actionUtils.isVersionTagRTM (existingRelease.tag) &&
+        actionUtils.isVersionTagRTM(existingRelease.tag) &&
         isRTMRelease) {
 
         newRelease.minorReleaseDate = existingRelease.minorReleaseDate;

--- a/.github/actions/update-releases-json/index.js
+++ b/.github/actions/update-releases-json/index.js
@@ -47,6 +47,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
 
     const [majorVersion, minorVersion, patchVersion, iteration] = actionUtils.splitVersionTag(releasePayload.tag_name);
     const releaseMajorMinorVersion = `${majorVersion}.${minorVersion}`;
+    const isRTMRelease = (iteration === undefined);
 
     // See if we're updating a release
     let existingRelease = releasesData.releases[releaseMajorMinorVersion];
@@ -59,7 +60,10 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
     };
 
     // Preserve the original minor release date and out-of-support date for RTM releases
-    if (existingRelease !== undefined && iteration === undefined) {
+    if (existingRelease !== undefined &&
+        actionUtils.isVersionTagRTM (existingRelease.tag) &&
+        isRTMRelease) {
+
         newRelease.minorReleaseDate = existingRelease.minorReleaseDate;
         newRelease.outOfSupportDate = existingRelease.outOfSupportDate;
     }
@@ -67,7 +71,7 @@ function addNewReleaseVersion(releasePayload, supportedFrameworks, releasesData)
     releasesData.releases[releaseMajorMinorVersion] = newRelease;
 
     // Check if we're going to be putting a version out-of-support.
-    if (minorVersion > 0 && patchVersion === 0 && iteration === undefined) {
+    if (minorVersion > 0 && patchVersion === 0 && isRTMRelease) {
         const endOfSupportDate = new Date(releaseDate.valueOf());
         endOfSupportDate.setMonth(endOfSupportDate.getMonth() + releasesData.policy.additionalMonthsOfSupportOnNewMinorRelease);
 


### PR DESCRIPTION
###### Summary

There's currently a bug where when we create a new release for a version that was previously a preview release (e.g. 8.0.0-rc.2 -> 8.0.0 GA) the "Original Release Date" field wasn't being reset to the new GA date. (As seen in https://github.com/dotnet/dotnet-monitor/pull/5687#discussion_r1392996312)  This PR fixes that bug and changes were locally tested.

Closes #5690 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
