### PR TITLE
Fix workflow names

### DIFF
--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -1,4 +1,4 @@
-run-name: 'Cleanup releases'
+name: 'Cleanup releases'
 
 on:
   schedule: # Run once a week to detect and manage out-of-support versions.

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,3 +1,4 @@
+name: 'Post release'
 run-name: '[${{ github.ref_name }}] Post release'
 
 on:


### PR DESCRIPTION
###### Summary

A couple of workflows didn't have static names, resulting in this view in under the workflows view

![image](https://github.com/dotnet/dotnet-monitor/assets/1146681/ec7c1167-5d0a-4cc2-ba08-c1316e17c422)




<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
