### PR TITLE
[Egress providers - S3 store]  Add support for service accounts when running dotnet monitor in kubernetes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="AWSSDK.S3" Version="$(AwsSdkS3Version)" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="$(AwsSdkSecurityTokenVersion)" />
     <PackageVersion Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageVersion Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />

--- a/documentation/configuration/egress-configuration.md
+++ b/documentation/configuration/egress-configuration.md
@@ -198,6 +198,14 @@ The Queue Message's payload will be the blob name (`<BlobPrefix>/<ArtifactName>`
  ```
 </details>
 
+### Authenticating to S3 using service accounts
+If running workloads in kubernetes it is common to authenticate with AWS via kubernetes service accounts ([AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)). This is supported in dotnet monitor if none of: `accessKeyId`, `secretAccessKey`, `awsProfileName` are specified. In this case dotnet monitor will fallback to load credentials to login using AWS default defined environment variables, this means that workloads running in EKS can utilise service accounts as discussed in the above AWS documentation.
+
+Specifically the use of service accounts set the following environment variables which are detected by AWS SDK and used for authentication as a fallback:
+ - AWS_REGION
+ - AWS_ROLE_ARN
+ - AWS_WEB_IDENTITY_TOKEN_FILE
+
 ## Filesystem egress provider
 
 | Name | Type | Description |

--- a/documentation/configuration/egress-configuration.md
+++ b/documentation/configuration/egress-configuration.md
@@ -199,7 +199,7 @@ The Queue Message's payload will be the blob name (`<BlobPrefix>/<ArtifactName>`
 </details>
 
 ### Authenticating to S3 using service accounts
-If running workloads in kubernetes it is common to authenticate with AWS via kubernetes service accounts ([AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)). This is supported in dotnet monitor if none of: `accessKeyId`, `secretAccessKey`, `awsProfileName` are specified. In this case dotnet monitor will fallback to load credentials to login using AWS default defined environment variables, this means that workloads running in EKS can utilise service accounts as discussed in the above AWS documentation.
+If running workloads in Kubernetes it is common to authenticate with AWS via Kubernetes service accounts ([AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)). This is supported in dotnet monitor if none of: `accessKeyId`, `secretAccessKey`, `awsProfileName` are specified. In this case dotnet monitor will fallback to load credentials to login using AWS default defined environment variables, this means that workloads running in EKS can utilize service accounts as discussed in the above AWS documentation.
 
 Specifically the use of service accounts set the following environment variables which are detected by AWS SDK and used for authentication as a fallback:
  - AWS_REGION

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <FileSignInfo Include="AWSSDK.Core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="AWSSDK.SecurityToken.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartySHA2" />

--- a/eng/dependabot/independent/Packages.props
+++ b/eng/dependabot/independent/Packages.props
@@ -19,5 +19,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="AWSSDK.S3" Version="$(AwsSdkS3Version)" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="$(AwsSdkSecurityTokenVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/independent/Versions.props
+++ b/eng/dependabot/independent/Versions.props
@@ -15,6 +15,7 @@
     <NJsonSchemaVersion>11.0.0</NJsonSchemaVersion>
     <SwashbuckleAspNetCoreVersion>6.5.0</SwashbuckleAspNetCoreVersion>
     <AwsSdkS3Version>3.7.305.7</AwsSdkS3Version>
+    <AwsSdkSecurityTokenVersion>3.7.300.33</AwsSdkSecurityTokenVersion>
 
     <!--
       Moq version & constants derived from Moq.

--- a/src/Extensions/S3Storage/S3Storage.csproj
+++ b/src/Extensions/S3Storage/S3Storage.csproj
@@ -11,12 +11,13 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="AWSSDK.SecurityToken" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.Extension.Common\Microsoft.Diagnostics.Monitoring.Extension.Common.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Update="OptionsDisplayStrings.Designer.cs">
       <DependentUpon>OptionsDisplayStrings.resx</DependentUpon>


### PR DESCRIPTION
###### Summary

**Reason for change**
As it stands, the S3 egress provider does not currently support the use of service accounts when running dotnet monitor in kubernetes.

This is one of the two recommended ways to give pods permission to access AWS resources via roles. This tends to be recommended over long lived access keys as it removes the need for regular rotation of credentials etc.

**Details of change made**

The full documentation for this lives [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) on AWS's documentation site. It uses OpenID Connect to do authentication and is natively supported in the existing C# SDK which is already used. However, there is a [note](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html) when talking about SDK support for .NET that says:

> You must also include `AWSSDK.SecurityToken.`

This is correlated to my experience trying service accounts on my own kubernetes cluster, as I tried to use service accounts and received the error:
```
{Succeeded:false,FailureMessage:Assembly AWSSDK.SecurityToken could not be found or loaded. This assembly must be available at runtime to use Amazon.Runtime.AssumeRoleAWSCredentials.}
```

This happens because the S3 Storage extension already uses `FallbackCredentialsFactory.GetCredentials`, which does all the authentication work automatically

https://github.com/dotnet/dotnet-monitor/blob/cca1dad491aaaa64f8fc41650f3c82cfd3380bb5/src/Extensions/S3Storage/S3Storage.cs#L71

(note that the different ways it can be authenticated are best shown in the [AWS SDK code itself](https://github.com/aws/aws-sdk-net/blob/1bf8c267744d66b2088c532cc97149c390f1e5d0/sdk/src/Core/Amazon.Runtime/Credentials/FallbackCredentialsFactory.cs#L56-L66), which shows it supports Web Identity Credentials (the thing needed for service accounts) as well as credentials from environment variables)

However, that function isn't possible unless `AWSSDK.SecurityToken` is available at runtime. Therefore, this PR adds a dependency to the S3 project to bring in `AWSSDK.SecurityToken`

**Places I was unsure**
I wasn't sure how the dependabot setup works. AFAICT it relies on variables defined in the `Versions` file, but I couldn't quite figure out how to get that linked up to actually work so any guidance on that would be much appreciated

I also very much welcome any feedback on the documentation, as I wasn't quite sure on tone of voice etc that made sense for this change

I haven't created an issue for this as it was such a small change, however, if you would rather I do so I would be happy to! 


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Support added for kubernetes service accounts when using the S3 storage egress provider