### PR TITLE
Update build container images

### DIFF
--- a/eng/pipelines/templates/pipeline-template.yml
+++ b/eng/pipelines/templates/pipeline-template.yml
@@ -27,13 +27,13 @@ extends:
   parameters:
     containers:
       build_linux_amd64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net8.0
       build_linux_arm64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm64-net8.0
       build_linux_musl_amd64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-alpine-net8.0
       build_linux_musl_arm64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm64-alpine-net8.0
       helix_linux_amd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04
       helix_linux_musl_amd64:


### PR DESCRIPTION
###### Summary

Replace CBL-Mariner 2.0 build containers with Azure Linux 3.0 build containers.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2443403&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
