### PR TITLE
Reenable log publishing

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -45,12 +45,10 @@ jobs:
     ${{ if eq(parameters.disableSbom, 'true') }}:
       enableSbom: false
     helixRepo: dotnet/dotnet-monitor
-    # Log publishing isn't ported over in arcade yet
-    ${{ if ne(parameters.is1ESPipeline, 'true') }}:
-      artifacts:
-        publish:
-          logs:
-            name: Logs_$(JobName)
+    artifacts:
+      publish:
+        logs:
+          name: Logs_$(JobName)
 
     # Default build pool is Windows; override for Linux and MacOS
     ${{ if in(parameters.osGroup, 'Linux', 'Linux_Musl') }}:

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -9,8 +9,8 @@ jobs:
       publish:
         artifacts:
           name: Artifacts_Pack_Sign
-        # logs:
-        #   name: Logs_Pack_Sign # Log publishing isn't ported over in arcade yet
+        logs:
+          name: Logs_Pack_Sign
         manifests: true
     variables:
     - _BuildConfig: Release

--- a/eng/pipelines/jobs/sign-binaries.yml
+++ b/eng/pipelines/jobs/sign-binaries.yml
@@ -8,10 +8,10 @@ jobs:
     name: Sign_Binaries
     displayName: Sign Binaries
     enableMicrobuild: true
-    # artifacts:
-    #   publish:
-    #     logs:
-    #       name: Logs_$(JobName) # Log publishing isn't ported over in arcade yet
+    artifacts:
+      publish:
+        logs:
+          name: Logs_$(JobName)
     variables:
     - _BuildConfig: ${{ parameters.configuration }}
     - _SignType: real


### PR DESCRIPTION
###### Summary

Arcade has fixes for log publishing in the 1ES templates. Remove the disablement / conditional enablement of logs to restore log publishing in the official builds.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2404357&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
