### PR TITLE
Use sentinel package for installable SDK version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,6 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="9.0.0-preview.6.24277.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="9.0.0-preview.6.24277.5" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>cf6266cccb7f112ff4a40db00704eb773a3c6833</Sha>
     </Dependency>
@@ -46,19 +46,19 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>7a3cfdfc6f2988f676ada70037df6b1a207ff55a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.100-preview.6.24277.6">
-      <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>bb53ee6f6d3dde829291b95978b6d22cadf9630d</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="9.0.0-preview.5.24272.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="9.0.0-preview.5.24272.2" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5c06e5d01fa0ea4122e7202cefb921a779f9843a</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.6.24277.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.6.24277.5" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>cf6266cccb7f112ff4a40db00704eb773a3c6833</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.5.24272.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0" Version="9.0.100-preview.6.24277.6">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha>bb53ee6f6d3dde829291b95978b6d22cadf9630d</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.0-preview.5.24272.2" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5c06e5d01fa0ea4122e7202cefb921a779f9843a</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftNETCoreAppRuntimewinx64Version>9.0.0-preview.5.24272.2</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6490Version>9.0.0-preview.5.24272.2</VSRedistCommonNetCoreSharedFrameworkx6490Version>
     <!-- dotnet/sdk references -->
-    <MicrosoftNETSdkVersion>9.0.100-preview.6.24277.6</MicrosoftNETSdkVersion>
+    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.100-preview.6.24277.6</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.527701</MicrosoftFileFormatsVersion>
   </PropertyGroup>
@@ -78,6 +78,10 @@
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftNETCoreApp70Version)</MicrosoftAspNetCoreApp70Version>
     <MicrosoftAspNetCoreApp80Version>$(MicrosoftNETCoreApp80Version)</MicrosoftAspNetCoreApp80Version>
     <MicrosoftAspNetCoreApp90Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp90Version>
+  </PropertyGroup>
+  <PropertyGroup Label="SDK Versions">
+    <!-- Use a non-final versioned sentinel package for installation of specific SDK version. -->
+    <InstallableSdkVersion>$(VSRedistCommonNetCoreSdkPlaceholderx6490Version)</InstallableSdkVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dev Workflow">
     <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -162,7 +162,7 @@
           BeforeTargets="AddAdditionalRuntimes">
     <!-- Correlation Payload: SDK (to use "dotnet test") -->
     <ItemGroup>
-      <AdditionalDotNetPackage Include="$(MicrosoftNETSdkVersion)">
+      <AdditionalDotNetPackage Include="$(InstallableSdkVersion)">
         <PackageType>sdk</PackageType>
       </AdditionalDotNetPackage>
     </ItemGroup>


### PR DESCRIPTION
###### Summary

Based on guidance, use non-final sentinel package for tracking the SDK version.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
