### PR TITLE
Branch sync improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -50,7 +50,6 @@
 
 ###############################################################################
 # Define branch specific files by overriding the merge driver
-#   Must be kept in sync with .github\workflows\sync-branches.yml
 ###############################################################################
 global.json merge=ours
 eng/branch-vscode-config merge=ours

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Sync branch
         run: |
-          git checkout "$base_branch" -- \
+          git checkout --no-overlay "$base_branch" -- \
             ".github" \
             ".devcontainer" \
             ".vscode" \
@@ -78,14 +78,12 @@ jobs:
           git config merge.ours.driver true
           git merge "$base_branch" --strategy=ort --strategy-option=theirs
 
-          # Must be kept in sync with .gitattributes
-          git checkout "origin/${{ matrix.branch }}" -- \
-            "global.json" \
-            "eng/branch-vscode-config" \
-            "eng/common" \
-            "eng/Common.props" \
-            "eng/Versions.props" \
-            "eng/Version.Details.xml"
+          matches=$(perl -ne '/^([^\s]+)\s+merge=ours/gm && print "$1 "' .gitattributes)
+          for match in $matches; do
+              git checkout --no-overlay "$target_branch" -- "$match"
+          done
+        env:
+          target_branch: origin/${{ matrix.branch }}
 
       - name: Open PR
         uses: ./.github/actions/open-pr


### PR DESCRIPTION
###### Summary
Various branch sync improvements:
1. When restoring branch-specific files/folders don't perform an overlay. This means files that appear in the branch being merged from, but not in the target branch, will be removed. The current behavior is resulting these files not being removed.  See https://github.com/dotnet/dotnet-monitor/pull/6168 for an example of this incorrect behavior.
2. Automatically determine the list of branch-specific files from the `.gitattributes` file in the branch being updated. This means our various branches can customize what files they want to preserve the sync-branches workflow will honor it.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
