### PR TITLE
[Nullable Context] Enable on `Microsoft.Diagnostics.Monitoring.ConfigurationSchema`

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/ExperimentalSchemaProcessor.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/ExperimentalSchemaProcessor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
             {
                 if (null != property.GetCustomAttribute<ExperimentalAttribute>())
                 {
-                    string description = context.Schema.Properties[property.Name].Description;
+                    string? description = context.Schema.Properties[property.Name].Description;
                     if (string.IsNullOrEmpty(description))
                     {
                         description = ExperimentalPrefix;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
     <TargetFrameworks>$(SchemaTargetFramework)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SCHEMAGEN</DefineConstants>
   </PropertyGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleFormatterOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.Options
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ConsoleFormatterOptions_TimestampFormat))]
         [DefaultValue(null)]
-        public string TimestampFormat { get; set; }
+        public string? TimestampFormat { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleLoggerOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/ConsoleLoggerOptions.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ConsoleLoggerOptions_FormatterOptions))]
-        public object FormatterOptions { get; set; }
+        public object? FormatterOptions { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ConsoleLoggerOptions_LogLevel))]
-        public IDictionary<string, LogLevel?> LogLevel { get; set; }
+        public IDictionary<string, LogLevel?>? LogLevel { get; set; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/JsonConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/JsonConsoleFormatterOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Monitoring.Options
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ConsoleFormatterOptions_TimestampFormat))]
         [DefaultValue(null)]
-        public string TimestampFormat { get; set; }
+        public string? TimestampFormat { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LogLevelOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LogLevelOptions.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LogLevelOptions_LogLevel))]
-        public IDictionary<string, LogLevel?> LogLevel { get; set; }
+        public IDictionary<string, LogLevel?>? LogLevel { get; set; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LoggingOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/LoggingOptions.cs
@@ -14,27 +14,27 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LoggingOptions_LogLevel))]
-        public IDictionary<string, LogLevel?> LogLevel { get; set; }
+        public IDictionary<string, LogLevel?>? LogLevel { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LoggingOptions_Console))]
-        public ConsoleLoggerOptions Console { get; set; }
+        public ConsoleLoggerOptions? Console { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LoggingOptions_EventLog))]
-        public LogLevelOptions EventLog { get; set; }
+        public LogLevelOptions? EventLog { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LoggingOptions_Debug))]
-        public LogLevelOptions Debug { get; set; }
+        public LogLevelOptions? Debug { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LoggingOptions_EventSource))]
-        public LogLevelOptions EventSource { get; set; }
+        public LogLevelOptions? EventSource { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/RootOptions.Logging.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/RootOptions.Logging.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal partial class RootOptions
     {
-        public LoggingOptions Logging { get; set; }
+        public LoggingOptions? Logging { get; set; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/SimpleConsoleFormatterOptions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/Options/SimpleConsoleFormatterOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Monitoring.Options
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ConsoleFormatterOptions_TimestampFormat))]
         [DefaultValue(null)]
-        public string TimestampFormat { get; set; }
+        public string? TimestampFormat { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema/SchemaGenerator.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
             string discriminatingPropertyName,
             string discriminatingPropertyValue,
             string discriminatedPropertyName,
-            JsonSchema subSchema = null)
+            JsonSchema? subSchema = null)
         {
             if (null == subSchema)
             {
@@ -283,7 +283,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema
             }
 
             JsonSchemaProperty discriminatingProperty = new JsonSchemaProperty();
-            discriminatingProperty.ExtensionData = new Dictionary<string, object>();
+            discriminatingProperty.ExtensionData = new Dictionary<string, object?>();
             discriminatingProperty.ExtensionData.Add("const", discriminatingPropertyValue);
 
             subSchema.Properties.Add(discriminatingPropertyName, discriminatingProperty);

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectDumpOptions.cs
@@ -35,6 +35,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectExceptionsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectExceptionsOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
@@ -25,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -36,6 +38,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectExceptionsOptions_Filters))]
-        public ExceptionsConfiguration Filters { get; set; }
+        public ExceptionsConfiguration? Filters { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectGCDumpOptions.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLiveMetricsOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
@@ -29,12 +31,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLiveMetricsOptions_Providers))]
-        public EventMetricsProvider[] Providers { get; set; }
+        public EventMetricsProvider[]? Providers { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLiveMetricsOptions_Meters))]
-        public EventMetricsMeter[] Meters { get; set; }
+        public EventMetricsMeter[]? Meters { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -52,6 +54,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
@@ -32,7 +34,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectLogsOptions_FilterSpecs))]
-        public Dictionary<string, LogLevel?> FilterSpecs { get; set; }
+        public Dictionary<string, LogLevel?>? FilterSpecs { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -56,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectStacksOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectTraceOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
@@ -30,7 +32,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_Providers))]
-        public List<EventPipeProvider> Providers { get; set; }
+        public List<EventPipeProvider>? Providers { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -61,11 +63,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
 #if !UNITTEST && !SCHEMAGEN
         [ValidateEgressProvider]
 #endif
-        public string Egress { get; set; }
+        public string Egress { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectTraceOptions_StoppingEvent))]
-        public TraceEventFilter StoppingEvent { get; set; }
+        public TraceEventFilter? StoppingEvent { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ExecuteOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -21,13 +23,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ExecuteOptions_Path))]
         [Required]
-        public string Path { get; set; }
+        public string Path { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ExecuteOptions_Arguments))]
         [ActionOptionsDependencyProperty]
-        public string Arguments { get; set; }
+        public string? Arguments { get; set; }
 
         [DefaultValue(ExecuteOptionsDefaults.IgnoreExitCode)]
         public bool? IgnoreExitCode { get; set; }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/GetEnvironmentVariableOptions.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_GetEnvironmentVariableOptions_Name))]
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/LoadProfilerOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/LoadProfilerOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_LoadProfilerOptions_Path))]
         [Required]
-        public string Path { get; set; }
+        public string Path { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/SetEnvironmentVariableOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
@@ -20,11 +22,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_SetEnvironmentVariableOptions_Name))]
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_SetEnvironmentVariableOptions_Value))]
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/TraceEventFilter.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/TraceEventFilter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -21,17 +23,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_TraceEventFilter_ProviderName))]
         [Required]
-        public string ProviderName { get; set; }
+        public string ProviderName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_TraceEventFilter_EventName))]
         [Required]
-        public string EventName { get; set; }
+        public string EventName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_TraceEventFilter_PayloadFilter))]
-        public IDictionary<string, string> PayloadFilter { get; set; }
+        public IDictionary<string, string>? PayloadFilter { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionDefaultsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionDefaultsOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;
 
@@ -11,6 +13,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleActionDefaultsOptions_Egress))]
-        public string Egress { get; set; }
+        public string? Egress { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleActionOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -17,18 +19,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleActionOptions_Name))]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleActionOptions_Type))]
         [Required]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleActionOptions_Settings))]
-        public object Settings { get; internal set; }
+        public object? Settings { get; internal set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleDefaultsOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;
 
@@ -11,16 +13,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleDefaultsOptions_Triggers))]
-        public CollectionRuleTriggerDefaultsOptions Triggers { get; set; }
+        public CollectionRuleTriggerDefaultsOptions? Triggers { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleDefaultsOptions_Actions))]
-        public CollectionRuleActionDefaultsOptions Actions { get; set; }
+        public CollectionRuleActionDefaultsOptions? Actions { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleDefaultsOptions_Limits))]
-        public CollectionRuleLimitsDefaultsOptions Limits { get; set; }
+        public CollectionRuleLimitsDefaultsOptions? Limits { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
@@ -19,11 +19,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Filters))]
         public List<ProcessFilterDescriptor>? Filters { get; } = new List<ProcessFilterDescriptor>(0);
 
+#nullable disable
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Trigger))]
         [Required]
-        public CollectionRuleTriggerOptions Trigger { get; set; } = new();
+        public CollectionRuleTriggerOptions Trigger { get; set; }
+#nullable enable
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -15,23 +17,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Filters))]
-        public List<ProcessFilterDescriptor> Filters { get; } = new List<ProcessFilterDescriptor>(0);
+        public List<ProcessFilterDescriptor>? Filters { get; } = new List<ProcessFilterDescriptor>(0);
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Trigger))]
         [Required]
-        public CollectionRuleTriggerOptions Trigger { get; set; }
+        public CollectionRuleTriggerOptions Trigger { get; set; } = new();
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Actions))]
-        public List<CollectionRuleActionOptions> Actions { get; } = new List<CollectionRuleActionOptions>(0);
+        public List<CollectionRuleActionOptions>? Actions { get; } = new List<CollectionRuleActionOptions>(0);
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Limits))]
-        public CollectionRuleLimitsOptions Limits { get; set; }
+        public CollectionRuleLimitsOptions? Limits { get; set; }
 
         internal List<ValidationResult> ErrorList { get; } = new List<ValidationResult>();
     }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleTriggerOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
@@ -17,11 +19,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleTriggerOptions_Type))]
         [Required]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleTriggerOptions_Settings))]
-        public object Settings { get; internal set; }
+        public object? Settings { get; internal set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/RegularExpressionsAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/RegularExpressionsAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 
@@ -13,7 +15,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         {
         }
 
-        public override bool IsValid(object value)
+        public override bool IsValid(object? value)
         {
             if (value is string[] values)
             {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/TemplateOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/TemplateOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -15,21 +17,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Filters))]
-        public IDictionary<string, ProcessFilterDescriptor> CollectionRuleFilters { get; set; } = new Dictionary<string, ProcessFilterDescriptor>();
+        public IDictionary<string, ProcessFilterDescriptor>? CollectionRuleFilters { get; set; } = new Dictionary<string, ProcessFilterDescriptor>();
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Trigger))]
-        public IDictionary<string, CollectionRuleTriggerOptions> CollectionRuleTriggers { get; set; } = new Dictionary<string, CollectionRuleTriggerOptions>();
+        public IDictionary<string, CollectionRuleTriggerOptions>? CollectionRuleTriggers { get; set; } = new Dictionary<string, CollectionRuleTriggerOptions>();
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Actions))]
-        public IDictionary<string, CollectionRuleActionOptions> CollectionRuleActions { get; set; } = new Dictionary<string, CollectionRuleActionOptions>();
+        public IDictionary<string, CollectionRuleActionOptions>? CollectionRuleActions { get; set; } = new Dictionary<string, CollectionRuleActionOptions>();
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Limits))]
-        public IDictionary<string, CollectionRuleLimitsOptions> CollectionRuleLimits { get; set; } = new Dictionary<string, CollectionRuleLimitsOptions>();
+        public IDictionary<string, CollectionRuleLimitsOptions>? CollectionRuleLimits { get; set; } = new Dictionary<string, CollectionRuleLimitsOptions>();
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestCountOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
 using System;
@@ -35,13 +37,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_IncludePaths))]
-        public string[] IncludePaths { get; set; }
+        public string[]? IncludePaths { get; set; }
 
         // CONSIDER: Currently described that paths have to exactly match one item in the list.
         // Consider allowing for wildcard/globbing to simplify list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestCountOptions_ExcludePaths))]
-        public string[] ExcludePaths { get; set; }
+        public string[]? ExcludePaths { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetRequestDurationOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
 using System;
@@ -46,13 +48,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_IncludePaths))]
-        public string[] IncludePaths { get; set; }
+        public string[]? IncludePaths { get; set; }
 
         // CONSIDER: Currently described that paths have to exactly match one item in the list.
         // Consider allowing for wildcard/globbing to simplify list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetRequestDurationOptions_ExcludePaths))]
-        public string[] ExcludePaths { get; set; }
+        public string[]? ExcludePaths { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
 using System;
@@ -25,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [RegularExpressions(StatusCodesRegex,
             ErrorMessageResourceType = typeof(OptionsDisplayStrings),
             ErrorMessageResourceName = nameof(OptionsDisplayStrings.ErrorMessage_StatusCodesRegularExpressionDoesNotMatch))]
-        public string[] StatusCodes { get; set; }
+        public string[] StatusCodes { get; set; } = [];
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -48,13 +50,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_IncludePaths))]
-        public string[] IncludePaths { get; set; }
+        public string[]? IncludePaths { get; set; }
 
         // CONSIDER: Currently described that paths have to exactly match one item in the list.
         // Consider allowing for wildcard/globbing to simplify list of matchable paths.
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_ExcludePaths))]
-        public string[] ExcludePaths { get; set; }
+        public string[]? ExcludePaths { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/AspNetResponseStatusOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         private const string StatusCodeRegex = "[1-5][0-9]{2}";
         private const string StatusCodesRegex = StatusCodeRegex + "(-" + StatusCodeRegex + ")?";
 
+#nullable disable
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AspNetResponseStatusOptions_StatusCodes))]
@@ -27,7 +28,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
         [RegularExpressions(StatusCodesRegex,
             ErrorMessageResourceType = typeof(OptionsDisplayStrings),
             ErrorMessageResourceName = nameof(OptionsDisplayStrings.ErrorMessage_StatusCodesRegularExpressionDoesNotMatch))]
-        public string[] StatusCodes { get; set; } = [];
+        public string[] StatusCodes { get; set; }
+#nullable enable
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventCounterOptions.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_ProviderName))]
         [Required]
-        public string ProviderName { get; set; }
+        public string ProviderName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventCounterOptions_CounterName))]
         [Required]
-        public string CounterName { get; set; }
+        public string CounterName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventMeterOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/EventMeterOptions.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventMeterOptions_MeterName))]
         [Required]
-        public string MeterName { get; set; }
+        public string MeterName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EventMeterOptions_InstrumentName))]
         [Required]
-        public string InstrumentName { get; set; }
+        public string InstrumentName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/IAspNetActionPathFilters.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Triggers/IAspNetActionPathFilters.cs
@@ -1,12 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Triggers
 {
     internal interface IAspNetActionPathFilters
     {
-        public string[] IncludePaths { get; }
+        public string[]? IncludePaths { get; }
 
-        public string[] ExcludePaths { get; }
+        public string[]? ExcludePaths { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/RootOptions.cs
+++ b/src/Tools/dotnet-monitor/RootOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
@@ -10,32 +12,32 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed partial class RootOptions
     {
-        public AuthenticationOptions Authentication { get; set; }
+        public AuthenticationOptions? Authentication { get; set; }
 
-        public IDictionary<string, CollectionRuleOptions> CollectionRules { get; set; }
+        public IDictionary<string, CollectionRuleOptions>? CollectionRules { get; set; }
             = new Dictionary<string, CollectionRuleOptions>(0);
 
-        public GlobalCounterOptions GlobalCounter { get; set; }
+        public GlobalCounterOptions? GlobalCounter { get; set; }
 
-        public InProcessFeaturesOptions InProcessFeatures { get; set; }
+        public InProcessFeaturesOptions? InProcessFeatures { get; set; }
 
-        public CorsConfigurationOptions CorsConfiguration { get; set; }
+        public CorsConfigurationOptions? CorsConfiguration { get; set; }
 
-        public DiagnosticPortOptions DiagnosticPort { get; set; }
+        public DiagnosticPortOptions? DiagnosticPort { get; set; }
 
-        public EgressOptions Egress { get; set; }
+        public EgressOptions? Egress { get; set; }
 
-        public MetricsOptions Metrics { get; set; }
+        public MetricsOptions? Metrics { get; set; }
 
-        public StorageOptions Storage { get; set; }
+        public StorageOptions? Storage { get; set; }
 
-        public ProcessFilterOptions DefaultProcess { get; set; }
+        public ProcessFilterOptions? DefaultProcess { get; set; }
 
-        public CollectionRuleDefaultsOptions CollectionRuleDefaults { get; set; }
+        public CollectionRuleDefaultsOptions? CollectionRuleDefaults { get; set; }
 
-        public TemplateOptions Templates { get; set; }
+        public TemplateOptions? Templates { get; set; }
 
-        public DotnetMonitorDebugOptions DotnetMonitorDebug { get; set; }
+        public DotnetMonitorDebugOptions? DotnetMonitorDebug { get; set; }
 
     }
 }


### PR DESCRIPTION
###### Summary

Enable nullable aware context for `Microsoft.Diagnostics.Monitoring.ConfigurationSchema`.  Just like https://github.com/dotnet/dotnet-monitor/pull/6924 this PR only contains no/low risk changes.

#### Why not use `required`  members?

Throughout this PR (and others in this series) you'll see I initialize option class members with a default value when they are `[Required]` instead of marking them as `required`. This is because in several places we constrain our options with the `new constraint`, meaning they must have a public parameterless constructor. Changing this would be a much larger effort.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
