### PR TITLE
Add missing resx entry for schema

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -1734,6 +1734,7 @@
           ]
         },
         "Filters": {
+          "description": "The filters that determine which exceptions should be included/excluded when collecting exceptions.",
           "oneOf": [
             {
               "type": "null"

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -770,6 +770,9 @@
   <data name="DisplayAttributeDescription_ExceptionsOptions_CollectionFilters" xml:space="preserve">
     <value>The filters that determine which exceptions should be included/excluded when collecting exceptions.</value>
   </data>
+  <data name="DisplayAttributeDescription_CollectExceptionsOptions_Filters" xml:space="preserve">
+    <value>The filters that determine which exceptions should be included/excluded when collecting exceptions.</value>
+  </data>
   <data name="DisplayAttributeDescription_MonitorApiKeyOptions_Issuer" xml:space="preserve">
     <value>The expected value of the 'iss' or Issuer field in the JWT (JSON Web Token).</value>
     <comment>The description provided for the Issuer parameter on MonitorApiKeyOptions.</comment>


### PR DESCRIPTION
###### Summary

The `DisplayAttributeDescription_CollectExceptionsOptions_Filters` resx entry is missing from `release/8.0` likely due to a incomplete backport. I've added it to make sure the schema documentation is correct and to allow easier backporting in the future so that there is not missing information from the schema.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
