### PR TITLE
Fix github-actions commit author

### DIFF
--- a/.github/actions/open-pr/action.yml
+++ b/.github/actions/open-pr/action.yml
@@ -49,8 +49,8 @@ runs:
 
         base_branch_name=${BASE_BRANCH_NAME:-${current_branch_name}}
 
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add ${{ inputs.files_to_commit }}
 
         are_files_changed=""


### PR DESCRIPTION
###### Summary

Fix the commit author name and email used by our workflows to correctly attribute it to the github bot.  This will results in commits made by it looking like this:
<img width="288" alt="image" src="https://github.com/dotnet/dotnet-monitor/assets/1146681/06ac1142-64a7-438a-b8f7-ab10e8f1eb18">


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
