### PR TITLE
[release/7.x] Pin Azurite version to 3.29.0

### DIFF
--- a/eng/pipelines/jobs/build-test.yml
+++ b/eng/pipelines/jobs/build-test.yml
@@ -73,7 +73,7 @@ jobs:
           displayName: Install Azurite
           inputs:
             command: custom
-            customCommand: install -g azurite
+            customCommand: install -g azurite@3.29.0
 
       # When using the Alpine build containers, the above npm install will install to the system's
       # node directory instead of the agent's copy.


### PR DESCRIPTION
###### Summary

The newest version of Azurite seems to not be compatible with node.js 10. I've attempted to update the node.js version to something more modern, but the build images seem to be too old to support the newer versions. Pin the Azurite version for .NET Monitor 7.x.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2440916&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
