### PR TITLE
ParameterCapturing: Remove quotes from string evaluations, include failure reason information make the value nullable

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -116,6 +116,8 @@ Object describing a captured parameter.
 | `value` | string | The parameter value. |
 | `typeName` | string | The parameter type name. |
 | `moduleName` | string | The parameter type module name. |
+| `evalFailReason` | string | The reason why evaluation failed. If missing the evaluation was successful. |
+| `isNull` | bool | Whether the evaluated parameter is null (value is omitted if false). |
 
 ## CaptureParametersConfiguration
 

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -95,7 +95,7 @@ Object describing a captured method and its parameters.
 
 | Name | Type | Description |
 |---|---|---|
-| `activityId` | string | An identifier for the current activity at the time of the capture. For more information see [Activity.Id](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.id).|
+| `activityId` | string? | An identifier for the current activity at the time of the capture. For more information see [Activity.Id](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.id).|
 | `activityIdFormat` | string | The activity Id format. For more information see [Activity.IdFormat](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.idformat).|
 | `threadId` | int | The managed thread id where the method was called.|
 | `timestamp` | DateTime | Time when the method call was captured. |
@@ -113,11 +113,10 @@ Object describing a captured parameter.
 | Name | Type | Description |
 |---|---|---|
 | `parameterName` | string | The parameter name. |
-| `value` | string | The parameter value. |
+| `value` | string? | The parameter value. |
 | `typeName` | string | The parameter type name. |
 | `moduleName` | string | The parameter type module name. |
 | `evalFailReason` | string | The reason why evaluation failed. If missing the evaluation was successful. |
-| `isNull` | bool | Whether the evaluated parameter is null (value is omitted if false). |
 
 ## CaptureParametersConfiguration
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
@@ -94,7 +94,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eve
                         param.Name ?? string.Empty,
                         param.Type ?? string.Empty,
                         param.TypeModuleName ?? string.Empty,
-                        param.Value,
+                        param.Value.FormattedValue,
+                        param.Value.Flags,
                         param.Attributes,
                         param.IsByRef);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eve
                         param.Type ?? string.Empty,
                         param.TypeModuleName ?? string.Empty,
                         param.Value.FormattedValue,
-                        param.Value.Flags,
+                        param.Value.EvalResult,
                         param.Attributes,
                         param.IsByRef);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Reflection;
+using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eventing
 {
@@ -88,11 +89,12 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eve
             string parameterType,
             string parameterTypeModuleName,
             string parameterValue,
+            ParameterEvaluationFlags parameterValueEvaluationFlags,
             ParameterAttributes parameterAttributes,
             bool isParameterTypeByRef
             )
         {
-            Span<EventData> data = stackalloc EventData[8];
+            Span<EventData> data = stackalloc EventData[9];
 
             using PinnedData pinnedName = PinnedData.Create(parameterName);
             using PinnedData pinnedType = PinnedData.Create(parameterType);
@@ -105,6 +107,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eve
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterType], pinnedType);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterTypeModuleName], pinnedTypeModuleName);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterValue], pinnedValue);
+            SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterValueEvaluationFlags], parameterValueEvaluationFlags);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterAttributes], parameterAttributes);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterTypeIsByRef], isParameterTypeByRef);
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eve
             string parameterType,
             string parameterTypeModuleName,
             string parameterValue,
-            ParameterEvaluationFlags parameterValueEvaluationFlags,
+            ParameterEvaluationResult parameterValueEvaluationResult,
             ParameterAttributes parameterAttributes,
             bool isParameterTypeByRef
             )
@@ -107,7 +107,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Eve
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterType], pinnedType);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterTypeModuleName], pinnedTypeModuleName);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterValue], pinnedValue);
-            SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterValueEvaluationFlags], parameterValueEvaluationFlags);
+            SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterValueEvaluationResult], parameterValueEvaluationResult);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterAttributes], parameterAttributes);
             SetValue(ref data[ParameterCapturingEvents.CapturedParameterPayloads.ParameterTypeIsByRef], isParameterTypeByRef);
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/EventSourceEmittingProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/FunctionProbes/EventSourceEmittingProbes.cs
@@ -58,24 +58,24 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Fun
                 resolvedArgs = new ResolvedParameterInfo[args.Length];
                 for (int i = 0; i < args.Length; i++)
                 {
-                    string value;
+                    ObjectFormatterResult evalResult;
                     if (!instrumentedMethod.SupportedParameters[i])
                     {
-                        value = ObjectFormatter.Tokens.Unsupported;
+                        evalResult = ObjectFormatterResult.Unsupported;
                     }
                     else if (args[i] == null)
                     {
-                        value = ObjectFormatter.Tokens.Null;
+                        evalResult = ObjectFormatterResult.Null;
                     }
                     else
                     {
-                        value = ObjectFormatter.FormatObject(_objectFormatterCache.GetFormatter(args[i].GetType()), args[i]);
+                        evalResult = ObjectFormatter.FormatObject(_objectFormatterCache.GetFormatter(args[i].GetType()), args[i], FormatSpecifier.NoQuotes);
                     }
                     resolvedArgs[i] = new ResolvedParameterInfo(
                         instrumentedMethod.MethodSignature.Parameters[i].Name,
                         instrumentedMethod.MethodSignature.Parameters[i].Type,
                         instrumentedMethod.MethodSignature.Parameters[i].TypeModuleName,
-                        value,
+                        evalResult,
                         instrumentedMethod.MethodSignature.Parameters[i].Attributes,
                         instrumentedMethod.MethodSignature.Parameters[i].IsByRef);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinder.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using static Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting.Formatters.DebuggerDisplay.DebuggerDisplayParser;
+using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting.Formatters.DebuggerDisplay
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
 
             if (debuggerDisplay.Expressions.Count == 0)
             {
-                return (_, _) => debuggerDisplay.FormatString;
+                return (_, _) => new() { FormattedValue = debuggerDisplay.FormatString, Flags = ParameterEvaluationFlags.None };
             }
 
             ExpressionEvaluator[] evaluators = new ExpressionEvaluator[debuggerDisplay.Expressions.Count];
@@ -58,10 +59,10 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
                     evaluationResults[i] = ObjectFormatter.FormatObject(
                         evaluatorFormatters[i],
                         evaluationResult,
-                        debuggerDisplay.Expressions[i].FormatSpecifier);
+                        debuggerDisplay.Expressions[i].FormatSpecifier).FormattedValue;
                 }
 
-                return ObjectFormatter.WrapValue(string.Format(debuggerDisplay.FormatString, evaluationResults));
+                return new() { FormattedValue = ObjectFormatter.WrapValue(string.Format(debuggerDisplay.FormatString, evaluationResults)), Flags = ParameterEvaluationFlags.None };
             };
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinder.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using static Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting.Formatters.DebuggerDisplay.DebuggerDisplayParser;
-using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting.Formatters.DebuggerDisplay
 {
@@ -27,7 +26,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
 
             if (debuggerDisplay.Expressions.Count == 0)
             {
-                return (_, _) => new() { FormattedValue = debuggerDisplay.FormatString, Flags = ParameterEvaluationFlags.None };
+                return (_, _) => new(debuggerDisplay.FormatString);
             }
 
             ExpressionEvaluator[] evaluators = new ExpressionEvaluator[debuggerDisplay.Expressions.Count];
@@ -62,7 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
                         debuggerDisplay.Expressions[i].FormatSpecifier).FormattedValue;
                 }
 
-                return new() { FormattedValue = ObjectFormatter.WrapValue(string.Format(debuggerDisplay.FormatString, evaluationResults)), Flags = ParameterEvaluationFlags.None };
+                return new(ObjectFormatter.WrapValue(string.Format(debuggerDisplay.FormatString, evaluationResults)));
             };
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormatters.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormatters.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting
 {
@@ -17,37 +16,19 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
             }
 
             string formatted = ((IConvertible)obj).ToString(CultureInfo.InvariantCulture);
-            return new()
-            {
-                FormattedValue = (formatSpecifier & FormatSpecifier.NoQuotes) == 0
-                    ? ObjectFormatter.WrapValue(formatted)
-                    : formatted,
-                Flags = ParameterEvaluationFlags.None
-            };
+            return new(formatSpecifier.HasFlag(FormatSpecifier.NoQuotes) ? formatted : ObjectFormatter.WrapValue(formatted));
         }
 
         public static ObjectFormatterResult IFormattableFormatter(object obj, FormatSpecifier formatSpecifier)
         {
             string formatted = ((IFormattable)obj).ToString(format: null, CultureInfo.InvariantCulture);
-            return new()
-            {
-                FormattedValue = (formatSpecifier & FormatSpecifier.NoQuotes) == 0
-                    ? ObjectFormatter.WrapValue(formatted)
-                    : formatted,
-                Flags = ParameterEvaluationFlags.None
-            };
+            return new(formatSpecifier.HasFlag(FormatSpecifier.NoQuotes) ? formatted : ObjectFormatter.WrapValue(formatted));
         }
 
         public static ObjectFormatterResult GeneralFormatter(object obj, FormatSpecifier formatSpecifier)
         {
             string formatted = obj.ToString() ?? string.Empty;
-            return new()
-            {
-                FormattedValue = (formatSpecifier & FormatSpecifier.NoQuotes) == 0
-                    ? ObjectFormatter.WrapValue(formatted)
-                    : formatted,
-                Flags = ParameterEvaluationFlags.None
-            };
+            return new(formatSpecifier.HasFlag(FormatSpecifier.NoQuotes) ? formatted : ObjectFormatter.WrapValue(formatted));
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormatters.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormatters.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Globalization;
+using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting
 {
     internal static class RuntimeFormatters
     {
-        public static string IConvertibleFormatter(object obj, FormatSpecifier formatSpecifier)
+        public static ObjectFormatterResult IConvertibleFormatter(object obj, FormatSpecifier formatSpecifier)
         {
             if (obj is not string)
             {
@@ -16,25 +17,37 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
             }
 
             string formatted = ((IConvertible)obj).ToString(CultureInfo.InvariantCulture);
-            return (formatSpecifier & FormatSpecifier.NoQuotes) == 0
-                ? ObjectFormatter.WrapValue(formatted)
-                : formatted;
+            return new()
+            {
+                FormattedValue = (formatSpecifier & FormatSpecifier.NoQuotes) == 0
+                    ? ObjectFormatter.WrapValue(formatted)
+                    : formatted,
+                Flags = ParameterEvaluationFlags.None
+            };
         }
 
-        public static string IFormattableFormatter(object obj, FormatSpecifier formatSpecifier)
+        public static ObjectFormatterResult IFormattableFormatter(object obj, FormatSpecifier formatSpecifier)
         {
             string formatted = ((IFormattable)obj).ToString(format: null, CultureInfo.InvariantCulture);
-            return (formatSpecifier & FormatSpecifier.NoQuotes) == 0
-                ? ObjectFormatter.WrapValue(formatted)
-                : formatted;
+            return new()
+            {
+                FormattedValue = (formatSpecifier & FormatSpecifier.NoQuotes) == 0
+                    ? ObjectFormatter.WrapValue(formatted)
+                    : formatted,
+                Flags = ParameterEvaluationFlags.None
+            };
         }
 
-        public static string GeneralFormatter(object obj, FormatSpecifier formatSpecifier)
+        public static ObjectFormatterResult GeneralFormatter(object obj, FormatSpecifier formatSpecifier)
         {
             string formatted = obj.ToString() ?? string.Empty;
-            return (formatSpecifier & FormatSpecifier.NoQuotes) == 0
-                ? ObjectFormatter.WrapValue(formatted)
-                : formatted;
+            return new()
+            {
+                FormattedValue = (formatSpecifier & FormatSpecifier.NoQuotes) == 0
+                    ? ObjectFormatter.WrapValue(formatted)
+                    : formatted,
+                Flags = ParameterEvaluationFlags.None
+            };
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/ObjectFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ObjectFormatting/ObjectFormatter.cs
@@ -17,17 +17,20 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.Obj
         NoSideEffects = 2
     }
 
-    internal readonly struct ObjectFormatterResult
+    internal readonly struct ObjectFormatterResult(string value, ParameterEvaluationResult evalResult)
     {
-        public string FormattedValue { get; init; }
+        public ObjectFormatterResult(string value) : this(value, ParameterEvaluationResult.Success)
+        {
+        }
 
-        public ParameterEvaluationFlags Flags { get; init; }
+        public string FormattedValue { get; } = value;
 
-        public static readonly ObjectFormatterResult Empty = new() { FormattedValue = string.Empty, Flags = ParameterEvaluationFlags.None };
-        public static readonly ObjectFormatterResult Null = new() { FormattedValue = ObjectFormatter.Tokens.Null, Flags = ParameterEvaluationFlags.IsNull };
-        public static readonly ObjectFormatterResult Unsupported = new() { FormattedValue = ObjectFormatter.Tokens.Unsupported, Flags = ParameterEvaluationFlags.UnsupportedEval };
-        public static readonly ObjectFormatterResult EvalException = new() { FormattedValue = ObjectFormatter.Tokens.Exception, Flags = ParameterEvaluationFlags.FailedEval };
-        public static readonly ObjectFormatterResult EvalWithSideEffects = new() { FormattedValue = ObjectFormatter.Tokens.CannotFormatWithoutSideEffects, Flags = ParameterEvaluationFlags.EvalHasSideEffects };
+        public ParameterEvaluationResult EvalResult { get; } = evalResult;
+
+        public static readonly ObjectFormatterResult Null = new(ObjectFormatter.Tokens.Null, ParameterEvaluationResult.IsNull);
+        public static readonly ObjectFormatterResult Unsupported = new(ObjectFormatter.Tokens.Unsupported, ParameterEvaluationResult.UnsupportedEval);
+        public static readonly ObjectFormatterResult EvalException = new(ObjectFormatter.Tokens.Exception, ParameterEvaluationResult.FailedEval);
+        public static readonly ObjectFormatterResult EvalWithSideEffects = new(ObjectFormatter.Tokens.CannotFormatWithoutSideEffects, ParameterEvaluationResult.EvalHasSideEffects);
     };
 
     internal static class ObjectFormatter

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ResolvedParameterInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ResolvedParameterInfo.cs
@@ -1,11 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting;
 using System.Reflection;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
 {
-    internal sealed record ResolvedParameterInfo(string? Name, string? Type, string? TypeModuleName, string Value, ParameterAttributes Attributes, bool IsByRef)
+    internal sealed record ResolvedParameterInfo(string? Name, string? Type, string? TypeModuleName, ObjectFormatterResult Value, ParameterAttributes Attributes, bool IsByRef)
     {
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CapturedParametersResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CapturedParametersResults.cs
@@ -21,6 +21,23 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 
         [JsonPropertyName("value")]
         public string Value { get; set; }
+
+        [JsonPropertyName("evalFailReason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public EvaluationFailureReason EvalFailReason { get; set; }
+
+        [JsonPropertyName("isNull")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool IsNull { get; set; }
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum EvaluationFailureReason
+    {
+        None = 0,
+        NotSupported = 1,
+        HasSideEffects = 2,
+        Unknown = 3
     }
 
     public class CapturedMethod

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CapturedParametersResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CapturedParametersResults.cs
@@ -6,29 +6,27 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 
+#nullable enable
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 {
-    public class CapturedParameter
+    public sealed class CapturedParameter
     {
         [JsonPropertyName("parameterName")]
-        public string Name { get; set; }
+        public required string Name { get; init; }
 
         [JsonPropertyName("typeName")]
-        public string Type { get; set; }
+        public required string Type { get; init; }
 
         [JsonPropertyName("moduleName")]
-        public string TypeModuleName { get; set; }
+        public required string TypeModuleName { get; init; }
 
         [JsonPropertyName("value")]
-        public string Value { get; set; }
+        public string? Value { get; init; }
 
         [JsonPropertyName("evalFailReason")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public EvaluationFailureReason EvalFailReason { get; set; }
-
-        [JsonPropertyName("isNull")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public bool IsNull { get; set; }
+        public EvaluationFailureReason EvalFailReason { get; init; }
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -40,31 +38,31 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         Unknown = 3
     }
 
-    public class CapturedMethod
+    public sealed class CapturedMethod
     {
         [JsonPropertyName("activityId")]
-        public string ActivityId { get; set; }
+        public string? ActivityId { get; init; }
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
         [JsonPropertyName("activityIdFormat")]
-        public ActivityIdFormat ActivityIdFormat { get; set; }
+        public ActivityIdFormat ActivityIdFormat { get; init; }
 
         [JsonPropertyName("threadId")]
-        public int ThreadId { get; set; }
+        public int ThreadId { get; init; }
 
         [JsonPropertyName("timestamp")]
-        public DateTime CapturedDateTime { get; set; }
+        public DateTime CapturedDateTime { get; init; }
 
         [JsonPropertyName("moduleName")]
-        public string ModuleName { get; set; }
+        public required string ModuleName { get; init; }
 
         [JsonPropertyName("typeName")]
-        public string TypeName { get; set; }
+        public required string TypeName { get; init; }
 
         [JsonPropertyName("methodName")]
-        public string MethodName { get; set; }
+        public required string MethodName { get; init; }
 
         [JsonPropertyName("parameters")]
-        public IList<CapturedParameter> Parameters { get; set; } = [];
+        public IList<CapturedParameter> Parameters { get; init; } = [];
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersFormatter.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
                 Name = param.Name,
                 Type = param.Type,
                 TypeModuleName = param.TypeModuleName,
-                Value = param.Value
+                Value = param.Value,
+                IsNull = param.IsNull,
+                EvalFailReason = param.EvalFailReason
             }).ToList()
         };
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersFormatter.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
                 Type = param.Type,
                 TypeModuleName = param.TypeModuleName,
                 Value = param.Value,
-                IsNull = param.IsNull,
                 EvalFailReason = param.EvalFailReason
             }).ToList()
         };

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
@@ -25,8 +25,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
 
             foreach (CapturedParameter parameter in capture.Parameters)
             {
-                builder.Append(FormattableString.Invariant($"{Indent}{Indent}{GetValueOrUnknown(parameter.TypeModuleName)}!{GetValueOrUnknown(parameter.Type)} "));
-                builder.AppendLine(FormattableString.Invariant($"{GetValueOrUnknown(parameter.Name)}: {GetValueOrUnknown(parameter.Value)}"));
+                builder.Append(FormattableString.Invariant($"{Indent}{Indent}{GetValueOrUnknown(parameter.TypeModuleName)}!{GetValueOrUnknown(parameter.Type)} {GetValueOrUnknown(parameter.Name)}: "));
+                string paramValue = parameter.EvalFailReason switch
+                {
+                    EvaluationFailureReason.None => parameter.IsNull ? "null" : GetValueOrUnknown(parameter.Value),
+                    EvaluationFailureReason.HasSideEffects => "<evaluation has side effects>",
+                    EvaluationFailureReason.NotSupported => "<evaluation not supported>",
+                    _ => "<unknown evaluation failure>",
+                };
+                builder.AppendLine(paramValue);
             }
 
             builder.AppendLine(FormattableString.Invariant($"{Indent})"));

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
                 builder.Append(FormattableString.Invariant($"{Indent}{Indent}{GetValueOrUnknown(parameter.TypeModuleName)}!{GetValueOrUnknown(parameter.Type)} {GetValueOrUnknown(parameter.Name)}: "));
                 string paramValue = parameter.EvalFailReason switch
                 {
-                    EvaluationFailureReason.None => parameter.IsNull ? "null" : GetValueOrUnknown(parameter.Value),
+                    EvaluationFailureReason.None => parameter.Value ?? "null",
                     EvaluationFailureReason.HasSideEffects => "<evaluation has side effects>",
                     EvaluationFailureReason.NotSupported => "<evaluation not supported>",
                     _ => "<unknown evaluation failure>",

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ParameterInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ParameterInfo.cs
@@ -1,9 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
 {
-    internal sealed record ParameterInfo(string Name, string Type, string TypeModuleName, string Value, bool IsIn, bool IsOut, bool IsByRef)
+    internal sealed record ParameterInfo(
+        string Name,
+        string Type,
+        string TypeModuleName,
+        string Value,
+        EvaluationFailureReason EvalFailReason,
+        bool IsNull,
+        bool IsIn,
+        bool IsOut,
+        bool IsByRef)
     {
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ParameterInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ParameterInfo.cs
@@ -3,15 +3,16 @@
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 
+#nullable enable
+
 namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
 {
     internal sealed record ParameterInfo(
         string Name,
         string Type,
         string TypeModuleName,
-        string Value,
+        string? Value,
         EvaluationFailureReason EvalFailReason,
-        bool IsNull,
         bool IsIn,
         bool IsOut,
         bool IsByRef)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/RequiredMemberAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/RequiredMemberAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Workaround for using the required modifier in .NET 6: https://github.com/dotnet/core/issues/8016
+#if NET6_0
+
+namespace System.Runtime.CompilerServices;
+
+[System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+public class RequiredMemberAttribute : Attribute { }
+
+[System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+public class CompilerFeatureRequiredAttribute : Attribute
+{
+    public CompilerFeatureRequiredAttribute(string name) { }
+}
+
+#endif 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
             // Assert
             Assert.Equal(FormattableString.Invariant($"'Count = {testObj.Count}'"), formattedResult.FormattedValue);
-            Assert.Equal(ParameterEvaluationFlags.None, formattedResult.Flags);
+            Assert.Equal(ParameterEvaluationResult.Success, formattedResult.EvalResult);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
             // Assert
             Assert.Equal(FormattableString.Invariant($"'Count = {testObj.Count} NullField = null'"), formattedResult.FormattedValue);
-            Assert.Equal(ParameterEvaluationFlags.None, formattedResult.Flags);
+            Assert.Equal(ParameterEvaluationResult.Success, formattedResult.EvalResult);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using Xunit;
 using static Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectFormatting.Formatters.DebuggerDisplay.DebuggerDisplayFormatter;
+using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing.ObjectFormatting.Formatters.DebuggerDisplay
 {
@@ -21,6 +22,14 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         }
         private sealed class DerivedWithBaseDebuggerDisplay : DebuggerDisplayClass { }
         private sealed class NoDebuggerDisplay { }
+
+        [DebuggerDisplay("Count = {Count} NullField = {NullField}")]
+        private sealed class DebuggerDisplayClassWithNullField
+        {
+            public int Count { get; set; }
+
+            public static string NullField => null;
+        }
 
         [Theory]
         [InlineData(typeof(NoDebuggerDisplay), null)]
@@ -75,10 +84,31 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             Assert.NotNull(factoryResult);
 
             // Act
-            string formattedResult = factoryResult.Formatter(testObj);
+            ObjectFormatterResult formattedResult = factoryResult.Formatter(testObj);
 
             // Assert
-            Assert.Equal(FormattableString.Invariant($"'Count = {testObj.Count}'"), formattedResult);
+            Assert.Equal(FormattableString.Invariant($"'Count = {testObj.Count}'"), formattedResult.FormattedValue);
+            Assert.Equal(ParameterEvaluationFlags.None, formattedResult.Flags);
+        }
+
+        [Fact]
+        public void GetDebuggerDisplayFormatter_FormatsNull()
+        {
+            // Arrange
+            DebuggerDisplayClassWithNullField testObj = new()
+            {
+                Count = 10
+            };
+
+            FormatterFactoryResult factoryResult = DebuggerDisplayFormatter.GetDebuggerDisplayFormatter(testObj.GetType());
+            Assert.NotNull(factoryResult);
+
+            // Act
+            ObjectFormatterResult formattedResult = factoryResult.Formatter(testObj);
+
+            // Assert
+            Assert.Equal(FormattableString.Invariant($"'Count = {testObj.Count} NullField = null'"), formattedResult.FormattedValue);
+            Assert.Equal(ParameterEvaluationFlags.None, formattedResult.Flags);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormattersTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormattersTests.cs
@@ -14,39 +14,39 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
     public class RuntimeFormattersTests
     {
         [Theory]
-        [InlineData("test", "'test'", ParameterEvaluationFlags.None, FormatSpecifier.None)]
-        [InlineData("test", "test", ParameterEvaluationFlags.None, FormatSpecifier.NoQuotes)]
-        [InlineData(5, "5", ParameterEvaluationFlags.None, FormatSpecifier.None)]
-        [InlineData(true, "True", ParameterEvaluationFlags.None, FormatSpecifier.None)]
-        [InlineData(MyEnum.ValueA, nameof(MyEnum.ValueA), ParameterEvaluationFlags.None, FormatSpecifier.None)]
-        internal void IConvertibleFormatter(object obj, string expectedFormattedValue, ParameterEvaluationFlags expectedEvaluationFlags, FormatSpecifier formatSpecifier)
+        [InlineData("test", "'test'", ParameterEvaluationResult.Success, FormatSpecifier.None)]
+        [InlineData("test", "test", ParameterEvaluationResult.Success, FormatSpecifier.NoQuotes)]
+        [InlineData(5, "5", ParameterEvaluationResult.Success, FormatSpecifier.None)]
+        [InlineData(true, "True", ParameterEvaluationResult.Success, FormatSpecifier.None)]
+        [InlineData(MyEnum.ValueA, nameof(MyEnum.ValueA), ParameterEvaluationResult.Success, FormatSpecifier.None)]
+        internal void IConvertibleFormatter(object obj, string expectedFormattedValue, ParameterEvaluationResult expectedEvaluationResult, FormatSpecifier formatSpecifier)
         {
             // Act
             ObjectFormatterResult actual = RuntimeFormatters.IConvertibleFormatter(obj, formatSpecifier);
 
             // Assert
             Assert.Equal(expectedFormattedValue, actual.FormattedValue);
-            Assert.Equal(expectedEvaluationFlags, actual.Flags);
+            Assert.Equal(expectedEvaluationResult, actual.EvalResult);
         }
 
 
         [Theory]
-        [InlineData("test", "'test'", ParameterEvaluationFlags.None, FormatSpecifier.None)]
-        [InlineData("test", "test", ParameterEvaluationFlags.None, FormatSpecifier.NoQuotes)]
-        internal void GeneralFormatter(object obj, string expectedFormattedValue, ParameterEvaluationFlags expectedEvaluationFlags, FormatSpecifier formatSpecifier)
+        [InlineData("test", "'test'", ParameterEvaluationResult.Success, FormatSpecifier.None)]
+        [InlineData("test", "test", ParameterEvaluationResult.Success, FormatSpecifier.NoQuotes)]
+        internal void GeneralFormatter(object obj, string expectedFormattedValue, ParameterEvaluationResult expectedEvaluationResult, FormatSpecifier formatSpecifier)
         {
             // Act
             ObjectFormatterResult actual = RuntimeFormatters.GeneralFormatter(obj, formatSpecifier);
 
             // Assert
             Assert.Equal(expectedFormattedValue, actual.FormattedValue);
-            Assert.Equal(expectedEvaluationFlags, actual.Flags);
+            Assert.Equal(expectedEvaluationResult, actual.EvalResult);
         }
 
         [Theory]
-        [InlineData("'test 1000'", ParameterEvaluationFlags.None, FormatSpecifier.None)]
-        [InlineData("test 1000", ParameterEvaluationFlags.None, FormatSpecifier.NoQuotes)]
-        internal void IFormattableFormatter(string expectedFormattedValue, ParameterEvaluationFlags expectedEvaluationFlags, FormatSpecifier formatSpecifier)
+        [InlineData("'test 1000'", ParameterEvaluationResult.Success, FormatSpecifier.None)]
+        [InlineData("test 1000", ParameterEvaluationResult.Success, FormatSpecifier.NoQuotes)]
+        internal void IFormattableFormatter(string expectedFormattedValue, ParameterEvaluationResult expectedEvaluationResult, FormatSpecifier formatSpecifier)
         {
             // Arrange
             int testFormatValue = 1000;
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
             // Assert
             Assert.Equal(expectedFormattedValue, actual.FormattedValue);
-            Assert.Equal(expectedEvaluationFlags, actual.Flags);
+            Assert.Equal(expectedEvaluationResult, actual.EvalResult);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormattersTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/RuntimeFormattersTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring.TestCommon;
 using SampleMethods;
 using System;
 using Xunit;
+using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing.ObjectFormatting.Formatters
 {
@@ -13,47 +14,50 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
     public class RuntimeFormattersTests
     {
         [Theory]
-        [InlineData("test", "'test'", FormatSpecifier.None)]
-        [InlineData("test", "test", FormatSpecifier.NoQuotes)]
-        [InlineData(5, "5", FormatSpecifier.None)]
-        [InlineData(true, "True", FormatSpecifier.None)]
-        [InlineData(MyEnum.ValueA, nameof(MyEnum.ValueA), FormatSpecifier.None)]
-        internal void IConvertibleFormatter(object obj, string expected, FormatSpecifier formatSpecifier)
+        [InlineData("test", "'test'", ParameterEvaluationFlags.None, FormatSpecifier.None)]
+        [InlineData("test", "test", ParameterEvaluationFlags.None, FormatSpecifier.NoQuotes)]
+        [InlineData(5, "5", ParameterEvaluationFlags.None, FormatSpecifier.None)]
+        [InlineData(true, "True", ParameterEvaluationFlags.None, FormatSpecifier.None)]
+        [InlineData(MyEnum.ValueA, nameof(MyEnum.ValueA), ParameterEvaluationFlags.None, FormatSpecifier.None)]
+        internal void IConvertibleFormatter(object obj, string expectedFormattedValue, ParameterEvaluationFlags expectedEvaluationFlags, FormatSpecifier formatSpecifier)
         {
             // Act
-            string actual = RuntimeFormatters.IConvertibleFormatter(obj, formatSpecifier);
+            ObjectFormatterResult actual = RuntimeFormatters.IConvertibleFormatter(obj, formatSpecifier);
 
             // Assert
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedFormattedValue, actual.FormattedValue);
+            Assert.Equal(expectedEvaluationFlags, actual.Flags);
         }
 
 
         [Theory]
-        [InlineData("test", "'test'", FormatSpecifier.None)]
-        [InlineData("test", "test", FormatSpecifier.NoQuotes)]
-        internal void GeneralFormatter(object obj, string expected, FormatSpecifier formatSpecifier)
+        [InlineData("test", "'test'", ParameterEvaluationFlags.None, FormatSpecifier.None)]
+        [InlineData("test", "test", ParameterEvaluationFlags.None, FormatSpecifier.NoQuotes)]
+        internal void GeneralFormatter(object obj, string expectedFormattedValue, ParameterEvaluationFlags expectedEvaluationFlags, FormatSpecifier formatSpecifier)
         {
             // Act
-            string actual = RuntimeFormatters.GeneralFormatter(obj, formatSpecifier);
+            ObjectFormatterResult actual = RuntimeFormatters.GeneralFormatter(obj, formatSpecifier);
 
             // Assert
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedFormattedValue, actual.FormattedValue);
+            Assert.Equal(expectedEvaluationFlags, actual.Flags);
         }
 
         [Theory]
-        [InlineData("'test 1000'", FormatSpecifier.None)]
-        [InlineData("test 1000", FormatSpecifier.NoQuotes)]
-        internal void IFormattableFormatter(string expected, FormatSpecifier formatSpecifier)
+        [InlineData("'test 1000'", ParameterEvaluationFlags.None, FormatSpecifier.None)]
+        [InlineData("test 1000", ParameterEvaluationFlags.None, FormatSpecifier.NoQuotes)]
+        internal void IFormattableFormatter(string expectedFormattedValue, ParameterEvaluationFlags expectedEvaluationFlags, FormatSpecifier formatSpecifier)
         {
             // Arrange
             int testFormatValue = 1000;
             FormattableString testFormattableObj = $"test {testFormatValue}";
 
             // Act
-            string actual = RuntimeFormatters.IFormattableFormatter(testFormattableObj, formatSpecifier);
+            ObjectFormatterResult actual = RuntimeFormatters.IFormattableFormatter(testFormattableObj, formatSpecifier);
 
             // Assert
-            Assert.Equal(expected, actual);
+            Assert.Equal(expectedFormattedValue, actual.FormattedValue);
+            Assert.Equal(expectedEvaluationFlags, actual.Flags);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/ObjectFormatterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/ObjectFormatterTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing.ObjectF
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;
 using Xunit;
+using static Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing.ParameterCapturingEvents;
 
 namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCapturing
 {
@@ -21,23 +22,25 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             };
 
             // Act
-            string actual = ObjectFormatter.FormatObject(formatter, 5);
+            ObjectFormatterResult actual = ObjectFormatter.FormatObject(formatter, 5);
 
             // Assert
-            Assert.Equal(ObjectFormatter.Tokens.Exception, actual);
+            Assert.Equal(ObjectFormatter.Tokens.Exception, actual.FormattedValue);
+            Assert.Equal(ParameterEvaluationFlags.FailedEval, actual.Flags);
         }
 
         [Fact]
         public void FormatObject_Handles_NoSideEffects()
         {
             // Arrange
-            ObjectFormatterFunc formatter = (object _, FormatSpecifier _) => { return string.Empty; };
+            ObjectFormatterFunc formatter = (object _, FormatSpecifier _) => { return ObjectFormatterResult.Empty; };
 
             // Act
-            string actual = ObjectFormatter.FormatObject(formatter, 5, FormatSpecifier.NoSideEffects);
+            ObjectFormatterResult actual = ObjectFormatter.FormatObject(formatter, 5, FormatSpecifier.NoSideEffects);
 
             // Assert
-            Assert.Equal(ObjectFormatter.Tokens.CannotFormatWithoutSideEffects, actual);
+            Assert.Equal(ObjectFormatter.Tokens.CannotFormatWithoutSideEffects, actual.FormattedValue);
+            Assert.Equal(ParameterEvaluationFlags.EvalHasSideEffects, actual.Flags);
         }
 
         [Fact]
@@ -48,11 +51,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             ObjectFormatterFunc formatter = (object obj, FormatSpecifier specifier) =>
             {
                 actualSpecifier = specifier;
-                return string.Empty;
+                return ObjectFormatterResult.Empty;
             };
 
             // Act
-            string actual = ObjectFormatter.FormatObject(formatter, 10, FormatSpecifier.NoQuotes);
+            ObjectFormatterResult actual = ObjectFormatter.FormatObject(formatter, 10, FormatSpecifier.NoQuotes);
 
             // Assert
             Assert.Equal(FormatSpecifier.NoQuotes, actualSpecifier);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/ObjectFormatterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/ObjectFormatterTests.cs
@@ -26,21 +26,21 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
             // Assert
             Assert.Equal(ObjectFormatter.Tokens.Exception, actual.FormattedValue);
-            Assert.Equal(ParameterEvaluationFlags.FailedEval, actual.Flags);
+            Assert.Equal(ParameterEvaluationResult.FailedEval, actual.EvalResult);
         }
 
         [Fact]
         public void FormatObject_Handles_NoSideEffects()
         {
             // Arrange
-            ObjectFormatterFunc formatter = (object _, FormatSpecifier _) => { return ObjectFormatterResult.Empty; };
+            ObjectFormatterFunc formatter = (object _, FormatSpecifier _) => { return new(string.Empty); };
 
             // Act
             ObjectFormatterResult actual = ObjectFormatter.FormatObject(formatter, 5, FormatSpecifier.NoSideEffects);
 
             // Assert
             Assert.Equal(ObjectFormatter.Tokens.CannotFormatWithoutSideEffects, actual.FormattedValue);
-            Assert.Equal(ParameterEvaluationFlags.EvalHasSideEffects, actual.Flags);
+            Assert.Equal(ParameterEvaluationResult.EvalHasSideEffects, actual.EvalResult);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             ObjectFormatterFunc formatter = (object obj, FormatSpecifier specifier) =>
             {
                 actualSpecifier = specifier;
-                return ObjectFormatterResult.Empty;
+                return new(string.Empty);
             };
 
             // Act

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParameters.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParameters.cs
@@ -6,13 +6,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#nullable enable
+
 namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 {
     internal sealed class CapturedParameters : ICapturedParameters
     {
         private readonly List<ParameterInfo> _parameters = [];
 
-        public CapturedParameters(string activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName)
+        public CapturedParameters(string? activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName)
         {
             ActivityId = activityId;
             ActivityIdFormat = activityIdFormat;
@@ -28,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             _parameters.Add(parameter);
         }
 
-        public string ActivityId { get; }
+        public string? ActivityId { get; }
 
         public ActivityIdFormat ActivityIdFormat { get; }
 

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
@@ -7,20 +7,22 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#nullable enable
+
 namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 {
     internal sealed class CapturedParametersBuilder
     {
         private readonly Dictionary<Guid, CapturedParameters> _capturedParameters = new();
 
-        public bool TryStartNewCaptureResponse(Guid captureId, string activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName)
+        public bool TryStartNewCaptureResponse(Guid captureId, string? activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName)
         {
             return _capturedParameters.TryAdd(captureId, new CapturedParameters(activityId, activityIdFormat, threadId, capturedDateTime, methodName, methodTypeName, methodModuleName));
         }
 
-        public bool TryFinalizeParameters(Guid captureId, out ICapturedParameters capturedParameters)
+        public bool TryFinalizeParameters(Guid captureId, out ICapturedParameters? capturedParameters)
         {
-            if (_capturedParameters.Remove(captureId, out CapturedParameters captured))
+            if (_capturedParameters.Remove(captureId, out CapturedParameters? captured))
             {
                 capturedParameters = captured;
                 return true;
@@ -35,14 +37,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             string parameterName,
             string parameterType,
             string parameterTypeModuleName,
-            string parameterValue,
+            string? parameterValue,
             EvaluationFailureReason evalFailReason,
-            bool isNull,
             bool isInParameter,
             bool isOutParameter,
             bool isByRefParameter)
         {
-            if (_capturedParameters.TryGetValue(captureId, out CapturedParameters captured))
+            if (_capturedParameters.TryGetValue(captureId, out CapturedParameters? captured))
             {
                 captured.AddParameter(new ParameterInfo(
                     Name: parameterName,
@@ -50,7 +51,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                     TypeModuleName: parameterTypeModuleName,
                     Value: parameterValue,
                     EvalFailReason: evalFailReason,
-                    IsNull: isNull,
                     IsIn: isInParameter,
                     IsOut: isOutParameter,
                     IsByRef: isByRefParameter));

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing;
 using System;
 using System.Collections.Generic;
@@ -35,6 +36,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             string parameterType,
             string parameterTypeModuleName,
             string parameterValue,
+            EvaluationFailureReason evalFailReason,
+            bool isNull,
             bool isInParameter,
             bool isOutParameter,
             bool isByRefParameter)
@@ -46,6 +49,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                     Type: parameterType,
                     TypeModuleName: parameterTypeModuleName,
                     Value: parameterValue,
+                    EvalFailReason: evalFailReason,
+                    IsNull: isNull,
                     IsIn: isInParameter,
                     IsOut: isOutParameter,
                     IsByRef: isByRefParameter));

--- a/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
@@ -151,9 +151,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                             parameterName: parameterName,
                             parameterType: parameterType,
                             parameterTypeModuleName: parameterTypeModuleName,
-                            parameterValue: parameterValue,
+                            parameterValue: parameterValueEvaluationFlags.HasFlag(ParameterEvaluationFlags.IsNull) ? null : parameterValue,
                             evalFailReason: evalFailReason,
-                            isNull: parameterValueEvaluationFlags.HasFlag(ParameterEvaluationFlags.IsNull),
                             isInParameter: (parameterAttributes & ParameterAttributes.In) != 0,
                             isOutParameter: (parameterAttributes & ParameterAttributes.Out) != 0,
                             isByRefParameter: isByRefParameter);

--- a/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 {
     internal static class ParameterCapturingEvents
@@ -88,8 +90,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             public const int ParameterType = 3;
             public const int ParameterTypeModuleName = 4;
             public const int ParameterValue = 5;
-            public const int ParameterAttributes = 6;
-            public const int ParameterTypeIsByRef = 7;
+            public const int ParameterValueEvaluationFlags = 6;
+            public const int ParameterAttributes = 7;
+            public const int ParameterTypeIsByRef = 8;
+        }
+
+        [Flags]
+        public enum ParameterEvaluationFlags
+        {
+            None = 0,
+            IsNull = 1,
+            FailedEval = 2,
+            UnsupportedEval = 4,
+            EvalHasSideEffects = 8
         }
     }
 }

--- a/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 {
     internal static class ParameterCapturingEvents
@@ -90,19 +88,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             public const int ParameterType = 3;
             public const int ParameterTypeModuleName = 4;
             public const int ParameterValue = 5;
-            public const int ParameterValueEvaluationFlags = 6;
+            public const int ParameterValueEvaluationResult = 6;
             public const int ParameterAttributes = 7;
             public const int ParameterTypeIsByRef = 8;
         }
 
-        [Flags]
-        public enum ParameterEvaluationFlags
+        public enum ParameterEvaluationResult : uint
         {
-            None = 0,
-            IsNull = 1,
-            FailedEval = 2,
-            UnsupportedEval = 4,
-            EvalHasSideEffects = 8
+            Success = 0,
+            IsNull,
+            FailedEval,
+            UnsupportedEval,
+            EvalHasSideEffects
         }
     }
 }


### PR DESCRIPTION
###### Summary

* Updated the captured parameter result so the value parameter and activity id are nullable strings.
* Introduced `ObjectFormatterResult` which includes the evaluated and formatted parameter value and evaluation metadata flags (`IsNull`, `FailedEval`, `UnsupportedEval`, `EvalHasSideEffects`). `ObjectFormatter now returns objects of the new type.
* `EventSourceEmittingProbes.EnterProbe` doesn't request adding quotes to the formatted value anymore. The quotes were added to easily parse the ILogger output, but we don't have that problem anymore.
* Updated `ParameterCapturingEventSource` to send the new evaluation flags as part of the captured paramater.
* Updated `WebApi.Models.CapturedParameter` to include a new optional property: `EvalFailReason`.
* Updated the formatter tests to support the new behavior.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

