### PR TITLE
[release/7.x] Minimize printing of potential secrets in tests

### DIFF
--- a/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/EnvironmentVariableActionTests.cs
@@ -27,7 +27,6 @@ namespace CollectionRuleActions.UnitTests
         private readonly EndpointUtilities _endpointUtilities;
 
         private const string DefaultRuleName = "StartupRule";
-        private const string DefaultVarName = "MyCustomVariable";
         private const string DefaultVarValue = "TheValueStoredIn the environment";
 
         public EnvironmentVariableActionTests(ITestOutputHelper outputHelper)
@@ -52,7 +51,7 @@ namespace CollectionRuleActions.UnitTests
                 {
                     rootOptions.CreateCollectionRule(DefaultRuleName)
                         .SetStartupTrigger()
-                        .AddSetEnvironmentVariableAction(DefaultVarName, DefaultVarValue);
+                        .AddSetEnvironmentVariableAction(TestAppScenarios.EnvironmentVariables.CustomVariableName, DefaultVarValue);
                 },
                 hostCallback: async (IHost host) =>
                 {
@@ -76,7 +75,7 @@ namespace CollectionRuleActions.UnitTests
 
                         await ActionTestsHelper.ExecuteAndDisposeAsync(setAction, CommonTestTimeouts.EnvVarsTimeout);
 
-                        Assert.Equal(DefaultVarValue, await runner.GetEnvironmentVariable(DefaultVarName, CommonTestTimeouts.EnvVarsTimeout));
+                        Assert.Equal(DefaultVarValue, await runner.GetEnvironmentVariable(TestAppScenarios.EnvironmentVariables.CustomVariableName, CommonTestTimeouts.EnvVarsTimeout));
 
                         await runner.SendCommandAsync(TestAppScenarios.EnvironmentVariables.Commands.ShutdownScenario);
                     });
@@ -166,8 +165,8 @@ namespace CollectionRuleActions.UnitTests
                 {
                     rootOptions.CreateCollectionRule(DefaultRuleName)
                         .SetStartupTrigger()
-                        .AddSetEnvironmentVariableAction(DefaultVarName, DefaultVarValue)
-                        .AddGetEnvironmentVariableAction(DefaultVarName);
+                        .AddSetEnvironmentVariableAction(TestAppScenarios.EnvironmentVariables.CustomVariableName, DefaultVarValue)
+                        .AddGetEnvironmentVariableAction(TestAppScenarios.EnvironmentVariables.CustomVariableName);
                 },
                 hostCallback: async (IHost host) =>
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static class EnvironmentVariables
         {
             public const string Name = nameof(EnvironmentVariables);
+            public const string CustomVariableName = nameof(CustomVariableName);
             public const string IncrementVariableName = nameof(IncrementVariableName);
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -92,11 +92,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             };
             ClaimsPrincipal claimsPrinciple = tokenHandler.ValidateToken(tokenStr, tokenValidationParams, out SecurityToken validatedToken);
 
-            ITestOutputHelper validationHelper = new PrefixedOutputHelper(_outputHelper, "[JWT Validation] ");
-            foreach (Claim c in claimsPrinciple.Claims)
-            {
-                validationHelper.WriteLine($"Token Claim: {c.Issuer}:{c.Type}=[{c.ValueType}]{c.Value}");
-            }
             Assert.True(claimsPrinciple.HasClaim(ClaimTypes.NameIdentifier, subject));
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/AppCommands.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/AppCommands.cs
@@ -4,32 +4,39 @@
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.UnitTestApp
 {
     internal static class AppCommands
     {
-        public static async Task<bool> TryProcessAppCommand(string potentialCommand, ILogger logger)
+        public static Task<bool> TryProcessAppCommand(string potentialCommand, ILogger logger)
         {
             switch (potentialCommand)
             {
                 case TestAppScenarios.Commands.PrintEnvironmentVariables:
-                    await PrintEnvironmentVariables(logger);
-                    return true;
+                    LogEnvironmentVariables(logger);
+                    return Task.FromResult(true);
             }
-            return false;
+
+            return Task.FromResult(false);
         }
 
-        private static Task PrintEnvironmentVariables(ILogger logger)
+        private static void LogEnvironmentVariables(ILogger logger)
         {
-            IDictionary vars = Environment.GetEnvironmentVariables();
-            foreach (DictionaryEntry entry in vars)
+            // Only log specific variables required for testing instead of logging all environment variables
+            LogEnvironmentVariableIfExist(logger, ProfilerIdentifiers.EnvironmentVariables.ProductVersion);
+            LogEnvironmentVariableIfExist(logger, TestAppScenarios.EnvironmentVariables.CustomVariableName);
+            LogEnvironmentVariableIfExist(logger, TestAppScenarios.EnvironmentVariables.IncrementVariableName);
+        }
+
+        private static void LogEnvironmentVariableIfExist(ILogger logger, string name)
+        {
+            string value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrEmpty(value))
             {
-                logger.EnvironmentVariable((string)entry.Key, (string)entry.Value);
+                logger.EnvironmentVariable(name, value);
             }
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
###### Summary

Manual backport of #6299 to release/7.x; only had to change `AppCommands.LogEnvironmentVariables` to report the product version of the only profiler (there is no mutating vs notification-only split in 7.x).

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
