### PR TITLE
Have automated merge commits respect branch-specific files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,3 +47,13 @@
 ###############################################################################
 *.png				binary
 *.snk       		binary
+
+###############################################################################
+# Define branch specific files by overriding the merge driver
+###############################################################################
+global.json merge=ours
+eng/branch-vscode-config merge=ours
+eng/common merge=ours
+eng/Common.props merge=ours
+eng/Versions.props merge=ours
+eng/Version.Details.xml merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -50,6 +50,7 @@
 
 ###############################################################################
 # Define branch specific files by overriding the merge driver
+#   Must be kept in sync with .github\workflows\sync-branches.yml
 ###############################################################################
 global.json merge=ours
 eng/branch-vscode-config merge=ours

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -78,6 +78,14 @@ jobs:
           git config merge.ours.driver true
           git merge "$base_branch" --strategy=ort --strategy-option=theirs
 
+          git checkout "origin/${{ matrix.branch }}" -- \
+            "global.json" \
+            "eng/branch-vscode-config" \
+            "eng/common" \
+            "eng/Common.props" \
+            "eng/Versions.props" \
+            "eng/Version.Details.xml"
+
       - name: Open PR
         uses: ./.github/actions/open-pr
         with:

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -78,6 +78,7 @@ jobs:
           git config merge.ours.driver true
           git merge "$base_branch" --strategy=ort --strategy-option=theirs
 
+          # Must be kept in sync with .gitattributes
           git checkout "origin/${{ matrix.branch }}" -- \
             "global.json" \
             "eng/branch-vscode-config" \
@@ -91,7 +92,7 @@ jobs:
         with:
           files_to_commit: "*"
           title: '[${{ matrix.branch }}] Sync branch with ${{ env.base_branch }}'
-          commit_message: Resolve merge conflicts
+          commit_message: Restore branch-specific files
           body: Sync branch with ${{ env.base_branch }}. This PR was auto generated and will not be automatically merged in.
           branch_name: sync/${{ matrix.branch }}
           fail_if_files_unchanged: false

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -74,16 +74,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
+          # Activate the ours merge driver to respect any branch specific files
+          git config merge.ours.driver true
           git merge "$base_branch" --strategy=ort --strategy-option=theirs
-
-          git checkout "origin/${{ matrix.branch }}" -- \
-            "global.json" \
-            "eng/branch-vscode-config" \
-            "eng/common" \
-            "eng/Common.props" \
-            "eng/Versions.props" \
-            "eng/Version.Details.xml"
 
       - name: Open PR
         uses: ./.github/actions/open-pr


### PR DESCRIPTION
###### Summary

This PR updates the (code) sync-branch workflow to understand and preserve branch-specific files during the automated merge. This means a seconds commit to re-apply branch-specific files is **usually** no longer needed. This works by overriding the merge driver for branch-specific files to always prefer the current branch's version of files.

Example PR: https://github.com/schmittjoseph/dotnet-monitor/pull/567

However, merge drivers are only involved if merge conflicts are present for a given file. That means it's possible for purely additive changes in `main` to still be merged into `feature/9.x` via this approach. To handle this we also perform the old approach of re-applying branch-specific files after a merge. If there were any files where this edge case occurs, they will be handled by this step.

Note that this requires us to maintain the list of branch-specific files in 2 places. We could likely consolidate this via some additional scripting in the workflow but I'd prefer that to be a separate piece of work if we end up wanting it.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
