### PR TITLE
Remove PublishedPath from release manifest

### DIFF
--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
@@ -69,7 +69,6 @@ namespace DiagnosticsReleaseTool.Impl
             {
                 writer.WriteStartObject();
                 writer.WriteString("PublishRelativePath", fileToRelease.FileMap.RelativeOutputPath);
-                writer.WriteString("PublishedPath", fileToRelease.PublishUri);
                 writer.WriteString("Sha512", fileToRelease.FileMetadata.Sha512);
                 writer.WriteEndObject();
             }

--- a/eng/release/DiagnosticsReleaseTool/README.md
+++ b/eng/release/DiagnosticsReleaseTool/README.md
@@ -54,13 +54,11 @@ This can be shared by anyone who needs to release files to CDN and generate rele
                 "ToolName": "dotnet-counters",
                 "Rid": "linux-arm",
                 "PublishRelativePath": "ToolBundleAssets\\linux-arm\\dotnet-counters",
-                "PublishedPath": "\\\\random\\share\\68656-20201030-04\\ToolBundleAssets\\linux-arm\\dotnet-counters"
             }
         ],
         "NugetAssets": [
             {
                 "PublishRelativePath": "NugetAssets\\dotnet-counters.5.0.152202.nupkg",
-                "PublishedPath": "\\\\random\\share\\68656-20201030-04\\ToolBundleAssets\\linux-arm\\dotnet-counters"
             }
         ]
     }


### PR DESCRIPTION
###### Summary

Remove `PublishedPath` from the release manifest to avoid writing SAS tokens into the manifest. This path is largely not needed except by the nuget publishing process; this process was updated to use the file found locally since it is already staged at where the script would download it.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
