### PR TITLE
Condense log messages when `DOTNET_STARTUP_HOOKS` is not properly configured

### DIFF
--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         ConnectionModeListen = 77,
         ExperimentalFeatureEnabled = 78,
         StartCollectArtifact = 79,
-        StartupHookEnvironmentMissing = 80,
-        StartupHookMissing = 81,
+        StartupHookEnvironmentMissing = 80, // Unused
+        StartupHookMissing = 81, // Unused
         StartupHookInstructions = 82,
         ExtensionProbeStart = 83,
         ExtensionProbeRepo = 84,

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -470,20 +470,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_StartCollectArtifact);
 
-        private static readonly Action<ILogger, int, Exception> _startupHookEnvironmentMissing =
-            LoggerMessage.Define<int>(
-                eventId: LoggingEventIds.StartupHookEnvironmentMissing.EventId(),
-                logLevel: LogLevel.Warning,
-                formatString: Strings.LogFormatString_StartupHookEnvironmentMissing);
-
-        private static readonly Action<ILogger, int, string, Exception> _startupHookMissing =
+        private static readonly Action<ILogger, int, string, Exception> _startupHookInstructions =
             LoggerMessage.Define<int, string>(
-                eventId: LoggingEventIds.StartupHookMissing.EventId(),
-                logLevel: LogLevel.Warning,
-                formatString: Strings.LogFormatString_StartupHookMissing);
-
-        private static readonly Action<ILogger, string, Exception> _startupHookInstructions =
-            LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.StartupHookInstructions.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_StartupHookInstructions);
@@ -931,19 +919,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _startCollectArtifact(logger, artifactType, null);
         }
 
-        public static void StartupHookEnvironmentMissing(this ILogger logger, int processId)
+        public static void StartupHookInstructions(this ILogger logger, int processId, string startupHookLibraryPath)
         {
-            _startupHookEnvironmentMissing(logger, processId, null);
-        }
-
-        public static void StartupHookMissing(this ILogger logger, int processId, string startupHookLibraryName)
-        {
-            _startupHookMissing(logger, processId, startupHookLibraryName, null);
-        }
-
-        public static void StartupHookInstructions(this ILogger logger, string startupHookLibraryPath)
-        {
-            _startupHookInstructions(logger, startupHookLibraryPath, null);
+            _startupHookInstructions(logger, processId, startupHookLibraryPath, null);
         }
 
         public static void UnableToWatchForDisconnect(this ILogger logger, Exception exception)

--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookValidator.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookValidator.cs
@@ -66,8 +66,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
             {
                 if (logInstructions)
                 {
-                    _logger.StartupHookEnvironmentMissing(endpointInfo.ProcessId);
-                    LogInstructions(startupHookLibraryFileInfo);
+                    LogInstructions(endpointInfo, startupHookLibraryFileInfo);
                 }
 
                 return false;
@@ -77,8 +76,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
             {
                 if (logInstructions)
                 {
-                    _logger.StartupHookMissing(endpointInfo.ProcessId, startupHookLibraryFileInfo.Name);
-                    LogInstructions(startupHookLibraryFileInfo);
+                    LogInstructions(endpointInfo, startupHookLibraryFileInfo);
                 }
 
                 return false;
@@ -96,9 +94,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
             return managedFileProvider.GetFileInfo(StartupHookFileName);
         }
 
-        private void LogInstructions(IFileInfo startupHookLibraryFileInfo)
+        private void LogInstructions(IEndpointInfo endpointInfo, IFileInfo startupHookLibraryFileInfo)
         {
-            _logger.StartupHookInstructions(startupHookLibraryFileInfo.PhysicalPath);
+            _logger.StartupHookInstructions(endpointInfo.ProcessId, startupHookLibraryFileInfo.PhysicalPath);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -1493,29 +1493,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The DOTNET_STARTUP_HOOKS environment variable is missing from target process {processId}..
-        /// </summary>
-        internal static string LogFormatString_StartupHookEnvironmentMissing {
-            get {
-                return ResourceManager.GetString("LogFormatString_StartupHookEnvironmentMissing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Exception-based features require that the DOTNET_STARTUP_HOOKS environment variable is set on the target process and must contain the path to the .NET Monitor startup hook library. The path to the library is &quot;{path}&quot;..
+        ///   Looks up a localized string similar to Exception-based features require that the DOTNET_STARTUP_HOOKS environment variable is set on the target process {processId} and must contain the path to the .NET Monitor startup hook library. The path to the library is &quot;{path}&quot;..
         /// </summary>
         internal static string LogFormatString_StartupHookInstructions {
             get {
                 return ResourceManager.GetString("LogFormatString_StartupHookInstructions", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The DOTNET_STARTUP_HOOKS environment variable for target process {processId} does not contain the &apos;{name}&apos; startup hook..
-        /// </summary>
-        internal static string LogFormatString_StartupHookMissing {
-            get {
-                return ResourceManager.GetString("LogFormatString_StartupHookMissing", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -814,14 +814,8 @@
   <data name="LogFormatString_StartCollectArtifact" xml:space="preserve">
     <value>Started capturing {artifactType} artifact.</value>
   </data>
-  <data name="LogFormatString_StartupHookEnvironmentMissing" xml:space="preserve">
-    <value>The DOTNET_STARTUP_HOOKS environment variable is missing from target process {processId}.</value>
-  </data>
   <data name="LogFormatString_StartupHookInstructions" xml:space="preserve">
-    <value>Exception-based features require that the DOTNET_STARTUP_HOOKS environment variable is set on the target process and must contain the path to the .NET Monitor startup hook library. The path to the library is "{path}".</value>
-  </data>
-  <data name="LogFormatString_StartupHookMissing" xml:space="preserve">
-    <value>The DOTNET_STARTUP_HOOKS environment variable for target process {processId} does not contain the '{name}' startup hook.</value>
+    <value>Exception-based features require that the DOTNET_STARTUP_HOOKS environment variable is set on the target process {processId} and must contain the path to the .NET Monitor startup hook library. The path to the library is "{path}".</value>
   </data>
   <data name="LogFormatString_UnableToApplyProfiler" xml:space="preserve">
     <value>Unable to apply profiler.</value>


### PR DESCRIPTION
###### Summary

Condense the log messages shown to the user when `DOTNET_STARTUP_HOOKS` isn't configured into a single message that contains all the necessary information.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
