### PR TITLE
Enable nullable types in HostingStartup.UnitTests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/BoxingInstructionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/BoxingInstructionsTests.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         public void GetBoxingInstructions_Detects_UnsupportedParameters(Type declaringType, string methodName, params bool[] supported)
         {
             // Arrange
-            MethodInfo method = declaringType.GetMethod(methodName);
+            MethodInfo? method = declaringType.GetMethod(methodName);
+            Assert.NotNull(method);
 
             // Act
             bool[] supportedParameters = BoxingInstructions.AreParametersSupported(BoxingInstructions.GetBoxingInstructions(method));
@@ -62,7 +63,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         public void GetBoxingInstructions_Handles_GenericParameters()
         {
             // Arrange
-            MethodInfo method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2").GetMethod("GenericParameters");
+            MethodInfo? method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2")?.GetMethod("GenericParameters");
+            Assert.NotNull(method);
             bool[] supported = new bool[] { true, true, true, true };
 
             // Act
@@ -90,7 +92,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
                 SpecialCaseBoxingTypes.Single,
                 SpecialCaseBoxingTypes.Double,
             ];
-            MethodInfo method = typeof(StaticTestMethodSignatures).GetMethod(nameof(StaticTestMethodSignatures.Primitives));
+            MethodInfo? method = typeof(StaticTestMethodSignatures).GetMethod(nameof(StaticTestMethodSignatures.Primitives));
+            Assert.NotNull(method);
 
             // Act
             ParameterBoxingInstructions[] actualInstructions = BoxingInstructions.GetBoxingInstructions(method);
@@ -108,7 +111,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
                 SpecialCaseBoxingTypes.Object,
                 SpecialCaseBoxingTypes.Object,
             ];
-            MethodInfo method = typeof(StaticTestMethodSignatures).GetMethod(nameof(StaticTestMethodSignatures.BuiltInReferenceTypes));
+            MethodInfo? method = typeof(StaticTestMethodSignatures).GetMethod(nameof(StaticTestMethodSignatures.BuiltInReferenceTypes));
+            Assert.NotNull(method);
 
             // Act
             ParameterBoxingInstructions[] actualInstructions = BoxingInstructions.GetBoxingInstructions(method);
@@ -140,14 +144,14 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.VarArgs))]
         public void ReflectionAndSignatureDecoder_Contract_InSync(Type declaringType, string methodName)
         {
-            MethodInfo method = declaringType.GetMethod(methodName);
+            MethodInfo? method = declaringType.GetMethod(methodName);
             ReflectionAndSignatureDecoder_Contract_InSyncCore(method);
         }
 
         [Fact]
         public void ReflectionAndSignatureDecoder_Contract_Generics_InSync()
         {
-            MethodInfo method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2").GetMethod("GenericParameters");
+            MethodInfo? method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2")?.GetMethod("GenericParameters");
             ReflectionAndSignatureDecoder_Contract_InSyncCore(method);
         }
 
@@ -155,13 +159,13 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         /// Tests if GetBoxingInstructionsFromReflection is in sync with the signature decoder support for a given method's parameters.
         /// </summary>
         /// <param name="method">The method whose parameters to test.</param>
-        private static void ReflectionAndSignatureDecoder_Contract_InSyncCore(MethodInfo method)
+        private static void ReflectionAndSignatureDecoder_Contract_InSyncCore(MethodInfo? method)
         {
             Assert.NotNull(method);
 
             ParameterInfo[] parameters = method.GetParameters();
 
-            ParameterBoxingInstructions[] signatureDecoderInstructions = BoxingInstructions.GetAncillaryBoxingInstructionsFromMethodSignature(method); ;
+            ParameterBoxingInstructions[]? signatureDecoderInstructions = BoxingInstructions.GetAncillaryBoxingInstructionsFromMethodSignature(method);
             Assert.NotNull(signatureDecoderInstructions);
             Assert.Equal(parameters.Length, signatureDecoderInstructions.Length);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/MethodDefinitionExtensionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Boxing/MethodDefinitionExtensionsTests.cs
@@ -21,14 +21,16 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         [InlineData(typeof(StaticTestMethodSignatures), nameof(StaticTestMethodSignatures.ValueType_TypeSpec), 6, 17)]
         public void GetParameterBoxingInstructions_Captures_MemoryRegion_ForTypeSpecs(Type declaringType, string methodName, params int[] parameterSignatureLengths)
         {
-            MethodInfo method = declaringType.GetMethod(methodName);
+            MethodInfo? method = declaringType.GetMethod(methodName);
+            Assert.NotNull(method);
             TestCore(method, parameterSignatureLengths);
         }
 
         [Fact]
         public void GetParameterBoxingInstructions_Captures_MemoryRegion_ForTypeGenerics()
         {
-            MethodInfo method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2").GetMethod("GenericParameters");
+            MethodInfo? method = Type.GetType($"{nameof(SampleMethods)}.GenericTestMethodSignatures`2")?.GetMethod("GenericParameters");
+            Assert.NotNull(method);
             int[] parameterSignatureLengths = [2, 2, 2];
             TestCore(method, parameterSignatureLengths);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodResolverTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodResolverTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             return new MethodDescription
             {
                 ModuleName = declaringType.Module.Name,
-                TypeName = declaringType.FullName,
+                TypeName = declaringType.FullName ?? string.Empty,
                 MethodName = methodName
             };
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodSignatureTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/MethodSignatureTests.cs
@@ -219,11 +219,11 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
                 ]);
 
         private static void TestCore(
-                                                                    MethodInfo methodInfo,
-                                                                    string expectedMethodName,
-                                                                    string expectedDeclaringType,
-                                                                    string expectedDeclaringTypeModuleName,
-                                                                    ExpectedParameterSignature[] expectedParameters)
+            MethodInfo? methodInfo,
+            string expectedMethodName,
+            string expectedDeclaringType,
+            string expectedDeclaringTypeModuleName,
+            ExpectedParameterSignature[] expectedParameters)
         {
             // Arrange
             Assert.NotNull(methodInfo);
@@ -249,9 +249,9 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
         private sealed record ExpectedParameterSignature(Type paramType)
         {
-            public string Name;
+            public string? Name;
 
-            public string Type;
+            public string? Type;
 
             public string TypeModuleName = paramType.Module.Name;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         {
             public int Count { get; set; }
 
+#pragma warning disable CS8603 // Possible null reference return.
             public static string NullField => null;
+#pragma warning restore CS8603 // Possible null reference return.
         }
 
         [Theory]
@@ -80,7 +82,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
                 Count = 10
             };
 
-            FormatterFactoryResult factoryResult = DebuggerDisplayFormatter.GetDebuggerDisplayFormatter(testObj.GetType());
+            FormatterFactoryResult? factoryResult = DebuggerDisplayFormatter.GetDebuggerDisplayFormatter(testObj.GetType());
             Assert.NotNull(factoryResult);
 
             // Act
@@ -100,7 +102,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
                 Count = 10
             };
 
-            FormatterFactoryResult factoryResult = DebuggerDisplayFormatter.GetDebuggerDisplayFormatter(testObj.GetType());
+            FormatterFactoryResult? factoryResult = DebuggerDisplayFormatter.GetDebuggerDisplayFormatter(testObj.GetType());
             Assert.NotNull(factoryResult);
 
             // Act

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayFormatterTests.cs
@@ -28,9 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         {
             public int Count { get; set; }
 
-#pragma warning disable CS8603 // Possible null reference return.
-            public static string NullField => null;
-#pragma warning restore CS8603 // Possible null reference return.
+            public static string? NullField => null;
         }
 
         [Theory]

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinderTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             }
             Assert.NotNull(evaluator);
 
-            object result = evaluator.Value.Evaluate(obj);
+            object? result = evaluator.Value.Evaluate(obj);
 
             // Assert
             Assert.Equal(expected, result);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/CaptureLimitPolicyProbesTests.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
         public void CacheMethods_PassesThrough()
         {
             // Arrange
-            List<MethodInfo> expectedMethods = [(MethodInfo)MethodBase.GetCurrentMethod()];
-            IList<MethodInfo> actualMethods = null;
+            List<MethodInfo> expectedMethods = [(MethodInfo)MethodBase.GetCurrentMethod()!];
+            IList<MethodInfo> actualMethods = [];
 
             TaskCompletionSource requestStop = new();
             CaptureLimitPolicyProbes probes = new(new TestFunctionProbes(
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             object[] expectedArgs = [new Uri("https://www.example.com"), 10];
 
             ulong? actualUniquifier = null;
-            object[] actualArgs = null;
+            object[] actualArgs = [];
 
             TaskCompletionSource requestStop = new();
             CaptureLimitPolicyProbes probes = new(new TestFunctionProbes(

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/ParameterCapturingPipelineTests.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 {
     internal sealed class TestFunctionProbesManager : IFunctionProbesManager
     {
-        private readonly Action<IList<MethodInfo>, IFunctionProbes> _onStart;
-        private readonly Action _onStop;
+        private readonly Action<IList<MethodInfo>, IFunctionProbes>? _onStart;
+        private readonly Action? _onStop;
 
-        public event EventHandler<InstrumentedMethod> OnProbeFault;
+        public event EventHandler<InstrumentedMethod>? OnProbeFault;
 
-        public TestFunctionProbesManager(Action<IList<MethodInfo>, IFunctionProbes> onStart = null, Action onStop = null)
+        public TestFunctionProbesManager(Action<IList<MethodInfo>, IFunctionProbes>? onStart = null, Action? onStop = null)
         {
             _onStart = onStart;
             _onStop = onStop;
@@ -57,16 +57,16 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
     internal sealed class TestParameterCapturingCallbacks : IParameterCapturingPipelineCallbacks
     {
-        private readonly Action<StartCapturingParametersPayload, IList<MethodInfo>> _onCapturingStart;
-        private readonly Action<Guid> _onCapturingStop;
-        private readonly Action<Guid, ParameterCapturingEvents.CapturingFailedReason, string> _onCapturingFailed;
-        private readonly Action<Guid, InstrumentedMethod> _onProbeFault;
+        private readonly Action<StartCapturingParametersPayload, IList<MethodInfo>>? _onCapturingStart;
+        private readonly Action<Guid>? _onCapturingStop;
+        private readonly Action<Guid, ParameterCapturingEvents.CapturingFailedReason, string>? _onCapturingFailed;
+        private readonly Action<Guid, InstrumentedMethod>? _onProbeFault;
 
         public TestParameterCapturingCallbacks(
-            Action<StartCapturingParametersPayload, IList<MethodInfo>> onCapturingStart = null,
-            Action<Guid> onCapturingStop = null,
-            Action<Guid, ParameterCapturingEvents.CapturingFailedReason, string> onCapturingFailed = null,
-            Action<Guid, InstrumentedMethod> onProbeFault = null)
+            Action<StartCapturingParametersPayload, IList<MethodInfo>>? onCapturingStart = null,
+            Action<Guid>? onCapturingStop = null,
+            Action<Guid, ParameterCapturingEvents.CapturingFailedReason, string>? onCapturingFailed = null,
+            Action<Guid, InstrumentedMethod>? onProbeFault = null)
         {
             _onCapturingStart = onCapturingStart;
             _onCapturingStop = onCapturingStop;
@@ -97,8 +97,8 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 
     internal sealed class TestMethodDescriptionValidator : IMethodDescriptionValidator
     {
-        private readonly Func<MethodDescription, bool> _onValidateMethods;
-        public TestMethodDescriptionValidator(Func<MethodDescription, bool> onValidateMethods = null)
+        private readonly Func<MethodDescription, bool>? _onValidateMethods;
+        public TestMethodDescriptionValidator(Func<MethodDescription, bool>? onValidateMethods = null)
         {
             _onValidateMethods = onValidateMethods;
         }
@@ -476,7 +476,7 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
             string moduleName = typeof(ParameterCapturingPipelineTests).Module.Name;
             Assert.NotNull(moduleName);
 
-            string typeName = typeof(ParameterCapturingPipelineTests).FullName;
+            string? typeName = typeof(ParameterCapturingPipelineTests).FullName;
             Assert.NotNull(typeName);
 
             return new StartCapturingParametersPayload()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/TestFunctionProbes.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/Pipeline/TestFunctionProbes.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.ParameterCap
 {
     internal sealed class TestFunctionProbes : IFunctionProbes
     {
-        private readonly Func<ulong, object[], bool> _onEnterProbe;
-        private readonly Action<IList<MethodInfo>> _onCacheMethods;
+        private readonly Func<ulong, object[], bool>? _onEnterProbe;
+        private readonly Action<IList<MethodInfo>>? _onCacheMethods;
 
-        public TestFunctionProbes(Func<ulong, object[], bool> onEnterProbe = null, Action<IList<MethodInfo>> onCacheMethods = null)
+        public TestFunctionProbes(Func<ulong, object[], bool>? onEnterProbe = null, Action<IList<MethodInfo>>? onCacheMethods = null)
         {
             _onEnterProbe = onEnterProbe;
             _onCacheMethods = onCacheMethods;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/SampleMethods.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests/ParameterCapturing/SampleMethods.cs
@@ -79,7 +79,7 @@ namespace SampleMethods
         {
             try
             {
-                return myObject.ToString();
+                return myObject.ToString() ?? string.Empty;
             }
             catch
             {


### PR DESCRIPTION
###### Summary
Enable nullable types in `Microsoft.Diagnostics.Monitoring.HostingStartup.UnitTests.csproj` and fix all build erros. The code changes are needed for when I'll move the tests in `Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.csproj` where nullable types are already enabled.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
