### PR TITLE
[Nullable Context] Enable on `Microsoft.Diagnostics.Monitoring.WebApi`

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ActionContextExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ActionContextExtensions.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         private static readonly ExecutionResult<T> _empty = new ExecutionResult<T>();
 
-        public Exception Exception { get; private set; }
-        public T Result { get; private set; }
-        public ProblemDetails ProblemDetails { get; private set; }
+        public Exception? Exception { get; private set; }
+        public T? Result { get; private set; }
+        public ProblemDetails? ProblemDetails { get; private set; }
 
         private ExecutionResult() { }
 
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         public static Task ProblemAsync(this ActionContext context, BadRequestObjectResult result)
         {
-            if (context.HttpContext.Features.Get<IHttpResponseFeature>().HasStarted)
+            if (context.HttpContext.Features.Get<IHttpResponseFeature>()?.HasStarted == true)
             {
                 // If already started writing response, do not rewrite
                 // as this will throw an InvalidOperationException.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/AssemblyExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/AssemblyExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal static class AssemblyExtensions
     {
-        public static string GetInformationalVersionString(this Assembly assembly)
+        public static string? GetInformationalVersionString(this Assembly assembly)
         {
             if (assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 is AssemblyInformationalVersionAttribute assemblyVersionAttribute)
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
             else
             {
-                return assembly.GetName().Version.ToString();
+                return assembly.GetName().Version?.ToString();
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ControllerExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ControllerExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             //We can convert ActionResult to ActionResult<T>
             //and then safely convert back.
-            return controller.InvokeService<object>(() => serviceCall(), logger).Result;
+            return controller.InvokeService<object>(() => serviceCall(), logger).Result!;
         }
 
         public static ActionResult<T> InvokeService<T>(this ControllerBase controller, Func<ActionResult<T>> serviceCall, ILogger logger)
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             //Task<ActionResult> -> Task<ActionResult<T>>
             //Then unwrap the result back to ActionResult
             ActionResult<object> result = await controller.InvokeService<object>(async () => await serviceCall(), logger);
-            return result.Result;
+            return result.Result!;
         }
 
         public static async Task<ActionResult<T>> InvokeService<T>(this ControllerBase controller, Func<Task<ActionResult<T>>> serviceCall, ILogger logger)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.Metrics.cs
@@ -33,13 +33,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -83,13 +83,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 
 #nullable disable
         private readonly IOptions<DiagnosticPortOptions> _diagnosticPortOptions;
-#nullable enable
+#nullable restore
         private readonly IOptions<CallStacksOptions> _callStacksOptions;
         private readonly IOptions<ParameterCapturingOptions> _parameterCapturingOptions;
         private readonly IOptionsMonitor<GlobalCounterOptions> _counterOptions;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
     {
         private const TraceProfile DefaultTraceProfiles = TraceProfile.Cpu | TraceProfile.Http | TraceProfile.Metrics | TraceProfile.GcCollect;
 
+#nullable disable
         private readonly IOptions<DiagnosticPortOptions> _diagnosticPortOptions;
+#nullable enable
         private readonly IOptions<CallStacksOptions> _callStacksOptions;
         private readonly IOptions<ParameterCapturingOptions> _parameterCapturingOptions;
         private readonly IOptionsMonitor<GlobalCounterOptions> _counterOptions;
@@ -77,7 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             return this.InvokeService(async () =>
             {
-                IProcessInfo defaultProcessInfo = null;
+                IProcessInfo? defaultProcessInfo = null;
                 try
                 {
                     defaultProcessInfo = await DiagnosticServices.GetProcessAsync(null, HttpContext.RequestAborted);
@@ -127,7 +129,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null)
+            string? name = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -165,7 +167,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null)
+            string? name = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -213,13 +215,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
             Models.DumpType type = Models.DumpType.WithHeap,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -257,11 +259,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -300,15 +302,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
             TraceProfile profile = DefaultTraceProfiles,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -348,13 +350,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -363,7 +365,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 foreach (Models.EventPipeProvider provider in configuration.Providers)
                 {
                     if (!CounterValidator.ValidateProvider(_counterOptions.CurrentValue,
-                        provider, out string errorMessage))
+                        provider, out string? errorMessage))
                     {
                         throw new ValidationException(errorMessage);
                     }
@@ -399,15 +401,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
             LogLevel? level = null,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -459,13 +461,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery][Range(-1, int.MaxValue)]
             int durationSeconds = 30,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 
@@ -495,7 +497,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         {
             return this.InvokeService(() =>
             {
-                string version = Assembly.GetExecutingAssembly().GetInformationalVersionString();
+                string? version = Assembly.GetExecutingAssembly().GetInformationalVersionString();
                 string runtimeVersion = Environment.Version.ToString();
                 DiagnosticPortConnectionMode diagnosticPortMode = _diagnosticPortOptions.Value.GetConnectionMode();
                 string diagnosticPortName = GetDiagnosticPortName();
@@ -528,7 +530,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null)
+            string? name = null)
         {
             return InvokeForProcess<Dictionary<string, CollectionRuleDescription>>(processInfo =>
             {
@@ -554,7 +556,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null)
+            string? name = null)
         {
             return InvokeForProcess<CollectionRuleDetailedDescription>(processInfo =>
             {
@@ -579,11 +581,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             if (!_parameterCapturingOptions.Value.GetEnabled())
             {
@@ -621,11 +623,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             if (!_callStacksOptions.Value.GetEnabled())
             {
@@ -660,8 +662,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             IProcessInfo processInfo,
             MonitoringSourceConfiguration configuration,
             TimeSpan duration,
-            string egressProvider,
-            string tags)
+            string? egressProvider,
+            string? tags)
         {
             IArtifactOperation traceOperation = _traceOperationFactory.Create(
                 processInfo.EndpointInfo,
@@ -679,8 +681,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         private Task<ActionResult> StartLogs(
             IProcessInfo processInfo,
             EventLogsPipelineSettings settings,
-            string egressProvider,
-            string tags)
+            string? egressProvider,
+            string? tags)
         {
             LogFormat? format = ComputeLogFormat(Request.GetTypedHeaders().Accept);
             if (null == format)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagnosticsControllerBase.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagnosticsControllerBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        protected Task<ActionResult> InvokeForProcess(Func<IProcessInfo, ActionResult> func, ProcessKey? processKey, string artifactType = null)
+        protected Task<ActionResult> InvokeForProcess(Func<IProcessInfo, ActionResult> func, ProcessKey? processKey, string? artifactType = null)
         {
             Func<IProcessInfo, Task<ActionResult>> asyncFunc =
                 processInfo => Task.FromResult(func(processInfo));
@@ -30,21 +30,21 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             return InvokeForProcess(asyncFunc, processKey, artifactType);
         }
 
-        protected async Task<ActionResult> InvokeForProcess(Func<IProcessInfo, Task<ActionResult>> func, ProcessKey? processKey, string artifactType)
+        protected async Task<ActionResult> InvokeForProcess(Func<IProcessInfo, Task<ActionResult>> func, ProcessKey? processKey, string? artifactType)
         {
             ActionResult<object> result = await InvokeForProcess<object>(async processInfo => await func(processInfo), processKey, artifactType);
 
-            return result.Result;
+            return result.Result!;
         }
 
-        protected Task<ActionResult<T>> InvokeForProcess<T>(Func<IProcessInfo, ActionResult<T>> func, ProcessKey? processKey, string artifactType = null)
+        protected Task<ActionResult<T>> InvokeForProcess<T>(Func<IProcessInfo, ActionResult<T>> func, ProcessKey? processKey, string? artifactType = null)
         {
             return InvokeForProcess(processInfo => Task.FromResult(func(processInfo)), processKey, artifactType);
         }
 
-        protected async Task<ActionResult<T>> InvokeForProcess<T>(Func<IProcessInfo, Task<ActionResult<T>>> func, ProcessKey? processKey, string artifactType = null)
+        protected async Task<ActionResult<T>> InvokeForProcess<T>(Func<IProcessInfo, Task<ActionResult<T>>> func, ProcessKey? processKey, string? artifactType = null)
         {
-            IDisposable artifactTypeRegistration = null;
+            IDisposable? artifactTypeRegistration = null;
             if (!string.IsNullOrEmpty(artifactType))
             {
                 KeyValueLogScope artifactTypeScope = new KeyValueLogScope();
@@ -75,10 +75,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 
         protected async Task<ActionResult> Result(
             string artifactType,
-            string providerName,
+            string? providerName,
             IArtifactOperation operation,
             IProcessInfo processInfo,
-            string tags,
+            string? tags,
             bool asAttachment = true)
         {
             KeyValueLogScope scope = Utilities.CreateArtifactScope(artifactType, processInfo.EndpointInfo);
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             }
         }
 
-        private async Task RegisterCurrentHttpResponseAsOperation(IProcessInfo processInfo, string artifactType, string tags, IArtifactOperation operation)
+        private async Task RegisterCurrentHttpResponseAsOperation(IProcessInfo processInfo, string artifactType, string? tags, IArtifactOperation operation)
         {
             // While not strictly a Location redirect, use the same header as externally egressed operations for consistency.
             HttpContext.Response.Headers["Location"] = await RegisterOperation(
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 limitKey: artifactType);
         }
 
-        private async Task<string> RegisterOperation(IEgressOperation egressOperation, string limitKey)
+        private async Task<string?> RegisterOperation(IEgressOperation egressOperation, string limitKey)
         {
             // Will throw TooManyRequestsException if there are too many concurrent operations.
             Guid operationId = await OperationStore.AddOperation(egressOperation, limitKey);
@@ -123,7 +123,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
 
         private async Task<ActionResult> SendToEgress(IEgressOperation egressOperation, string limitKey)
         {
-            string operationUrl = await RegisterOperation(egressOperation, limitKey);
+            string? operationUrl = await RegisterOperation(egressOperation, limitKey);
             return Accepted(operationUrl);
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/ExceptionsController.cs
@@ -55,11 +55,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             if (!_options.Value.GetEnabled())
             {
@@ -107,11 +107,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
-            string egressProvider = null,
+            string? egressProvider = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             if (!_options.Value.GetEnabled())
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         private const string ArtifactType_Metrics = "metrics";
 
         private readonly ILogger<MetricsController> _logger;
-        #nullable disable
+#nullable disable
         private readonly MetricsStoreService _metricsStore;
-        #nullable enable
+#nullable restore
         private readonly MetricsOptions _metricsOptions;
 
         public MetricsController(ILogger<MetricsController> logger,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/MetricsController.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         private const string ArtifactType_Metrics = "metrics";
 
         private readonly ILogger<MetricsController> _logger;
+        #nullable disable
         private readonly MetricsStoreService _metricsStore;
+        #nullable enable
         private readonly MetricsOptions _metricsOptions;
 
         public MetricsController(ILogger<MetricsController> logger,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/OperationsController.cs
@@ -45,9 +45,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             Guid? uid = null,
             [FromQuery]
-            string name = null,
+            string? name = null,
             [FromQuery]
-            string tags = null)
+            string? tags = null)
         {
             ProcessKey? processKey = Utilities.GetProcessKey(pid, uid, name);
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         public DiagProcessFilterCriteria Criteria { get; set; }
 
-        public string Value { get; set; }
+        public string Value { get; set; } = string.Empty;
 
         public DiagProcessFilterMatchType MatchType { get; set; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _logger = logger;
         }
 
-        public async Task<IEnumerable<IProcessInfo>> GetProcessesAsync(DiagProcessFilter processFilterConfig, CancellationToken token)
+        public async Task<IEnumerable<IProcessInfo>> GetProcessesAsync(DiagProcessFilter? processFilterConfig, CancellationToken token)
         {
-            IEnumerable<IProcessInfo> processes = null;
+            IEnumerable<IProcessInfo>? processes = null;
 
             try
             {
                 using CancellationTokenSource extendedInfoCancellation = CancellationTokenSource.CreateLinkedTokenSource(token);
-                IList<Task<IProcessInfo>> processInfoTasks = new List<Task<IProcessInfo>>();
+                IList<Task<IProcessInfo?>> processInfoTasks = new List<Task<IProcessInfo?>>();
                 foreach (IEndpointInfo endpointInfo in await _endpointInfoSource.GetEndpointInfoAsync(token))
                 {
                     // CONSIDER: Can this processing be pushed into the IEndpointInfoSource implementation and cached
@@ -71,7 +71,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
                 processes = processInfoTasks
                     .Where(t => t.Result != null)
-                    .Select(t => t.Result);
+                    .Select(t => t.Result)
+                    .Cast<IProcessInfo>();
             }
             catch (UnauthorizedAccessException)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagnosticServices.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public async Task<IEnumerable<IProcessInfo>> GetProcessesAsync(DiagProcessFilter? processFilterConfig, CancellationToken token)
         {
-            IEnumerable<IProcessInfo>? processes = null;
+            IEnumerable<IProcessInfo> processes = [];
 
             try
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             string dumpFilePath = Path.Combine(dumpTempFolder, FormattableString.Invariant($"{Guid.NewGuid()}_{endpointInfo.ProcessId}"));
             DumpType dumpType = MapDumpType(mode);
 
-            IDisposable operationRegistration = null;
+            IDisposable? operationRegistration = null;
             // Only track operation status for endpoints from a listening server because:
             // 1) Each process only ever has a single instance of an IEndpointInfo
             // 2) Only the listening server will query the dump service for the operation status of an endpoint.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/EndpointInfo/IEndpointInfoSource.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         Guid RuntimeInstanceCookie { get; }
 
-        string CommandLine { get; }
+        string? CommandLine { get; }
 
-        string OperatingSystem { get; }
+        string? OperatingSystem { get; }
 
-        string ProcessArchitecture { get; }
+        string? ProcessArchitecture { get; }
 
-        Version RuntimeVersion { get; }
+        Version? RuntimeVersion { get; }
 
         IServiceProvider ServiceProvider { get; }
     }
@@ -42,11 +42,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public abstract int ProcessId { get; protected set; }
         public abstract Guid RuntimeInstanceCookie { get; protected set; }
-        public abstract string CommandLine { get; protected set; }
-        public abstract string OperatingSystem { get; protected set; }
-        public abstract string ProcessArchitecture { get; protected set; }
+        public abstract string? CommandLine { get; protected set; }
+        public abstract string? OperatingSystem { get; protected set; }
+        public abstract string? ProcessArchitecture { get; protected set; }
 
-        public abstract Version RuntimeVersion { get; protected set; }
+        public abstract Version? RuntimeVersion { get; protected set; }
 
         public abstract IServiceProvider ServiceProvider { get; protected set; }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsConfigurationSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsConfigurationSettings.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 
         public List<ExceptionFilterSettings> Exclude { get; set; } = new();
 
-        private static bool CheckConfiguration(IExceptionInstance exception, List<ExceptionFilterSettings> filterList, Func<ExceptionFilterSettings, CallStackFrame, bool> evaluateFilterList)
+        private static bool CheckConfiguration(IExceptionInstance exception, List<ExceptionFilterSettings> filterList, Func<ExceptionFilterSettings, CallStackFrame?, bool> evaluateFilterList)
         {
             var topFrame = exception.CallStack?.Frames.FirstOrDefault();
 
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 
         internal bool ShouldInclude(IExceptionInstance exception)
         {
-            Func<ExceptionFilterSettings, CallStackFrame, bool> evaluateFilterList = (configuration, topFrame) =>
+            Func<ExceptionFilterSettings, CallStackFrame?, bool> evaluateFilterList = (configuration, topFrame) =>
             {
                 bool include = true;
                 if (topFrame != null)
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 
         internal bool ShouldExclude(IExceptionInstance exception)
         {
-            Func<ExceptionFilterSettings, CallStackFrame, bool> evaluateFilterList = (configuration, topFrame) =>
+            Func<ExceptionFilterSettings, CallStackFrame?, bool> evaluateFilterList = (configuration, topFrame) =>
             {
                 bool? exclude = null;
                 if (topFrame != null)
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
             return CheckConfiguration(exception, Exclude, evaluateFilterList);
         }
 
-        private static void CompareIncludeValues(string configurationValue, string actualValue, ref bool include)
+        private static void CompareIncludeValues(string? configurationValue, string actualValue, ref bool include)
         {
             if (include && !string.IsNullOrEmpty(configurationValue))
             {
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
             }
         }
 
-        private static void CompareExcludeValues(string configurationValue, string actualValue, ref bool? exclude)
+        private static void CompareExcludeValues(string? configurationValue, string actualValue, ref bool? exclude)
         {
             if (exclude != false && !string.IsNullOrEmpty(configurationValue))
             {
@@ -96,12 +96,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 
     internal sealed class ExceptionFilterSettings
     {
-        public string MethodName { get; set; }
+        public string? MethodName { get; set; }
 
-        public string ExceptionType { get; set; }
+        public string? ExceptionType { get; set; }
 
-        public string TypeName { get; set; }
+        public string? TypeName { get; set; }
 
-        public string ModuleName { get; set; }
+        public string? ModuleName { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/IExceptionInstance.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 
         DateTime Timestamp { get; }
 
-        CallStack CallStack { get; }
+        CallStack? CallStack { get; }
 
         ulong[] InnerExceptionIds { get; }
 
-        public string ActivityId { get; }
+        public string? ActivityId { get; }
 
         public ActivityIdFormat ActivityIdFormat { get; }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IDiagnosticServices.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         /// <summary>
         /// Returns running processes, optionally based on filter criteria.
         /// </summary>
-        Task<IEnumerable<IProcessInfo>> GetProcessesAsync(DiagProcessFilter processFilter, CancellationToken token);
+        Task<IEnumerable<IProcessInfo>> GetProcessesAsync(DiagProcessFilter? processFilter, CancellationToken token);
 
         /// <summary>
         /// Returns a process based on a key. If no key is specified, the DefaultProcess configuration is used.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IEgressService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             string fileName,
             string contentType,
             IEndpointInfo source,
-            CollectionRuleMetadata collectionRuleMetadata,
+            CollectionRuleMetadata? collectionRuleMetadata,
             CancellationToken token);
 
         Task ValidateProviderOptionsAsync(

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/LoggingExtensions.cs
@@ -15,31 +15,31 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_RequestFailed);
 
-        private static readonly Action<ILogger, Exception> _requestCanceled =
+        private static readonly Action<ILogger, Exception?> _requestCanceled =
             LoggerMessage.Define(
                 eventId: new EventId(2, "RequestCanceled"),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_RequestCanceled);
 
-        private static readonly Action<ILogger, Exception> _resolvedTargetProcess =
+        private static readonly Action<ILogger, Exception?> _resolvedTargetProcess =
             LoggerMessage.Define(
                 eventId: new EventId(3, "ResolvedTargetProcess"),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ResolvedTargetProcess);
 
-        private static readonly Action<ILogger, string, Exception> _egressedArtifact =
+        private static readonly Action<ILogger, string, Exception?> _egressedArtifact =
             LoggerMessage.Define<string>(
                 eventId: new EventId(4, "EgressedArtifact"),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_EgressedArtifact);
 
-        private static readonly Action<ILogger, Exception> _writtenToHttpStream =
+        private static readonly Action<ILogger, Exception?> _writtenToHttpStream =
             LoggerMessage.Define(
                 eventId: new EventId(5, "WrittenToHttpStream"),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_WrittenToHttpStream);
 
-        private static readonly Action<ILogger, int, int, Exception> _throttledEndpoint =
+        private static readonly Action<ILogger, int, int, Exception?> _throttledEndpoint =
             LoggerMessage.Define<int, int>(
                 eventId: new EventId(6, "ThrottledEndpoint"),
                 logLevel: LogLevel.Warning,
@@ -51,13 +51,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DefaultProcessUnexpectedFailure);
 
-        private static readonly Action<ILogger, string, string, Exception> _stoppingTraceEventHit =
+        private static readonly Action<ILogger, string, string, Exception?> _stoppingTraceEventHit =
             LoggerMessage.Define<string, string>(
                 eventId: new EventId(8, "StoppingTraceEventHit"),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_StoppingTraceEventHit);
 
-        private static readonly Action<ILogger, string, string, string, Exception> _stoppingTraceEventPayloadFilterMismatch =
+        private static readonly Action<ILogger, string, string, string, Exception?> _stoppingTraceEventPayloadFilterMismatch =
             LoggerMessage.Define<string, string, string>(
                 eventId: new EventId(9, "StoppingTraceEventPayloadFilterMismatch"),
                 logLevel: LogLevel.Warning,
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_StopOperationFailed);
 
-        private static readonly Action<ILogger, long, Exception> _metricsDropped =
+        private static readonly Action<ILogger, long, Exception?> _metricsDropped =
             LoggerMessage.Define<long>(
                 eventId: new EventId(12, "MetricsDropped"),
                 logLevel: LogLevel.Warning,
@@ -87,31 +87,31 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_MetricsWriteFailed);
 
-        private static readonly Action<ILogger, Exception> _metricsAbandonCompletion =
+        private static readonly Action<ILogger, Exception?> _metricsAbandonCompletion =
             LoggerMessage.Define(
                 eventId: new EventId(14, "MetricsAbandonCompletion"),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_MetricsAbandonCompletion);
 
-        private static readonly Action<ILogger, int, Exception> _metricsUnprocessed =
+        private static readonly Action<ILogger, int, Exception?> _metricsUnprocessed =
             LoggerMessage.Define<int>(
                 eventId: new EventId(15, "MetricsUnprocessed"),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_MetricsUnprocessed);
 
-        private static readonly Action<ILogger, string, Exception> _counterEndedPayload =
+        private static readonly Action<ILogger, string, Exception?> _counterEndedPayload =
             LoggerMessage.Define<string>(
                 eventId: new EventId(16, "CounterEndedPayload"),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_CounterEndedPayload);
 
-        private static readonly Action<ILogger, string, Exception> _errorPayload =
+        private static readonly Action<ILogger, string, Exception?> _errorPayload =
             LoggerMessage.Define<string>(
                 eventId: new EventId(17, "ErrorPayload"),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ErrorPayload);
 
-        private static readonly Action<ILogger, Exception> _generatedInProcessArtifact =
+        private static readonly Action<ILogger, Exception?> _generatedInProcessArtifact =
             LoggerMessage.Define(
                 eventId: new EventId(18, "GeneratedInProcessArtifact"),
                 logLevel: LogLevel.Information,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     /// </summary>
     internal sealed class MetricsService : BackgroundService
     {
-        private MetricsPipeline _counterPipeline;
+        private MetricsPipeline? _counterPipeline;
         private readonly IDiagnosticServices _services;
         private readonly MetricsStoreService _store;
         private IOptionsMonitor<MetricsOptions> _optionsMonitor;
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     using var optionsTokenSource = new CancellationTokenSource();
 
                     //If metric options change, we need to cancel the existing metrics pipeline and restart with the new settings.
-                    using IDisposable monitorListener = _optionsMonitor.OnChange((_, _) => optionsTokenSource.SafeCancel());
+                    using IDisposable? monitorListener = _optionsMonitor.OnChange((_, _) => optionsTokenSource.SafeCancel());
 
                     MetricsPipelineSettings counterSettings = MetricsSettingsFactory.CreateSettings(counterOptions, Timeout.Infinite, options);
                     counterSettings.UseSharedSession = pi.EndpointInfo.RuntimeVersion?.Major >= 8;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsSettingsFactory.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             foreach (EventPipeCounterGroup counterGroup in eventPipeCounterGroups)
             {
-                if (intervalMap.TryGetValue(counterGroup.ProviderName, out GlobalProviderOptions providerInterval))
+                if (intervalMap.TryGetValue(counterGroup.ProviderName, out GlobalProviderOptions? providerInterval))
                 {
                     Debug.Assert(counterGroup.IntervalSeconds == null, "Unexpected value for provider interval");
                     counterGroup.IntervalSeconds = providerInterval.IntervalSeconds;
@@ -120,7 +120,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return counterGroups;
         }
 
-        private static List<EventPipeCounterGroup> ConvertCounterGroups(IList<Models.EventMetricsProvider> providers, IList<Models.EventMetricsMeter> meters)
+        private static List<EventPipeCounterGroup> ConvertCounterGroups(IList<Models.EventMetricsProvider>? providers, IList<Models.EventMetricsMeter>? meters)
         {
             List<EventPipeCounterGroup> counterGroups = new();
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 return code.ToHashCode();
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj is MetricKey metricKey)
                 {
@@ -99,7 +99,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             lock (_allMetrics)
             {
                 var metricKey = new MetricKey(metric);
-                if (!_allMetrics.TryGetValue(metricKey, out Queue<ICounterPayload> metrics))
+                if (!_allMetrics.TryGetValue(metricKey, out Queue<ICounterPayload>? metrics))
                 {
                     metrics = new Queue<ICounterPayload>();
                     _allMetrics.Add(metricKey, metrics);
@@ -120,7 +120,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public async Task SnapshotMetrics(Stream outputStream, CancellationToken token)
         {
-            Dictionary<MetricKey, Queue<ICounterPayload>> copy = null;
+            Dictionary<MetricKey, Queue<ICounterPayload>>? copy = null;
             lock (_allMetrics)
             {
                 copy = new Dictionary<MetricKey, Queue<ICounterPayload>>();

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/PrometheusDataModel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/PrometheusDataModel.cs
@@ -28,22 +28,20 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public static string GetPrometheusNormalizedName(string metricProvider, string metric, string unit)
         {
-            string baseUnit = null;
+            string? baseUnit = null;
             if ((unit != null) && (!KnownUnits.TryGetValue(unit, out baseUnit)))
             {
                 baseUnit = unit;
             }
 
-            bool hasUnit = !string.IsNullOrEmpty(baseUnit);
-
             //The +1's account for separators
             //CONSIDER Can we optimize with Span/stackalloc here instead of using StringBuilder?
-            StringBuilder builder = new StringBuilder(metricProvider.Length + metric.Length + (hasUnit ? baseUnit.Length + 1 : 0) + 1);
+            StringBuilder builder = new StringBuilder(metricProvider.Length + metric.Length + (!string.IsNullOrEmpty(baseUnit) ? baseUnit.Length + 1 : 0) + 1);
 
             NormalizeString(builder, metricProvider, isProvider: true);
             builder.Append(SeparatorChar);
             NormalizeString(builder, metric, isProvider: false);
-            if (hasUnit)
+            if (!string.IsNullOrEmpty(baseUnit))
             {
                 builder.Append(SeparatorChar);
                 NormalizeString(builder, baseUnit, isProvider: false);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/StreamingCounterLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/StreamingCounterLogger.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Microsoft.Diagnostics.Monitoring.WebApi.csproj
@@ -15,6 +15,7 @@
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -10,16 +10,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     public class CallStackFrame
     {
         [JsonPropertyName("methodName")]
-        public string MethodName { get; set; }
+        public string MethodName { get; set; } = string.Empty;
 
         [JsonPropertyName("methodToken")]
         public uint MethodToken { get; set; }
 
         [JsonPropertyName("typeName")]
-        public string TypeName { get; set; }
+        public string TypeName { get; set; } = string.Empty;
 
         [JsonPropertyName("moduleName")]
-        public string ModuleName { get; set; }
+        public string ModuleName { get; set; } = string.Empty;
 
         [JsonPropertyName("moduleVersionId")]
         public Guid ModuleVersionId { get; set; }
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public uint ThreadId { get; set; }
 
         [JsonPropertyName("threadName")]
-        public string ThreadName { get; set; }
+        public string ThreadName { get; set; } = string.Empty;
 
         [JsonPropertyName("frames")]
         public IList<CallStackFrame> Frames { get; set; } = new List<CallStackFrame>();

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CollectionRuleDescription.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CollectionRuleDescription.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         /// Human-readable explanation for the current state of the collection rule.
         /// </summary>
         [JsonPropertyName("stateReason")]
-        public string StateReason { get; set; }
+        public string? StateReason { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/DotnetMonitorInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/DotnetMonitorInfo.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         /// The dotnet monitor version.
         /// </summary>
         [JsonPropertyName("version")]
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
         /// <summary>
         /// The dotnet runtime version.
         /// </summary>
         [JsonPropertyName("runtimeVersion")]
-        public string RuntimeVersion { get; set; }
+        public string? RuntimeVersion { get; set; }
 
         /// <summary>
         /// Indicates whether dotnet monitor is in 'connect' mode or 'listen' mode.
@@ -29,6 +29,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         /// The name of the named pipe or unix domain socket to use for connecting to the diagnostic server.
         /// </summary>
         [JsonPropertyName("diagnosticPortName")]
-        public string DiagnosticPortName { get; set; }
+        public string? DiagnosticPortName { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EgressOperationStatus.cs
@@ -22,16 +22,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public OperationState Status { get; set; }
 
         [JsonPropertyName("process")]
-        public OperationProcessInfo Process { get; set; }
+        public OperationProcessInfo? Process { get; set; }
 
         [JsonPropertyName("egressProviderName")]
-        public string EgressProviderName { get; set; }
+        public string? EgressProviderName { get; set; }
 
         [JsonPropertyName("isStoppable")]
         public bool IsStoppable { get; set; }
 
         [JsonPropertyName("tags")]
-        public ISet<string> Tags { get; set; }
+        public ISet<string>? Tags { get; set; }
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public Guid Uid { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 
     /// <summary>
@@ -58,11 +58,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 
         //Success cases
         [JsonPropertyName("resourceLocation")]
-        public string ResourceLocation { get; set; }
+        public string? ResourceLocation { get; set; }
 
         //Failure cases
         [JsonPropertyName("error")]
-        public OperationError Error { get; set; }
+        public OperationError? Error { get; set; }
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -79,9 +79,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     public class OperationError
     {
         [JsonPropertyName("code")]
-        public string Code { get; set; }
+        public string? Code { get; set; }
 
         [JsonPropertyName("message")]
-        public string Message { get; set; }
+        public string? Message { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventMetricsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventMetricsConfiguration.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Imported by Microsoft.Diagnostics.Monitoring.ConfigurationSchema
+#nullable enable
+
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -13,29 +16,29 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public bool IncludeDefaultProviders { get; set; } = true;
 
         [JsonPropertyName("providers")]
-        public EventMetricsProvider[] Providers { get; set; }
+        public EventMetricsProvider[]? Providers { get; set; }
 
         [JsonPropertyName("meters")]
-        public EventMetricsMeter[] Meters { get; set; }
+        public EventMetricsMeter[]? Meters { get; set; }
     }
 
     public class EventMetricsProvider
     {
         [Required]
         [JsonPropertyName("providerName")]
-        public string ProviderName { get; set; }
+        public string ProviderName { get; set; } = string.Empty;
 
         [JsonPropertyName("counterNames")]
-        public string[] CounterNames { get; set; }
+        public string[]? CounterNames { get; set; }
     }
 
     public class EventMetricsMeter
     {
         [Required]
         [JsonPropertyName("meterName")]
-        public string MeterName { get; set; }
+        public string MeterName { get; set; } = string.Empty;
 
         [JsonPropertyName("instrumentNames")]
-        public string[] InstrumentNames { get; set; }
+        public string[]? InstrumentNames { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     {
         [JsonPropertyName("providers")]
         [Required, MinLength(1)]
-        public EventPipeProvider[] Providers { get; set; }
+        public EventPipeProvider[] Providers { get; set; } = [];
 
         [JsonPropertyName("requestRundown")]
         public bool RequestRundown { get; set; } = true;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/EventPipeProvider.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Imported by Microsoft.Diagnostics.Monitoring.ConfigurationSchema
+#nullable enable
+
 #if !SCHEMAGEN
 using Microsoft.Diagnostics.Monitoring.WebApi.Validation;
 #endif
@@ -15,19 +18,19 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     {
         [JsonPropertyName("name")]
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         [JsonPropertyName("keywords")]
 #if !SCHEMAGEN
         [IntegerOrHexString]
 #endif
-        public string Keywords { get; set; } = "0x" + EventKeywords.All.ToString("X");
+        public string? Keywords { get; set; } = "0x" + EventKeywords.All.ToString("X");
 
         [JsonPropertyName("eventLevel")]
         [EnumDataType(typeof(EventLevel))]
         public EventLevel EventLevel { get; set; } = EventLevel.Verbose;
 
         [JsonPropertyName("arguments")]
-        public IDictionary<string, string> Arguments { get; set; }
+        public IDictionary<string, string>? Arguments { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/LogsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/LogsConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         /// The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.
         /// </summary>
         [JsonPropertyName("filterSpecs")]
-        public Dictionary<string, LogLevel?> FilterSpecs { get; set; }
+        public Dictionary<string, LogLevel?>? FilterSpecs { get; set; }
 
         /// <summary>
         /// Set to true to collect logs at the application-defined categories and levels.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessIdentifier.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessIdentifier.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public Guid Uid { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonPropertyName("isDefault")]
         public bool IsDefault { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ProcessInfo.cs
@@ -15,15 +15,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public Guid Uid { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonPropertyName("commandLine")]
-        public string CommandLine { get; set; }
+        public string? CommandLine { get; set; }
 
         [JsonPropertyName("operatingSystem")]
-        public string OperatingSystem { get; set; }
+        public string? OperatingSystem { get; set; }
 
         [JsonPropertyName("processArchitecture")]
-        public string ProcessArchitecture { get; set; }
+        public string? ProcessArchitecture { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/SpeedScopeStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/SpeedScopeStackResults.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     public class SpeedscopeResult
     {
         [JsonPropertyName("exporter")]
-        public string Exporter { get; set; }
+        public string? Exporter { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonPropertyName("activeProfileIndex")]
         public int ActiveProfileIndex { get; set; }
@@ -21,22 +21,22 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public string Schema { get; set; } = "https://www.speedscope.app/file-format-schema.json";
 
         [JsonPropertyName("profiles")]
-        public List<Profile> Profiles { get; set; }
+        public List<Profile>? Profiles { get; set; }
 
         [JsonPropertyName("shared")]
-        public SharedFrames Shared { get; set; }
+        public SharedFrames? Shared { get; set; }
     }
 
     public class SharedFrames
     {
         [JsonPropertyName("frames")]
-        public List<SharedFrame> Frames { get; set; }
+        public List<SharedFrame>? Frames { get; set; }
     }
 
     public class SharedFrame
     {
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonPropertyName("col")]
         public int? Column { get; set; }
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public int? Line { get; set; }
 
         [JsonPropertyName("file")]
-        public string File { get; set; }
+        public string? File { get; set; }
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public ProfileType Type { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonPropertyName("unit")]
         public UnitType Unit { get; set; }
@@ -103,6 +103,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public double EndValue { get; set; }
 
         [JsonPropertyName("events")]
-        public List<ProfileEvent> Events { get; set; }
+        public List<ProfileEvent>? Events { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperation.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private readonly IArtifactOperation _operation;
 
-        public EgressOperation(IArtifactOperation operation, string endpointName, IProcessInfo processInfo, KeyValueLogScope scope, string tags, CollectionRuleMetadata collectionRuleMetadata = null)
+        public EgressOperation(IArtifactOperation operation, string endpointName, IProcessInfo processInfo, KeyValueLogScope scope, string? tags, CollectionRuleMetadata? collectionRuleMetadata = null)
         {
             _egress = (service, token) => service.EgressAsync(
                 endpointName,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             public ExecutionResult<EgressResult> ExecutionResult { get; set; }
 #nullable restore
 
-            public Models.OperationState State { get; set; }
+            public required Models.OperationState State { get; set; }
 
             public required EgressRequest EgressRequest { get; set; }
 
             public DateTime CreatedDateTime { get; } = DateTime.UtcNow;
 
-            public Guid OperationId { get; set; }
+            public required Guid OperationId { get; set; }
 
             public required ISet<string> Tags { get; set; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/EgressOperationStore.cs
@@ -23,16 +23,19 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 }
             }
 
+#nullable disable
             public ExecutionResult<EgressResult> ExecutionResult { get; set; }
+#nullable restore
+
             public Models.OperationState State { get; set; }
 
-            public EgressRequest EgressRequest { get; set; }
+            public required EgressRequest EgressRequest { get; set; }
 
             public DateTime CreatedDateTime { get; } = DateTime.UtcNow;
 
             public Guid OperationId { get; set; }
 
-            public ISet<string> Tags { get; set; }
+            public required ISet<string> Tags { get; set; }
 
             public TaskCompletionSource TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
@@ -55,9 +58,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             EgressEntry entry = await AddOperationInternal(egressOperation, RequestLimitTracker.Unlimited);
 
-            await entry?.TaskCompletionSource.Task;
+            await entry.TaskCompletionSource.Task;
 
-            return entry?.ExecutionResult;
+            return entry.ExecutionResult;
         }
 
         public async Task<Guid> AddOperation(IEgressOperation egressOperation, string limitKey)
@@ -105,7 +108,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             lock (_requests)
             {
-                if (!_requests.TryGetValue(operationId, out EgressEntry entry))
+                if (!_requests.TryGetValue(operationId, out EgressEntry? entry))
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_OperationNotFound);
                 }
@@ -125,7 +128,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
                 CancellationToken token = entry.EgressRequest.CancellationTokenSource.Token;
                 _ = Task.Run(() => entry.EgressRequest.EgressOperation.StopAsync(token), token)
-                    .ContinueWith(task => onStopException(task.Exception),
+                    .ContinueWith(task => onStopException(task.Exception!),
                     token,
                     TaskContinuationOptions.OnlyOnFaulted,
                     TaskScheduler.Default);
@@ -136,7 +139,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             lock (_requests)
             {
-                if (!_requests.TryGetValue(operationId, out EgressEntry entry))
+                if (!_requests.TryGetValue(operationId, out EgressEntry? entry))
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_OperationNotFound);
                 }
@@ -154,7 +157,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             lock (_requests)
             {
-                if (!_requests.TryGetValue(operationId, out EgressEntry entry))
+                if (!_requests.TryGetValue(operationId, out EgressEntry? entry))
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_OperationNotFound);
                 }
@@ -178,7 +181,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             lock (_requests)
             {
-                if (!_requests.TryGetValue(operationId, out EgressEntry entry))
+                if (!_requests.TryGetValue(operationId, out EgressEntry? entry))
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_OperationNotFound);
                 }
@@ -206,7 +209,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
         }
 
-        public IEnumerable<Models.OperationSummary> GetOperations(ProcessKey? processKey, string tags)
+        public IEnumerable<Models.OperationSummary> GetOperations(ProcessKey? processKey, string? tags)
         {
             lock (_requests)
             {
@@ -278,7 +281,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             lock (_requests)
             {
-                if (!_requests.TryGetValue(operationId, out EgressEntry entry))
+                if (!_requests.TryGetValue(operationId, out EgressEntry? entry))
                 {
                     throw new InvalidOperationException(Strings.ErrorMessage_OperationNotFound);
                 }
@@ -307,11 +310,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 }
                 else if (entry.State == Models.OperationState.Failed)
                 {
+#nullable disable
                     status.Error = new Models.OperationError
                     {
                         Code = entry.ExecutionResult.ProblemDetails.Status?.ToString(CultureInfo.InvariantCulture),
                         Message = entry.ExecutionResult.ProblemDetails.Detail
                     };
+#nullable restore
                 }
 
                 return status;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/HttpResponseEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/HttpResponseEgressOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private readonly TaskCompletionSource<int> _responseFinishedCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public EgressProcessInfo ProcessInfo { get; private set; }
-        public string EgressProviderName { get { return null; } }
+        public string? EgressProviderName { get { return null; } }
         public bool IsStoppable { get { return _operation?.IsStoppable ?? false; } }
         public ISet<string> Tags { get; private set; }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private readonly IArtifactOperation _operation;
 
-        public HttpResponseEgressOperation(HttpContext context, IProcessInfo processInfo, string tags, IArtifactOperation operation)
+        public HttpResponseEgressOperation(HttpContext context, IProcessInfo processInfo, string? tags, IArtifactOperation operation)
         {
             _httpContext = context;
             _httpContext.Response.OnCompleted(() =>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperation.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public ISet<string> Tags { get; }
 
-        public string EgressProviderName { get; }
+        public string? EgressProviderName { get; }
 
         public EgressProcessInfo ProcessInfo { get; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperationStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Operation/IEgressOperationStore.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         void CompleteOperation(Guid operationId, ExecutionResult<EgressResult> result);
 
-        IEnumerable<Models.OperationSummary> GetOperations(ProcessKey? processKey, string tags);
+        IEnumerable<Models.OperationSummary> GetOperations(ProcessKey? processKey, string? tags);
 
         Models.OperationStatus GetOperationStatus(Guid operationId);
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/OutputStreamResult.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         private readonly Func<Stream, CancellationToken, Task> _action;
         private readonly string _contentType;
-        private readonly string _fileDownloadName;
+        private readonly string? _fileDownloadName;
         private readonly KeyValueLogScope _scope;
 
-        public OutputStreamResult(Func<Stream, CancellationToken, Task> action, string contentType, string fileDownloadName, KeyValueLogScope scope)
+        public OutputStreamResult(Func<Stream, CancellationToken, Task> action, string contentType, string? fileDownloadName, KeyValueLogScope scope)
         {
             _contentType = contentType;
             _fileDownloadName = fileDownloadName;
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _scope = scope;
         }
 
-        public OutputStreamResult(IArtifactOperation operation, string fileDownloadName, KeyValueLogScope scope)
+        public OutputStreamResult(IArtifactOperation operation, string? fileDownloadName, KeyValueLogScope scope)
             : this(operation.ExecuteAsync, operation.ContentType, fileDownloadName, scope)
         {
         }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
@@ -51,6 +51,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
             await _writer.DisposeAsync();
         }
 
-        private static string GetValueOrUnknown(string value) => string.IsNullOrEmpty(value) ? "<unknown>" : value;
+        private static string GetValueOrUnknown(string? value) => string.IsNullOrEmpty(value) ? "<unknown>" : value;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ICapturedParameters.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ICapturedParameters.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
 {
     internal interface ICapturedParameters
     {
-        string ActivityId { get; }
+        string? ActivityId { get; }
 
         ActivityIdFormat ActivityIdFormat { get; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessInfoImpl.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public ProcessInfoImpl(
             IEndpointInfo endpointInfo,
-            string commandLine,
-            string processName)
+            string? commandLine,
+            string? processName)
         {
             EndpointInfo = endpointInfo;
 
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             DiagnosticsClient client = new(endpointInfo.Endpoint);
 
-            string commandLine = endpointInfo.CommandLine;
+            string? commandLine = endpointInfo.CommandLine;
             if (string.IsNullOrEmpty(commandLine))
             {
                 // The EventProcessInfoPipeline will frequently block during disposal of its
@@ -70,10 +70,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 // not cancellable and hangs the entire operation for at least 30 seconds. To
                 // mitigate, start the pipeline, get the command line, and they start the disposal
                 // on a separate Task that is not awaited.
-                EventProcessInfoPipeline pipeline = null;
+                EventProcessInfoPipeline? pipeline = null;
                 try
                 {
-                    TaskCompletionSource<string> commandLineSource =
+                    TaskCompletionSource<string?> commandLineSource =
                         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     using IDisposable registration = extendedInfoCancellationToken.Register(
@@ -106,7 +106,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 }
             }
 
-            string processName = GetProcessName(commandLine, endpointInfo.OperatingSystem);
+            string? processName = GetProcessName(commandLine, endpointInfo.OperatingSystem);
 
             return new ProcessInfoImpl(
                 endpointInfo,
@@ -114,9 +114,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 processName);
         }
 
-        internal static string GetProcessName(string commandLine, string operatingSystem)
+        internal static string? GetProcessName(string? commandLine, string? operatingSystem)
         {
-            string processName = null;
+            string? processName = null;
             if (!string.IsNullOrEmpty(commandLine))
             {
                 // Get the process name from the command line

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessKey.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProcessKey.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             RuntimeInstanceCookie = null;
         }
 
-        public ProcessKey(int? processId = null, Guid? runtimeInstanceCookie = null, string processName = null)
+        public ProcessKey(int? processId = null, Guid? runtimeInstanceCookie = null, string? processName = null)
         {
             ProcessId = processId;
             ProcessName = processName;
@@ -40,14 +40,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         public int? ProcessId { get; }
 
-        public string ProcessName { get; }
+        public string? ProcessName { get; }
 
         public Guid? RuntimeInstanceCookie { get; }
     }
 
     internal class ProcessKeyTypeConverter : TypeConverter
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             if (null == sourceType)
             {
@@ -56,7 +56,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return sourceType == typeof(string) || sourceType == typeof(ProcessKey);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             if (value is string valueString)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackData.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/CallStackData.cs
@@ -34,6 +34,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 
         public uint ThreadId { get; set; }
 
-        public string ThreadName { get; set; }
+        public string ThreadName { get; set; } = string.Empty;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/EventStacksPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/EventStacksPipeline.cs
@@ -91,10 +91,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                             Offset = offsets[i]
                         };
 
-                        if (_result.NameCache.FunctionData.TryGetValue(stackFrame.FunctionId, out FunctionData functionData))
+                        if (_result.NameCache.FunctionData.TryGetValue(stackFrame.FunctionId, out FunctionData? functionData))
                         {
                             stackFrame.MethodToken = functionData.MethodToken;
-                            if (_result.NameCache.ModuleData.TryGetValue(functionData.ModuleId, out ModuleData moduleData))
+                            if (_result.NameCache.ModuleData.TryGetValue(functionData.ModuleId, out ModuleData? moduleData))
                             {
                                 stackFrame.ModuleVersionId = moduleData.ModuleVersionId;
                             }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                         profile.Events.Add(NativeProfileEvent);
 
                     }
-                    else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData functionData))
+                    else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData? functionData))
                     {
                         if (!functionToSharedFrameMap.TryGetValue(frame.FunctionId, out int mapping))
                         {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/StacksFormatter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 
         public abstract Task FormatStack(CallStackResult stackResult, CancellationToken token);
 
-        protected static string FormatThreadName(uint threadId, string threadName)
+        protected static string FormatThreadName(uint threadId, string? threadName)
         {
             const string Separator = " ";
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             {
                 builder.Append(NativeFrame);
             }
-            else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData functionData))
+            else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData? functionData))
             {
                 builder.Append(NameFormatter.GetModuleName(cache, functionData.ModuleId));
                 builder.Append(ModuleSeparator);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
@@ -39,6 +39,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
     public sealed class StreamingLogger : ILogger
     {
+        private sealed class EmptyScope : IDisposable
+        {
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         private readonly ScopeState _scopes = new ScopeState();
         private readonly Stream _outputStream;
         private readonly string _categoryName;
@@ -68,18 +76,18 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             _logLevel = logLevel;
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        IDisposable ILogger.BeginScope<TState>(TState state)
         {
             if (state is LogObject logObject)
             {
                 return _scopes.Push(logObject);
             }
-            return null;
+            return new EmptyScope();
         }
 
         public bool IsEnabled(LogLevel logLevel) => (_logLevel == null) ? true : logLevel <= _logLevel.Value;
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             if (_logFormat == LogFormat.NewlineDelimitedJson)
             {
@@ -95,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
         }
 
-        private void LogJson<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter, LogFormat jsonFormat = LogFormat.NewlineDelimitedJson)
+        private void LogJson<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter, LogFormat jsonFormat = LogFormat.NewlineDelimitedJson)
         {
             Stream outputStream = _outputStream;
 
@@ -161,7 +169,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             outputStream.Flush();
         }
 
-        private void LogText<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        private void LogText<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             Stream outputStream = _outputStream;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/StreamingLogger.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         {
             public void Dispose()
             {
-                throw new NotImplementedException();
             }
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/TaskCompletionSourceExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/TaskCompletionSourceExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
@@ -60,12 +60,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 frameModel.ModuleName = StacksFormatter.NativeFrame;
                 frameModel.TypeName = StacksFormatter.NativeFrame;
             }
-            else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData functionData))
+            else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData? functionData))
             {
                 frameModel.MethodToken = functionData.MethodToken;
                 frameModel.ModuleName = NameFormatter.GetModuleName(cache, functionData.ModuleId);
 
-                if (cache.ModuleData.TryGetValue(functionData.ModuleId, out ModuleData moduleData))
+                if (cache.ModuleData.TryGetValue(functionData.ModuleId, out ModuleData? moduleData))
                 {
                     frameModel.ModuleVersionId = moduleData.ModuleVersionId;
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/TraceUtilities.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             foreach (Models.EventPipeProvider providerModel in configurationProviders)
             {
-                if (!IntegerOrHexStringAttribute.TryParse(providerModel.Keywords, out long keywords, out string parseError))
+                if (!IntegerOrHexStringAttribute.TryParse(providerModel.Keywords, out long keywords, out string? parseError))
                 {
                     throw new InvalidOperationException(parseError);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/Utilities.cs
@@ -40,12 +40,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return scope;
         }
 
-        public static ProcessKey? GetProcessKey(int? pid, Guid? uid, string name)
+        public static ProcessKey? GetProcessKey(int? pid, Guid? uid, string? name)
         {
             return (!pid.HasValue && !uid.HasValue && string.IsNullOrEmpty(name)) ? null : new ProcessKey(pid, uid, name);
         }
 
-        public static ISet<string> SplitTags(string tags)
+        public static ISet<string> SplitTags(string? tags)
         {
             if (string.IsNullOrEmpty(tags))
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/CounterValidator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
@@ -10,11 +11,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
     {
         public static bool ValidateProvider(GlobalCounterOptions counterOptions,
             EventPipeProvider provider,
-            out string errorMessage)
+            [NotNullWhen(false)] out string? errorMessage)
         {
             errorMessage = null;
 
-            if (provider.Arguments?.TryGetValue("EventCounterIntervalSec", out string intervalValue) == true)
+            if (provider.Arguments?.TryGetValue("EventCounterIntervalSec", out string? intervalValue) == true)
             {
                 if (float.TryParse(intervalValue, out float intervalSeconds) &&
                     intervalSeconds != counterOptions.GetProviderSpecificInterval(provider.Name))

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/IntegerOrHexStringAttribute.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Validation/IntegerOrHexStringAttribute.cs
@@ -3,26 +3,27 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Validation
 {
     public class IntegerOrHexStringAttribute : ValidationAttribute
     {
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             if (!(value is string stringValue))
             {
                 return new ValidationResult(Strings.ErrorMessage_ValueNotString);
             }
-            else if (!TryParse(stringValue, out _, out string error))
+            else if (!TryParse(stringValue, out _, out string? error))
             {
                 return new ValidationResult(error);
             }
             return ValidationResult.Success;
         }
 
-        public static bool TryParse(string value, out long result, out string error)
+        public static bool TryParse(string? value, out long result, [NotNullWhen(false)] out string? error)
         {
             result = 0;
             error = null;


### PR DESCRIPTION
###### Summary

This is the first PR in a series to enable nullable aware context throughout our code. To help with ease of review and minimize the chance of introducing regressions, I'll be organizing the PRs as follows:
- Each project will have nullable aware context enabled in its own PR.
  - These PRs will be **large** but **only** contain trivial, low/no-risk, changes.  Namely they'll primarily contain the addition of the new nullable syntaxes (`?` and `!`) and static analysis attributes (e.g. `[NotNullWhen(..)]`).
  - Nullable context will be disabled around pieces of code that contain some level of risk to update. These sections of code will be addressed in follow up PRs so they can be properly reviewed. (e.g. `#nullable disable ... #nullable restore`)
  - If you see anything that you feel like could introduce a regression or is non-trivial in these PRs, leave a comment and I'll pull out those changes.
 
- All PRs in this effort will **not** contain any breaking changes.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
