### PR TITLE
Use add_compiler_options to enable spectre mitigations and sdl checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,4 @@ if(CLR_CMAKE_HOST_WIN32)
         )
 endif(CLR_CMAKE_HOST_WIN32)
 
-if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qspectre")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Qspectre")
-endif()
-
 add_subdirectory(src/Profilers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif(CLR_CMAKE_HOST_WIN32)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qspectre")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Qspectre")
 endif()
 
 add_subdirectory(src/Profilers)

--- a/eng/native/override/configurecompiler.cmake
+++ b/eng/native/override/configurecompiler.cmake
@@ -5,4 +5,7 @@ if (MSVC)
   add_linker_flag(/INCREMENTAL:NO DEBUG) # prevent "warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:REF' specification"
   add_linker_flag(/OPT:REF DEBUG)
   add_linker_flag(/OPT:NOICF DEBUG)
+
+  add_compile_options(/sdl)
+  add_compile_options(/Qspectre)
 endif(MSVC)


### PR DESCRIPTION
###### Summary

Use `add_compiler_options` to enable spectre mitigations and sdl checks. This helps pass the spectre mitigation flags to more of the vcxproj properties and SDL checks are enabled.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2452865&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
