### PR TITLE
[release/6.x] Use federated connections for storage account

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -130,22 +130,9 @@ jobs:
 
     steps:
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - ${{ if eq(parameters.osGroup, 'Windows') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - ${{ if ne(parameters.osGroup, 'Windows') }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - template: /eng/pipelines/steps/setup-nuget-sources.yml@self
+        parameters:
+          osGroup: ${{ parameters.osGroup }}
 
     - ${{ each step in parameters.preBuildSteps }}:
       - ${{ step }}

--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -106,10 +106,9 @@ jobs:
       - _CrossBuildArgs: '-cross'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      - group: DotNet-MSRC-Storage
       - _InternalInstallArgs: >-
-          -RuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet
-          -RuntimeSourceFeedKey $(dotnetclimsrc-read-sas-token-base64)
+          -RuntimeSourceFeed https://dotnetbuilds.blob.core.windows.net/internal
+          -RuntimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - _InternalBuildArgs: >-
@@ -150,6 +149,9 @@ jobs:
 
     - ${{ each step in parameters.preBuildSteps }}:
       - ${{ step }}
+
+    # Populate internal runtime access variables
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
     - script: >-
         $(Build.SourcesDirectory)/eng/cibuild$(scriptExt)

--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -31,6 +31,8 @@ jobs:
       inputs:
         artifactName: 'THIRD-PARTY-NOTICES'
         targetPath: '$(Build.SourcesDirectory)'
+    # Populate internal runtime access variables
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
     - script: >-
         $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
         /p:TeamName=$(_TeamName)

--- a/eng/pipelines/jobs/sign-binaries.yml
+++ b/eng/pipelines/jobs/sign-binaries.yml
@@ -23,6 +23,9 @@ jobs:
         artifactName: Build_Published_${{ parameters.configuration }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
 
+    # Populate internal runtime access variables
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+
     - script: >-
         $(Build.SourcesDirectory)/restore.cmd
         -configuration ${{ parameters.configuration }}

--- a/eng/pipelines/jobs/tpn.yml
+++ b/eng/pipelines/jobs/tpn.yml
@@ -5,10 +5,25 @@ jobs:
     displayName: Generate TPN
     disableComponentGovernance: true
     enableSbom: false
+    variables:
+    - _InternalInstallArgs: ''
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - _InternalInstallArgs: >-
+          /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+          /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
     steps:
-    # Only restore the dotnet-monitor project so only packages we ship get included in the below CG scan
+    - template: /eng/pipelines/steps/setup-nuget-sources.yml@self
+      parameters:
+        osGroup: Windows
+
+    # Populate internal runtime access variables
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+
+    # Only restore the projects that are shipped so only packages we ship get included in the below CG scan
     - script: >-
-        $(Build.SourcesDirectory)/restore.cmd -ci -projects $(Build.SourcesDirectory)/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+        $(Build.SourcesDirectory)/restore.cmd -ci
+        -projects $(Build.SourcesDirectory)/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+        $(_InternalInstallArgs)
       displayName: Restore dotnet-monitor tool packages
 
     - task: ComponentGovernanceComponentDetection@0

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -20,7 +20,6 @@ stages:
       - group: DotNet-Diagnostics-Storage
       - group: DotNet-DotNetStage-Storage
       - group: Release-Pipeline
-      - group: DotNetBuilds storage account read tokens
     steps:
     - task: UseDotNet@2
       displayName: 'Use .NET 6'
@@ -48,6 +47,28 @@ stages:
             -BarId $(BARBuildId)
             -MaestroToken $(MaestroAccessToken)
             -TaskVariableName 'BuildVersion'
+
+      # Populate dotnetbuilds-internal-container-read-token
+      - template: /eng/common/templates-official/steps/get-delegation-sas.yml
+        parameters:
+          federatedServiceConnection: 'dotnetbuilds-internal-read'
+          outputVariableName: 'dotnetbuilds-internal-checksums-container-read-token'
+          expiryInHours: 1
+          base64Encode: false
+          storageAccount: dotnetbuilds
+          container: internal-checksums
+          permissions: rl
+
+      # Populate dotnetbuilds-internal-container-read-token
+      - template: /eng/common/templates-official/steps/get-delegation-sas.yml
+        parameters:
+          federatedServiceConnection: 'dotnetbuilds-internal-read'
+          outputVariableName: 'dotnetbuilds-internal-container-read-token'
+          expiryInHours: 1
+          base64Encode: false
+          storageAccount: dotnetbuilds
+          container: internal
+          permissions: rl
 
       - task: AzureCLI@2
         displayName: 'Download Build Assets'

--- a/eng/pipelines/steps/setup-nuget-sources.yml
+++ b/eng/pipelines/steps/setup-nuget-sources.yml
@@ -1,0 +1,21 @@
+parameters:
+# Operating system group (Windows, Linux, MacOS, etc)
+  osGroup: Windows
+
+steps:
+- ${{ if eq(parameters.osGroup, 'Windows') }}:
+  - task: PowerShell@2
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+- ${{ else }}:
+  - task: Bash@3
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)


### PR DESCRIPTION
###### Summary

Manual backport of #6892 to release/6.x; conflicts were for the compliance pipeline (which doesn't exist in release/6.x), the build.yml job around the runtime source feed information being updated, and the tpn.yml job around the runtime source feed information. I've also included setup-nuget-sources.yml to allow for better incorporation with this backported change as well as future backports that will likely occur in this area.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
