### PR TITLE
Run scheduled builds for feature/9.x branch

### DIFF
--- a/eng/pipelines/dotnet-monitor-official.yml
+++ b/eng/pipelines/dotnet-monitor-official.yml
@@ -25,6 +25,7 @@ schedules:
   displayName: M-F Scheduled Build
   branches:
     include:
+    - feature/9.x
     - main
 
 parameters:


### PR DESCRIPTION
###### Summary

Run scheduled builds for `feature/9.x` so that dotnet/dotnet-docker can pick up nightly updates for 9.0.

Corresponding change in dotnet/dotnet-docker: https://github.com/dotnet/dotnet-docker/pull/5314

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
