### PR TITLE
Add semaphore around service scopes dictionary

### DIFF
--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -220,7 +220,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
 
                 EndpointInfo endpointInfo = await EndpointInfo.FromIpcEndpointInfoAsync(info, scope.ServiceProvider, token);
-                _activeEndpointServiceScopes.Add(endpointInfo.RuntimeInstanceCookie, scope);
+                await _activeEndpointsSemaphore.WaitAsync(token);
+                try
+                {
+                    _activeEndpointServiceScopes.Add(endpointInfo.RuntimeInstanceCookie, scope);
+                }
+                finally
+                {
+                    _activeEndpointsSemaphore.Release();
+                }
 
                 // Initialize endpoint information within the service scope
                 endpointInfo.ServiceProvider.GetRequiredService<ScopedEndpointInfo>().Set(endpointInfo);


### PR DESCRIPTION
###### Summary

The `_activeEndpointServiceScopes` dictionary is largely protected from simultaneous mutation using the `_activeEndpointsSemaphore` semaphore. However, there is one place where this lock is not taken which is likely causing the issue reported in #6569. Add the semaphore usage so that the dictionary is fully protected.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Fix an issue that could cause monitored processes to fail to resume when in listen mode: [#6569](https://github.com/dotnet/dotnet-monitor/issues/6569)