### PR TITLE
Use managed identity to publish release assets

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -116,7 +116,6 @@ extends:
             value: dotnetcli
           - name: ChecksumsAccountName
             value: dotnetclichecksums
-        - group: DotNet-DotNetStage-Storage
 
         workspace:
           clean: all

--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -70,7 +70,7 @@ extends:
               -BarId $(BarId)
               -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'ReleaseVersion'
-        
+
         - task: PowerShell@2
           displayName: Get Build Version
           inputs:
@@ -98,7 +98,7 @@ extends:
 
       jobs:
       - deployment: PublishToStorageAccounts
-        displayName: Publish to Storage Accounts
+        displayName: Publish to Storage Accounts WIF
 
         ${{ if eq(parameters.IsTestRun, 'true') }}:
           environment: Diagnostics-Monitor-Storage-Test
@@ -107,9 +107,15 @@ extends:
 
         variables:
         - ${{ if eq(parameters.IsTestRun, 'true') }}:
-          - group: DotNet-Diagnostics-Storage-Test
+          - name: DestinationAccountName
+            value: monitortestcli
+          - name: ChecksumsAccountName
+            value: monitortestchecksums
         - ${{ else }}:
-          - group: DotNetCli storage account tokens
+          - name: DestinationAccountName
+            value: dotnetcli
+          - name: ChecksumsAccountName
+            value: dotnetclichecksums
         - group: DotNet-DotNetStage-Storage
 
         workspace:
@@ -164,42 +170,28 @@ extends:
               - powershell: Install-Module Az.Storage -Force -Scope CurrentUser -AllowClobber -Verbose -RequiredVersion 5.10.1
                 displayName: Install Az.Storage Module 5.10.1
 
-              - powershell: |
-                  Write-Host "##vso[task.setvariable variable=DestinationAccountName]$env:DESTINATION_ACCOUNT_NAME"
-                  Write-Host "##vso[task.setvariable variable=DestinationSasTokenBase64;issecret=true]$env:DESTINATION_SAS_TOKEN_BASE64"
-                  Write-Host "##vso[task.setvariable variable=ChecksumsAccountName]$env:CHECKSUMS_ACCOUNT_NAME"
-                  Write-Host "##vso[task.setvariable variable=ChecksumsSasTokenBase64;issecret=true]$env:CHECKSUMS_SAS_TOKEN_BASE64"
-                displayName: Set Storage Accounts
-                ${{ if eq(parameters.IsTestRun, 'true') }}:
-                  env:
-                    # Variables provided by DotNet-Diagnostics-Storage-Test group
-                    DESTINATION_ACCOUNT_NAME: $(dotnet-monitor-test-storage-accountname)
-                    DESTINATION_SAS_TOKEN_BASE64: $(dotnet-monitor-test-blob-write-token-base64)
-                    CHECKSUMS_ACCOUNT_NAME: $(dotnet-monitor-checksums-test-storage-accountname)
-                    CHECKSUMS_SAS_TOKEN_BASE64: $(dotnet-monitor-checksums-test-blob-write-token-base64)
-                ${{ else }}:
-                  env:
-                    # Variables provided by "DotNetCli storage account tokens" group
-                    DESTINATION_ACCOUNT_NAME: dotnetcli
-                    DESTINATION_SAS_TOKEN_BASE64: $(dotnetcli-account-blob-write-token-base64)
-                    CHECKSUMS_ACCOUNT_NAME: dotnetclichecksums
-                    CHECKSUMS_SAS_TOKEN_BASE64: $(dotnetclichecksums-account-blob-write-token-base64)
-
-              - task: PowerShell@2
+              - task: AzureCLI@2
                 displayName: Publish Assets
                 inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/release/Scripts/PublishToBlobAccounts.ps1
+                  # It seems that azureSubscription can't use runtime expressions, so we need to use a compile time expression
+                  # to set it.
+                  ${{ if eq(parameters.IsTestRun, 'true') }}:
+                    azureSubscription: dotnet-monitor-test-publish
+                  ${{ else }}:
+                    azureSubscription: dotnet-monitor-cli-storage-accounts-publish
+                  # Save the service principal details to the environment so that azcopy can use them
+                  addSpnToEnvironment: true
+                  scriptType: ps
+                  scriptLocation: scriptPath
+                  scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/PublishToBlobAccounts.ps1
                   arguments: >-
                     -AzCopyPath $(AzCopyPath)
                     -BuildVersion $(BuildVersion)
                     -ReleaseVersion $(ReleaseVersion)
-                    -DotnetStageAccountKey $(dotnetstage-storage-key)
                     -DestinationAccountName $(DestinationAccountName)
-                    -DestinationSasTokenBase64 $(DestinationSasTokenBase64)
                     -ChecksumsAccountName $(ChecksumsAccountName)
-                    -ChecksumsSasTokenBase64 $(ChecksumsSasTokenBase64)
                     -WhatIf:${{ format('${0}', parameters.IsDryRun) }}
-              
+
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: Publish Logs
                 inputs:

--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -98,7 +98,7 @@ extends:
 
       jobs:
       - deployment: PublishToStorageAccounts
-        displayName: Publish to Storage Accounts WIF
+        displayName: Publish to Storage Accounts
 
         ${{ if eq(parameters.IsTestRun, 'true') }}:
           environment: Diagnostics-Monitor-Storage-Test

--- a/eng/release/Scripts/PublishToBlobAccounts.ps1
+++ b/eng/release/Scripts/PublishToBlobAccounts.ps1
@@ -3,22 +3,19 @@ Param(
     [Parameter(Mandatory=$true)][string]$AzCopyPath,
     [Parameter(Mandatory=$true)][string]$BuildVersion,
     [Parameter(Mandatory=$true)][string]$ReleaseVersion,
-    [Parameter(Mandatory=$true)][string]$DotnetStageAccountKey,
     [Parameter(Mandatory=$true)][string]$DestinationAccountName,
-    [Parameter(Mandatory=$true)][string]$DestinationSasTokenBase64,
-    [Parameter(Mandatory=$true)][string]$ChecksumsAccountName,
-    [Parameter(Mandatory=$true)][string]$ChecksumsSasTokenBase64
+    [Parameter(Mandatory=$true)][string]$ChecksumsAccountName
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
+# Use the OAuth token that was obtained by the az cli when it logged in.
+$Env:AZCOPY_AUTO_LOGIN_TYPE="AZCLI"
+
 $sourceAccountName = 'dotnetstage'
 $sourceContainerName = 'dotnet-monitor'
 $destinationContainerName = 'dotnet'
-
-$destinationSasToken = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($DestinationSasTokenBase64))
-$checksumsSasToken = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($ChecksumsSasTokenBase64))
 
 function Generate-Source-Uri{
     [CmdletBinding()]
@@ -38,34 +35,11 @@ function Generate-Destination-Uri{
     return "https://$AccountName.blob.core.windows.net/$destinationContainerName/diagnostics/monitor/$ReleaseVersion"
 }
 
-function Generate-Sas-Token{
-    [CmdletBinding()]
-    Param(
-        [Parameter(Mandatory=$true)][string]$StorageAccountName,
-        [Parameter(Mandatory=$true)][string]$ContainerName,
-        [Parameter(Mandatory=$true)][string]$AccountKey,
-        [Parameter(Mandatory=$true)][string]$Permissions
-    )
-
-    $context = New-AzStorageContext `
-        -StorageAccountName $StorageAccountName `
-        -StorageAccountKey $AccountKey
-
-    return New-AzStorageContainerSASToken `
-        -Container $ContainerName `
-        -Context $context `
-        -Permission $Permissions `
-        -StartTime (Get-Date).AddMinutes(-15.0) `
-        -ExpiryTime (Get-Date).AddHours(1.0)
-}
-
 function Transfer-File{
     [CmdletBinding(SupportsShouldProcess)]
     Param(
         [Parameter(Mandatory=$true)][string]$From,
-        [Parameter(Mandatory=$true)][string]$To,
-        [Parameter(Mandatory=$true)][string]$FromToken,
-        [Parameter(Mandatory=$true)][string]$ToToken
+        [Parameter(Mandatory=$true)][string]$To
     )
 
     Write-Host "Copy $From -> $To"
@@ -73,8 +47,8 @@ function Transfer-File{
     if ($From -eq $to) {
         Write-Host 'Skipping copy because source and destination are the same.'
     } else {
-        [array]$azCopyArgs = "$From$FromToken"
-        $azCopyArgs += "$To$ToToken"
+        [array]$azCopyArgs = "$From"
+        $azCopyArgs += "$To"
         $azCopyArgs += "--s2s-preserve-properties"
         $azCopyArgs += "--s2s-preserve-access-tier=false"
         if ($WhatIfPreference) {
@@ -84,14 +58,9 @@ function Transfer-File{
     }
 }
 
-# Create source URI and SAS token
+# Create source URI
 $sourceUri = Generate-Source-Uri `
     -AssetType 'Blob'
-$soureSasToken = Generate-Sas-Token `
-    -StorageAccountName $sourceAccountName `
-    -ContainerName $sourceContainerName `
-    -AccountKey $DotnetStageAccountKey `
-    -Permissions 'rl'
 
 # Create destination URI
 $destinationUri = Generate-Destination-Uri `
@@ -100,9 +69,7 @@ $destinationUri = Generate-Destination-Uri `
 # Copy files to destination account
 Transfer-File `
     -From $sourceUri `
-    -FromToken $soureSasToken `
     -To $destinationUri `
-    -ToToken $destinationSasToken `
     -WhatIf:$WhatIfPreference
 
 # Create source checksums URI
@@ -116,7 +83,5 @@ $checksumsDestinationUri = Generate-Destination-Uri `
 # Copy checksums to checksum account
 Transfer-File `
     -From $checksumsSourceUri `
-    -FromToken $soureSasToken `
     -To $checksumsDestinationUri `
-    -ToToken $checksumsSasToken `
     -WhatIf:$WhatIfPreference


### PR DESCRIPTION
###### Summary

Use a managed identity when publishing staged release assets to `dotnetcli` and `dotnetclichecksums` (as well as `monitortestcli` and `monitortestchecksums` in test mode).

Pipeline runs:
- Test account: https://dev.azure.com/dnceng/internal/_build/results?buildId=2483916&view=results
- [Dry] Prod account: https://dev.azure.com/dnceng/internal/_build/results?buildId=2483991&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
