### PR TITLE
Limit learning path automation to main repo

### DIFF
--- a/.github/workflows/check-learning-path-links.yml
+++ b/.github/workflows/check-learning-path-links.yml
@@ -8,6 +8,7 @@ permissions: {}
   
 jobs:
   check-learning-path-links:
+    if: github.repository == 'dotnet/dotnet-monitor'
     name: 'Check Learning Path Links'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
###### Summary

Our scheduled workflows should only be running on the main repo and not forks, update `check-learning-path-links` accordingly.

Note that our other scheduled workflows already do this:
https://github.com/dotnet/dotnet-monitor/blob/ef4e70e84376d45119465339f1dc35aea4dab404/.github/workflows/sync-branches.yml#L14


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
