### PR TITLE
Update MacOS version to 12

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -70,7 +70,7 @@ jobs:
     ${{ if in(parameters.osGroup, 'MacOS') }}:
       pool:
         name: Azure Pipelines
-        vmImage: macos-11
+        vmImage: macos-12
         os: macOS
 
     ${{ if ne(parameters.container, '') }}:


### PR DESCRIPTION
###### Summary

It seems that .NET 9 Preview 4 requires MacOS 12 at minimum to run. When installing newer Preview 4 candidates, running dotnet will fail with:

```
Failed to load /Users/runner/work/1/s/.dotnet/host/fxr/9.0.0-preview.4.24223.11/libhostfxr.dylib, error: dlopen(/Users/runner/work/1/s/.dotnet/host/fxr/9.0.0-preview.4.24223.11/libhostfxr.dylib, 1): Symbol not found: __ZNSt3__113basic_filebufIcNS_11char_traitsIcEEE4openEPKcj
  Referenced from: /Users/runner/work/1/s/.dotnet/host/fxr/9.0.0-preview.4.24223.11/libhostfxr.dylib (which was built for Mac OS X 12.0)
  Expected in: /usr/lib/libc++.1.dylib
```

Update the MacOS version for pipeline jobs to 12.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
