### PR TITLE
Add documentation note about in-process features are only supported in Listen mode.

### DIFF
--- a/.github/linters/check-markdown-links-config.json
+++ b/.github/linters/check-markdown-links-config.json
@@ -11,6 +11,9 @@
         },
         {
             "pattern": "^https://www\\.dotnetfoundation.org/.*"
+        },
+        {
+            "pattern": "^https://hub\\.docker\\.com/.*"
         }
     ],
     "aliveStatusCodes": [

--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Check markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
+        uses: gaurav-nelson/github-action-markdown-link-check@7d83e59a57f3c201c76eed3d33dff64ec4452d27
         with:
           config-file: .github/linters/check-markdown-links-config.json
           use-quiet-mode: 'yes'

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -54,7 +54,7 @@ Object describing the basic state of a collection rule for the executing instanc
 
 | Name | Type | Description |
 |---|---|---|
-| State | [CollectionRuleState](#collectionrulestate-63) | Indicates what state the collection rule is in for the current process. |
+| State | [CollectionRuleState](#collectionrulestate) | Indicates what state the collection rule is in for the current process. |
 | StateReason | string | Human-readable explanation for the current state of the collection rule. |
 
 ## CollectionRuleDetailedDescription
@@ -65,7 +65,7 @@ Object describing the detailed state of a collection rule for the executing inst
 
 | Name | Type | Description |
 |---|---|---|
-| State | [CollectionRuleState](#collectionrulestate-63) | Indicates what state the collection rule is in for the current process. |
+| State | [CollectionRuleState](#collectionrulestate) | Indicates what state the collection rule is in for the current process. |
 | StateReason | string | Human-readable explanation for the current state of the collection rule. |
 | LifetimeOccurrences | int | The number of times the trigger has executed for a process in its lifetime. |
 | SlidingWindowOccurrences | int | The number of times the trigger has executed within the current sliding window. |

--- a/documentation/api/stacks.md
+++ b/documentation/api/stacks.md
@@ -62,7 +62,7 @@ Allowed schemes:
 ### Sample Request
 
 ```http
-GET /stack?pid=21632 HTTP/1.1
+GET /stacks?pid=21632 HTTP/1.1
 Host: localhost:52323
 Authorization: Bearer fffffffffffffffffffffffffffffffffffffffffff=
 Accept: application/json
@@ -100,7 +100,7 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
 ### Sample Request
 
 ```http
-GET /stack?pid=21632 HTTP/1.1
+GET /stacks?pid=21632 HTTP/1.1
 Host: localhost:52323
 Authorization: Bearer fffffffffffffffffffffffffffffffffffffffffff=
 Accept: text/plain

--- a/documentation/configuration/in-process-features-configuration.md
+++ b/documentation/configuration/in-process-features-configuration.md
@@ -4,6 +4,10 @@
 
 First Available: 8.0 Preview 7
 
+> [!NOTE]
+> In-process features are only supported when running dotnet-monitor in `Listen` mode. 
+> See [Diagnostic Port](./diagnostic-port-configuration.md) configuration for details.
+
 Some features of `dotnet monitor` require loading libraries into target applications. These libraries ship with `dotnet monitor` and are provisioned to be available to target applications using the `DefaultSharedPath` option in the [storage configuration](./storage-configuration.md) section. The following features require these in-process libraries to be used:
 
 - [Call Stacks](#call-stacks)


### PR DESCRIPTION
###### Summary
This PR adds a note to "In Process Features Configuration" section to make it clear that it works only in Listen mode.
Based on conversation in issue #6753. 


###### Release Notes Entry
