### PR TITLE
Remove continue on error for win-arm64 tests

### DIFF
--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -184,12 +184,6 @@ jobs:
         HelixAccessToken: $(HelixApiAccessToken)
         DotNetBuildsInternalContainerReadToken: $(dotnetbuilds-internal-container-read-token)
 
-    # .NET 9 Windows ARM64 dotnet test currently stalls and times out without error. Allow
-    # the test step to continue on error for this configuration.
-    # Issue: https://github.com/dotnet/dotnet-monitor/issues/6531
-    ${{ if eq(parameters.targetRid, 'win-arm64') }}:
-      buildContinueOnError: true
-
     postBuildSteps:
     - ${{ if ne(parameters.useHelix, 'true')}}:
       # Publish test results to Azure Pipelines


### PR DESCRIPTION
###### Summary

Tests on win-arm64 no longer stall.

closes #6531