### PR TITLE
Ignore deleted files when check markdown feedback links

### DIFF
--- a/.github/workflows/add-markdown-feedback.yml
+++ b/.github/workflows/add-markdown-feedback.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get changed files
         run: |
-          changed_source_files=$(git diff-tree --no-commit-id --name-only -r "$base_sha" "$GITHUB_SHA" -- documentation ':!documentation/releaseNotes/*' | { grep "**.md$" || test $? = 1; })
+          changed_source_files=$(git diff-tree --no-commit-id --name-only --diff-filter=d -r "$base_sha" "$GITHUB_SHA" -- documentation ':!documentation/releaseNotes/*' | { grep "**.md$" || test $? = 1; })
           echo "Files to validate: '${changed_source_files}'"
           changed_source_files=$(echo "$changed_source_files" | xargs | sed 's/ documentation/,documentation/g')
           echo "updated_files=$(echo ${changed_source_files})" >> $GITHUB_ENV


### PR DESCRIPTION
###### Summary

The "Add Markdown Feedback" workflow will fail if any of the documentation files have been deleted. Since we don't need to add the feedback links to deleted files, skip them when collecting the file list.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
