### PR TITLE
Use long-term pool images

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -65,7 +65,7 @@ jobs:
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         pool:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-2204-pt
+          demands: ImageOverride -equals 1es-ubuntu-2204
           os: linux
 
     # Build OSX Pool

--- a/eng/pipelines/templates/pipeline-template.yml
+++ b/eng/pipelines/templates/pipeline-template.yml
@@ -50,7 +50,7 @@ extends:
       sdl:
         sourceAnalysisPool:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
+          image: 1es-windows-2022
           os: windows
         ${{ if parameters.sdl }}:
           ${{ each pair in parameters.sdl }}:


### PR DESCRIPTION
###### Summary

The `*-pt` images are short-term migration images that will be removed in a later infrastructure rollout. Switch to the long-term images.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2403324&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
