### PR TITLE
Fix ErrorMessage_CouldNotMapToAction usage

### DIFF
--- a/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
@@ -7,6 +7,7 @@ using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -83,7 +84,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
                         if (!_actionOperations.TryCreateFactory(actionOption.Type, out factory))
                         {
-                            throw new InvalidOperationException(Strings.ErrorMessage_CouldNotMapToAction);
+                            throw new InvalidOperationException(string.Format(
+                                CultureInfo.InvariantCulture,
+                                Strings.ErrorMessage_CouldNotMapToAction,
+                                actionOption.Type
+                                ));
                         }
 
                         object newSettings = dependencyAnalyzer.SubstituteOptionValues(actionResults, actionIndex, actionOption.Settings);


### PR DESCRIPTION
###### Summary

While working on another feature I came across a bug where we don't use `ErrorMessage_CouldNotMapToAction` correctly - we weren't supplying the necessary argument to it.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Fix the error log message shown when an action could not be registered.
