### PR TITLE
Remove `sudo` From `test-binaries.yml`

### DIFF
--- a/eng/pipelines/dotnet-monitor-public.yml
+++ b/eng/pipelines/dotnet-monitor-public.yml
@@ -48,17 +48,6 @@ extends:
     - stage: Build
       displayName: Build and Test
       jobs:
-      # Build and (optionally) test binaries
-      - template: /eng/pipelines/jobs/platform-matrix.yml@self
-        parameters:
-          jobTemplate: /eng/pipelines/jobs/build-binaries.yml@self
-          includeArm64: true
-          includeDebug: true
-          jobParameters:
-            publishBinaries: true
-            is1ESPipeline: false
-            commonTemplatesFolderName: 'templates'
-
       - ${{ if ne(parameters.testGroup, 'None') }}:
         - template: /eng/pipelines/jobs/platform-matrix.yml@self
           parameters:

--- a/eng/pipelines/dotnet-monitor-public.yml
+++ b/eng/pipelines/dotnet-monitor-public.yml
@@ -48,6 +48,17 @@ extends:
     - stage: Build
       displayName: Build and Test
       jobs:
+      # Build and (optionally) test binaries
+      - template: /eng/pipelines/jobs/platform-matrix.yml@self
+        parameters:
+          jobTemplate: /eng/pipelines/jobs/build-binaries.yml@self
+          includeArm64: true
+          includeDebug: true
+          jobParameters:
+            publishBinaries: true
+            is1ESPipeline: false
+            commonTemplatesFolderName: 'templates'
+
       - ${{ if ne(parameters.testGroup, 'None') }}:
         - template: /eng/pipelines/jobs/platform-matrix.yml@self
           parameters:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -83,10 +83,25 @@ jobs:
         # Linux builds (of all variants) run in Mariner containers and do not include pwsh by default
         - ${{ if eq(parameters.osGroup, 'Linux') }}:
           - script: |
-              $(Build.SourcesDirectory)/artifacts/restore.sh
-              export DOTNET_ROOT="$Build.SourcesDirectory/artifacts/.dotnet"
-              $(Build.SourcesDirectory)/artifacts/.dotnet/dotnet tool install PowerShell --tool-path $(Build.SourcesDirectory)/artifacts/tools
-              export PATH=$PATH:$(Build.SourcesDirectory)/artifacts/tools
+              echo "Before Restore"
+              ls
+              $(Build.SourcesDirectory)/restore.sh
+              echo "After Restore"
+              ls
+              export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
+              echo "After Dotnet Root"
+              ls
+              $(Build.SourcesDirectory)/.dotnet/dotnet tool install PowerShell --tool-path $(Build.SourcesDirectory)/tools
+              echo "After Pwsh"
+              ls
+              cd tools
+              echo "After CD 1"
+              ls
+              echo "After CD 2"
+              cd ..
+              export PATH=$PATH:$(Build.SourcesDirectory)/tools
+              echo "After PATH"
+              echo "$PATH"
 
             const branchName = `bot/${process.env.TARGET_BRANCH_POSTFIX}`;
 

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -94,8 +94,8 @@ jobs:
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
               ls -a
-              echo ##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools
-              echo ##vso[task.prependpath]home/cloudtest_azpcontainer/.dotnet/tools
+              echo "##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools"
+              echo "##vso[task.prependpath]home/cloudtest_azpcontainer/.dotnet/tools"
               echo "After PATH"
               echo "$PATH"
               ls -a
@@ -103,6 +103,8 @@ jobs:
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
         - script: |
+            echo "$PATH"
+            export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
             echo "$PATH"
             pwd
             ls -a
@@ -120,6 +122,8 @@ jobs:
             path: $(HelixNodejsPayloadPath)
 
         - script: |
+            echo "$PATH"
+            export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
             echo "$PATH"
             pwd
             ls -a

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -82,6 +82,7 @@ jobs:
         # Linux builds (of all variants) run in Mariner containers and do not include pwsh by default
         - ${{ if eq(parameters.osGroup, 'Linux') }}:
           - script: |
+              pwd
               echo "Before Restore"
               ls
               $(Build.SourcesDirectory)/restore.sh
@@ -90,17 +91,9 @@ jobs:
               export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
               echo "After Dotnet Root"
               ls
-              $(Build.SourcesDirectory)/.dotnet/dotnet tool install PowerShell --tool-path $(Build.SourcesDirectory)/tools
+              $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
               ls
-              cd tools
-              echo "After CD 1"
-              ls
-              echo "After CD 2"
-              cd ..
-              export PATH=$PATH:$(Build.SourcesDirectory)/tools
-              echo "After PATH"
-              echo "$PATH"
             displayName: Install pwsh
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -102,32 +102,6 @@ jobs:
               export PATH=$PATH:$(Build.SourcesDirectory)/tools
               echo "After PATH"
               echo "$PATH"
-
-            const branchName = `bot/${process.env.TARGET_BRANCH_POSTFIX}`;
-
-            const prs = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:${branchName}`,
-              base: process.env.BASE_BRANCH
-            });
-
-            if (prs !== undefined && prs.length > 0) {
-              return;
-            }
-
-            const baseRefName = `heads/${process.env.BASE_BRANCH}`
-
-            const baseRef = await github.rest.git.getRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: baseRefName
-            });
-
-            const createOrUpdateRef = require('./.github/actions/gh-script-utils/create-or-update-ref.js');
-            await createOrUpdateRef(github, context, baseRef.data.object.sha, branchName);
-
             displayName: Install pwsh
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -94,6 +94,10 @@ jobs:
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
               ls
+              export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
+              echo "After PATH"
+              echo "$PATH"
+              ls
             displayName: Install pwsh
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -82,34 +82,17 @@ jobs:
         # Linux builds (of all variants) run in Mariner containers and do not include pwsh by default
         - ${{ if eq(parameters.osGroup, 'Linux') }}:
           - script: |
-              pwd
-              echo "Before Restore"
-              ls -a
               $(Build.SourcesDirectory)/restore.sh
-              echo "After Restore"
-              ls -a
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
-              echo "After Pwsh"
-              ls -a
               echo "##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools"
-              echo "After PATH"
-              echo "$PATH"
-              ls -a
             displayName: Install pwsh
 
-        # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
-        - script: |
-            echo "$PATH"
-            export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
-            echo "$DOTNET_ROOT"
-            export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
-            echo "$PATH"
-            pwd
-            ls -a
-            cd .dotnet
-            ls -a
-            pwsh ../eng/helix/GetNodejsVersion.ps1 -MajorVersion $(NodeMajorVersion) -TaskVariableName 'FqNodejsVersion'
-            cd ..
+        - pwsh: eng/helix/GetNodejsVersion.ps1
+              -MajorVersion $(NodeMajorVersion)
+              -TaskVariableName 'FqNodejsVersion'
+          ${{ if eq(parameters.osGroup, 'Linux') }}:
+            env:
+              DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
           displayName: Calculate Node.js version
 
         - task: Cache@2
@@ -119,18 +102,13 @@ jobs:
             key: 'nodejs | ${{ parameters.osGroup }} | ${{ parameters.architecture }} | "$(FqNodejsVersion)"'
             path: $(HelixNodejsPayloadPath)
 
-        - script: |
-            echo "$PATH"
-            export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
-            echo "$DOTNET_ROOT"
-            export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
-            echo "$PATH"
-            pwd
-            ls -a
-            cd .dotnet
-            ls -a
-            pwsh ../eng/helix/InstallNodejs.ps1 -Version $(FqNodejsVersion) -Architecture ${{ parameters.architecture }} -DestinationFolder "$(HelixNodejsPayloadPath)"
-            cd ..
+        - pwsh: eng/helix/InstallNodejs.ps1
+            -Version $(FqNodejsVersion)
+            -Architecture ${{ parameters.architecture }}
+            -DestinationFolder "$(HelixNodejsPayloadPath)"
+          ${{ if eq(parameters.osGroup, 'Linux') }}:
+            env:
+              DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
           displayName: Hydrate Node.js Installation
 
     - ${{ else }}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -75,7 +75,7 @@ jobs:
       inputs:
         buildType: 'specific'
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-        project: 'dotnet/dotnet-monitor'
+        project: 'dotnet-monitor-ci'
         targetPath: '$(Build.SourcesDirectory)/artifacts'
         buildVersionToDownload: 'specific'
         pipelineId: 645559

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -89,11 +89,10 @@ jobs:
 
           # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
           - script: |
-              export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
-              cd .dotnet
               pwsh ../eng/helix/GetNodejsVersion.ps1 -MajorVersion $(NodeMajorVersion) -TaskVariableName 'FqNodejsVersion'
-              cd ..
             displayName: Calculate Node.js version Linux
+            env:
+              DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
   
           - task: Cache@2
             displayName: Node.js Cache Linux
@@ -103,11 +102,11 @@ jobs:
               path: $(HelixNodejsPayloadPath)
   
           - script: |
-              export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
-              cd .dotnet
               pwsh ../eng/helix/InstallNodejs.ps1 -Version $(FqNodejsVersion) -Architecture ${{ parameters.architecture }} -DestinationFolder "$(HelixNodejsPayloadPath)"
-              cd ..
             displayName: Hydrate Node.js Installation Linux
+            env:
+              DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
+
         - ${{ else }}:
           - pwsh: eng/helix/GetNodejsVersion.ps1
                 -MajorVersion $(NodeMajorVersion)

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -33,6 +33,7 @@ jobs:
     architecture: ${{ parameters.architecture }}
     enableCrossBuild: ${{ parameters.useHelix }}
     timeoutInMinutes: 120
+    dependsOn: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     disableComponentGovernance: true
     disableSbom: true
     is1ESPipeline: ${{ parameters.is1ESPipeline }}
@@ -73,13 +74,8 @@ jobs:
     - task: DownloadPipelineArtifact@2
       displayName: Download Binaries
       inputs:
-        buildType: 'specific'
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-        project: 'public'
         targetPath: '$(Build.SourcesDirectory)/artifacts'
-        buildVersionToDownload: 'specific'
-        pipelineId: 645559
-        definition: 78
 
     - ${{ if eq(parameters.useHelix, 'true')}}:
       - ${{ if ne(parameters.osGroup, 'Linux_Musl')}}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -88,14 +88,10 @@ jobs:
               $(Build.SourcesDirectory)/restore.sh
               echo "After Restore"
               ls -a
-              export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
-              echo "After Dotnet Root"
-              ls -a
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
               ls -a
               echo "##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools"
-              echo "##vso[task.prependpath]home/cloudtest_azpcontainer/.dotnet/tools"
               echo "After PATH"
               echo "$PATH"
               ls -a
@@ -104,6 +100,7 @@ jobs:
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
         - script: |
             echo "$PATH"
+            export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
             export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
             echo "$PATH"
             pwd
@@ -123,6 +120,7 @@ jobs:
 
         - script: |
             echo "$PATH"
+            export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
             export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
             echo "$PATH"
             pwd

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -75,6 +75,7 @@ jobs:
       inputs:
         buildType: 'specific'
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
+        project: 'dotnet-monitor'
         targetPath: '$(Build.SourcesDirectory)/artifacts'
         buildVersionToDownload: 'specific'
         pipelineId: 645559

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -73,8 +73,10 @@ jobs:
     - task: DownloadPipelineArtifact@2
       displayName: Download Binaries
       inputs:
+        buildType: 'specific'
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
+        buildVersionToDownload: 'specific'
         pipelineId: 645559
 
     - ${{ if eq(parameters.useHelix, 'true')}}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -91,6 +91,7 @@ jobs:
           - script: |
               pwsh ../eng/helix/GetNodejsVersion.ps1 -MajorVersion $(NodeMajorVersion) -TaskVariableName 'FqNodejsVersion'
             displayName: Calculate Node.js version Linux
+            workingDirectory: "$(Build.SourcesDirectory)/.dotnet"
             env:
               DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
   
@@ -104,6 +105,7 @@ jobs:
           - script: |
               pwsh ../eng/helix/InstallNodejs.ps1 -Version $(FqNodejsVersion) -Architecture ${{ parameters.architecture }} -DestinationFolder "$(HelixNodejsPayloadPath)"
             displayName: Hydrate Node.js Installation Linux
+            workingDirectory: "$(Build.SourcesDirectory)/.dotnet"
             env:
               DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
 

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -94,7 +94,7 @@ jobs:
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
               ls -a
-              export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
+              ##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools
               echo "After PATH"
               echo "$PATH"
               ls -a
@@ -102,9 +102,12 @@ jobs:
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
         - script: |
-            cd $Build.SourcesDirectory/.dotnet
+            pwd
+            ls -a
+            cd .dotnet
+            ls -a
             pwsh ../eng/helix/GetNodejsVersion.ps1 -MajorVersion $(NodeMajorVersion) -TaskVariableName 'FqNodejsVersion'
-            cd $Build.SourcesDirectory
+            cd ..
           displayName: Calculate Node.js version
 
         - task: Cache@2
@@ -115,9 +118,12 @@ jobs:
             path: $(HelixNodejsPayloadPath)
 
         - script: |
-            cd $Build.SourcesDirectory/.dotnet
+            pwd
+            ls -a
+            cd .dotnet
+            ls -a
             pwsh ../eng/helix/InstallNodejs.ps1 -Version $(FqNodejsVersion) -Architecture ${{ parameters.architecture }} -DestinationFolder "$(HelixNodejsPayloadPath)"
-            cd $Build.SourcesDirectory
+            cd ..
           displayName: Hydrate Node.js Installation
 
     - ${{ else }}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -75,7 +75,7 @@ jobs:
       inputs:
         buildType: 'specific'
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-        project: 'dotnet-monitor-ci'
+        project: 'public'
         targetPath: '$(Build.SourcesDirectory)/artifacts'
         buildVersionToDownload: 'specific'
         pipelineId: 645559

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -76,12 +76,13 @@ jobs:
       inputs:
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
+        pipelineId: 646778
 
     - ${{ if eq(parameters.useHelix, 'true')}}:
       - ${{ if ne(parameters.osGroup, 'Linux_Musl')}}:
         # Linux builds (of all variants) run in Mariner containers and do not include pwsh by default
         - ${{ if eq(parameters.osGroup, 'Linux') }}:
-          - script: sudo -n tdnf install -y --refresh powershell
+          - script: dotnet tool install --global PowerShell
             displayName: Install pwsh
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -75,7 +75,7 @@ jobs:
       inputs:
         buildType: 'specific'
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
-        project: 'dotnet-monitor'
+        project: 'dotnet/dotnet-monitor'
         targetPath: '$(Build.SourcesDirectory)/artifacts'
         buildVersionToDownload: 'specific'
         pipelineId: 645559

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -87,29 +87,45 @@ jobs:
               echo "##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools"
             displayName: Install pwsh
 
-        - pwsh: eng/helix/GetNodejsVersion.ps1
-              -MajorVersion $(NodeMajorVersion)
-              -TaskVariableName 'FqNodejsVersion'
-          ${{ if eq(parameters.osGroup, 'Linux') }}:
-            env:
-              DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
-          displayName: Calculate Node.js version
-
-        - task: Cache@2
-          displayName: Node.js Cache
-          inputs:
-            # Wrap FqNodejsVersion in quotes to prevent it being interpreted as a file
-            key: 'nodejs | ${{ parameters.osGroup }} | ${{ parameters.architecture }} | "$(FqNodejsVersion)"'
-            path: $(HelixNodejsPayloadPath)
-
-        - pwsh: eng/helix/InstallNodejs.ps1
-            -Version $(FqNodejsVersion)
-            -Architecture ${{ parameters.architecture }}
-            -DestinationFolder "$(HelixNodejsPayloadPath)"
-          ${{ if eq(parameters.osGroup, 'Linux') }}:
-            env:
-              DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
-          displayName: Hydrate Node.js Installation
+          # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
+          - script: |
+              export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
+              cd .dotnet
+              pwsh ../eng/helix/GetNodejsVersion.ps1 -MajorVersion $(NodeMajorVersion) -TaskVariableName 'FqNodejsVersion'
+              cd ..
+            displayName: Calculate Node.js version Linux
+  
+          - task: Cache@2
+            displayName: Node.js Cache Linux
+            inputs:
+              # Wrap FqNodejsVersion in quotes to prevent it being interpreted as a file
+              key: 'nodejs | ${{ parameters.osGroup }} | ${{ parameters.architecture }} | "$(FqNodejsVersion)"'
+              path: $(HelixNodejsPayloadPath)
+  
+          - script: |
+              export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
+              cd .dotnet
+              pwsh ../eng/helix/InstallNodejs.ps1 -Version $(FqNodejsVersion) -Architecture ${{ parameters.architecture }} -DestinationFolder "$(HelixNodejsPayloadPath)"
+              cd ..
+            displayName: Hydrate Node.js Installation Linux
+        - ${{ else }}:
+          - pwsh: eng/helix/GetNodejsVersion.ps1
+                -MajorVersion $(NodeMajorVersion)
+                -TaskVariableName 'FqNodejsVersion'
+            displayName: Calculate Node.js version Non-Linux
+  
+          - task: Cache@2
+            displayName: Node.js Cache Non-Linux
+            inputs:
+              # Wrap FqNodejsVersion in quotes to prevent it being interpreted as a file
+              key: 'nodejs | ${{ parameters.osGroup }} | ${{ parameters.architecture }} | "$(FqNodejsVersion)"'
+              path: $(HelixNodejsPayloadPath)
+  
+          - pwsh: eng/helix/InstallNodejs.ps1
+              -Version $(FqNodejsVersion)
+              -Architecture ${{ parameters.architecture }}
+              -DestinationFolder "$(HelixNodejsPayloadPath)"
+            displayName: Hydrate Node.js Installation Non-Linux
 
     - ${{ else }}:
       - ${{ if ne(parameters.osGroup, 'Windows') }}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -94,7 +94,8 @@ jobs:
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
               ls -a
-              ##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools
+              echo ##vso[task.prependpath]/home/cloudtest_azpcontainer/.dotnet/tools
+              echo ##vso[task.prependpath]home/cloudtest_azpcontainer/.dotnet/tools
               echo "After PATH"
               echo "$PATH"
               ls -a
@@ -102,6 +103,7 @@ jobs:
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
         - script: |
+            echo "$PATH"
             pwd
             ls -a
             cd .dotnet
@@ -118,6 +120,7 @@ jobs:
             path: $(HelixNodejsPayloadPath)
 
         - script: |
+            echo "$PATH"
             pwd
             ls -a
             cd .dotnet

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -79,6 +79,7 @@ jobs:
         targetPath: '$(Build.SourcesDirectory)/artifacts'
         buildVersionToDownload: 'specific'
         pipelineId: 645559
+        definition: 78
 
     - ${{ if eq(parameters.useHelix, 'true')}}:
       - ${{ if ne(parameters.osGroup, 'Linux_Musl')}}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -84,26 +84,27 @@ jobs:
           - script: |
               pwd
               echo "Before Restore"
-              ls
+              ls -a
               $(Build.SourcesDirectory)/restore.sh
               echo "After Restore"
-              ls
+              ls -a
               export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
               echo "After Dotnet Root"
-              ls
+              ls -a
               $(Build.SourcesDirectory)/.dotnet/dotnet tool install --global PowerShell
               echo "After Pwsh"
-              ls
+              ls -a
               export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
               echo "After PATH"
               echo "$PATH"
-              ls
+              ls -a
             displayName: Install pwsh
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
-        - pwsh: eng/helix/GetNodejsVersion.ps1
-              -MajorVersion $(NodeMajorVersion)
-              -TaskVariableName 'FqNodejsVersion'
+        - script: |
+            cd $Build.SourcesDirectory/.dotnet
+            pwsh ../eng/helix/GetNodejsVersion.ps1 -MajorVersion $(NodeMajorVersion) -TaskVariableName 'FqNodejsVersion'
+            cd $Build.SourcesDirectory
           displayName: Calculate Node.js version
 
         - task: Cache@2
@@ -113,10 +114,10 @@ jobs:
             key: 'nodejs | ${{ parameters.osGroup }} | ${{ parameters.architecture }} | "$(FqNodejsVersion)"'
             path: $(HelixNodejsPayloadPath)
 
-        - pwsh: eng/helix/InstallNodejs.ps1
-            -Version $(FqNodejsVersion)
-            -Architecture ${{ parameters.architecture }}
-            -DestinationFolder "$(HelixNodejsPayloadPath)"
+        - script: |
+            cd $Build.SourcesDirectory/.dotnet
+            pwsh ../eng/helix/InstallNodejs.ps1 -Version $(FqNodejsVersion) -Architecture ${{ parameters.architecture }} -DestinationFolder "$(HelixNodejsPayloadPath)"
+            cd $Build.SourcesDirectory
           displayName: Hydrate Node.js Installation
 
     - ${{ else }}:

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -76,13 +76,43 @@ jobs:
       inputs:
         artifactName: Build_Binaries_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
-        pipelineId: 646778
+        pipelineId: 645559
 
     - ${{ if eq(parameters.useHelix, 'true')}}:
       - ${{ if ne(parameters.osGroup, 'Linux_Musl')}}:
         # Linux builds (of all variants) run in Mariner containers and do not include pwsh by default
         - ${{ if eq(parameters.osGroup, 'Linux') }}:
-          - script: dotnet tool install --global PowerShell
+          - script: |
+              $(Build.SourcesDirectory)/artifacts/restore.sh
+              export DOTNET_ROOT="$Build.SourcesDirectory/artifacts/.dotnet"
+              $(Build.SourcesDirectory)/artifacts/.dotnet/dotnet tool install PowerShell --tool-path $(Build.SourcesDirectory)/artifacts/tools
+              export PATH=$PATH:$(Build.SourcesDirectory)/artifacts/tools
+
+            const branchName = `bot/${process.env.TARGET_BRANCH_POSTFIX}`;
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${branchName}`,
+              base: process.env.BASE_BRANCH
+            });
+
+            if (prs !== undefined && prs.length > 0) {
+              return;
+            }
+
+            const baseRefName = `heads/${process.env.BASE_BRANCH}`
+
+            const baseRef = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: baseRefName
+            });
+
+            const createOrUpdateRef = require('./.github/actions/gh-script-utils/create-or-update-ref.js');
+            await createOrUpdateRef(github, context, baseRef.data.object.sha, branchName);
+
             displayName: Install pwsh
 
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -33,7 +33,6 @@ jobs:
     architecture: ${{ parameters.architecture }}
     enableCrossBuild: ${{ parameters.useHelix }}
     timeoutInMinutes: 120
-    dependsOn: Build_${{ parameters.configuration }}_${{ parameters.osGroup }}_${{ parameters.architecture }}
     disableComponentGovernance: true
     disableSbom: true
     is1ESPipeline: ${{ parameters.is1ESPipeline }}

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -100,7 +100,8 @@ jobs:
         # Calculate the fully qualified Nodejs version first so that any new releases will result in a new cache key
         - script: |
             echo "$PATH"
-            export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
+            export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
+            echo "$DOTNET_ROOT"
             export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
             echo "$PATH"
             pwd
@@ -120,7 +121,8 @@ jobs:
 
         - script: |
             echo "$PATH"
-            export DOTNET_ROOT="$Build.SourcesDirectory/.dotnet"
+            export DOTNET_ROOT="$(Build.SourcesDirectory)/.dotnet"
+            echo "$DOTNET_ROOT"
             export PATH="$PATH:/home/cloudtest_azpcontainer/.dotnet/tools"
             echo "$PATH"
             pwd


### PR DESCRIPTION
###### Summary

Dotnet Monitor builds are currently failing due to the use of `sudo` to install PowerShell on Linux in `test-binaries.yml`. This circumvents the issue by using `dotnet tool install` to acquire PowerShell on Linux.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
