### PR TITLE
[Profiler] Record mvid information and add GUID support to event pipe

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -66,6 +66,7 @@
         "msbuild",
         "msdata",
         "MSRC",
+        "mvid",
         "ndjson",
         "netcoreapp",
         "newtonsoft",

--- a/src/Profilers/CommonMonitorProfiler/CommonUtilities/ClrData.h
+++ b/src/Profilers/CommonMonitorProfiler/CommonUtilities/ClrData.h
@@ -11,15 +11,17 @@
 class ModuleData
 {
 public:
-    ModuleData(tstring&& name) :
-        _moduleName(name)
+    ModuleData(tstring&& name, GUID mvid) :
+        _moduleName(name), _mvid(mvid)
     {
     }
 
     const tstring& GetName() const { return _moduleName; }
+    const GUID GetMvid() const { return _mvid; }
 
 private:
     tstring _moduleName;
+    GUID _mvid;
 };
 
 enum class ClassFlags : UINT32

--- a/src/Profilers/CommonMonitorProfiler/CommonUtilities/NameCache.cpp
+++ b/src/Profilers/CommonMonitorProfiler/CommonUtilities/NameCache.cpp
@@ -40,9 +40,9 @@ bool NameCache::TryGetTokenData(ModuleID modId, mdTypeDef token, std::shared_ptr
     return false;
 }
 
-void NameCache::AddModuleData(ModuleID moduleId, tstring&& name)
+void NameCache::AddModuleData(ModuleID moduleId, tstring&& name, GUID mvid)
 {
-    _moduleNames.emplace(moduleId, std::make_shared<ModuleData>(std::move(name)));
+    _moduleNames.emplace(moduleId, std::make_shared<ModuleData>(std::move(name), mvid));
 }
 
 HRESULT NameCache::GetFullyQualifiedName(FunctionID id, tstring& name)

--- a/src/Profilers/CommonMonitorProfiler/CommonUtilities/NameCache.h
+++ b/src/Profilers/CommonMonitorProfiler/CommonUtilities/NameCache.h
@@ -24,7 +24,7 @@ public:
     bool TryGetModuleData(ModuleID id, std::shared_ptr<ModuleData>& data);
     bool TryGetTokenData(ModuleID modId, mdTypeDef token, std::shared_ptr<TokenData>& data);
 
-    void AddModuleData(ModuleID moduleId, tstring&& name);
+    void AddModuleData(ModuleID moduleId, tstring&& name, GUID mvid);
     void AddFunctionData(ModuleID moduleId, FunctionID id, tstring&& name, ClassID parent, mdToken methodToken, mdTypeDef parentToken, ClassID* typeArgs, int typeArgsCount);
     void AddClassData(ModuleID moduleId, ClassID id, mdTypeDef typeDef, ClassFlags flags, ClassID* typeArgs, int typeArgsCount);
     void AddTokenData(ModuleID moduleId, mdTypeDef typeDef, mdTypeDef outerToken, tstring&& name, tstring&& Namespace);

--- a/src/Profilers/CommonMonitorProfiler/CommonUtilities/TypeNameUtilities.cpp
+++ b/src/Profilers/CommonMonitorProfiler/CommonUtilities/TypeNameUtilities.cpp
@@ -244,18 +244,20 @@ HRESULT TypeNameUtilities::GetModuleInfo(NameCache& nameCache, ModuleID moduleId
         return S_OK;
     }
 
+    ComPtr<IMetaDataImport> pIMDImport;
+    IfFailRet(_profilerInfo->GetModuleMetaData(moduleId,
+        ofRead,
+        IID_IMetaDataImport,
+        (IUnknown**)&pIMDImport));
+
     WCHAR moduleFullName[256];
     ULONG nameLength = 0;
-    AssemblyID assemblyID;
-
-    IfFailRet(_profilerInfo->GetModuleInfo(moduleId,
-        nullptr,
+    GUID mvid = {0};
+    IfFailRet(pIMDImport->GetScopeProps(
+        moduleFullName,
         256,
         &nameLength,
-        moduleFullName,
-        &assemblyID));
-
-    WCHAR* ptr = nullptr;
+        &mvid));
 
     int pathSeparatorIndex = nameLength - 1;
     while (pathSeparatorIndex >= 0)
@@ -277,7 +279,7 @@ HRESULT TypeNameUtilities::GetModuleInfo(NameCache& nameCache, ModuleID moduleId
         moduleName = tstring(moduleFullName, pathSeparatorIndex + 1, nameLength - pathSeparatorIndex - 1);
     }
 
-    nameCache.AddModuleData(moduleId, std::move(moduleName));
+    nameCache.AddModuleData(moduleId, std::move(moduleName), mvid);
 
     return S_OK;
 }

--- a/src/Profilers/CommonMonitorProfiler/EventProvider/EventTypeMapping.h
+++ b/src/Profilers/CommonMonitorProfiler/EventProvider/EventTypeMapping.h
@@ -60,6 +60,17 @@ public:
 };
 
 template<>
+class EventTypeMapping<GUID>
+{
+public:
+    void GetType(COR_PRF_EVENTPIPE_PARAM_DESC& descriptor)
+    {
+        descriptor.type = COR_PRF_EVENTPIPE_GUID;
+        descriptor.elementType = 0;
+    }
+};
+
+template<>
 class EventTypeMapping<std::vector<UINT64>>
 {
 public:


### PR DESCRIPTION
###### Summary

This PR makes infrastructure changes to the notify-only profiler to support us enhancing frame data in our artifacts. There are **no** functional changes in this PR, this is solely focused on profiler infrastructure changes that will be leveraged in future PRs. 

Profiler changes:
- Record the mvid of modules when collecting call stacks.
- Upgrade our event pipe related code to support writing guid payloads.


I've verified that the recorded mvids are correct and that guids we send over eventpipe are deserialized correctly.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
