### PR TITLE
Simplify dependabot version imports

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,6 @@
 <Project>
   <!-- Import references updated by Dependabot. This file is for package references updated manually or by Maestro. -->
-  <Import Project="dependabot/independent/Versions.props" />
-  <Import Project="dependabot/nuget.org/Versions.props" />
-  <Import Project="dependabot/net6.0/Versions.props" />
-  <Import Project="dependabot/net7.0/Versions.props" />
-  <Import Project="dependabot/net8.0/Versions.props" />
-  <Import Project="dependabot/netcoreapp3.1/Versions.props" />
+  <Import Project="dependabot/Versions.props" />
   <PropertyGroup Label="Versioning">
     <RepositoryUrl>https://github.com/dotnet/dotnet-monitor</RepositoryUrl>
     <VersionPrefix>8.1.0</VersionPrefix>

--- a/eng/dependabot/Versions.props
+++ b/eng/dependabot/Versions.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="independent/Versions.props" />
+  <Import Project="nuget.org/Versions.props" />
+  <Import Project="net6.0/Versions.props" />
+  <Import Project="net7.0/Versions.props" />
+  <Import Project="net8.0/Versions.props" />
+  <Import Project="netcoreapp3.1/Versions.props" />
+</Project>


### PR DESCRIPTION
###### Summary

Use a `Versions.props` file that brings in all package versions managed by dependabot. This will minimize differences in `eng/Versions.props` between branches and help with a more automated release branch merge strategy.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
