### PR TITLE
Remove debug legs from CI build

### DIFF
--- a/eng/pipelines/dotnet-monitor-official.yml
+++ b/eng/pipelines/dotnet-monitor-official.yml
@@ -83,7 +83,6 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/jobs/build-binaries.yml@self
           includeArm64: ${{ or(ne(variables['System.TeamProject'], 'public'), eq(parameters.useHelix, 'true')) }}
-          includeDebug: true
           jobParameters:
             publishBinaries: true
             publishArtifacts: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}


### PR DESCRIPTION
###### Summary

There is practically no utility in building the debug variants of the product in the official CI build:
- The official CI build already does not test debug bits.
- The public PR builds already build and run all of the latest TFM tests for debug binaries, which should provide enough coverage for new changes that introduce problems that would only show in debug builds.
- Very little of the source code makes use of debug flags for altering product or test functionality.
- Historically, very few issues have been caught by debug build legs in the CI build.

By removing debug variants from the CI build, compute utilization will be reduced and compliance tooling will not have to consider debug bits.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
