### PR TITLE
Refactor FunctionProbesTests to use the AppRunner instead of ScenarioRunner in net7 or higher tests

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/FunctionProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/FunctionProbesTests.cs
@@ -2,19 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
-using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
+using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
-using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
-using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Diagnostics.Tools.Monitor.HostingStartup;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+
+#if !NET7_0_OR_GREATER
+using Microsoft.Diagnostics.Monitoring.TestCommon.Options;
+using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Extensions.Logging;
+#endif
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 {
@@ -38,7 +44,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         public static IEnumerable<object[]> GetAllTestScenarios()
         {
             List<object[]> arguments = new();
-
             IEnumerable<object[]> testArchitectures = ProfilerHelper.GetArchitecture();
             List<string> commands = typeof(TestAppScenarios.FunctionProbes.SubScenarios).GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
                 .Select(p => p.Name)
@@ -57,9 +62,40 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             return arguments;
         }
 
+#if !NET7_0_OR_GREATER
+        [Theory(Skip ="This test installs the mutating profiler which is not enabled on net6 or lower.")]
+#else
         [Theory]
+#endif
         [MemberData(nameof(FunctionProbesTests.GetAllTestScenarios), MemberType = typeof(FunctionProbesTests))]
         public async Task RunTestScenario(Architecture targetArchitecture, string subScenario)
+        {
+            await using AppRunner appRunner = new(_outputHelper, Assembly.GetExecutingAssembly())
+            {
+                Architecture = targetArchitecture,
+                ScenarioName = TestAppScenarios.FunctionProbes.Name,
+                SubScenarioName = subScenario
+            };
+
+            // Enable the mutating profiler
+            string profilerPath = NativeLibraryHelper.GetSharedLibraryPath(targetArchitecture, ProfilerIdentifiers.MutatingProfiler.LibraryRootFileName);
+            appRunner.Environment.Add(ProfilerHelper.ClrEnvVarEnableNotificationProfilers, ProfilerHelper.ClrEnvVarEnabledValue);
+            appRunner.Environment.Add(ProfilerHelper.ClrEnvVarEnableProfiling, ProfilerHelper.ClrEnvVarEnabledValue);
+            appRunner.Environment.Add(ProfilerHelper.ClrEnvVarProfiler, ProfilerIdentifiers.MutatingProfiler.Clsid.StringWithBraces);
+            appRunner.Environment.Add(ProfilerHelper.ClrEnvVarProfilerPath, profilerPath);
+
+            // The profiler checks this env variable to enable parameter capturing features.
+            appRunner.Environment.Add(InProcessFeaturesIdentifiers.EnvironmentVariables.ParameterCapturing.Enable, "1");
+
+            await appRunner.ExecuteAsync(() => Task.CompletedTask);
+
+            Assert.Equal(0, appRunner.ExitCode);
+        }
+
+#if !NET7_0_OR_GREATER
+        [Theory]
+        [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
+        public async Task ValidateProfilerIsNotInstalledOnNet6(Architecture targetArchitecture)
         {
             await ScenarioRunner.SingleTarget(
                 _outputHelper,
@@ -80,7 +116,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     };
                 },
                 profilerLogLevel: LogLevel.Trace,
-                subScenarioName: subScenario);
+                subScenarioName: TestAppScenarios.FunctionProbes.SubScenarios.ValidateNoMutatingProfiler);
         }
+#endif // NET7_0_OR_GREATER
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/FunctionProbesTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/FunctionProbesTests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             appRunner.Environment.Add(ProfilerHelper.ClrEnvVarEnableProfiling, ProfilerHelper.ClrEnvVarEnabledValue);
             appRunner.Environment.Add(ProfilerHelper.ClrEnvVarProfiler, ProfilerIdentifiers.MutatingProfiler.Clsid.StringWithBraces);
             appRunner.Environment.Add(ProfilerHelper.ClrEnvVarProfilerPath, profilerPath);
+            appRunner.Environment.Add(ProfilerIdentifiers.MutatingProfiler.EnvironmentVariables.ModulePath, profilerPath);
 
             // The profiler checks this env variable to enable parameter capturing features.
             appRunner.Environment.Add(InProcessFeaturesIdentifiers.EnvironmentVariables.ParameterCapturing.Enable, "1");


### PR DESCRIPTION
`FunctionProbesTests` verify `FunctionProbesManager` and mutating profiler features, it's not verifying the interaction with dotnet-monitor. To simplify the tests I'm proposing using `AppRunner` to execute these scenarios which will also unblock PR #6707 because the startup hook assembly is not loaded in the test application and the `ParameterCapturingService` will not automatically start.

Currently there's only one .NET 6 test which verifies the profiler wasn't loaded. I've decide to keep that test as-is and use the `ScenarioRunner` just for it, because it acually verified that we don't accidently inject the profiler.

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
