### PR TITLE
Let dependabot manage `AWSSDK.S3`

### DIFF
--- a/eng/dependabot/independent/Packages.props
+++ b/eng/dependabot/independent/Packages.props
@@ -18,5 +18,6 @@
     <PackageReference Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="AWSSDK.S3" Version="$(AwsSdkS3Version)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
###### Summary

NOTE: `AwsSdkS3Version` is already defined in `eng/dependabot/independent/Versions.props`, we just never had the necessary `PackageReference` for it.

https://github.com/dotnet/dotnet-monitor/blob/da106122009394c318b37dc437c52d24df8b93ba/eng/dependabot/independent/Versions.props#L17

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
