### PR TITLE
Trace probe faults through event source

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingService.cs
@@ -12,6 +12,7 @@ using Microsoft.Diagnostics.Tools.Monitor.StartupHook;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -83,7 +84,16 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing
 
         public void ProbeFault(Guid requestId, InstrumentedMethod faultingMethod)
         {
-            // TODO: Report back this fault on ParameterCapturingEventSource.
+            _eventSource.FailedToCapture(
+                requestId,
+                ParameterCapturingEvents.CapturingFailedReason.ProbeFaulted,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    ParameterCapturingStrings.StoppingParameterCapturingDueToProbeFault,
+                    faultingMethod.MethodSignature.ModuleName,
+                    faultingMethod.MethodSignature.TypeName,
+                    faultingMethod.MethodSignature.MethodName
+                ));
             try
             {
                 _pipeline?.RequestStop(requestId);

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.Designer.cs
@@ -62,15 +62,6 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cancellation has been requested during probe installation. Cancellation tokens request state (Provided:{isProvidedTokenCancelled}, Disposal:{isDisposalTokenCancelled})..
-        /// </summary>
-        internal static string CancellationRequestedDuringProbeInstallation {
-            get {
-                return ResourceManager.GetString("CancellationRequestedDuringProbeInstallation", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The following method descriptions are not allowed: {0}.
         /// </summary>
         internal static string DeniedMethodsFormatString {
@@ -107,43 +98,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.ParameterCapturing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to create an ILogger instance in the target process..
-        /// </summary>
-        internal static string FeatureUnsupported_NoLogger {
-            get {
-                return ResourceManager.GetString("FeatureUnsupported_NoLogger", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {callbackName}, hr={hr}.
-        /// </summary>
-        internal static string ProbeManagementCallback {
-            get {
-                return ResourceManager.GetString("ProbeManagementCallback", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Started parameter capturing for {duration} on {numberOfMethods} method(s)..
-        /// </summary>
-        internal static string StartParameterCapturingFormatString {
-            get {
-                return ResourceManager.GetString("StartParameterCapturingFormatString", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Stopped parameter capturing..
-        /// </summary>
-        internal static string StopParameterCapturing {
-            get {
-                return ResourceManager.GetString("StopParameterCapturing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Parameter capturing encountered an internal error when processing &apos;{method}&apos;, stopping..
+        ///   Looks up a localized string similar to Parameter capturing encountered an internal error when processing &apos;{0}!{1}.{2}&apos;, stopping..
         /// </summary>
         internal static string StoppingParameterCapturingDueToProbeFault {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.HostingStartup/ParameterCapturing/ParameterCapturingStrings.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CancellationRequestedDuringProbeInstallation" xml:space="preserve">
-    <value>Cancellation has been requested during probe installation. Cancellation tokens request state (Provided:{isProvidedTokenCancelled}, Disposal:{isDisposalTokenCancelled}).</value>
-  </data>
   <data name="DeniedMethodsFormatString" xml:space="preserve">
     <value>The following method descriptions are not allowed: {0}</value>
   </data>
@@ -132,20 +129,9 @@
   <data name="ErrorMessage_SignatureIsNotForAMethod" xml:space="preserve">
     <value>The provided signature blob must be for a method.</value>
   </data>
-  <data name="FeatureUnsupported_NoLogger" xml:space="preserve">
-    <value>Unable to create an ILogger instance in the target process.</value>
-  </data>
-  <data name="ProbeManagementCallback" xml:space="preserve">
-    <value>{callbackName}, hr={hr}</value>
-  </data>
-  <data name="StartParameterCapturingFormatString" xml:space="preserve">
-    <value>Started parameter capturing for {duration} on {numberOfMethods} method(s).</value>
-  </data>
-  <data name="StopParameterCapturing" xml:space="preserve">
-    <value>Stopped parameter capturing.</value>
-  </data>
   <data name="StoppingParameterCapturingDueToProbeFault" xml:space="preserve">
-    <value>Parameter capturing encountered an internal error when processing '{method}', stopping.</value>
+    <value>Parameter capturing encountered an internal error when processing '{0}!{1}.{2}', stopping.</value>
+    <comment>0 is the module name, 1 is the method type and 2 is the method name.</comment>
   </data>
   <data name="TooManyRequestsErrorMessage" xml:space="preserve">
     <value>Too many requests</value>

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -219,7 +219,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             {
                 case ParameterCapturingEvents.CapturingFailedReason.UnresolvedMethods:
                 case ParameterCapturingEvents.CapturingFailedReason.InvalidRequest:
-                case ParameterCapturingEvents.CapturingFailedReason.ProbeFaulted:
                     ex = new MonitoringException(args.Details);
                     break;
                 default:

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -219,6 +219,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             {
                 case ParameterCapturingEvents.CapturingFailedReason.UnresolvedMethods:
                 case ParameterCapturingEvents.CapturingFailedReason.InvalidRequest:
+                case ParameterCapturingEvents.CapturingFailedReason.ProbeFaulted:
                     ex = new MonitoringException(args.Details);
                     break;
                 default:

--- a/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             UnresolvedMethods = 0,
             InvalidRequest,
             TooManyRequests,
-            InternalError
+            InternalError,
+            ProbeFaulted
         }
 
         public static class CapturingFailedPayloads


### PR DESCRIPTION
###### Summary
Previously we were using the `ILogger` infrastructure to log probe faults. This PR adds a replacement by using the existing `ParameterCapturingEventSource.FailedToCapture` event with a new reason: `ProbeFaulted`.
While working on this I noticed we stopped using some resource strings so I remove them.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
