### PR TITLE
Run compliance with two-part version

### DIFF
--- a/eng/pipelines/dotnet-monitor-compliance.yml
+++ b/eng/pipelines/dotnet-monitor-compliance.yml
@@ -43,13 +43,23 @@ extends:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         
         - task: PowerShell@2
-          displayName: 'Get Build Version'
+          displayName: 'Get Build Version (Full)'
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
             arguments: >-
               -BarId $(BuildBarId)
               -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'BuildVersion'
+
+        - task: PowerShell@2
+          displayName: 'Get Build Version (Major.Minor)'
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+            arguments: >-
+              -BarId $(BuildBarId)
+              -MaestroToken $(MaestroAccessToken)
+              -TaskVariableName 'BuildMajorMinorVersion'
+              -MajorMinorOnly
 
         # Only scan the files that are being shipped; use the same gathering procedure
         # that the asset staging process uses.
@@ -96,8 +106,8 @@ extends:
           displayName: Run APIScan
           inputs:
             softwareFolder: '$(System.ArtifactsDirectory)\ScannableBinaries'
-            softwareName: 'Dotnet-Monitor'
-            softwareVersionNum: '$(BuildVersion)'
+            softwareName: 'DotnetMonitor'
+            softwareVersionNum: '$(BuildMajorMinorVersion)'
             softwareBuildNum: '$(resources.pipeline.Build.runID)'
             symbolsFolder: 'SRV*http://symweb;$(System.ArtifactsDirectory)\UnpackedSymbols'
           env:

--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -4,7 +4,8 @@ Param(
     [Parameter(Mandatory=$true)][string] $MaestroToken,
     [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
     [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2020-02-20',
-    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null
+    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null,
+    [Parameter(Mandatory=$false)][switch] $MajorMinorOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -26,6 +27,10 @@ if ($matchingData.Length -ne 1) {
 }
 
 $version = $matchingData[0].Version
+
+if ($MajorMinorOnly) {
+    $version = ($version -split '\.')[0..1] -join '.'
+}
 
 Write-Verbose "Build Version: $version"
 


### PR DESCRIPTION
###### Summary

Run APIScan compliance with two-part version (e.g. `8.0`) instead of full version. This allows bundling all runs for a given major.minor version together such that APIScan service settings can be applied by group instead of each individual build.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
