### PR TITLE
[Parameter Capturing] Add capture limit option

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -97,6 +97,7 @@ Object describing the list of methods to capture parameters for.
 |---|---|---|
 | `methods` | [MethodDescription](#methoddescription)[] | Array of methods to capture parameters for. |
 | `useDebuggerDisplayAttribute` | bool | Determines if parameters should be formatted using their [`DebuggerDisplayAttribute`](https://learn.microsoft.com/dotnet/api/system.diagnostics.debuggerdisplayattribute) if available and supported. Expressions in attributes may consist of properties, fields, methods without parameters, or any combination of these. |
+| `captureLimit` | int | The number of times to capture parameters before stopping. Note that parameters may continue to be captured for a short amount of time after this limit is reached. |
 
 ## DotnetMonitorInfo
 

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -97,7 +97,7 @@ Object describing the list of methods to capture parameters for.
 |---|---|---|
 | `methods` | [MethodDescription](#methoddescription)[] | Array of methods to capture parameters for. |
 | `useDebuggerDisplayAttribute` | bool | Determines if parameters should be formatted using their [`DebuggerDisplayAttribute`](https://learn.microsoft.com/dotnet/api/system.diagnostics.debuggerdisplayattribute) if available and supported. Expressions in attributes may consist of properties, fields, methods without parameters, or any combination of these. |
-| `captureLimit` | int | The number of times to capture parameters before stopping. Note that parameters may continue to be captured for a short amount of time after this limit is reached. |
+| `captureLimit` | int | The number of times to capture parameters before stopping. If the specified duration elapses the operation will stop even if the capture limit is not yet reached. Note that parameters may continue to be captured for a short amount of time after this limit is reached. |
 
 ## DotnetMonitorInfo
 

--- a/documentation/api/parameters.md
+++ b/documentation/api/parameters.md
@@ -115,7 +115,8 @@ Authorization: Bearer fffffffffffffffffffffffffffffffffffffffffff=
             "typeName": "System.String",
             "methodName": "Concat"
         }
-    ]
+    ],
+    "captureLimit": 2
 }
 ```
 

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1617,6 +1617,13 @@
           },
           "useDebuggerDisplayAttribute": {
             "type": "boolean"
+          },
+          "captureLimit": {
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesStub.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/FunctionProbesStub.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
             try
             {
                 s_inProbe = true;
-                probes.EnterProbe(uniquifier, args);
+                _ = probes.EnterProbe(uniquifier, args);
             }
             finally
             {

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/IFunctionProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/IFunctionProbes.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
     {
         public void CacheMethods(IList<MethodInfo> methods);
 
-        public void EnterProbe(ulong uniquifier, object[] args);
+        /// <summary>
+        /// </summary>
+        /// <param name="uniquifier">The uniquifier which identifies the method calling the probe.</param>
+        /// <param name="args">The arguments passed into the method.</param>
+        /// <returns>True if the the arguments were captured by the probe.</returns>
+        public bool EnterProbe(ulong uniquifier, object[] args);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/LogEmittingProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/LogEmittingProbes.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
             }
         }
 
-        public void EnterProbe(ulong uniquifier, object[] args)
+        public bool EnterProbe(ulong uniquifier, object[] args)
         {
             // We allow the instrumentation of system types, but these types can also be part of an ILogger implementation.
             // In addition, certain loggers don't log directly, but into a background thread.
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
 
             if (!_logger.ShouldLog())
             {
-                return;
+                return false;
             }
 
             FunctionProbesState? state = FunctionProbesStub.State;
@@ -51,12 +51,12 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
                 !state.InstrumentedMethods.TryGetValue(uniquifier, out InstrumentedMethod? instrumentedMethod) ||
                 args.Length != instrumentedMethod?.SupportedParameters.Length)
             {
-                return;
+                return false;
             }
 
             if (instrumentedMethod.CaptureMode == ParameterCaptureMode.Disallowed)
             {
-                return;
+                return false;
             }
 
             string[] argValues;
@@ -87,6 +87,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
             }
 
             _logger.Log(instrumentedMethod.CaptureMode, instrumentedMethod.MethodTemplateString, argValues);
+
+            return true;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/CaptureLimitPolicyProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/CaptureLimitPolicyProbes.cs
@@ -10,20 +10,19 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline
 {
-    internal sealed class PolicyEnforcerProbe : IFunctionProbes
+    internal sealed class CaptureLimitPolicyProbes : IFunctionProbes
     {
         private readonly IFunctionProbes _probes;
         private readonly int _captureLimit;
-
-        private int _captureCount;
         private readonly TaskCompletionSource _stopRequest;
 
+        private int _captureCount;
         private bool _stopped;
 
-        public PolicyEnforcerProbe(IFunctionProbes probes, int captureLimit, TaskCompletionSource stopRequest)
+        public CaptureLimitPolicyProbes(IFunctionProbes probes, int captureLimit, TaskCompletionSource stopRequest)
         {
-            _captureLimit = captureLimit;
             _probes = probes;
+            _captureLimit = captureLimit;
             _stopRequest = stopRequest;
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/CaptureLimitPolicyProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/CaptureLimitPolicyProbes.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline
 {
     internal sealed class CaptureLimitPolicyProbes : IFunctionProbes

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/ParameterCapturingPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/ParameterCapturingPipeline.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pip
                 StopRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 Probes = payload.Configuration.CaptureLimit.HasValue
-                    ? new PolicyEnforcerProbe(probes, payload.Configuration.CaptureLimit.Value, StopRequest)
+                    ? new CaptureLimitPolicyProbes(probes, payload.Configuration.CaptureLimit.Value, StopRequest)
                     : probes;
             }
 
@@ -170,6 +170,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pip
             if (payload.Configuration.Methods.Length == 0)
             {
                 throw new ArgumentException(nameof(payload.Configuration.Methods));
+            }
+
+            if (payload.Configuration.CaptureLimit.HasValue && payload.Configuration.CaptureLimit.Value <= 0)
+            {
+                throw new ArgumentException(nameof(payload.Configuration.CaptureLimit));
             }
 
             List<MethodDescription> _deniedMethodDescriptions = new();

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/ParameterCapturingPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/ParameterCapturingPipeline.cs
@@ -22,8 +22,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pip
             public CapturingRequest(StartCapturingParametersPayload payload, IFunctionProbes probes)
             {
                 Payload = payload;
-                Probes = probes;
                 StopRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                Probes = payload.Configuration.CaptureLimit.HasValue
+                    ? new PolicyEnforcerProbe(probes, payload.Configuration.CaptureLimit.Value, StopRequest)
+                    : probes;
             }
 
             public StartCapturingParametersPayload Payload { get; }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/PolicyEnforcerProbe.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Pipeline/PolicyEnforcerProbe.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline
+{
+    internal sealed class PolicyEnforcerProbe : IFunctionProbes
+    {
+        private readonly IFunctionProbes _probes;
+        private readonly int _captureLimit;
+
+        private int _captureCount;
+        private readonly TaskCompletionSource _stopRequest;
+
+        private bool _stopped;
+
+        public PolicyEnforcerProbe(IFunctionProbes probes, int captureLimit, TaskCompletionSource stopRequest)
+        {
+            _captureLimit = captureLimit;
+            _probes = probes;
+            _stopRequest = stopRequest;
+        }
+
+        public void CacheMethods(IList<MethodInfo> methods) => _probes.CacheMethods(methods);
+
+        public bool EnterProbe(ulong uniquifier, object[] args)
+        {
+            // In addition to the stop request, use a flag to more quickly react to the limit being reached,
+            // limiting the amount of extra data being captured which is important in the case of hot paths.
+            if (_stopped)
+            {
+                return false;
+            }
+
+            bool didCapture = _probes.EnterProbe(uniquifier, args);
+            if (didCapture && Interlocked.Increment(ref _captureCount) == _captureLimit)
+            {
+                _stopped = true;
+                _ = _stopRequest.TrySetResult();
+            }
+
+            return didCapture;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CaptureParametersConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CaptureParametersConfiguration.cs
@@ -19,5 +19,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 
         [JsonPropertyName("useDebuggerDisplayAttribute")]
         public bool UseDebuggerDisplayAttribute { get; set; } = true;
+
+        [JsonPropertyName("captureLimit")]
+        [Range(1, int.MaxValue)]
+        public int? CaptureLimit { get; set; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -41,6 +41,25 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         }
 
         [Fact]
+        public void EnterProbe_DoesNotRequestStop_WhenProbeDoesNotCapture()
+        {
+            // Arrange
+            TestFunctionProbes testProbes = new(onEnterProbe: (_, _) =>
+            {
+                return false;
+            });
+
+            TaskCompletionSource requestStop = new();
+            CaptureLimitPolicyProbes probes = new(testProbes, captureLimit: 1, requestStop);
+
+            // Act
+            probes.EnterProbe(1, []);
+
+            // Assert
+            Assert.False(requestStop.Task.IsCompleted);
+        }
+
+        [Fact]
         public void EnterProbe_ShortCircuts_WhenLimitReached()
         {
             // Arrange

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -4,6 +4,8 @@
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -83,7 +85,28 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         }
 
         [Fact]
-        public void EnterProbe_PassesThroughArguments()
+        public void EnterProbe_PassesThrough_CacheMethods()
+        {
+            // Arrange
+            List<MethodInfo> expectedMethods = [(MethodInfo)MethodBase.GetCurrentMethod()];
+            IList<MethodInfo> actualMethods = null;
+
+            TaskCompletionSource requestStop = new();
+            CaptureLimitPolicyProbes probes = new(new TestFunctionProbes(
+                onCacheMethods: (methods) =>
+                {
+                    actualMethods = methods;
+                }), captureLimit: 1, requestStop);
+
+            // Act
+            probes.CacheMethods(expectedMethods);
+
+            // Assert
+            Assert.Equal(expectedMethods, actualMethods);
+        }
+
+        [Fact]
+        public void EnterProbe_PassesThrough_EnterProbe()
         {
             // Arrange
             const ulong expectedUniquifier = 15;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         }
 
         [Fact]
-        public void EnterProbe_ShortCircuts_WhenLimitReached()
+        public void EnterProbe_ShortCircuits_WhenLimitReached()
         {
             // Arrange
             int invokeCount = 0;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         }
 
         [Fact]
-        public void EnterProbe_PassesThrough_CacheMethods()
+        public void CacheMethods_PassesThrough()
         {
             // Arrange
             List<MethodInfo> expectedMethods = [(MethodInfo)MethodBase.GetCurrentMethod()];
@@ -106,7 +106,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         }
 
         [Fact]
-        public void EnterProbe_PassesThrough_EnterProbe()
+        public void EnterProbe_PassesThrough()
         {
             // Arrange
             const ulong expectedUniquifier = 15;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -79,6 +80,33 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
             // Assert
             Assert.Equal(1, invokeCount);
+        }
+
+        [Fact]
+        public void EnterProbe_PassesThroughArguments()
+        {
+            // Arrange
+            const ulong expectedUniquifier = 15;
+            object[] expectedArgs = [new Uri("https://www.example.com"), 10];
+
+            ulong? actualUniquifier = null;
+            object[] actualArgs = null;
+
+            TaskCompletionSource requestStop = new();
+            CaptureLimitPolicyProbes probes = new(new TestFunctionProbes(
+                onEnterProbe: (uniquifier, args) =>
+                {
+                    actualUniquifier = uniquifier;
+                    actualArgs = args;
+                    return true;
+                }), captureLimit: 1, requestStop);
+
+            // Act
+            probes.EnterProbe(expectedUniquifier, expectedArgs);
+
+            // Assert
+            Assert.Equal(expectedUniquifier, actualUniquifier);
+            Assert.Equal(expectedArgs, actualArgs);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Pipeline;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing.Pipeline
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    public class CaptureLimitPolicyProbesTests
+    {
+        [Fact]
+        public void EnterProbe_RequestStop_OnLimitReached()
+        {
+            // Arrange
+            TaskCompletionSource requestStop = new();
+            CaptureLimitPolicyProbes probes = new(new TestFunctionProbes(), captureLimit: 1, requestStop);
+
+            // Act
+            probes.EnterProbe(1, []);
+
+            // Assert
+            Assert.True(requestStop.Task.IsCompleted);
+        }
+
+        [Fact]
+        public void EnterProbe_DoesNotRequestStop_WhenLimitNotReached()
+        {
+            // Arrange
+            TaskCompletionSource requestStop = new();
+            CaptureLimitPolicyProbes probes = new(new TestFunctionProbes(), captureLimit: 2, requestStop);
+
+            // Act
+            probes.EnterProbe(1, []);
+
+            // Assert
+            Assert.False(requestStop.Task.IsCompleted);
+        }
+
+        [Fact]
+        public void EnterProbe_ShortCircuts_WhenLimitReached()
+        {
+            // Arrange
+            int invokeCount = 0;
+            TestFunctionProbes testProbes = new(onEnterProbe: (_, _) =>
+            {
+                Interlocked.Increment(ref invokeCount);
+                return true;
+            });
+
+            TaskCompletionSource requestStop = new();
+            CaptureLimitPolicyProbes probes = new(testProbes, captureLimit: 1, requestStop);
+
+            // Act
+            probes.EnterProbe(1, []);
+            probes.EnterProbe(2, []);
+
+            // Assert
+            Assert.Equal(1, invokeCount);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         {
         }
 
-        public void EnterProbe(ulong uniquifier, object[] args)
+        public bool EnterProbe(ulong uniquifier, object[] args)
         {
+            return true;
         }
     }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
@@ -196,25 +196,15 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             Assert.Throws<DeniedMethodsException>(() => pipeline.SubmitRequest(payload, probes));
         }
 
-        [Fact]
-        public void Request_ZeroCaptureLimit_Throws()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Request_InvalidCaptureLimit_Throws(int captureLimit)
         {
             // Arrange
             ParameterCapturingPipeline pipeline = new(new TestFunctionProbesManager(), new TestParameterCapturingCallbacks(), new TestMethodDescriptionValidator());
             TestFunctionProbes probes = new();
-            StartCapturingParametersPayload payload = CreateStartCapturingPayload(Timeout.InfiniteTimeSpan, captureLimit: 0);
-
-            // Act & Assert
-            Assert.Throws<ArgumentException>(() => pipeline.SubmitRequest(payload, probes));
-        }
-
-        [Fact]
-        public void Request_NegativeCaptureLimit_Throws()
-        {
-            // Arrange
-            ParameterCapturingPipeline pipeline = new(new TestFunctionProbesManager(), new TestParameterCapturingCallbacks(), new TestMethodDescriptionValidator());
-            TestFunctionProbes probes = new();
-            StartCapturingParametersPayload payload = CreateStartCapturingPayload(Timeout.InfiniteTimeSpan, captureLimit: -1);
+            StartCapturingParametersPayload payload = CreateStartCapturingPayload(Timeout.InfiniteTimeSpan, captureLimit: captureLimit);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => pipeline.SubmitRequest(payload, probes));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/TestFunctionProbes.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/TestFunctionProbes.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.FunctionProbes;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing.Pipeline
+{
+    internal sealed class TestFunctionProbes : IFunctionProbes
+    {
+        private readonly Func<ulong, object[], bool> _onEnterProbe;
+        private readonly Action<IList<MethodInfo>> _onCacheMethods;
+
+        public TestFunctionProbes(Func<ulong, object[], bool> onEnterProbe = null, Action<IList<MethodInfo>> onCacheMethods = null)
+        {
+            _onEnterProbe = onEnterProbe;
+            _onCacheMethods = onCacheMethods;
+        }
+
+
+        public void CacheMethods(IList<MethodInfo> methods)
+        {
+            _onCacheMethods?.Invoke(methods);
+        }
+
+        public bool EnterProbe(ulong uniquifier, object[] args)
+        {
+            return _onEnterProbe != null
+                ? _onEnterProbe(uniquifier, args)
+                : true;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/FunctionProbes/PerFunctionProbeProxy.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/FunctionProbes/PerFunctionProbeProxy.cs
@@ -83,14 +83,16 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
             return exception != null;
         }
 
-        public void EnterProbe(ulong uniquifier, object[] args)
+        public bool EnterProbe(ulong uniquifier, object[] args)
         {
             if (!_perFunctionProbes.TryGetValue(uniquifier, out PerFunctionProbeWrapper probe))
             {
-                return;
+                return false;
             }
 
             probe.Invoke(args);
+
+            return true;
         }
 
         public void CacheMethods(IList<MethodInfo> methods)


### PR DESCRIPTION
###### Summary

Add a new option to parameter capturing that will stop the capturing session after a certain number of times parameters are captured. Note that this refers to the number of "sets" of parameters collected, not the total number of individual parameters. For example if `MyMethod(int a, int b, int c)` is called twice, then that would be 2 sets of parameters.



<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Update `POST /parameters` to support stopping after a certain number of times parameters are captured.
