### PR TITLE
[Nullable Context] Enable on `Microsoft.Diagnostics.Monitoring.Options`

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.Options/AuthenticationOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AuthenticationOptions.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AuthenticationOptions_MonitorApiKey))]
-        public MonitorApiKeyOptions MonitorApiKey { get; set; }
+        public MonitorApiKeyOptions? MonitorApiKey { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AuthenticationOptions_AzureAd))]
-        public AzureAdOptions AzureAd { get; set; }
+        public AzureAdOptions? AzureAd { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptions.cs
@@ -14,29 +14,29 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_Instance))]
         [DefaultValue(AzureAdOptionsDefaults.DefaultInstance)]
-        public Uri Instance { get; set; }
+        public Uri? Instance { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_TenantId))]
         [DefaultValue(AzureAdOptionsDefaults.DefaultTenantId)]
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_ClientId))]
         [Required]
-        public string ClientId { get; set; }
+        public string ClientId { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_AppIdUri))]
-        public Uri AppIdUri { get; set; }
+        public Uri? AppIdUri { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_RequiredRole))]
         [Required]
-        public string RequiredRole { get; set; }
+        public string RequiredRole { get; set; } = string.Empty;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleMetadata.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal class CollectionRuleMetadata
     {
-        public string CollectionRuleName { get; set; } = string.Empty; // JSFIX
+        public string CollectionRuleName { get; set; } = string.Empty;
 
         public int ActionListIndex { get; set; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CollectionRuleMetadata.cs
@@ -5,10 +5,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
     internal class CollectionRuleMetadata
     {
-        public string CollectionRuleName { get; set; }
+        public string CollectionRuleName { get; set; } = string.Empty; // JSFIX
 
         public int ActionListIndex { get; set; }
 
-        public string ActionName { get; set; }
+        public string? ActionName { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Required]
         public string AllowedOrigins { get; set; } = string.Empty;
 
-        public string[] GetOrigins() => AllowedOrigins?.Split(';') ?? [];
+        public string[]? GetOrigins() => AllowedOrigins?.Split(';');
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CorsConfiguration_AllowedOrigins))]
         [Required]
-        public string AllowedOrigins { get; set; }
+        public string AllowedOrigins { get; set; } = string.Empty;
 
-        public string[] GetOrigins() => AllowedOrigins?.Split(';');
+        public string[] GetOrigins() => AllowedOrigins?.Split(';') ?? [];
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/DiagnosticPortOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_DiagnosticPortOptions_EndpointName))]
-        public string EndpointName { get; set; }
+        public string? EndpointName { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Microsoft.Diagnostics.Monitoring.Options/DotnetMonitorDebugOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/DotnetMonitorDebugOptions.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Diagnostics.Monitoring.Options
     /// </summary>
     internal sealed class DotnetMonitorDebugOptions
     {
-        public ExceptionsDebugOptions Exceptions { get; set; }
+        public ExceptionsDebugOptions? Exceptions { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/EgressOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/EgressOptions.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EgressOptions_FileSystem))]
-        public IDictionary<string, FileSystemEgressProviderOptions> FileSystem { get; set; }
+        public IDictionary<string, FileSystemEgressProviderOptions>? FileSystem { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_EgressOptions_Properties))]
-        public IDictionary<string, string> Properties { get; set; }
+        public IDictionary<string, string>? Properties { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsConfiguration.cs
@@ -13,25 +13,28 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         /// Each configuration is a logical OR, so if any of the configurations match, the exception is shown.
         /// </summary>
         [JsonPropertyName("include")]
-        public List<ExceptionFilter> Include { get; set; } = new();
+        public List<ExceptionFilter>? Include { get; set; } = new();
 
         /// <summary>
         /// The list of exception configurations that determine which exceptions should be shown.
         /// Each configuration is a logical OR, so if any of the configurations match, the exception isn't shown.
         /// </summary>
         [JsonPropertyName("exclude")]
-        public List<ExceptionFilter> Exclude { get; set; } = new();
+        public List<ExceptionFilter>? Exclude { get; set; } = new();
     }
 
-    public sealed class ExceptionFilter : IMethodDescription
+    public sealed class ExceptionFilter
     {
         [JsonPropertyName("exceptionType")]
-        public string ExceptionType { get; set; }
+        public string? ExceptionType { get; set; }
 
-        public string ModuleName { get; set; }
+        [JsonPropertyName("moduleName")]
+        public string? ModuleName { get; set; }
 
-        public string TypeName { get; set; }
+        [JsonPropertyName("typeName")]
+        public string? TypeName { get; set; }
 
-        public string MethodName { get; set; }
+        [JsonPropertyName("methodName")]
+        public string? MethodName { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsOptions.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ExceptionsOptions_CollectionFilters))]
-        public ExceptionsConfiguration CollectionFilters { get; set; }
+        public ExceptionsConfiguration? CollectionFilters { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/FileSystemEgressProviderOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/FileSystemEgressProviderOptions.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_FileSystemEgressProviderOptions_DirectoryPath))]
         [Required]
-        public string DirectoryPath { get; set; }
+        public string DirectoryPath { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_FileSystemEgressProviderOptions_IntermediateDirectoryPath))]
-        public string IntermediateDirectoryPath { get; set; }
+        public string? IntermediateDirectoryPath { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/GlobalCounterOptions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_GlobalCounterOptions_Providers))]
-        public System.Collections.Generic.IDictionary<string, GlobalProviderOptions> Providers { get; set; } = new Dictionary<string, GlobalProviderOptions>(StringComparer.OrdinalIgnoreCase);
+        public System.Collections.Generic.IDictionary<string, GlobalProviderOptions>? Providers { get; set; } = new Dictionary<string, GlobalProviderOptions>(StringComparer.OrdinalIgnoreCase);
     }
 
     public class GlobalProviderOptions
@@ -53,15 +53,19 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             var results = new List<ValidationResult>();
-            var providerResults = new List<ValidationResult>();
-            foreach ((string provider, GlobalProviderOptions options) in Providers)
+
+            if (Providers != null)
             {
-                providerResults.Clear();
-                if (!Validator.TryValidateObject(options, new ValidationContext(options), providerResults, true))
+                var providerResults = new List<ValidationResult>();
+                foreach ((string provider, GlobalProviderOptions options) in Providers)
                 {
-                    // We prefix the validation error with the provider.
-                    results.AddRange(providerResults.Select(r => new ValidationResult(
-                        string.Format(CultureInfo.CurrentCulture, OptionsDisplayStrings.ErrorMessage_NestedProviderValidationError, provider, r.ErrorMessage))));
+                    providerResults.Clear();
+                    if (!Validator.TryValidateObject(options, new ValidationContext(options), providerResults, true))
+                    {
+                        // We prefix the validation error with the provider.
+                        results.AddRange(providerResults.Select(r => new ValidationResult(
+                            string.Format(CultureInfo.CurrentCulture, OptionsDisplayStrings.ErrorMessage_NestedProviderValidationError, provider, r.ErrorMessage))));
+                    }
                 }
             }
 
@@ -81,6 +85,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             options.MaxTimeSeries.GetValueOrDefault(GlobalCounterOptionsDefaults.MaxTimeSeries);
 
         public static float GetProviderSpecificInterval(this GlobalCounterOptions options, string providerName) =>
-            options.Providers.TryGetValue(providerName, out GlobalProviderOptions providerOptions) ? providerOptions.IntervalSeconds ?? options.GetIntervalSeconds() : options.GetIntervalSeconds();
+            options.Providers?.TryGetValue(providerName, out GlobalProviderOptions? providerOptions) == true ? providerOptions.IntervalSeconds ?? options.GetIntervalSeconds() : options.GetIntervalSeconds();
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/InProcessFeaturesOptions.cs
@@ -21,17 +21,17 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_InProcessFeaturesOptions_CallStacks))]
-        public CallStacksOptions CallStacks { get; set; }
+        public CallStacksOptions? CallStacks { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_InProcessFeaturesOptions_Exceptions))]
-        public ExceptionsOptions Exceptions { get; set; }
+        public ExceptionsOptions? Exceptions { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_InProcessFeaturesOptions_ParameterCapturing))]
         [Experimental]
-        public ParameterCapturingOptions ParameterCapturing { get; set; }
+        public ParameterCapturingOptions? ParameterCapturing { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_Endpoints))]
-        public string Endpoints { get; set; }
+        public string? Endpoints { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -43,12 +43,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_Providers))]
-        public List<MetricProvider> Providers { get; set; } = new List<MetricProvider>(0);
+        public List<MetricProvider>? Providers { get; set; } = new List<MetricProvider>(0);
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_Meters))]
-        public List<MeterConfiguration> Meters { get; set; } = new List<MeterConfiguration>(0);
+        public List<MeterConfiguration>? Meters { get; set; } = new List<MeterConfiguration>(0);
     }
 
     public class MetricProvider
@@ -57,12 +57,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricProvider_ProviderName))]
         [Required]
-        public string ProviderName { get; set; }
+        public string ProviderName { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricProvider_CounterNames))]
-        public List<string> CounterNames { get; set; } = new List<string>(0);
+        public List<string>? CounterNames { get; set; } = new List<string>(0);
     }
 
     public class MeterConfiguration
@@ -70,11 +70,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MeterConfiguration_MeterName))]
-        public string MeterName { get; set; }
+        public string? MeterName { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MeterConfiguration_InstrumentNames))]
-        public List<string> InstrumentNames { get; set; } = new List<string>(0);
+        public List<string>? InstrumentNames { get; set; } = new List<string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/Microsoft.Diagnostics.Monitoring.Options.csproj
@@ -8,6 +8,7 @@
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsShippingAssembly>true</IsShippingAssembly>
     <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MonitorApiKeyOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MonitorApiKeyOptions.cs
@@ -12,18 +12,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MonitorApiKeyOptions_Subject))]
         [Required]
-        public string Subject { get; set; }
+        public string Subject { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MonitorApiKeyOptions_PublicKey))]
         [RegularExpression("[0-9a-zA-Z_-]+")]
         [Required]
-        public string PublicKey { get; set; }
+        public string PublicKey { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MonitorApiKeyOptions_Issuer))]
-        public string Issuer { get; set; }
+        public string? Issuer { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterOptions_Filters))]
-        public List<ProcessFilterDescriptor> Filters { get; set; } = new List<ProcessFilterDescriptor>(0);
+        public List<ProcessFilterDescriptor>? Filters { get; set; } = new List<ProcessFilterDescriptor>(0);
     }
 
     public sealed partial class ProcessFilterDescriptor
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_Value))]
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
@@ -65,17 +65,17 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_ProcessName))]
-        public string ProcessName { get; set; }
+        public string? ProcessName { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_ProcessId))]
-        public string ProcessId { get; set; }
+        public string? ProcessId { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterDescriptor_CommandLine))]
-        public string CommandLine { get; set; }
+        public string? CommandLine { get; set; }
     }
 
     partial class ProcessFilterDescriptor : IValidatableObject

--- a/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
@@ -11,17 +11,17 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_StorageOptions_DefaultSharedPath))]
-        public string DefaultSharedPath { get; set; }
+        public string? DefaultSharedPath { get; set; }
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_StorageOptions_DumpTempFolder))]
-        public string DumpTempFolder { get; set; }
+        public string? DumpTempFolder { get; set; }
 
         [Experimental]
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_StorageOptions_SharedLibraryPath))]
-        public string SharedLibraryPath { get; set; }
+        public string? SharedLibraryPath { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -500,7 +500,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
                 string? version = Assembly.GetExecutingAssembly().GetInformationalVersionString();
                 string runtimeVersion = Environment.Version.ToString();
                 DiagnosticPortConnectionMode diagnosticPortMode = _diagnosticPortOptions.Value.GetConnectionMode();
-                string diagnosticPortName = GetDiagnosticPortName();
+                string? diagnosticPortName = GetDiagnosticPortName();
 
                 DotnetMonitorInfo dotnetMonitorInfo = new()
                 {
@@ -653,7 +653,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             }, processKey, Utilities.ArtifactType_Stacks);
         }
 
-        private string GetDiagnosticPortName()
+        private string? GetDiagnosticPortName()
         {
             return _diagnosticPortOptions.Value.EndpointName;
         }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return FromConfiguration(options.Filters);
         }
 
-        public static DiagProcessFilter FromConfiguration(IEnumerable<ProcessFilterDescriptor> filters)
+        public static DiagProcessFilter FromConfiguration(IEnumerable<ProcessFilterDescriptor>? filters)
         {
             var filter = new DiagProcessFilter();
-            foreach (ProcessFilterDescriptor processFilter in filters)
+            foreach (ProcessFilterDescriptor processFilter in filters ?? [])
             {
                 filter.Filters.Add(TransformDescriptor(processFilter));
             }
@@ -96,23 +96,24 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 };
             }
 
+            string filterValue = processFilterDescriptor.Value!; // Guarenteed not to be null by ProcessFilterDescriptor.Validate. https://github.com/dotnet/dotnet-monitor/issues/6929.
             switch (processFilterDescriptor.Key)
             {
                 case ProcessFilterKey.ProcessId:
-                    return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = processFilterDescriptor.Value };
+                    return new DiagProcessFilterEntry { Criteria = DiagProcessFilterCriteria.ProcessId, MatchType = DiagProcessFilterMatchType.Exact, Value = filterValue };
                 case ProcessFilterKey.ProcessName:
                     return new DiagProcessFilterEntry
                     {
                         Criteria = DiagProcessFilterCriteria.ProcessName,
                         MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
-                        Value = processFilterDescriptor.Value
+                        Value = filterValue
                     };
                 case ProcessFilterKey.CommandLine:
                     return new DiagProcessFilterEntry
                     {
                         Criteria = DiagProcessFilterCriteria.CommandLine,
                         MatchType = (processFilterDescriptor.MatchType == ProcessFilterType.Exact) ? DiagProcessFilterMatchType.Exact : DiagProcessFilterMatchType.Contains,
-                        Value = processFilterDescriptor.Value
+                        Value = filterValue
                     };
                 default:
                     throw new ArgumentException(

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 };
             }
 
-            string filterValue = processFilterDescriptor.Value!; // Guaranteed not to be null by ProcessFilterDescriptor.Validate. https://github.com/dotnet/dotnet-monitor/issues/6929.
+            string filterValue = processFilterDescriptor.Value!; // Guaranteed not to be null by ProcessFilterDescriptor.Validate.
             switch (processFilterDescriptor.Key)
             {
                 case ProcessFilterKey.ProcessId:

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -39,10 +39,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         public static DiagProcessFilter FromConfiguration(IEnumerable<ProcessFilterDescriptor>? filters)
         {
             var filter = new DiagProcessFilter();
-            foreach (ProcessFilterDescriptor processFilter in filters ?? [])
+            if (filters != null)
             {
-                filter.Filters.Add(TransformDescriptor(processFilter));
+                foreach (ProcessFilterDescriptor processFilter in filters)
+                {
+                    filter.Filters.Add(TransformDescriptor(processFilter));
+                }
             }
+
             return filter;
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 };
             }
 
-            string filterValue = processFilterDescriptor.Value!; // Guarenteed not to be null by ProcessFilterDescriptor.Validate. https://github.com/dotnet/dotnet-monitor/issues/6929.
+            string filterValue = processFilterDescriptor.Value!; // Guaranteed not to be null by ProcessFilterDescriptor.Validate. https://github.com/dotnet/dotnet-monitor/issues/6929.
             switch (processFilterDescriptor.Key)
             {
                 case ProcessFilterKey.ProcessId:

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 throw new ArgumentNullException(nameof(endpointInfo));
             }
 
-            // Guarenteed to not be null by StoragePostConfigureOptions.PostConfigure. https://github.com/dotnet/dotnet-monitor/issues/6929.
+            // Guaranteed to not be null by StoragePostConfigureOptions.PostConfigure. https://github.com/dotnet/dotnet-monitor/issues/6929.
             string dumpTempFolder = _storageOptions.CurrentValue.DumpTempFolder!;
 
             // Ensure folder exists before issue command.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 throw new ArgumentNullException(nameof(endpointInfo));
             }
 
-            // Guaranteed to not be null by StoragePostConfigureOptions.PostConfigure. https://github.com/dotnet/dotnet-monitor/issues/6929.
+            // Guaranteed to not be null by StoragePostConfigureOptions.PostConfigure.
             string dumpTempFolder = _storageOptions.CurrentValue.DumpTempFolder!;
 
             // Ensure folder exists before issue command.

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 throw new ArgumentNullException(nameof(endpointInfo));
             }
 
-            string dumpTempFolder = _storageOptions.CurrentValue.DumpTempFolder;
+            // Guarenteed to not be null by StoragePostConfigureOptions.PostConfigure. https://github.com/dotnet/dotnet-monitor/issues/6929.
+            string dumpTempFolder = _storageOptions.CurrentValue.DumpTempFolder!;
 
             // Ensure folder exists before issue command.
             if (!Directory.Exists(dumpTempFolder))

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
                 return configurationSettings;
             }
 
-            foreach (var filter in configuration.Include)
+            foreach (var filter in configuration.Include ?? [])
             {
                 configurationSettings.Include.Add(ConvertExceptionFilter(filter));
             }
 
-            foreach (var filter in configuration.Exclude)
+            foreach (var filter in configuration.Exclude ?? [])
             {
                 configurationSettings.Exclude.Add(ConvertExceptionFilter(filter));
             }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
@@ -19,14 +19,20 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
                 return configurationSettings;
             }
 
-            foreach (var filter in configuration.Include ?? [])
+            if (configuration.Include != null)
             {
-                configurationSettings.Include.Add(ConvertExceptionFilter(filter));
+                foreach (var filter in configuration.Include)
+                {
+                    configurationSettings.Include.Add(ConvertExceptionFilter(filter));
+                }
             }
 
-            foreach (var filter in configuration.Exclude ?? [])
+            if (configuration.Exclude != null)
             {
-                configurationSettings.Exclude.Add(ConvertExceptionFilter(filter));
+                foreach (var filter in configuration.Exclude)
+                {
+                    configurationSettings.Exclude.Add(ConvertExceptionFilter(filter));
+                }
             }
 
             return configurationSettings;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsSettingsFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private static MetricsPipelineSettings CreateSettings(bool includeDefaults,
             int durationSeconds,
             float counterInterval,
-            IDictionary<string, GlobalProviderOptions> intervalMap,
+            IDictionary<string, GlobalProviderOptions>? intervalMap,
             int maxHistograms,
             int maxTimeSeries,
             Func<List<EventPipeCounterGroup>> createCounterGroups)
@@ -68,12 +68,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 eventPipeCounterGroups.Add(new EventPipeCounterGroup { ProviderName = MonitoringSourceConfiguration.GrpcAspNetCoreServer, Type = CounterGroupType.EventCounter });
             }
 
-            foreach (EventPipeCounterGroup counterGroup in eventPipeCounterGroups)
+            if (intervalMap != null)
             {
-                if (intervalMap.TryGetValue(counterGroup.ProviderName, out GlobalProviderOptions? providerInterval))
+                foreach (EventPipeCounterGroup counterGroup in eventPipeCounterGroups)
                 {
-                    Debug.Assert(counterGroup.IntervalSeconds == null, "Unexpected value for provider interval");
-                    counterGroup.IntervalSeconds = providerInterval.IntervalSeconds;
+                    if (intervalMap.TryGetValue(counterGroup.ProviderName, out GlobalProviderOptions? providerInterval))
+                    {
+                        Debug.Assert(counterGroup.IntervalSeconds == null, "Unexpected value for provider interval");
+                        counterGroup.IntervalSeconds = providerInterval.IntervalSeconds;
+                    }
                 }
             }
 
@@ -87,7 +90,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             };
         }
 
-        private static List<EventPipeCounterGroup> ConvertCounterGroups(IList<MetricProvider> providers, IList<MeterConfiguration> meters)
+        private static List<EventPipeCounterGroup> ConvertCounterGroups(IList<MetricProvider>? providers, IList<MeterConfiguration>? meters)
         {
             List<EventPipeCounterGroup> counterGroups = new();
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ProfilerChannel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ProfilerChannel.cs
@@ -119,8 +119,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private string ComputeChannelPath(IEndpointInfo endpointInfo)
         {
-            string defaultSharedPath = _storageOptions.CurrentValue.DefaultSharedPath;
-            if (string.IsNullOrEmpty(_storageOptions.CurrentValue.DefaultSharedPath))
+            string? defaultSharedPath = _storageOptions.CurrentValue.DefaultSharedPath;
+            if (string.IsNullOrEmpty(defaultSharedPath))
             {
                 //Note this fallback does not work well for sidecar scenarios.
                 defaultSharedPath = Path.GetTempPath();


### PR DESCRIPTION
###### Summary

Enable nullable aware context for `Microsoft.Diagnostics.Monitoring.Options`.  Just like https://github.com/dotnet/dotnet-monitor/pull/6924 this PR only contains no/low risk changes.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
