### PR TITLE
[release/7.x] Add issuer and expiration validation for API keys

### DIFF
--- a/documentation/api-key-format.md
+++ b/documentation/api-key-format.md
@@ -31,12 +31,18 @@ The header (decoded from the token above) must contain at least 2 elements: `alg
 > The `alg` requirement is designed to enforce `dotnet monitor` to use public/private key signed tokens. This allows the key that is stored in configuration (as `Authentication__MonitorApiKey__PublicKey`) to only contain public key information and thus does not need to be kept secret.
 
 ### Payload
-The payload (also decoded from the token above) must contain at least 2 elements: `aud` (or [Audience](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)), and `sub` (or [Subject](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)). `dotnet monitor` expects the `aud` to always be `https://github.com/dotnet/dotnet-monitor` which signals that the token is intended for dotnet-monitor. The `sub` field is any non-empty string defined in `Authentication__MonitorApiKey__Subject`, this is used to validate that the token provided is for the expected instance and is user-defined in configuration.
+The payload (also decoded from the token above) must contain at least 4 elements: `aud` , `exp`  `iss`, and `sub`.
+- The `aud` field ([Audience](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)) must to always be `https://github.com/dotnet/dotnet-monitor` which signals that the token is intended for dotnet-monitor.
+- The `exp` field ([Expiration](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4)) is the expiration date of the token in the form of an integer that is the number of seconds since Unix epoch.
+- The `iss` field ([Issuer](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1)) is any non-empty string defined in `Authentication__MonitorApiKey__Issuer`, this is used to validate that the token provided was produced by the expected issuer. If `Authentication__MonitorApiKey__Issuer` is not specified, the value in the token must be `https://github.com/dotnet/dotnet-monitor/generatekey+MonitorApiKey`.
+- The `sub` field ([Subject](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)) is any non-empty string defined in `Authentication__MonitorApiKey__Subject`, this is used to validate that the token provided is for the expected instance and is user-defined in configuration.
 
-When using the `generatekey` command, the `sub` field will be a randomly-generated `Guid` but the `sub` field may be any non-empty string that matches the configuration. The `iss` (or [Issuer](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1)) field will be set to `https://github.com/dotnet/dotnet-monitor/generatekey+MonitorApiKey` to specify the source of the token, however `dotnet monitor` will accept any `iss` field value, and does not need to be present.
+When using the `generatekey` command, the `sub` field will be a randomly-generated `Guid` but the `sub` field may be any non-empty string that matches the configuration. The `iss` (or [Issuer](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1)) field will be set to `https://github.com/dotnet/dotnet-monitor/generatekey+MonitorApiKey` to specify the source of the token.
+
 ```json
 {
   "aud": "https://github.com/dotnet/dotnet-monitor",
+  "exp": "1713799523",
   "iss": "https://github.com/dotnet/dotnet-monitor/generatekey+MonitorApiKey",
   "sub": "ae5473b6-8dad-498d-b915-ffffffffffff"
 }

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -439,6 +439,13 @@
           "description": "The public key used to sign the JWT (JSON Web Token) used for authentication. This field is a JSON Web Key serialized as JSON encoded with base64Url encoding. The JWK must have a kty field of RSA or EC and should not have the private key information.",
           "minLength": 1,
           "pattern": "[0-9a-zA-Z_-]+"
+        },
+        "Issuer": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The expected value of the 'iss' or Issuer field in the JWT (JSON Web Token)."
         }
       }
     },

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MonitorApiKeyOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MonitorApiKeyOptions.cs
@@ -20,5 +20,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         [RegularExpression("[0-9a-zA-Z_-]+")]
         [Required]
         public string PublicKey { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MonitorApiKeyOptions_Issuer))]
+        public string Issuer { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -1330,6 +1330,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The expected value of the &apos;iss&apos; or Issuer field in the JWT (JSON Web Token)..
+        /// </summary>
+        public static string DisplayAttributeDescription_MonitorApiKeyOptions_Issuer {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_MonitorApiKeyOptions_Issuer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The public key used to sign the JWT (JSON Web Token) used for authentication. This field is a JSON Web Key serialized as JSON encoded with base64Url encoding. The JWK must have a kty field of RSA or EC and should not have the private key information..
         /// </summary>
         public static string DisplayAttributeDescription_MonitorApiKeyOptions_PublicKey {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -808,4 +808,8 @@
   <data name="DisplayAttributeDescription_AzureBlobEgressProviderOptions_UseWorkloadIdentityFromEnvironment" xml:space="preserve">
     <value>Uses WorkloadIdentity for authentication. The environment variables AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE, and AZURE_AUTHORITY_HOST are used to authenticate.</value>
   </data>
+  <data name="DisplayAttributeDescription_MonitorApiKeyOptions_Issuer" xml:space="preserve">
+    <value>The expected value of the 'iss' or Issuer field in the JWT (JSON Web Token).</value>
+    <comment>The description provided for the Issuer parameter on MonitorApiKeyOptions.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Auth/AuthConstants.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Auth/AuthConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
@@ -16,7 +17,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public const string ApiKeyJwtInternalIssuer = "https://github.com/dotnet/dotnet-monitor/generatekey+MonitorApiKey";
         public const string ApiKeyJwtAudience = "https://github.com/dotnet/dotnet-monitor";
         public const string ClaimAudienceStr = "aud";
+        public const string ClaimExpirationStr = "exp";
         public const string ClaimIssuerStr = "iss";
         public const string ClaimSubjectStr = "sub";
+
+        public static readonly TimeSpan ApiKeyJwtDefaultExpiration = TimeSpan.FromDays(7);
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Auth/ApiKey/ApiKeySignInfo.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Auth/ApiKey/ApiKeySignInfo.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
+{
+    internal sealed class ApiKeySignInfo
+    {
+        public readonly JwtHeader Header;
+        public readonly string PublicKeyEncoded;
+        public readonly string PrivateKeyEncoded;
+
+        private ApiKeySignInfo(JwtHeader header, string publicKeyEncoded, string privateKeyEncoded)
+        {
+            Header = header;
+            PublicKeyEncoded = publicKeyEncoded;
+            PrivateKeyEncoded = privateKeyEncoded;
+        }
+
+        public static ApiKeySignInfo Create(string algorithmName)
+        {
+            SigningCredentials signingCreds;
+            JsonWebKey exportableJwk;
+            JsonWebKey privateJwk;
+            switch (algorithmName)
+            {
+                case SecurityAlgorithms.EcdsaSha256:
+                case SecurityAlgorithms.EcdsaSha256Signature:
+                case SecurityAlgorithms.EcdsaSha384:
+                case SecurityAlgorithms.EcdsaSha384Signature:
+                case SecurityAlgorithms.EcdsaSha512:
+                case SecurityAlgorithms.EcdsaSha512Signature:
+                    ECDsa ecDsa = ECDsa.Create(GetEcCurveFromName(algorithmName));
+                    ECDsaSecurityKey ecSecKey = new ECDsaSecurityKey(ecDsa);
+                    signingCreds = new SigningCredentials(ecSecKey, algorithmName);
+                    ECDsa pubEcDsa = ECDsa.Create(ecDsa.ExportParameters(false));
+                    ECDsaSecurityKey pubEcSecKey = new ECDsaSecurityKey(pubEcDsa);
+                    exportableJwk = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(pubEcSecKey);
+                    privateJwk = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(ecSecKey);
+                    break;
+
+                case SecurityAlgorithms.RsaSha256:
+                case SecurityAlgorithms.RsaSha256Signature:
+                case SecurityAlgorithms.RsaSha384:
+                case SecurityAlgorithms.RsaSha384Signature:
+                case SecurityAlgorithms.RsaSha512:
+                case SecurityAlgorithms.RsaSha512Signature:
+                    RSA rsa = RSA.Create(GetRsaKeyLengthFromName(algorithmName));
+                    RsaSecurityKey rsaSecKey = new RsaSecurityKey(rsa);
+                    signingCreds = new SigningCredentials(rsaSecKey, algorithmName);
+                    RSA pubRsa = RSA.Create(rsa.ExportParameters(false)); // lgtm[cs/weak-asymmetric-algorithm] Intentional testing rejection of weak algorithm
+                    RsaSecurityKey pubRsaSecKey = new RsaSecurityKey(pubRsa);
+                    exportableJwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(pubRsaSecKey);
+                    privateJwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(rsaSecKey);
+                    break;
+
+                case SecurityAlgorithms.HmacSha256:
+                case SecurityAlgorithms.HmacSha384:
+                case SecurityAlgorithms.HmacSha512:
+                    HMAC hmac = GetHmacAlgorithmFromName(algorithmName);
+                    SymmetricSecurityKey hmacSecKey = new SymmetricSecurityKey(hmac.Key);
+                    signingCreds = new SigningCredentials(hmacSecKey, algorithmName);
+                    exportableJwk = JsonWebKeyConverter.ConvertFromSymmetricSecurityKey(hmacSecKey);
+                    privateJwk = JsonWebKeyConverter.ConvertFromSymmetricSecurityKey(hmacSecKey);
+                    break;
+
+                default:
+                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
+            }
+
+            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonSerializerOptionsFactory.JsonIgnoreCondition.WhenWritingNull);
+
+            string publicKeyJson = JsonSerializer.Serialize(exportableJwk, serializerOptions);
+            string publicKeyEncoded = Base64UrlEncoder.Encode(publicKeyJson);
+
+            string privateKeyJson = JsonSerializer.Serialize(privateJwk, serializerOptions);
+            string privateKeyEncoded = Base64UrlEncoder.Encode(privateKeyJson);
+
+            JwtHeader newHeader = new JwtHeader(signingCreds, null, JwtConstants.HeaderType);
+
+            return new ApiKeySignInfo(newHeader, publicKeyEncoded, privateKeyEncoded);
+        }
+
+        private static HMAC GetHmacAlgorithmFromName(string algorithmName)
+        {
+            switch (algorithmName)
+            {
+                case SecurityAlgorithms.HmacSha256:
+                    return new HMACSHA256();
+                case SecurityAlgorithms.HmacSha384:
+                    return new HMACSHA384();
+                case SecurityAlgorithms.HmacSha512:
+                    return new HMACSHA512();
+                default:
+                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
+            }
+        }
+
+        private static int GetRsaKeyLengthFromName(string algorithmName)
+        {
+            switch (algorithmName)
+            {
+                case SecurityAlgorithms.RsaSha256:
+                case SecurityAlgorithms.RsaSha256Signature:
+                    return 2048;
+                case SecurityAlgorithms.RsaSha384:
+                case SecurityAlgorithms.RsaSha384Signature:
+                    return 3072;
+                case SecurityAlgorithms.RsaSha512:
+                case SecurityAlgorithms.RsaSha512Signature:
+                    return 4096;
+                default:
+                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
+            }
+        }
+
+        private static ECCurve GetEcCurveFromName(string algorithmName)
+        {
+            switch (algorithmName)
+            {
+                case SecurityAlgorithms.EcdsaSha256:
+                case SecurityAlgorithms.EcdsaSha256Signature:
+                    return ECCurve.NamedCurves.nistP256;
+                case SecurityAlgorithms.EcdsaSha384:
+                case SecurityAlgorithms.EcdsaSha384Signature:
+                    return ECCurve.NamedCurves.nistP384;
+                case SecurityAlgorithms.EcdsaSha512:
+                case SecurityAlgorithms.EcdsaSha512Signature:
+                    return ECCurve.NamedCurves.nistP521;
+                default:
+                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Auth/ApiKey/ApiKeyToken.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Auth/ApiKey/ApiKeyToken.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IdentityModel.Tokens.Jwt;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
+{
+    internal sealed class ApiKeyToken
+    {
+        public static string Create(ApiKeySignInfo signInfo, JwtPayload customPayload)
+        {
+            JwtSecurityToken newToken = new JwtSecurityToken(signInfo.Header, customPayload);
+            JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
+            return tokenHandler.WriteToken(newToken);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http;
@@ -329,9 +330,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Guid subject = Guid.NewGuid();
             string subjectStr = subject.ToString("D");
             const string BadApiKeyJwtAudience = "SomeOtherAudience";
-            JwtPayload newPayload = GetJwtPayload(BadApiKeyJwtAudience, subjectStr, AuthConstants.ApiKeyJwtInternalIssuer);
+            JwtPayload newPayload = GetJwtPayload(BadApiKeyJwtAudience, subjectStr, AuthConstants.ApiKeyJwtInternalIssuer, AuthConstants.ApiKeyJwtDefaultExpiration);
 
-            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string apiKey);
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string token);
 
             // Start dotnet-monitor
             await toolRunner.StartAsync();
@@ -339,7 +340,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Create HttpClient with default request headers
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
             httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, apiKey);
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
@@ -357,9 +358,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             Guid subject = Guid.NewGuid();
             string subjectStr = subject.ToString("D");
-            JwtPayload newPayload = GetJwtPayload(null, subjectStr, AuthConstants.ApiKeyJwtInternalIssuer);
+            JwtPayload newPayload = GetJwtPayload(null, subjectStr, AuthConstants.ApiKeyJwtInternalIssuer, AuthConstants.ApiKeyJwtDefaultExpiration);
 
-            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string apiKey);
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string token);
 
             // Start dotnet-monitor
             await toolRunner.StartAsync();
@@ -367,7 +368,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Create HttpClient with default request headers
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
             httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, apiKey);
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
@@ -376,7 +377,35 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         }
 
         [Fact]
-        public async Task AllowDifferentIssuer()
+        public async Task RejectsMissingIssuer()
+        {
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.DisableMetricsViaCommandLine = true;
+
+            _outputHelper.WriteLine("Generating API key.");
+
+            Guid subject = Guid.NewGuid();
+            string subjectStr = subject.ToString("D");
+            JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, subjectStr, issuer: null, AuthConstants.ApiKeyJwtDefaultExpiration);
+
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string token);
+
+            // Start dotnet-monitor
+            await toolRunner.StartAsync();
+
+            // Create HttpClient with default request headers
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
+            ApiClient apiClient = new(_outputHelper, httpClient);
+
+            var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
+                apiClient.GetProcessesAsync);
+            Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
+        }
+
+        [Fact]
+        public async Task RejectsDifferentIssuer()
         {
             await using MonitorCollectRunner toolRunner = new(_outputHelper);
             toolRunner.DisableMetricsViaCommandLine = true;
@@ -386,9 +415,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Guid subject = Guid.NewGuid();
             string subjectStr = subject.ToString("D");
             const string ApiKeyJwtIssuer = "MyOtherServiceMintingTokens";
-            JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, subjectStr, ApiKeyJwtIssuer);
+            JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, subjectStr, ApiKeyJwtIssuer, AuthConstants.ApiKeyJwtDefaultExpiration);
 
-            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string apiKey);
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, subjectStr, newPayload, out string token);
 
             // Start dotnet-monitor
             await toolRunner.StartAsync();
@@ -396,11 +425,43 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Create HttpClient with default request headers
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
             httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, apiKey);
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
-            var processes = await apiClient.GetProcessesAsync();
-            Assert.NotNull(processes);
+            var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
+                apiClient.GetProcessesAsync);
+            Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
+        }
+
+        [Fact]
+        public async Task AllowsConfiguredIssuer()
+        {
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.DisableMetricsViaCommandLine = true;
+
+            _outputHelper.WriteLine("Generating API key.");
+
+            ApiKeySignInfo signInfo = ApiKeySignInfo.Create(SecurityAlgorithms.EcdsaSha384);
+
+            Guid subject = Guid.NewGuid();
+            string subjectStr = subject.ToString("D");
+            const string ApiKeyJwtIssuer = "MyOtherServiceMintingTokens";
+            JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, subjectStr, ApiKeyJwtIssuer, AuthConstants.ApiKeyJwtDefaultExpiration);
+
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(signInfo, subjectStr, ApiKeyJwtIssuer);
+
+            string token = ApiKeyToken.Create(signInfo, newPayload);
+
+            // Start dotnet-monitor
+            await toolRunner.StartAsync();
+
+            // Create HttpClient with default request headers
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
+            ApiClient apiClient = new(_outputHelper, httpClient);
+
+            await apiClient.GetProcessesAsync();
         }
 
         /// <summary>
@@ -421,9 +482,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             _outputHelper.WriteLine("Generating API key.");
 
-            JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, jwtSubject, AuthConstants.ApiKeyJwtInternalIssuer);
+            JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, jwtSubject, AuthConstants.ApiKeyJwtInternalIssuer, AuthConstants.ApiKeyJwtDefaultExpiration);
 
-            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, configSubject, newPayload, out string apiKey);
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(SecurityAlgorithms.EcdsaSha384, configSubject, newPayload, out string token);
 
             // Start dotnet-monitor
             await toolRunner.StartAsync();
@@ -431,12 +492,86 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             // Create HttpClient with default request headers
             using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
             httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, apiKey);
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
             ApiClient apiClient = new(_outputHelper, httpClient);
 
             var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
                 () => apiClient.GetProcessesAsync());
             Assert.Equal(expectedError, statusCodeException.StatusCode);
+        }
+
+        [Fact]
+        public async Task RejectsMissingExpiration()
+        {
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.DisableMetricsViaCommandLine = true;
+
+            _outputHelper.WriteLine("Generating API key.");
+
+            ApiKeySignInfo signInfo = ApiKeySignInfo.Create(SecurityAlgorithms.EcdsaSha384);
+
+            Guid subject = Guid.NewGuid();
+            string subjectStr = subject.ToString("D");
+
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(signInfo, subjectStr);
+
+            // Create token without expiration
+            JwtPayload newPayload = GetJwtPayload(
+                AuthConstants.ApiKeyJwtAudience,
+                subjectStr,
+                AuthConstants.ApiKeyJwtInternalIssuer,
+                expiration: null);
+            string token = ApiKeyToken.Create(signInfo, newPayload);
+
+            // Start dotnet-monitor
+            await toolRunner.StartAsync();
+
+            // Create HttpClient with default request headers
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
+            ApiClient apiClient = new(_outputHelper, httpClient);
+
+            var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
+                apiClient.GetProcessesAsync);
+            Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
+        }
+
+        [Fact]
+        public async Task RejectsExpiredToken()
+        {
+            await using MonitorCollectRunner toolRunner = new(_outputHelper);
+            toolRunner.DisableMetricsViaCommandLine = true;
+
+            _outputHelper.WriteLine("Generating API key.");
+
+            ApiKeySignInfo signInfo = ApiKeySignInfo.Create(SecurityAlgorithms.EcdsaSha384);
+
+            Guid subject = Guid.NewGuid();
+            string subjectStr = subject.ToString("D");
+
+            toolRunner.ConfigurationFromEnvironment.UseApiKey(signInfo, subjectStr);
+
+            // Create token that expired yesterday
+            JwtPayload newPayload = GetJwtPayload(
+                AuthConstants.ApiKeyJwtAudience,
+                subjectStr,
+                AuthConstants.ApiKeyJwtInternalIssuer,
+                DateTime.UtcNow.AddDays(-1));
+            string token = ApiKeyToken.Create(signInfo, newPayload);
+
+            // Start dotnet-monitor
+            await toolRunner.StartAsync();
+
+            // Create HttpClient with default request headers
+            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
+            ApiClient apiClient = new(_outputHelper, httpClient);
+
+            var statusCodeException = await Assert.ThrowsAsync<ApiStatusCodeException>(
+                apiClient.GetProcessesAsync);
+            Assert.Equal(HttpStatusCode.Unauthorized, statusCodeException.StatusCode);
         }
 
         /// <summary>
@@ -457,35 +592,21 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                 Guid subject = Guid.NewGuid();
                 string subjectStr = subject.ToString("D");
-                JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, subjectStr, AuthConstants.ApiKeyJwtInternalIssuer);
+                JwtPayload newPayload = GetJwtPayload(AuthConstants.ApiKeyJwtAudience, subjectStr, AuthConstants.ApiKeyJwtInternalIssuer, AuthConstants.ApiKeyJwtDefaultExpiration);
                 RootOptions opts = new();
-                opts.UseApiKey(signingAlgo, subjectStr, newPayload, out string apiKey, out SecurityKey creds);
 
-                JsonWebKey exportableJwk = null;
-                if (signingAlgo.StartsWith("RS"))
-                {
-                    exportableJwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(creds as RsaSecurityKey);
-                }
-                else if (signingAlgo.StartsWith("ES"))
-                {
-                    exportableJwk = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(creds as ECDsaSecurityKey);
-                }
-                else
-                {
-                    Assert.True(false, "Unknown algorithm");
-                }
+                ApiKeySignInfo signInfo = ApiKeySignInfo.Create(signingAlgo);
+                opts.UseApiKey(signInfo, subjectStr, newPayload, out string token);
 
                 JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonSerializerOptionsFactory.JsonIgnoreCondition.WhenWritingNull);
                 serializerOptions.IgnoreReadOnlyProperties = true;
-                string privateKeyJson = JsonSerializer.Serialize(exportableJwk, serializerOptions);
-                string privateKeyEncoded = Base64UrlEncoder.Encode(privateKeyJson);
 
                 AuthenticationOptions authOpts = new AuthenticationOptions()
                 {
                     MonitorApiKey = new MonitorApiKeyOptions()
                     {
                         Subject = opts.Authentication.MonitorApiKey.Subject,
-                        PublicKey = privateKeyEncoded,
+                        PublicKey = signInfo.PrivateKeyEncoded,
                     },
                 };
                 toolRunner.ConfigurationFromEnvironment.Authentication = authOpts;
@@ -496,7 +617,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 // Create HttpClient with default request headers
                 using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory);
                 httpClient.DefaultRequestHeaders.Authorization =
-                    new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, apiKey);
+                    new AuthenticationHeaderValue(AuthConstants.ApiKeySchema, token);
                 ApiClient apiClient = new(_outputHelper, httpClient);
 
                 await apiClient.GetProcessesAsync();
@@ -676,7 +797,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             _warnPrivateKeyLog.Add((fieldName, DateTime.Now));
         }
 
-        private static JwtPayload GetJwtPayload(string audience, string subject, string issuer)
+        private static JwtPayload GetJwtPayload(string audience, string subject, string issuer, TimeSpan expiration)
+        {
+            return GetJwtPayload(audience, subject, issuer, DateTime.UtcNow + expiration);
+        }
+
+        private static JwtPayload GetJwtPayload(string audience, string subject, string issuer, DateTime? expiration)
         {
             List<Claim> claims = new();
 
@@ -694,6 +820,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             {
                 Claim audClaim = new Claim(AuthConstants.ClaimIssuerStr, issuer);
                 claims.Add(audClaim);
+            }
+            if (expiration.HasValue)
+            {
+                long expirationSecondsSinceEpoch = EpochTime.GetIntDate(expiration.Value);
+                Claim expClaim = new Claim(AuthConstants.ClaimExpirationStr, expirationSecondsSinceEpoch.ToString(CultureInfo.InvariantCulture));
+                claims.Add(expClaim);
             }
 
             JwtPayload newPayload = new JwtPayload(claims);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/GenerateKeyTests.cs
@@ -77,8 +77,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 ValidAlgorithms = JwtAlgorithmChecker.GetAllowedJwsAlgorithmList(),
 
                 // Issuer Settings
-                ValidateIssuer = true, // This setting differs from actual token validation in the product because we want to make sure we set our Issuer
+                ValidateIssuer = true,
                 ValidIssuer = AuthConstants.ApiKeyJwtInternalIssuer,
+
+                // Issuer Signing Key Settings
                 ValidateIssuerSigningKey = true,
                 IssuerSigningKeys = new SecurityKey[] { validatingKey },
                 TryAllIssuerSigningKeys = true,
@@ -89,7 +91,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                 // Other Settings
                 ValidateActor = false,
-                ValidateLifetime = false,
+                ValidateLifetime = true,
             };
             // Required for CodeQL. 
             tokenValidationParams.EnableAadSigningKeyIssuerValidation();

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.ApiKey.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.ApiKey.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
+{
+    internal static partial class OptionsExtensions
+    {
+        /// <summary>
+        /// Sets API Key authentication. Use this overload for most operations, unless specifically testing Authentication
+        /// </summary>
+        public static RootOptions UseApiKey(this RootOptions options, string algorithmName, Guid subject, out string token)
+        {
+            string subjectStr = subject.ToString("D");
+            Claim audClaim = new Claim(AuthConstants.ClaimAudienceStr, AuthConstants.ApiKeyJwtAudience);
+            long expirationSecondsSinceEpoch = EpochTime.GetIntDate(DateTime.UtcNow + AuthConstants.ApiKeyJwtDefaultExpiration);
+            Claim expClaim = new Claim(AuthConstants.ClaimExpirationStr, expirationSecondsSinceEpoch.ToString(CultureInfo.InvariantCulture));
+            Claim issClaim = new Claim(AuthConstants.ClaimIssuerStr, AuthConstants.ApiKeyJwtInternalIssuer);
+            Claim subClaim = new Claim(AuthConstants.ClaimSubjectStr, subjectStr);
+            JwtPayload newPayload = new JwtPayload(new Claim[] { audClaim, expClaim, issClaim, subClaim });
+
+            return options.UseApiKey(algorithmName, subjectStr, newPayload, out token);
+        }
+
+        public static RootOptions UseApiKey(this RootOptions options, string algorithmName, string subject, JwtPayload customPayload, out string token)
+        {
+            return options.UseApiKey(ApiKeySignInfo.Create(algorithmName), subject, customPayload, out token);
+        }
+
+        public static RootOptions UseApiKey(this RootOptions options, ApiKeySignInfo signInfo, string subject, JwtPayload customPayload, out string token)
+        {
+            options.UseApiKey(signInfo, subject);
+
+            token = ApiKeyToken.Create(signInfo, customPayload);
+
+            return options;
+        }
+
+        public static RootOptions UseApiKey(this RootOptions options, ApiKeySignInfo signInfo, string subject, string issuer = null)
+        {
+            if (null == options.Authentication)
+            {
+                options.Authentication = new AuthenticationOptions();
+            }
+
+            if (null == options.Authentication.MonitorApiKey)
+            {
+                options.Authentication.MonitorApiKey = new MonitorApiKeyOptions();
+            }
+
+            options.Authentication.MonitorApiKey.Subject = subject;
+            options.Authentication.MonitorApiKey.PublicKey = signInfo.PublicKeyEncoded;
+            if (!string.IsNullOrEmpty(issuer))
+            {
+                options.Authentication.MonitorApiKey.Issuer = issuer;
+            }
+
+            return options;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -5,18 +5,13 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem;
-using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Text.Json;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
 {
-    internal static class OptionsExtensions
+    internal static partial class OptionsExtensions
     {
         public static RootOptions AddFileSystemEgress(this RootOptions options, string name, string outputPath)
         {
@@ -111,21 +106,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
         }
 
         /// <summary>
-        /// Sets API Key authentication. Use this overload for most operations, unless specifically testing Authentication or Authorization.
-        /// </summary>
-        public static RootOptions UseApiKey(this RootOptions options, string algorithmName, Guid subject, out string token)
-        {
-            string subjectStr = subject.ToString("D");
-            Claim audClaim = new Claim(AuthConstants.ClaimAudienceStr, AuthConstants.ApiKeyJwtAudience);
-            Claim issClaim = new Claim(AuthConstants.ClaimIssuerStr, AuthConstants.ApiKeyJwtInternalIssuer);
-            Claim subClaim = new Claim(AuthConstants.ClaimSubjectStr, subjectStr);
-            JwtPayload newPayload = new JwtPayload(new Claim[] { audClaim, issClaim, subClaim });
-
-            return options.UseApiKey(algorithmName, subjectStr, newPayload, out token);
-        }
-
-
-        /// <summary>
         /// Sets AzureAd authentication. Use this overload for most operations, unless specifically testing Authentication or Authorization.
         /// </summary>
         public static RootOptions UseAzureAd(this RootOptions options)
@@ -167,140 +147,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             options.Authentication.AzureAd = azureAd;
 
             return options;
-        }
-
-        public static RootOptions UseApiKey(this RootOptions options, string algorithmName, string subject, JwtPayload customPayload, out string token)
-        {
-            return options.UseApiKey(algorithmName, subject, customPayload, out token, out SecurityKey _);
-        }
-
-        public static RootOptions UseApiKey(this RootOptions options, string algorithmName, string subject, JwtPayload customPayload, out string token, out SecurityKey privateKey)
-        {
-            if (null == options.Authentication)
-            {
-                options.Authentication = new AuthenticationOptions();
-            }
-
-            if (null == options.Authentication.MonitorApiKey)
-            {
-                options.Authentication.MonitorApiKey = new MonitorApiKeyOptions();
-            }
-
-            SigningCredentials signingCreds;
-            JsonWebKey exportableJwk;
-            switch (algorithmName)
-            {
-                case SecurityAlgorithms.EcdsaSha256:
-                case SecurityAlgorithms.EcdsaSha256Signature:
-                case SecurityAlgorithms.EcdsaSha384:
-                case SecurityAlgorithms.EcdsaSha384Signature:
-                case SecurityAlgorithms.EcdsaSha512:
-                case SecurityAlgorithms.EcdsaSha512Signature:
-                    ECDsa ecDsa = ECDsa.Create(GetEcCurveFromName(algorithmName));
-                    ECDsaSecurityKey ecSecKey = new ECDsaSecurityKey(ecDsa);
-                    signingCreds = new SigningCredentials(ecSecKey, algorithmName);
-                    ECDsa pubEcDsa = ECDsa.Create(ecDsa.ExportParameters(false));
-                    ECDsaSecurityKey pubEcSecKey = new ECDsaSecurityKey(pubEcDsa);
-                    exportableJwk = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(pubEcSecKey);
-                    privateKey = ecSecKey;
-                    break;
-
-                case SecurityAlgorithms.RsaSha256:
-                case SecurityAlgorithms.RsaSha256Signature:
-                case SecurityAlgorithms.RsaSha384:
-                case SecurityAlgorithms.RsaSha384Signature:
-                case SecurityAlgorithms.RsaSha512:
-                case SecurityAlgorithms.RsaSha512Signature:
-                    RSA rsa = RSA.Create(GetRsaKeyLengthFromName(algorithmName));
-                    RsaSecurityKey rsaSecKey = new RsaSecurityKey(rsa);
-                    signingCreds = new SigningCredentials(rsaSecKey, algorithmName);
-                    RSA pubRsa = RSA.Create(rsa.ExportParameters(false)); // lgtm[cs/weak-asymmetric-algorithm] Intentional testing rejection of weak algorithm
-                    RsaSecurityKey pubRsaSecKey = new RsaSecurityKey(pubRsa);
-                    exportableJwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(pubRsaSecKey);
-                    privateKey = rsaSecKey;
-                    break;
-
-                case SecurityAlgorithms.HmacSha256:
-                case SecurityAlgorithms.HmacSha384:
-                case SecurityAlgorithms.HmacSha512:
-                    HMAC hmac = GetHmacAlgorithmFromName(algorithmName);
-                    SymmetricSecurityKey hmacSecKey = new SymmetricSecurityKey(hmac.Key);
-                    signingCreds = new SigningCredentials(hmacSecKey, algorithmName);
-                    exportableJwk = JsonWebKeyConverter.ConvertFromSymmetricSecurityKey(hmacSecKey);
-                    privateKey = hmacSecKey;
-                    break;
-
-                default:
-                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
-            }
-
-            JwtHeader newHeader = new JwtHeader(signingCreds, null, JwtConstants.HeaderType);
-            JwtSecurityToken newToken = new JwtSecurityToken(newHeader, customPayload);
-            JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
-            string resultToken = tokenHandler.WriteToken(newToken);
-
-            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonSerializerOptionsFactory.JsonIgnoreCondition.WhenWritingNull);
-            string publicKeyJson = JsonSerializer.Serialize(exportableJwk, serializerOptions);
-
-            string publicKeyEncoded = Base64UrlEncoder.Encode(publicKeyJson);
-
-            options.Authentication.MonitorApiKey.Subject = subject;
-            options.Authentication.MonitorApiKey.PublicKey = publicKeyEncoded;
-
-            token = resultToken;
-
-            return options;
-        }
-
-        private static HMAC GetHmacAlgorithmFromName(string algorithmName)
-        {
-            switch (algorithmName)
-            {
-                case SecurityAlgorithms.HmacSha256:
-                    return new HMACSHA256();
-                case SecurityAlgorithms.HmacSha384:
-                    return new HMACSHA384();
-                case SecurityAlgorithms.HmacSha512:
-                    return new HMACSHA512();
-                default:
-                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
-            }
-        }
-
-        private static int GetRsaKeyLengthFromName(string algorithmName)
-        {
-            switch (algorithmName)
-            {
-                case SecurityAlgorithms.RsaSha256:
-                case SecurityAlgorithms.RsaSha256Signature:
-                    return 2048;
-                case SecurityAlgorithms.RsaSha384:
-                case SecurityAlgorithms.RsaSha384Signature:
-                    return 3072;
-                case SecurityAlgorithms.RsaSha512:
-                case SecurityAlgorithms.RsaSha512Signature:
-                    return 4096;
-                default:
-                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
-            }
-        }
-
-        private static ECCurve GetEcCurveFromName(string algorithmName)
-        {
-            switch (algorithmName)
-            {
-                case SecurityAlgorithms.EcdsaSha256:
-                case SecurityAlgorithms.EcdsaSha256Signature:
-                    return ECCurve.NamedCurves.nistP256;
-                case SecurityAlgorithms.EcdsaSha384:
-                case SecurityAlgorithms.EcdsaSha384Signature:
-                    return ECCurve.NamedCurves.nistP384;
-                case SecurityAlgorithms.EcdsaSha512:
-                case SecurityAlgorithms.EcdsaSha512Signature:
-                    return ECCurve.NamedCurves.nistP521;
-                default:
-                    throw new ArgumentException($"Algorithm name '{algorithmName}' not supported", nameof(algorithmName));
-            }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerOptionsExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 {
     internal static class JwtBearerOptionsExtensions
     {
-        public static void ConfigureApiKeyTokenValidation(this JwtBearerOptions options, SecurityKey publicKey)
+        public static void ConfigureApiKeyTokenValidation(this JwtBearerOptions options, SecurityKey publicKey, string issuer)
         {
             TokenValidationParameters tokenValidationParameters = new TokenValidationParameters
             {
@@ -19,7 +19,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
                 ValidAlgorithms = JwtAlgorithmChecker.GetAllowedJwsAlgorithmList(),
 
                 // Issuer Settings
-                ValidateIssuer = false,
+                ValidateIssuer = true,
+                ValidIssuer = issuer,
+
+                // Issuer Signing Key Settings
                 ValidateIssuerSigningKey = true,
                 IssuerSigningKeys = new SecurityKey[] { publicKey },
                 TryAllIssuerSigningKeys = true,
@@ -30,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 
                 // Other Settings
                 ValidateActor = false,
-                ValidateLifetime = false,
+                ValidateLifetime = true,
             };
 
             // Required for CodeQL. 

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerPostConfigure.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
                 return;
             }
 
-            options.ConfigureApiKeyTokenValidation(configSnapshot.PublicKey);
+            options.ConfigureApiKeyTokenValidation(configSnapshot.PublicKey, configSnapshot.Issuer);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyConfiguration.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
         public string Subject { get; set; }
         public SecurityKey PublicKey { get; set; }
         public IEnumerable<ValidationResult> ValidationErrors { get; set; }
+        public string Issuer { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyPostConfigure.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -113,11 +114,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
             {
                 options.Subject = string.Empty;
                 options.PublicKey = null;
+                options.Issuer = string.Empty;
             }
             else
             {
                 options.Subject = sourceOptions.Subject;
                 options.PublicKey = jwk;
+                options.Issuer = string.IsNullOrEmpty(sourceOptions.Issuer) ?
+                    AuthConstants.ApiKeyJwtInternalIssuer :
+                    sourceOptions.Issuer;
             }
         }
     }

--- a/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
     /// </summary>
     internal static class GenerateApiKeyCommandHandler
     {
-        public static void Invoke(OutputFormat output, TextWriter outputWriter)
+        public static void Invoke(OutputFormat output, TimeSpan expiration, TextWriter outputWriter)
         {
-            GeneratedJwtKey newJwt = GeneratedJwtKey.Create();
+            GeneratedJwtKey newJwt = GeneratedJwtKey.Create(expiration);
 
             RootOptions opts = new()
             {

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                     if (settings.AuthenticationMode == StartupAuthenticationMode.TemporaryKey)
                     {
-                        GeneratedJwtKey jwtKey = GeneratedJwtKey.Create();
+                        GeneratedJwtKey jwtKey = GeneratedJwtKey.Create(AuthConstants.ApiKeyJwtDefaultExpiration);
                         context.Properties.Add(typeof(GeneratedJwtKey), jwtKey);
 
                         // These are configured via the command line configuration source so that

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.Commands;
 using System;
 using System.CommandLine;
@@ -17,13 +18,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 name: "generatekey",
                 description: Strings.HelpDescription_CommandGenerateKey)
             {
-                OutputOption
+                OutputOption,
+                ExpirationOption
             };
 
             command.SetAction((result) =>
             {
                 GenerateApiKeyCommandHandler.Invoke(
                     result.GetValue(OutputOption),
+                    result.GetValue(ExpirationOption),
                     result.Configuration.Output);
             });
 
@@ -176,6 +179,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 DefaultValueFactory = (_) => OutputFormat.Json,
                 Description = Strings.HelpDescription_OutputFormat,
                 HelpName = "output"
+            };
+
+        private static CliOption<TimeSpan> ExpirationOption =
+            new CliOption<TimeSpan>("--expiration", "-e")
+            {
+                DefaultValueFactory = (_) => AuthConstants.ApiKeyJwtDefaultExpiration,
+                Description = Strings.HelpDescription_Expiration,
+                HelpName = "expiration"
             };
 
         private static CliOption<ConfigDisplayLevel> ConfigLevelOption =

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -205,6 +205,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The expiration offset must be a positive time span value..
+        /// </summary>
+        internal static string ErrorMessage_ExpirationMustBePositive {
+            get {
+                return ResourceManager.GetString("ErrorMessage_ExpirationMustBePositive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value of field {0} must be less than the value of field {1}..
         /// </summary>
         internal static string ErrorMessage_FieldMustBeLessThanOtherField {
@@ -544,6 +553,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         internal static string HelpDescription_CommandShow {
             get {
                 return ResourceManager.GetString("HelpDescription_CommandShow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The expiration time on or after the generated key will no longer be accepted. This is a time span offset (e.g. &quot;7.00:00:00&quot; for 7 days) that will be added to the current date time to create the expiration date time..
+        /// </summary>
+        internal static string HelpDescription_Expiration {
+            get {
+                return ResourceManager.GetString("HelpDescription_Expiration", resourceCulture);
             }
         }
         

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -813,4 +813,11 @@
     <value>:REDACTED:</value>
     <comment>Gets a string similar to ":REDACTED:".</comment>
   </data>
+  <data name="HelpDescription_Expiration" xml:space="preserve">
+    <value>The expiration time on or after the generated key will no longer be accepted. This is a time span offset (e.g. "7.00:00:00" for 7 days) that will be added to the current date time to create the expiration date time.</value>
+    <comment>Gets the string to display in help that explains what the '--expiration' option does.</comment>
+  </data>
+  <data name="ErrorMessage_ExpirationMustBePositive" xml:space="preserve">
+    <value>The expiration offset must be a positive time span value.</value>
+  </data>
 </root>


### PR DESCRIPTION
###### Summary

Manual backport of #6456 to `release/7.x`; several merge conflicts on string resources and tests were manually resolved.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
