### PR TITLE
Enable parameter capturing in no suspend mode.

### DIFF
--- a/documentation/api/parameters.md
+++ b/documentation/api/parameters.md
@@ -128,12 +128,10 @@ Content-Type: application/x-ndjson
 
 ## Additional Requirements
 
-- The target application must use ASP.NET Core.
 - The target application cannot have [Hot Reload](https://learn.microsoft.com/visualstudio/debugger/hot-reload) enabled.
 - `dotnet-monitor` must be set to `Listen` mode. See [diagnostic port configuration](../configuration/diagnostic-port-configuration.md) for information on how to do this.
-- If the target application has the `dotnet-monitor` startup hook manually configured then the feature will only work if the target application is started suspended.
+- If the target application is using .NET 7 then the dotnet-monitor startup hook must be manually configured and the target application must start suspended. In .NET 8+ this is not a requirement.
 - This feature relies on a [ICorProfilerCallback](https://docs.microsoft.com/dotnet/framework/unmanaged-api/profiling/icorprofilercallback-interface) implementation. If the target application is already using an `ICorProfiler` that isn't notify-only, this feature will not be available.
-- If a target application is using .NET 7 then the `dotnet-monitor` startup hook must be configured. This is automatically done in .NET 8+.
 
 ## Additional Notes
 

--- a/documentation/api/parameters.md
+++ b/documentation/api/parameters.md
@@ -131,6 +131,7 @@ Content-Type: application/x-ndjson
 - The target application must use ASP.NET Core.
 - The target application cannot have [Hot Reload](https://learn.microsoft.com/visualstudio/debugger/hot-reload) enabled.
 - `dotnet-monitor` must be set to `Listen` mode. See [diagnostic port configuration](../configuration/diagnostic-port-configuration.md) for information on how to do this.
+- If the target application has the `dotnet-monitor` startup hook manually configured then the feature will only work if the target application is started suspended.
 - This feature relies on a [ICorProfilerCallback](https://docs.microsoft.com/dotnet/framework/unmanaged-api/profiling/icorprofilercallback-interface) implementation. If the target application is already using an `ICorProfiler` that isn't notify-only, this feature will not be available.
 - If a target application is using .NET 7 then the `dotnet-monitor` startup hook must be configured. This is automatically done in .NET 8+.
 

--- a/documentation/api/parameters.md
+++ b/documentation/api/parameters.md
@@ -130,7 +130,7 @@ Content-Type: application/x-ndjson
 
 - The target application must use ASP.NET Core.
 - The target application cannot have [Hot Reload](https://learn.microsoft.com/visualstudio/debugger/hot-reload) enabled.
-- `dotnet-monitor` must be set to `Listen` mode, and the target application must start suspended. See [diagnostic port configuration](../configuration/diagnostic-port-configuration.md) for information on how to do this.
+- `dotnet-monitor` must be set to `Listen` mode. See [diagnostic port configuration](../configuration/diagnostic-port-configuration.md) for information on how to do this.
 - This feature relies on a [ICorProfilerCallback](https://docs.microsoft.com/dotnet/framework/unmanaged-api/profiling/icorprofilercallback-interface) implementation. If the target application is already using an `ICorProfiler` that isn't notify-only, this feature will not be available.
 - If a target application is using .NET 7 then the `dotnet-monitor` startup hook must be configured. This is automatically done in .NET 8+.
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 {
                     runner.EnableMonitorStartupHook = true;
                     runner.Architecture = targetArchitecture;
+                    runner.DiagnosticPortSuspend = shouldSuspendTargetApp;
                 },
                 configureTool: (toolRunner) =>
                 {
@@ -172,8 +173,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 },
                 profilerLogLevel: LogLevel.Trace,
-                subScenarioName: subScenarioName,
-                shouldSuspendProcess: shouldSuspendTargetApp);
+                subScenarioName: subScenarioName);
         }
 
         private static CaptureParametersConfiguration GetValidConfiguration()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             Action<MonitorCollectRunner> configureTool = null,
             bool disableHttpEgress = false,
             LogLevel profilerLogLevel = LogLevel.Error,
-            string subScenarioName = null)
+            string subScenarioName = null,
+            bool startAppBeforeTool = false)
         {
             DiagnosticPortHelper.Generate(
                 mode,
@@ -43,37 +44,66 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
             configureTool?.Invoke(toolRunner);
 
-            await toolRunner.StartAsync();
-
-            using HttpClient httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(httpClientFactory);
-            ApiClient apiClient = new(outputHelper, httpClient);
-
-            await using AppRunner appRunner = new(outputHelper, Assembly.GetExecutingAssembly());
-            if (profilerLogLevel != LogLevel.None)
+            if (!startAppBeforeTool)
             {
-                appRunner.ProfilerLogLevel = profilerLogLevel.ToString("G");
+                await toolRunner.StartAsync();
             }
-            appRunner.ConnectionMode = appConnectionMode;
-            appRunner.DiagnosticPortPath = diagnosticPortPath;
-            appRunner.ScenarioName = scenarioName;
-            appRunner.SubScenarioName = subScenarioName;
 
-            configureApp?.Invoke(appRunner);
+#nullable enable
+            HttpClient? httpClient = null;
+            ApiClient? apiClient = null;
 
-            await appRunner.ExecuteAsync(async () =>
+            try
             {
-                // Wait for the process to be discovered.
-                int processId = await appRunner.ProcessIdTask;
-                _ = await apiClient.GetProcessWithRetryAsync(outputHelper, pid: processId);
+                if (!startAppBeforeTool)
+                {
+                    httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(httpClientFactory);
+                    apiClient = new(outputHelper, httpClient);
+                }
 
-                await appValidate(appRunner, apiClient);
-            });
-            Assert.Equal(0, appRunner.ExitCode);
+                await using AppRunner appRunner = new(outputHelper, Assembly.GetExecutingAssembly());
+                if (profilerLogLevel != LogLevel.None)
+                {
+                    appRunner.ProfilerLogLevel = profilerLogLevel.ToString("G");
+                }
+                appRunner.ConnectionMode = appConnectionMode;
+                appRunner.DiagnosticPortPath = diagnosticPortPath;
+                appRunner.ScenarioName = scenarioName;
+                appRunner.SubScenarioName = subScenarioName;
 
-            if (null != postAppValidate)
-            {
-                await postAppValidate(apiClient, await appRunner.ProcessIdTask);
+                configureApp?.Invoke(appRunner);
+
+                await appRunner.ExecuteAsync(async () =>
+                {
+                    if (startAppBeforeTool)
+                    {
+                        await toolRunner.StartAsync();
+                        httpClient = await toolRunner.CreateHttpClientDefaultAddressAsync(httpClientFactory);
+                        apiClient = new(outputHelper, httpClient);
+                    }
+
+                    // Wait for the process to be discovered.
+                    int processId = await appRunner.ProcessIdTask;
+                    _ = await apiClient.GetProcessWithRetryAsync(outputHelper, pid: processId);
+
+                    Assert.NotNull(apiClient);
+
+                    await appValidate(appRunner, apiClient);
+                });
+                Assert.Equal(0, appRunner.ExitCode);
+
+                Assert.NotNull(apiClient);
+
+                if (null != postAppValidate)
+                {
+                    await postAppValidate(apiClient, await appRunner.ProcessIdTask);
+                }
             }
+            finally
+            {
+                httpClient?.Dispose();
+            }
+#nullable disable
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             Action<MonitorCollectRunner> configureTool = null,
             bool disableHttpEgress = false,
             LogLevel profilerLogLevel = LogLevel.Error,
-            string subScenarioName = null)
+            string subScenarioName = null,
+            bool shouldSuspendProcess = true)
         {
             DiagnosticPortHelper.Generate(
                 mode,
@@ -57,6 +58,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             appRunner.DiagnosticPortPath = diagnosticPortPath;
             appRunner.ScenarioName = scenarioName;
             appRunner.SubScenarioName = subScenarioName;
+            appRunner.DiagnosticPortSuspend = shouldSuspendProcess;
 
             configureApp?.Invoke(appRunner);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/ScenarioRunner.cs
@@ -28,8 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             Action<MonitorCollectRunner> configureTool = null,
             bool disableHttpEgress = false,
             LogLevel profilerLogLevel = LogLevel.Error,
-            string subScenarioName = null,
-            bool shouldSuspendProcess = true)
+            string subScenarioName = null)
         {
             DiagnosticPortHelper.Generate(
                 mode,
@@ -58,7 +57,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             appRunner.DiagnosticPortPath = diagnosticPortPath;
             appRunner.ScenarioName = scenarioName;
             appRunner.SubScenarioName = subScenarioName;
-            appRunner.DiagnosticPortSuspend = shouldSuspendProcess;
 
             configureApp?.Invoke(appRunner);
 

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -131,11 +131,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                 services.AddSingleton<ProfilerChannel>();
                 services.ConfigureCollectionRules();
                 services.ConfigureLibrarySharing();
+                /*
+                 * ConfigureInProcessFeatures needs to be called before ConfigureProfiler
+                 * because the profiler needs to have access to environment variables set by in process features.
+                 */
+                services.ConfigureInProcessFeatures(context.Configuration);
                 services.ConfigureProfiler();
                 services.ConfigureStartupHook();
                 services.ConfigureExceptions();
                 services.ConfigureStartupLoggers(authConfigurator);
-                services.ConfigureInProcessFeatures(context.Configuration);
                 services.AddSingleton<IInProcessFeatures, InProcessFeatures>();
                 services.AddSingleton<IDumpOperationFactory, DumpOperationFactory>();
                 services.AddSingleton<ILogsOperationFactory, LogsOperationFactory>();


### PR DESCRIPTION
###### Summary
*  Moved the `InProcessFeaturesService` registration before the `ProfilerService` registration because the `IEndpointInfoSourceCallbacks` need to first reach the in process service so it can set the `DotnetMonitor_InProcessFeatures_ParameterCapturing_Enable` environment variable which is later checked by the profiler initialization.
* Reworked `ParameterCapturingTests` to include the new `shouldSuspendTargetApp` arg and added tests to verify the new scenarios: `CapturesParametersNoSuspend` & `AppWithStartupHookFailsInNoSuspend`.
* Updated `ScenarioRunner.SingleTarget()` to support starting the target process befor the monitor process.

* Updated docs.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
