### PR TITLE
Fix inline data nullable parameters

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayParserTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/DebuggerDisplayParserTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.ParameterCaptur
         [InlineData("Test: {prop1} - {prop2} - {method()}", "Test: {0} - {1} - {2}", "prop1", "prop2", "method()")]
         // Complex expressions
         [InlineData("Test: {propertyName - 2}", "Test: {0}", "propertyName - 2")]
-        public void ParseDebuggerDisplay(string debuggerDisplay, string formatString, params string[] expressions)
+        public void ParseDebuggerDisplay(string debuggerDisplay, string? formatString, params string[] expressions)
         {
             // Act
             ParsedDebuggerDisplay? parsed = DebuggerDisplayParser.ParseDebuggerDisplay(debuggerDisplay);
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.ParameterCaptur
         [InlineData("{((a)}", null, FormatSpecifier.None)]
         [InlineData("{\\}}", null, FormatSpecifier.None)]
         [InlineData("{a}", "a", FormatSpecifier.None)]
-        internal void ParseExpression(string rawExpression, string expressionString, FormatSpecifier formatSpecifier)
+        internal void ParseExpression(string rawExpression, string? expressionString, FormatSpecifier formatSpecifier)
         {
             // Act
             Expression? expression = DebuggerDisplayParser.ParseExpression(rawExpression.AsMemory(), out _);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinderTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/ParameterCapturing/ObjectFormatting/Formatters/DebuggerDisplay/ExpressionBinderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests.ParameterCaptur
         [InlineData("Recursion().RecursionProp.MyUri.Host", true, "www.example.com")]
         // Chained expression with static property
         [InlineData("Recursion().StaticProperty.Host", true, "www.example.com")]
-        public void BindExpression(string expression, bool doesBind, object expected)
+        public void BindExpression(string expression, bool doesBind, object? expected)
         {
             // Arrange
             DebuggerDisplayClass obj = new("https://www.example.com/abc");


### PR DESCRIPTION
###### Summary

We have some inline data that was using `null` for parameters not marked a `nullable`.  This is resulting in analyzer failures in `feature/9.x`

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
