### PR TITLE
Enable spectre-mitigations for native builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,4 +41,8 @@ if(CLR_CMAKE_HOST_WIN32)
         )
 endif(CLR_CMAKE_HOST_WIN32)
 
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qspectre")
+endif()
+
 add_subdirectory(src/Profilers)

--- a/eng/pipelines/dotnet-monitor-public.yml
+++ b/eng/pipelines/dotnet-monitor-public.yml
@@ -42,7 +42,7 @@ extends:
     is1ESPipeline: false
     pool:
       name: $(DncEngPublicBuildPool)
-      image: windows.vs2022preview.amd64.open
+      image: 1es-windows-2022-open
       os: windows
     stages:
     - stage: Build

--- a/eng/pipelines/templates/pipeline-template.yml
+++ b/eng/pipelines/templates/pipeline-template.yml
@@ -9,7 +9,7 @@ parameters:
   type: object
   default:
     name: $(DncEngInternalBuildPool)
-    image: windows.vs2022preview.amd64
+    image: 1es-windows-2022
     os: windows
 - name: sdl
   type: object


### PR DESCRIPTION
###### Summary

Enable spectre-mitigations on Windows native builds. As part of this we need to switch to using the 1ES Windows images during builds as these images have the necessary spectre-mitigated libraries.

Test builds:
- [Internal](https://dev.azure.com/dnceng/internal/_build/results?buildId=2420193)
- [Public](https://dev.azure.com/dnceng-public/public/_build/results?buildId=629290)

NOTE: Devs will need to install the relevant spectre-mitigated libraries on their machines to build the profilers now if they didn't already have them. They are installable via VS, and if you're missing them the build will fail with a message explaining that you're missing them and how to install them.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
