### PR TITLE
Use VS.Tools.Net.Core.SDK.x86 to track installer updates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,10 +38,6 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ed14da5934ffb536cff8f41f8b5719334524cbed</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="9.0.100-preview.5.24258.1">
-      <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>05ec25e1549a0653393a4f6782b4af6a0cbfbcf0</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="9.0.0-beta.24266.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ed14da5934ffb536cff8f41f8b5719334524cbed</Sha>
@@ -61,6 +57,10 @@
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>84b33395057737db3ea342a5151feb6b90c1b6f6</Sha>
+    </Dependency>
+    <Dependency Name="VS.Tools.Net.Core.SDK.x86" Version="9.0.100-preview.5.24258.1">
+      <Uri>https://github.com/dotnet/installer</Uri>
+      <Sha>05ec25e1549a0653393a4f6782b4af6a0cbfbcf0</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,8 @@
     <MicrosoftDiagnosticsMonitoringVersion>8.0.0-preview.24267.2</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>8.0.0-preview.24267.2</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/installer references -->
-    <MicrosoftDotnetSdkInternalVersion>9.0.100-preview.5.24258.1</MicrosoftDotnetSdkInternalVersion>
+    <VSToolsNetCoreSDKx86Version>9.0.100-preview.5.24258.1</VSToolsNetCoreSDKx86Version>
+    <MicrosoftDotnetSdkInternalVersion>$(VSToolsNetCoreSDKx86Version)</MicrosoftDotnetSdkInternalVersion>
     <!-- dotnet/roslyn-analyzers -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>9.0.0-preview.24225.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- dotnet/runtime references -->


### PR DESCRIPTION
###### Summary

The `Microsoft.Dotnet.Sdk.Internal` package was removed from `dotnet\installer` as part of https://github.com/dotnet/installer/pull/19707, which is causing the `feature/9.x` branch to no longer receive coherent updates that are in lock-step with `dotnet/installer`. Change to the `VS.Tools.NetCore.SDK.x86` package instead for the same purpose.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
