### PR TITLE
ParameterCapturingTests: Increase capture duration and set limit to 1

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/HttpApi/ApiClient.cs
@@ -628,7 +628,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi
             }
 
             bool isInfinite = (duration == Timeout.InfiniteTimeSpan);
-            string uri = FormattableString.Invariant($"/parameters?pid={processId}&durationSeconds={(isInfinite ? -1 : duration.Seconds)}");
+            string uri = FormattableString.Invariant($"/parameters?pid={processId}&durationSeconds={(isInfinite ? -1 : duration.TotalSeconds)}");
             if (!string.IsNullOrEmpty(egressProvider))
             {
                 uri += FormattableString.Invariant($"&egressProvider={egressProvider}");

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -21,9 +21,8 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-#if NET7_0_OR_GREATER
 using System.Threading;
-#endif
+
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -114,7 +113,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
                 CaptureParametersConfiguration config = GetValidConfiguration();
 
-                ValidationProblemDetailsException validationException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(1), config));
+                ValidationProblemDetailsException validationException = await Assert.ThrowsAsync<ValidationProblemDetailsException>(() => apiClient.CaptureParametersAsync(processId, Timeout.InfiniteTimeSpan, config));
                 Assert.Equal(HttpStatusCode.BadRequest, validationException.StatusCode);
 
                 await appRunner.SendCommandAsync(TestAppScenarios.ParameterCapturing.Commands.Continue);
@@ -131,7 +130,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 CaptureParametersConfiguration config = GetValidConfiguration();
                 MethodDescription expectedCapturedMethod = config.Methods[0];
 
-                OperationResponse response = await apiClient.CaptureParametersAsync(processId, TimeSpan.FromSeconds(2), config, format, FileProviderName);
+                OperationResponse response = await apiClient.CaptureParametersAsync(processId, CommonTestTimeouts.GeneralTimeout, config, format, FileProviderName);
                 Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
                 OperationStatusResponse _ = await apiClient.WaitForOperationToStart(response.OperationUri);
@@ -194,7 +193,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         TypeName = "SampleMethods.StaticTestMethodSignatures",
                         MethodName = "NoArgs"
                     }
-                }
+                },
+                CaptureLimit = 1
             };
         }
 


### PR DESCRIPTION
###### Summary
The parameter capturing tests are still flaky even after the first try to fix them. I think I figured out the root cause for the current issue and this is a fix for it:
* Updated the capturing duration to `CommonTestTimeouts.GeneralTimeout` and set the limit to 1 so it completes as soon as the expected method is called.
* Fixed bug in `ApiClient.CaptureParametersAsync`  to properly compute the total seconds from a `TimeSpan`.



<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
