### PR TITLE
[Nullable Context] Standardize optional arrays in schema

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -513,10 +513,7 @@
       ],
       "properties": {
         "Filters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "Process filters used to determine to which process(es) the collection rule is applied. All filters must match. If no filters are specified, the rule is applied to all discovered processes.",
           "items": {
             "$ref": "#/definitions/ProcessFilterDescriptor"
@@ -531,10 +528,7 @@
           ]
         },
         "Actions": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "The list of actions to be executed when the trigger raises its notification.",
           "items": {
             "$ref": "#/definitions/CollectionRuleActionOptions"
@@ -1130,20 +1124,14 @@
       "additionalProperties": false,
       "properties": {
         "Include": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "The list of exception configurations that determine which exceptions should be shown.\nEach configuration is a logical OR, so if any of the configurations match, the exception is shown.",
           "items": {
             "$ref": "#/definitions/ExceptionFilter"
           }
         },
         "Exclude": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "The list of exception configurations that determine which exceptions should be shown.\nEach configuration is a logical OR, so if any of the configurations match, the exception isn't shown.",
           "items": {
             "$ref": "#/definitions/ExceptionFilter"
@@ -1384,20 +1372,14 @@
           "default": true
         },
         "Providers": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "Providers for custom metrics.",
           "items": {
             "$ref": "#/definitions/MetricProvider"
           }
         },
         "Meters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "Names of meters to collect from the System.Diagnostics.Metrics provider.",
           "items": {
             "$ref": "#/definitions/MeterConfiguration"
@@ -1418,10 +1400,7 @@
           "minLength": 1
         },
         "CounterNames": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "Name of custom metrics counters.",
           "items": {
             "type": "string"
@@ -1441,10 +1420,7 @@
           "description": "Name of the custom meter."
         },
         "InstrumentNames": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "Names of the custom instruments.",
           "items": {
             "type": "string"
@@ -1484,10 +1460,7 @@
       "additionalProperties": false,
       "properties": {
         "Filters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "Process filters used to determine which process to use if one is not explicitly specified. All filters must match.",
           "items": {
             "$ref": "#/definitions/ProcessFilterDescriptor"

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsConfiguration.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Diagnostics.Monitoring.Options
         /// Each configuration is a logical OR, so if any of the configurations match, the exception is shown.
         /// </summary>
         [JsonPropertyName("include")]
-        public List<ExceptionFilter>? Include { get; set; } = new();
+        public List<ExceptionFilter> Include { get; set; } = [];
 
         /// <summary>
         /// The list of exception configurations that determine which exceptions should be shown.
         /// Each configuration is a logical OR, so if any of the configurations match, the exception isn't shown.
         /// </summary>
         [JsonPropertyName("exclude")]
-        public List<ExceptionFilter>? Exclude { get; set; } = new();
+        public List<ExceptionFilter> Exclude { get; set; } = [];
     }
 
     public sealed class ExceptionFilter

--- a/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/MetricsOptions.cs
@@ -43,12 +43,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_Providers))]
-        public List<MetricProvider>? Providers { get; set; } = new List<MetricProvider>(0);
+        public List<MetricProvider> Providers { get; set; } = [];
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricsOptions_Meters))]
-        public List<MeterConfiguration>? Meters { get; set; } = new List<MeterConfiguration>(0);
+        public List<MeterConfiguration> Meters { get; set; } = [];
     }
 
     public class MetricProvider
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MetricProvider_CounterNames))]
-        public List<string>? CounterNames { get; set; } = new List<string>(0);
+        public List<string> CounterNames { get; set; } = [];
     }
 
     public class MeterConfiguration
@@ -75,6 +75,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_MeterConfiguration_InstrumentNames))]
-        public List<string>? InstrumentNames { get; set; } = new List<string>(0);
+        public List<string> InstrumentNames { get; set; } = [];
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ProcessFilterOptions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_ProcessFilterOptions_Filters))]
-        public List<ProcessFilterDescriptor>? Filters { get; set; } = new List<ProcessFilterDescriptor>(0);
+        public List<ProcessFilterDescriptor> Filters { get; set; } = [];
     }
 
     public sealed partial class ProcessFilterDescriptor

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
@@ -19,20 +19,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
                 return configurationSettings;
             }
 
-            if (configuration.Include != null)
+            foreach (var filter in configuration.Include)
             {
-                foreach (var filter in configuration.Include)
-                {
-                    configurationSettings.Include.Add(ConvertExceptionFilter(filter));
-                }
+                configurationSettings.Include.Add(ConvertExceptionFilter(filter));
             }
 
-            if (configuration.Exclude != null)
+            foreach (var filter in configuration.Exclude)
             {
-                foreach (var filter in configuration.Exclude)
-                {
-                    configurationSettings.Exclude.Add(ConvertExceptionFilter(filter));
-                }
+                configurationSettings.Exclude.Add(ConvertExceptionFilter(filter));
             }
 
             return configurationSettings;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Filters))]
-        public List<ProcessFilterDescriptor>? Filters { get; } = new List<ProcessFilterDescriptor>(0);
+        public List<ProcessFilterDescriptor> Filters { get; set; } = [];
 
 #nullable disable
         [Display(
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CollectionRuleOptions_Actions))]
-        public List<CollectionRuleActionOptions>? Actions { get; } = new List<CollectionRuleActionOptions>(0);
+        public List<CollectionRuleActionOptions> Actions { get; set; } = [];
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),


### PR DESCRIPTION
###### Summary

Now that we have nullable contexts enabled for our schema, we can fix an issue where we were reporting optional lists could be set as a null. 

This PR standardizes **all** of our optional Lists to default to an empty collection and not be nullable and also have setters (we rely on these setters quite a bit in our tests).


Partial fix for #6929 
Additional ref: https://github.com/dotnet/dotnet-monitor/pull/6932/files#r1663237955

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
