### PR TITLE
Fix flaky test in ParameterCapturingTests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -134,8 +134,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 OperationResponse response = await apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(2), config, format, FileProviderName);
                 Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
-                OperationStatusResponse operationStatus = await apiClient.WaitForOperationToStart(response.OperationUri);
-                Assert.Equal(OperationState.Running, operationStatus.OperationStatus.Status);
+                OperationStatusResponse _ = await apiClient.WaitForOperationToStart(response.OperationUri);
 
                 await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue);
 


### PR DESCRIPTION
###### Summary
`ParameterCapturingTests.CapturesParametersCore` had a race condition where it expected the operation state to be always `Running` after the call to `ApiClient.WaitForOperationToStart`, ingoring the case where the operation already completed.
I removed the assert since we didn't actually need it.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
