### PR TITLE
[release/8.0] Replace SwaggerUI and SwaggerScope option with OpenAPI document

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,6 @@
     <PackageVersion Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />
     <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="$(NJsonSchemaVersion)" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreVersion)" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -490,13 +490,6 @@
           "type": "string",
           "description": "The role required to be able to authenticate.",
           "minLength": 1
-        },
-        "SwaggerScope": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "The API scope required by users to be able to interactively authenticate using the in-box Swagger UI. If not specified, users will not be able to interactively authenticate."
         }
       }
     },

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,7 +6,6 @@
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Swashbuckle.AspNetCore.SwaggerGen.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Swashbuckle.AspNetCore.SwaggerUI.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
   <ItemGroup Condition="'$(SignAllBinaries)' != 'true'">
     <!--

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptions.cs
@@ -38,10 +38,5 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_RequiredRole))]
         [Required]
         public string RequiredRole { get; set; }
-
-        [Display(
-            ResourceType = typeof(OptionsDisplayStrings),
-            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_SwaggerScope))]
-        public string SwaggerScope { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -241,15 +241,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The API scope required by users to be able to interactively authenticate using the in-box Swagger UI. If not specified, users will not be able to interactively authenticate..
-        /// </summary>
-        public static string DisplayAttributeDescription_AzureAdOptions_SwaggerScope {
-            get {
-                return ResourceManager.GetString("DisplayAttributeDescription_AzureAdOptions_SwaggerScope", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The tenant id of the Azure Active Directory tenant, or its tenant domain..
         /// </summary>
         public static string DisplayAttributeDescription_AzureAdOptions_TenantId {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -712,10 +712,6 @@
     <value>The role required to be able to authenticate.</value>
     <comment>The description provided for the RequiredRole parameter on AzureAdOptions.</comment>
   </data>
-  <data name="DisplayAttributeDescription_AzureAdOptions_SwaggerScope" xml:space="preserve">
-    <value>The API scope required by users to be able to interactively authenticate using the in-box Swagger UI. If not specified, users will not be able to interactively authenticate.</value>
-    <comment>The description provided for the SwaggerScope parameter on AzureAdOptions.</comment>
-  </data>
   <data name="DisplayAttributeDescription_AzureAdOptions_TenantId" xml:space="preserve">
     <value>The tenant id of the Azure Active Directory tenant, or its tenant domain.</value>
     <comment>The description provided for the TenantId parameter on AzureAdOptions.</comment>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -6,8 +6,6 @@ using Microsoft.Diagnostics.Tools.Monitor.Auth;
 using Microsoft.Diagnostics.Tools.Monitor.Swagger;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Writers;
 using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.Globalization;
@@ -47,14 +45,10 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
                 })
                 .Build();
 
-            // Generate the OpenAPI document
-            OpenApiDocument document = host.Services
-                .GetRequiredService<ISwaggerProvider>()
-                .GetSwagger("v1");
-
-            // Serialize the document to the file
+            // Serialize the OpenApi document
             using StringWriter outputWriter = new(CultureInfo.InvariantCulture);
-            document.SerializeAsV3(new OpenApiJsonWriter(outputWriter));
+            ISwaggerProvider provider = host.Services.GetRequiredService<ISwaggerProvider>();
+            provider.WriteTo(outputWriter);
             outputWriter.Flush();
 
             // Normalize line endings before writing

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Options/OptionsExtensions.cs
@@ -184,7 +184,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             return options.UseAzureAd(
                 tenantId: Guid.NewGuid().ToString("D"),
                 clientId: Guid.NewGuid().ToString("D"),
-                swaggerScope: Guid.NewGuid().ToString("D"),
                 requiredRole: Guid.NewGuid().ToString("D"));
         }
 
@@ -193,18 +192,16 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Options
             return options.UseAzureAd(
                 tenantId: Guid.NewGuid().ToString("D"),
                 clientId: Guid.NewGuid().ToString("D"),
-                swaggerScope: Guid.NewGuid().ToString("D"),
                 requiredRole: requiredRole);
         }
 
-        public static RootOptions UseAzureAd(this RootOptions options, string tenantId, string clientId, string swaggerScope, string requiredRole)
+        public static RootOptions UseAzureAd(this RootOptions options, string tenantId, string clientId, string requiredRole)
         {
             return options.UseAzureAd(new AzureAdOptions
             {
                 TenantId = tenantId,
                 ClientId = clientId,
-                RequiredRole = requiredRole,
-                SwaggerScope = swaggerScope
+                RequiredRole = requiredRole
             });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/RootTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/RootTests.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             await using MonitorCollectRunner toolRunner = new(_outputHelper);
             await toolRunner.StartAsync();
 
-            // Test default URL root returns HTTP 302 meaning that its an explicit redirect rather than implicitly handled by something unexpected
+            // Test that the root route returns HTTP 200 OK
             using HttpClient defaultHttpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(_httpClientFactory, ServiceProviderFixture.HttpClientName_NoRedirect);
             ApiClient defaultApiClient = new(_outputHelper, defaultHttpClient);
 
             var rootResult = await defaultApiClient.GetRootAsync();
-            Assert.Equal(HttpStatusCode.Redirect, rootResult.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, rootResult.StatusCode);
 
 
             // Disabled as there doesn't seem to be anything different about the metrics root URL from the one above.

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyAuthConfigurator.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyAuthConfigurator.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 using System.Collections.Generic;
 
@@ -65,10 +64,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
         {
             const string ApiKeySecurityDefinitionName = "ApiKeyAuth";
             options.AddBearerTokenAuthOption(ApiKeySecurityDefinitionName);
-        }
-
-        public void ConfigureSwaggerUI(SwaggerUIOptions options)
-        {
         }
 
         public IStartupLogger CreateStartupLogger(ILogger<Startup> logger, IServiceProvider serviceProvider)

--- a/src/Tools/dotnet-monitor/Auth/IAuthenticationConfigurator.cs
+++ b/src/Tools/dotnet-monitor/Auth/IAuthenticationConfigurator.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Auth
@@ -14,7 +13,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth
     {
         void ConfigureApiAuth(IServiceCollection services, HostBuilderContext context);
         void ConfigureSwaggerGenAuth(SwaggerGenOptions options);
-        void ConfigureSwaggerUI(SwaggerUIOptions options);
         IStartupLogger CreateStartupLogger(ILogger<Startup> logger, IServiceProvider serviceProvider);
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/NoAuth/NoAuthConfigurator.cs
+++ b/src/Tools/dotnet-monitor/Auth/NoAuth/NoAuthConfigurator.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Auth.NoAuth
@@ -25,10 +24,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.NoAuth
         }
 
         public void ConfigureSwaggerGenAuth(SwaggerGenOptions options)
-        {
-        }
-
-        public void ConfigureSwaggerUI(SwaggerUIOptions options)
         {
         }
 

--- a/src/Tools/dotnet-monitor/Strings.Designer.cs
+++ b/src/Tools/dotnet-monitor/Strings.Designer.cs
@@ -764,15 +764,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Swagger UI permission.
-        /// </summary>
-        internal static string HelpDescription_SwaggerScope_AzureAd {
-            get {
-                return ResourceManager.GetString("HelpDescription_SwaggerScope_AzureAd", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Collection rule action options &apos;{settingsType}&apos; must implement ICloneable to support property tokenization..
         /// </summary>
         internal static string LogFormatString_ActionSettingsTokenizationNotSupported {

--- a/src/Tools/dotnet-monitor/Strings.resx
+++ b/src/Tools/dotnet-monitor/Strings.resx
@@ -445,10 +445,6 @@
     <value>JWT Authorization header using bearer token authentication. Put the Authorization header value ("Bearer" prefix and the JWT value) in the textbox when prompted.</value>
     <comment>Gets a string used in the generated OpenAPI doc for the auth scheme</comment>
   </data>
-  <data name="HelpDescription_SwaggerScope_AzureAd" xml:space="preserve">
-    <value>Swagger UI permission</value>
-    <comment>Gets a string used in the generated OpenAPI doc for the auth scheme</comment>
-  </data>
   <data name="LogFormatString_ActionSettingsTokenizationNotSupported" xml:space="preserve">
     <value>Collection rule action options '{settingsType}' must implement ICloneable to support property tokenization.</value>
   </data>

--- a/src/Tools/dotnet-monitor/Swagger/SwaggerProviderExtensions.cs
+++ b/src/Tools/dotnet-monitor/Swagger/SwaggerProviderExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Swashbuckle.AspNetCore.Swagger;
+using System.IO;
+
+namespace Microsoft.Diagnostics.Tools.Monitor.Swagger
+{
+    internal static class SwaggerProviderExtensions
+    {
+        public static void WriteTo(this ISwaggerProvider provider, Stream stream)
+        {
+            using StreamWriter writer = new(stream);
+
+            provider.WriteTo(writer);
+        }
+
+        public static void WriteTo(this ISwaggerProvider provider, TextWriter writer)
+        {
+            OpenApiDocument document = provider.GetSwagger("v1");
+
+            document.SerializeAsV3(new OpenApiJsonWriter(writer));
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">


### PR DESCRIPTION
###### Summary

Manual backport of #6146 to `release/8.0`; manually resolved merge conflict in learning path documents due to commit IDs changing.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
