### PR TITLE
Skip `CollectionRulePipeline_EventMeterTriggerTest_Histogram_GreaterThan`

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         /// <summary>
         /// Test that the pipeline works with the EventMeter trigger greater-than (histogram instrument).
         /// </summary>
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/dotnet-monitor/issues/6154")]
         [MemberData(nameof(GetCurrentTfm))]
         public Task CollectionRulePipeline_EventMeterTriggerTest_Histogram_GreaterThan(TargetFrameworkMoniker appTfm)
         {


### PR DESCRIPTION
###### Summary

`CollectionRulePipeline_EventMeterTriggerTest_Histogram_GreaterThan` has been extremely flaky lately. Skipping this test. Issue tracking the test failure: https://github.com/dotnet/dotnet-monitor/issues/6154

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
