### PR TITLE
Support collecting GC collect only trace using a simplified profile

### DIFF
--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -2174,7 +2174,8 @@
           "Cpu",
           "Http",
           "Logs",
-          "Metrics"
+          "Metrics",
+          "GcCollect"
         ],
         "type": "string"
       },

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -2093,13 +2093,15 @@
         "Cpu",
         "Http",
         "Logs",
-        "Metrics"
+        "Metrics",
+        "GcCollect"
       ],
       "enum": [
         "Cpu",
         "Http",
         "Logs",
-        "Metrics"
+        "Metrics",
+        "GcCollect"
       ]
     },
     "EventPipeProvider": {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
     public partial class DiagController : DiagnosticsControllerBase
     {
-        private const TraceProfile DefaultTraceProfiles = TraceProfile.Cpu | TraceProfile.Http | TraceProfile.Metrics;
+        private const TraceProfile DefaultTraceProfiles = TraceProfile.Cpu | TraceProfile.Http | TraceProfile.Metrics | TraceProfile.GcCollect;
 
         private readonly IOptions<DiagnosticPortOptions> _diagnosticPortOptions;
         private readonly IOptions<CallStacksOptions> _callStacksOptions;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/TraceProfile.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/TraceProfile.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         Cpu = 0x1,
         Http = 0x2,
         Logs = 0x4,
-        Metrics = 0x8
+        Metrics = 0x8,
+        GcCollect = 0x10,
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
@@ -11,6 +11,30 @@ using System.Linq;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
+    internal sealed class GcCollectConfiguration : MonitoringSourceConfiguration
+    {
+        public GcCollectConfiguration()
+        {
+            RequestRundown = false;
+        }
+
+        public override IList<EventPipeProvider> GetProviders() =>            
+            new EventPipeProvider[] {
+                    new EventPipeProvider(
+                        name: "Microsoft-Windows-DotNETRuntime",
+                        eventLevel: System.Diagnostics.Tracing.EventLevel.Informational,
+                        // keywords: (long)ClrTraceEventParser.Keywords.GC
+                        keywords: 1
+                    ),
+                    new EventPipeProvider(
+                        name: "Microsoft-Windows-DotNETRuntimePrivate",
+                        eventLevel: System.Diagnostics.Tracing.EventLevel.Informational,
+                        // keywords: (long)ClrTraceEventParser.Keywords.GC
+                        keywords: 1
+                    )
+            };
+    }
+
     internal static class TraceUtilities
     {
         public static MonitoringSourceConfiguration GetTraceConfiguration(Models.TraceProfile profile, GlobalCounterOptions options)
@@ -43,6 +67,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 });
 
                 configurations.Add(new MetricSourceConfiguration(options.GetIntervalSeconds(), defaultProviders));
+            }
+            if (profile.HasFlag(Models.TraceProfile.GcCollect))
+            {
+                configurations.Add(new GcCollectConfiguration());
             }
 
             return new AggregateSourceConfiguration(configurations.ToArray());

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
@@ -11,30 +11,6 @@ using System.Linq;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
-    internal sealed class GcCollectConfiguration : MonitoringSourceConfiguration
-    {
-        public GcCollectConfiguration()
-        {
-            RequestRundown = false;
-        }
-
-        public override IList<EventPipeProvider> GetProviders() =>            
-            new EventPipeProvider[] {
-                    new EventPipeProvider(
-                        name: "Microsoft-Windows-DotNETRuntime",
-                        eventLevel: System.Diagnostics.Tracing.EventLevel.Informational,
-                        // keywords: (long)ClrTraceEventParser.Keywords.GC
-                        keywords: 1
-                    ),
-                    new EventPipeProvider(
-                        name: "Microsoft-Windows-DotNETRuntimePrivate",
-                        eventLevel: System.Diagnostics.Tracing.EventLevel.Informational,
-                        // keywords: (long)ClrTraceEventParser.Keywords.GC
-                        keywords: 1
-                    )
-            };
-    }
-
     internal static class TraceUtilities
     {
         public static MonitoringSourceConfiguration GetTraceConfiguration(Models.TraceProfile profile, GlobalCounterOptions options)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 yield return new object[] { tfm, TraceProfile.Metrics };
                 yield return new object[] { tfm, TraceProfile.Http };
                 yield return new object[] { tfm, TraceProfile.Cpu };
+                yield return new object[] { tfm, TraceProfile.GcCollect };
             }
         }
 


### PR DESCRIPTION
###### Summary
Fixes #4605

To make collecting gc-collect only traces easier with dotnet-monitor. I have made this change so that you can have a gc profile.

~Ideally, the class `GcCollectConfiguration` should be part of `Microsoft.Diagnostics.Monitoring.EventPipe.dll`. it will be after https://github.com/dotnet/diagnostics/pull/4568~

> Edit: Merged and consumed.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Add `GcCollect` trace profile for collecting lightweight GC collection events, same as the `gc-collect` profile in the `dotnet-trace` tool.