### PR TITLE
Use dotnet-public instead of nuget.org for dependabot

### DIFF
--- a/eng/dependabot/nuget.org/NuGet.config
+++ b/eng/dependabot/nuget.org/NuGet.config
@@ -5,11 +5,12 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <!-- This feed is roughly equivalent to nuget.org but managed by dotnet as an Azure Artifacts feed. -->
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
-        <package pattern="*" />
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
###### Summary

For better compliance, the dependabot NuGet.config files should be using Azure Artifacts feeds that are managed by the dotnet team. Instead of using `nuget.org`, use the `dotnet-public` feed, which is public feed mirror of packages that are on nuget.org.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
