### PR TITLE
Increase helix test timeouts by 10 minutes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     <SignAndNotarizeRuntimeIdentifiers>osx-arm64;osx-x64</SignAndNotarizeRuntimeIdentifiers>
     <DefaultRuntimeIdentifiers>$(SignOnlyRuntimeIdentifiers);$(SignAndNotarizeRuntimeIdentifiers)</DefaultRuntimeIdentifiers>
     <DisableCustomBlobStoragePublishing Condition="'$(DisableCustomBlobStoragePublishing)' == ''">false</DisableCustomBlobStoragePublishing>
-    <TestRunnerTestTimeoutMinutes>15</TestRunnerTestTimeoutMinutes>
+    <TestRunnerTestTimeoutMinutes>25</TestRunnerTestTimeoutMinutes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
###### Summary

Windows arm64 tests have been failing a lot recently due to test timeouts. Increase our timeout by 10 minutes. Note that these test failures are occurring in `feature/9.x`, but I'm targeting `main` as this change will flow into `feature/9.x` via branch merges.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
