### PR TITLE
[Parameter Capturing] Fix race condition when starting operation

### DIFF
--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                 };
 
                 await using EventParameterCapturingPipeline eventTracePipeline = new(_endpointInfo.Endpoint, settings);
-                await eventTracePipeline.StartAsync(token);
+                await eventTracePipeline.StartAsync(token).ConfigureAwait(false);
 
                 await _profilerChannel.SendMessage(
                     _endpointInfo,

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                 };
 
                 await using EventParameterCapturingPipeline eventTracePipeline = new(_endpointInfo.Endpoint, settings);
-                Task runPipelineTask = eventTracePipeline.StartAsync(token);
+                await eventTracePipeline.StartAsync(token);
 
                 await _profilerChannel.SendMessage(
                     _endpointInfo,


### PR DESCRIPTION
###### Summary

Fix a race condition when starting the parameter capturing operation. We never waited for the event pipeline to start running before issuing the start IPC command. This means that the parameter capturing operation could start before dotnet-monitor was listening and so it'd never receive the start event.

This issue rarely occurs due to the amount of work parameter capturing does in-proc before starting.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
