### PR TITLE
[release/6.x] Enable AAD signing key issuer validation for API Key auth

### DIFF
--- a/eng/dependabot/independent/Packages.props
+++ b/eng/dependabot/independent/Packages.props
@@ -12,6 +12,7 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="$(MicrosoftOpenApiReadersVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelTokensVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSourceVersion)" />

--- a/eng/dependabot/independent/Versions.props
+++ b/eng/dependabot/independent/Versions.props
@@ -12,6 +12,7 @@
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingEventSourceVersion>6.0.0</MicrosoftExtensionsLoggingEventSourceVersion>
     <MicrosoftIdentityModelTokensVersion>7.5.1</MicrosoftIdentityModelTokensVersion>
+    <MicrosoftIdentityModelValidatorsVersion>7.5.1</MicrosoftIdentityModelValidatorsVersion>
     <MicrosoftOpenApiReadersVersion>1.6.13</MicrosoftOpenApiReadersVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading;
@@ -90,6 +91,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 ValidateActor = false,
                 ValidateLifetime = false,
             };
+            // Required for CodeQL. 
+            tokenValidationParams.EnableAadSigningKeyIssuerValidation();
+
             ClaimsPrincipal claimsPrinciple = tokenHandler.ValidateToken(tokenStr, tokenValidationParams, out SecurityToken validatedToken);
 
             Assert.True(claimsPrinciple.HasClaim(ClaimTypes.NameIdentifier, subject));

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -76,6 +76,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />
     <PackageReference Include="Microsoft.FileFormats" Version="$(MicrosoftFileFormatsVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelTokensVersion)" />
+    <PackageReference Include="System.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(MicrosoftIdentityModelTokensVersion)" />
   </ItemGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />
     <PackageReference Include="Microsoft.FileFormats" Version="$(MicrosoftFileFormatsVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelTokensVersion)" />
-    <PackageReference Include="System.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(MicrosoftIdentityModelTokensVersion)" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/JwtBearerPostConfigure.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
 using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
@@ -52,6 +53,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 ValidateActor = false,
                 ValidateLifetime = false,
             };
+
+            // Required for CodeQL.
+            tokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+
             options.TokenValidationParameters = tokenValidationParameters;
         }
     }

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -10,11 +10,11 @@
     <RollForward>Major</RollForward>
     <!-- File locking warnings (that are typically resolved with automatic retries) are failing builds
          quite frequently with messages such as:
-         
+
          error MSB3026: (NETCORE_ENGINEERING_TELEMETRY=Build) Could not copy "...\dotnet-monitor.dll" to
          "...\dotnet-monitor.dll". Beginning retry 1 in 1000ms. The process cannot access the file
          '...\dotnet-monitor.dll' because it is being used by another process.
-         
+
          work around this problem by telling the compiler to not warn about the issue. A file lock that
          actually prevents the build from completing correctly should still fail the compilation with
          an MSB3027 error. -->
@@ -31,6 +31,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(MicrosoftIdentityModelTokensVersion)" />
+    <PackageReference Include="System.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
     <!-- Used to upgrade to a higher version than what is provided from indirect dependencies. -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(MicrosoftIdentityModelTokensVersion)" />
-    <PackageReference Include="System.IdentityModel.Validators" Version="$(MicrosoftIdentityModelValidatorsVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">


### PR DESCRIPTION
###### Summary

Manual backport of #6459 to release/6.x. Manual backport was needed due to a difference in dependencies. `release/6.x` doesn't have AAD auth, so it doesn't pull in `Microsoft.Identity.Web`. As a result it doesn't have the needed `Microsoft.IdentityModel.Validators` package. Add `Microsoft.IdentityModel.Validators` explicitly.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
