### PR TITLE
Enable AAD signing key issuer validation for API Key auth

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading;
@@ -90,6 +91,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 ValidateActor = false,
                 ValidateLifetime = false,
             };
+            // Required for CodeQL. 
+            tokenValidationParams.EnableAadSigningKeyIssuerValidation();
+
             ClaimsPrincipal claimsPrinciple = tokenHandler.ValidateToken(tokenStr, tokenValidationParams, out SecurityToken validatedToken);
 
             Assert.True(claimsPrinciple.HasClaim(ClaimTypes.NameIdentifier, subject));

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerOptionsExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 {
@@ -31,6 +32,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
                 ValidateActor = false,
                 ValidateLifetime = false,
             };
+
+            // Required for CodeQL. 
+            tokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+
             options.TokenValidationParameters = tokenValidationParameters;
         }
     }


### PR DESCRIPTION
###### Summary

When using API Key auth, enable AAD signing key issuer validation -- this is required by CodeQL. 

We already have an official way of performing AAD auth, so this is change largely a no-op. The full effects of adding this validation are as follows:
-  If an [`OpenIdConnectConfiguration`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.protocols.openidconnect.openidconnectconfiguration?view=msal-web-dotnet-latest) is configured then extra validation will be performed on it. When using API Key auth, we never add this configuration so nothing will happen unless the user somehow has.
- If the API key is derived from an X.509 certificate then we will now validate the lifetime of the certificate (if it is already active and non-expired).


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
