### PR TITLE
[release/6.x] Enable spectre-mitigations for native builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,4 +45,8 @@ else(CLR_CMAKE_HOST_WIN32)
         )
 endif(CLR_CMAKE_HOST_WIN32)
 
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qspectre")
+endif()
+
 add_subdirectory(src/MonitorProfiler)

--- a/eng/pipelines/dotnet-monitor-public.yml
+++ b/eng/pipelines/dotnet-monitor-public.yml
@@ -40,7 +40,7 @@ extends:
     is1ESPipeline: false
     pool:
       name: NetCore-Svc-Public
-      image: windows.vs2022preview.amd64.open
+      image: 1es-windows-2022-open
       os: windows
     stages:
     - stage: Build

--- a/eng/pipelines/templates/pipeline-template.yml
+++ b/eng/pipelines/templates/pipeline-template.yml
@@ -9,7 +9,7 @@ parameters:
   type: object
   default:
     name: NetCore1ESPool-Svc-Internal
-    image: windows.vs2022preview.amd64
+    image: 1es-windows-2022
     os: windows
 - name: sdl
   type: object


### PR DESCRIPTION
###### Summary

Manual backport of #6398 to release/6.x. Manual port was needed because:
- The mutating profiler doesn't exist in this branch, thus our `CMakeLists.txt` looks a little different in this branch.
- The pipelines don't reference `$(DncEngPublicBuildPool)` and `$(DncEngInternalBuildPool)` so the yaml was little different in this branch.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
