### PR TITLE
Configure request limits via DI

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimit.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimit.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    public sealed record RequestLimit(string Key, int Limit);
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimitTracker.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/RequestThrottling/RequestLimitTracker.cs
@@ -27,19 +27,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private readonly ConcurrentDictionary<string, RequestCount> _requestCounts = new();
         private readonly ILogger<RequestLimitTracker> _logger;
 
-        public RequestLimitTracker(ILogger<RequestLimitTracker> logger)
+        public RequestLimitTracker(ILogger<RequestLimitTracker> logger, IEnumerable<RequestLimit> limits)
         {
-            //CONSIDER Should we have configuration for these?
+            foreach (RequestLimit requestLimit in limits)
+            {
+                _requestLimitTable.Add(requestLimit.Key, requestLimit.Limit);
+            }
 
-            _requestLimitTable.Add(Utilities.ArtifactType_Dump, 1);
-            _requestLimitTable.Add(Utilities.ArtifactType_GCDump, 1);
-            _requestLimitTable.Add(Utilities.ArtifactType_Logs, 3);
-            _requestLimitTable.Add(Utilities.ArtifactType_Trace, 3);
-            _requestLimitTable.Add(Utilities.ArtifactType_Metrics, 3);
-            _requestLimitTable.Add(Utilities.ArtifactType_Stacks, 1);
-            _requestLimitTable.Add(Utilities.ArtifactType_Exceptions, 1);
-            _requestLimitTable.Add(Utilities.ArtifactType_Parameters, 1);
-            _requestLimitTable.Add(Unlimited, int.MaxValue);
 
             _logger = logger;
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/TestHostHelper.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     }
 
                     services.ConfigureEgress();
-                    services.AddSingleton<IRequestLimitTracker, RequestLimitTracker>();
+                    services.ConfigureRequestLimits();
                     services.ConfigureOperationStore();
 
                     services.ConfigureDiagnosticPort(context.Configuration);

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
                 services.AddSingleton<IDumpService, DumpService>();
                 services.AddSingleton<IEndpointInfoSourceCallbacks, OperationTrackerServiceEndpointInfoSourceCallback>();
-                services.AddSingleton<IRequestLimitTracker, RequestLimitTracker>();
+                services.ConfigureRequestLimits();
                 services.ConfigureOperationStore();
                 services.ConfigureExtensions();
                 services.ConfigureExtensionLocations(settings);

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.IO;
+using Utils = Microsoft.Diagnostics.Monitoring.WebApi.Utilities;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -362,6 +363,22 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             services.AddScoped<HostingStartupService>();
             services.AddScopedForwarder<IDiagnosticLifetimeService, HostingStartupService>();
+            return services;
+        }
+
+        public static IServiceCollection ConfigureRequestLimits(this IServiceCollection services)
+        {
+            services.AddSingleton<IRequestLimitTracker, RequestLimitTracker>();
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Dump, 1); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_GCDump, 1); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Logs, 3); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Trace, 3); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Metrics, 3); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Stacks, 1); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Exceptions, 1); });
+            services.AddSingleton((_) => { return new RequestLimit(Utils.ArtifactType_Parameters, 1); });
+            services.AddSingleton((_) => { return new RequestLimit(RequestLimitTracker.Unlimited, int.MaxValue); });
+
             return services;
         }
 


### PR DESCRIPTION
###### Summary

This PR updates how we configure request limits from being a hard-coded implementation detail to be done via dependency injection. This enables additional request limits to be added via DI.

Note: This PR preserves the current behavior and concepts. There's a few ways we probably want to refactor the request limit tracker / request limit concept but that should be done separately. 


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
