### PR TITLE
Update and re-enable ParameterCapturingTests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -196,15 +196,14 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
             public static class SubScenarios
             {
-                public const string ExpectLogStatement = nameof(ExpectLogStatement);
-                public const string DoNotExpectLogStatement = nameof(DoNotExpectLogStatement);
                 public const string AspNetApp = nameof(AspNetApp);
+                public const string AspNetAppWithSampleMethod = nameof(AspNetAppWithSampleMethod);
                 public const string NonAspNetApp = nameof(NonAspNetApp);
             }
 
             public static class Commands
             {
-                public const string Validate = nameof(Validate);
+                public const string CallMethod = nameof(CallMethod);
                 public const string Continue = nameof(Continue);
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -197,13 +197,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             public static class SubScenarios
             {
                 public const string AspNetApp = nameof(AspNetApp);
-                public const string AspNetAppWithSampleMethod = nameof(AspNetAppWithSampleMethod);
                 public const string NonAspNetApp = nameof(NonAspNetApp);
             }
 
             public static class Commands
             {
-                public const string CallMethod = nameof(CallMethod);
                 public const string Continue = nameof(Continue);
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
@@ -614,8 +614,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
             throw await CreateUnexpectedStatusCodeExceptionAsync(responseBox.Value).ConfigureAwait(false);
         }
 
-        public async Task<OperationResponse> CaptureParametersAsync(int processId, TimeSpan duration, string egressProvider, CaptureParametersConfiguration config, CancellationToken token)
+        public async Task<OperationResponse> CaptureParametersAsync(int processId, TimeSpan duration, string egressProvider, CaptureParametersConfiguration config, CapturedParameterFormat format, CancellationToken token)
         {
+            string contentType = "";
+
+            if (format == CapturedParameterFormat.JsonSequence)
+            {
+                contentType = ContentTypes.ApplicationJsonSequence;
+            }
+            else if (format == CapturedParameterFormat.NewlineDelimitedJson)
+            {
+                contentType = ContentTypes.ApplicationNDJson;
+            }
+
             bool isInfinite = (duration == Timeout.InfiniteTimeSpan);
             string uri = FormattableString.Invariant($"/parameters?pid={processId}&durationSeconds={(isInfinite ? -1 : duration.Seconds)}");
             if (!string.IsNullOrEmpty(egressProvider))
@@ -624,6 +635,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
             }
 
             using HttpRequestMessage request = new(HttpMethod.Post, uri);
+
+            request.Headers.Add(HeaderNames.Accept, contentType);
 
             string content = JsonSerializer.Serialize(config, DefaultJsonSerializeOptions);
             request.Content = new StringContent(content, Encoding.UTF8, ContentTypes.ApplicationJson);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClientExtensions.cs
@@ -516,24 +516,32 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
         /// </summary>
         public static Task<OperationResponse> CaptureParametersAsync(this ApiClient client, int pid, TimeSpan duration, CaptureParametersConfiguration config)
         {
-            return client.CaptureParametersAsync(pid, duration, config, string.Empty, TestTimeouts.HttpApi);
+            return client.CaptureParametersAsync(pid, duration, config, CapturedParameterFormat.JsonSequence, string.Empty, TestTimeouts.HttpApi);
         }
 
         /// <summary>
         /// POST /parameters
         /// </summary>
-        public static Task<OperationResponse> CaptureParametersAsync(this ApiClient client, int pid, TimeSpan duration, CaptureParametersConfiguration config, string egressProvider)
+        public static Task<OperationResponse> CaptureParametersAsync(this ApiClient client, int pid, TimeSpan duration, CaptureParametersConfiguration config, CapturedParameterFormat format)
         {
-            return client.CaptureParametersAsync(pid, duration, config, egressProvider, TestTimeouts.HttpApi);
+            return client.CaptureParametersAsync(pid, duration, config, format, string.Empty, TestTimeouts.HttpApi);
         }
 
         /// <summary>
         /// POST /parameters
         /// </summary>
-        public static async Task<OperationResponse> CaptureParametersAsync(this ApiClient client, int pid, TimeSpan duration, CaptureParametersConfiguration config, string egressProvider, TimeSpan timeout)
+        public static Task<OperationResponse> CaptureParametersAsync(this ApiClient client, int pid, TimeSpan duration, CaptureParametersConfiguration config, CapturedParameterFormat format, string egressProvider)
+        {
+            return client.CaptureParametersAsync(pid, duration, config, format, egressProvider, TestTimeouts.HttpApi);
+        }
+
+        /// <summary>
+        /// POST /parameters
+        /// </summary>
+        public static async Task<OperationResponse> CaptureParametersAsync(this ApiClient client, int pid, TimeSpan duration, CaptureParametersConfiguration config, CapturedParameterFormat format, string egressProvider, TimeSpan timeout)
         {
             using CancellationTokenSource timeoutSource = new(timeout);
-            return await client.CaptureParametersAsync(pid, duration, egressProvider, config, timeoutSource.Token).ConfigureAwait(false);
+            return await client.CaptureParametersAsync(pid, duration, egressProvider, config, format, timeoutSource.Token).ConfigureAwait(false);
         }
 
         public static Task<OperationStatusResponse> WaitForOperationToStart(this ApiClient apiClient, Uri operationUrl)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
@@ -9,12 +10,17 @@ using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using Microsoft.Diagnostics.Tools.Monitor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 #if NET7_0_OR_GREATER
 using System.Threading;
 #endif
@@ -26,19 +32,23 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
     [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
     [Collection(DefaultCollectionFixture.Name)]
-    public class ParameterCapturingTests
+    public class ParameterCapturingTests : IDisposable
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ITestOutputHelper _outputHelper;
+        private readonly TemporaryDirectory _tempDirectory;
+
+        private const string FileProviderName = "files";
 
         public ParameterCapturingTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
         {
             _httpClientFactory = serviceProviderFixture.ServiceProvider.GetService<IHttpClientFactory>();
             _outputHelper = outputHelper;
+            _tempDirectory = new(outputHelper);
         }
 
 #if NET7_0_OR_GREATER
-        [Theory(Skip = "The test will be replaced in a future commit to properly verify the new parameter capturing behavior.")]
+        [Theory]
         [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
         public async Task UnresolvableMethodsFailsOperation(Architecture targetArchitecture)
         {
@@ -59,18 +69,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     }
                 };
 
-                OperationResponse response = await apiClient.CaptureParametersAsync(processId, Timeout.InfiniteTimeSpan, config);
-                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-
-                OperationStatusResponse operationResult = await apiClient.PollOperationToCompletion(response.OperationUri);
-                Assert.Equal(HttpStatusCode.OK, operationResult.StatusCode);
-                Assert.Equal(OperationState.Failed, operationResult.OperationStatus.Status);
+                ValidationProblemDetailsException validationException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => apiClient.CaptureParametersAsync(processId, Timeout.InfiniteTimeSpan, config));
+                Assert.Equal(HttpStatusCode.BadRequest, validationException.StatusCode);
 
                 await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue);
             });
         }
 
-        [Theory(Skip = "The test will be replaced in a future commit to properly verify the new parameter capturing behavior.")]
+        [Theory]
         [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
         public async Task NonAspNetAppFailsOperation(Architecture targetArchitecture)
         {
@@ -80,59 +86,25 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                 CaptureParametersConfiguration config = GetValidConfiguration();
 
-                OperationResponse response = await apiClient.CaptureParametersAsync(processId, Timeout.InfiniteTimeSpan, config);
-                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-
-                OperationStatusResponse operationResult = await apiClient.PollOperationToCompletion(response.OperationUri);
-                Assert.Equal(HttpStatusCode.OK, operationResult.StatusCode);
-                Assert.Equal(OperationState.Failed, operationResult.OperationStatus.Status);
+                ValidationProblemDetailsException validationException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => apiClient.CaptureParametersAsync(processId, Timeout.InfiniteTimeSpan, config));
+                Assert.Equal(HttpStatusCode.BadRequest, validationException.StatusCode);
 
                 await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue);
             });
         }
 
-        [Theory(Skip = "The test will be replaced in a future commit to properly verify the new parameter capturing behavior.")]
+        [Theory]
         [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
-        public async Task DoesProduceLogStatements(Architecture targetArchitecture)
-        {
-            await RunTestCaseCore(TestAppScenarios.ParameterCapturing.SubScenarios.ExpectLogStatement, targetArchitecture, async (appRunner, apiClient) =>
-            {
-                int processId = await appRunner.ProcessIdTask;
+        public Task CapturesParametersAndOutputJsonSequence(Architecture targetArchitecture) =>
+                CapturesParametersCore(targetArchitecture, CapturedParameterFormat.JsonSequence);
 
-                CaptureParametersConfiguration config = GetValidConfiguration();
-
-                OperationResponse response = await apiClient.CaptureParametersAsync(processId, Timeout.InfiniteTimeSpan, config);
-                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-
-                OperationStatusResponse operationStatus = await apiClient.WaitForOperationToStart(response.OperationUri);
-                Assert.Equal(OperationState.Running, operationStatus.OperationStatus.Status);
-
-                await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Validate);
-            });
-        }
-
-        [Theory(Skip = "The test will be replaced in a future commit to properly verify the new parameter capturing behavior.")]
+        [Theory]
         [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
-        public async Task StopsProducingLogStatementsAfterOperationCompletes(Architecture targetArchitecture)
-        {
-            await RunTestCaseCore(TestAppScenarios.ParameterCapturing.SubScenarios.DoNotExpectLogStatement, targetArchitecture, async (appRunner, apiClient) =>
-            {
-                int processId = await appRunner.ProcessIdTask;
+        public Task CapturesParametersAndOutputNewlineDelimitedJson(Architecture targetArchitecture) =>
+                CapturesParametersCore(targetArchitecture, CapturedParameterFormat.NewlineDelimitedJson);
 
-                CaptureParametersConfiguration config = GetValidConfiguration();
-
-                OperationResponse response = await apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(2), config);
-                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-
-                OperationStatusResponse operationResult = await apiClient.PollOperationToCompletion(response.OperationUri);
-                Assert.Equal(HttpStatusCode.Created, operationResult.StatusCode);
-                Assert.Equal(OperationState.Succeeded, operationResult.OperationStatus.Status);
-
-                await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Validate);
-            });
-        }
 #else // NET7_0_OR_GREATER
-        [Theory(Skip = "The test will be replaced in a future commit to properly verify the new parameter capturing behavior.")]
+        [Theory]
         [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
         public async Task Net6AppFailsOperation(Architecture targetArchitecture)
         {
@@ -142,17 +114,47 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                 CaptureParametersConfiguration config = GetValidConfiguration();
 
-                OperationResponse response = await apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(1), config);
-                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-
-                OperationStatusResponse operationResult = await apiClient.PollOperationToCompletion(response.OperationUri);
-                Assert.Equal(HttpStatusCode.OK, operationResult.StatusCode);
-                Assert.Equal(OperationState.Failed, operationResult.OperationStatus.Status);
+                ValidationProblemDetailsException validationException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(1), config));
+                Assert.Equal(HttpStatusCode.BadRequest, validationException.StatusCode);
 
                 await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue);
             });
         }
 #endif // NET7_0_OR_GREATER
+
+        private async Task CapturesParametersCore(Architecture targetArchitecture, CapturedParameterFormat format)
+        {
+            await RunTestCaseCore(TestAppScenarios.ParameterCapturing.SubScenarios.AspNetAppWithSampleMethod, targetArchitecture, async (appRunner, apiClient) =>
+            {
+                int processId = await appRunner.ProcessIdTask;
+
+                CaptureParametersConfiguration config = GetValidConfiguration();
+
+                OperationResponse response = await apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(2), config, format, FileProviderName);
+                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+                OperationStatusResponse operationStatus = await apiClient.WaitForOperationToStart(response.OperationUri);
+                Assert.Equal(OperationState.Running, operationStatus.OperationStatus.Status);
+
+                await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.CallMethod);
+
+                OperationStatusResponse operationResult = await apiClient.PollOperationToCompletion(response.OperationUri);
+                Assert.Equal(HttpStatusCode.Created, operationResult.StatusCode);
+                Assert.Equal(OperationState.Succeeded, operationResult.OperationStatus.Status);
+
+                await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue);
+
+                Assert.True(File.Exists(operationResult.OperationStatus.ResourceLocation));
+                using FileStream resultStream = new(operationResult.OperationStatus.ResourceLocation, FileMode.Open);
+
+                List<CapturedMethod> capturedMethods = await DeserializeCapturedMethodsAsync(resultStream, format);
+
+                Assert.NotNull(capturedMethods);
+                Assert.Single(capturedMethods);
+                Assert.Equal(config.Methods[0].TypeName, capturedMethods[0].TypeName);
+                Assert.Equal(config.Methods[0].MethodName, capturedMethods[0].MethodName);
+            });
+        }
 
         private async Task RunTestCaseCore(string subScenarioName, Architecture targetArchitecture, Func<AppRunner, ApiClient, Task> appValidate)
         {
@@ -174,6 +176,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     {
                         Enabled = true
                     };
+                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 },
                 profilerLogLevel: LogLevel.Trace,
                 subScenarioName: subScenarioName);
@@ -195,5 +198,36 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             };
         }
 
+        public void Dispose()
+        {
+            _tempDirectory.Dispose();
+        }
+
+        private static async Task<List<CapturedMethod>> DeserializeCapturedMethodsAsync(Stream inputStream, CapturedParameterFormat format)
+        {
+            List<CapturedMethod> capturedMethods = [];
+            JsonSerializerOptions options = new();
+            options.Converters.Add(new JsonStringEnumConverter());
+
+            using StreamReader reader = new StreamReader(inputStream);
+
+            string line;
+            while (null != (line = await reader.ReadLineAsync()))
+            {
+                if (format == CapturedParameterFormat.JsonSequence)
+                {
+                    Assert.True(line.Length > 1);
+                    Assert.Equal(JsonSequenceRecordSeparator, line[0]);
+                    Assert.NotEqual(JsonSequenceRecordSeparator, line[1]);
+
+                    line = line.TrimStart(JsonSequenceRecordSeparator);
+                }
+
+                capturedMethods.Add(JsonSerializer.Deserialize<CapturedMethod>(line, options));
+            }
+            return capturedMethods;
+        }
+
+        private const char JsonSequenceRecordSeparator = '\u001E';
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ParameterCapturingScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ParameterCapturingScenario.cs
@@ -22,13 +22,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
             CliCommand nonAspNetAppCommand = new(TestAppScenarios.ParameterCapturing.SubScenarios.NonAspNetApp);
             nonAspNetAppCommand.SetAction(NonAspNetAppAsync);
 
-            CliCommand aspNetAppWithSampleCommand = new(TestAppScenarios.ParameterCapturing.SubScenarios.AspNetAppWithSampleMethod);
-            aspNetAppWithSampleCommand.SetAction(AspNetAppWithSampleMethodAsync);
-
             CliCommand scenarioCommand = new(TestAppScenarios.ParameterCapturing.Name);
             scenarioCommand.Subcommands.Add(aspNetAppCommand);
             scenarioCommand.Subcommands.Add(nonAspNetAppCommand);
-            scenarioCommand.Subcommands.Add(aspNetAppWithSampleCommand);
 
             return scenarioCommand;
         }
@@ -39,6 +35,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                 func: async logger =>
                 {
                     await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue, logger);
+
+                    SampleMethods.StaticTestMethodSignatures.NoArgs();
+
                     return 0;
                 }, token);
         }
@@ -52,21 +51,6 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                     return 0;
                 }, token);
         }
-
-        public static Task<int> AspNetAppWithSampleMethodAsync(ParseResult result, CancellationToken token)
-        {
-            return ScenarioHelpers.RunWebScenarioAsync<Startup>(
-                func: async logger =>
-                {
-                    await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.ParameterCapturing.Commands.CallMethod, logger);
-
-                    SampleMethods.StaticTestMethodSignatures.NoArgs();
-
-                    await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue, logger);
-                    return 0;
-                }, token);
-        }
-
 
         private sealed class Startup
         {


### PR DESCRIPTION
###### Summary
- The new parameter capturing logic doesn't rely on logs anymore, so I've updated the test scenarios to remove the logs related ones.
- Re-enable ParameterCapturingTests, and replaced the log tests with ones that verify the http response.