### PR TITLE
[Nullable Context] Enable on `dotnet-monitor`

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/CorsConfigurationOptions.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         [Required]
         public string AllowedOrigins { get; set; } = string.Empty;
 
-        public string[]? GetOrigins() => AllowedOrigins?.Split(';');
+        public string[] GetOrigins() => AllowedOrigins.Split(';');
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsDebugOptionsExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/ExceptionsDebugOptionsExtensions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Diagnostics.Monitoring.Options
 {
     internal static class ExceptionsDebugOptionsExtensions
     {
-        public static bool GetIncludeMonitorExceptions(this ExceptionsDebugOptions options)
+        public static bool GetIncludeMonitorExceptions(this ExceptionsDebugOptions? options)
         {
             return (options?.IncludeMonitorExceptions).GetValueOrDefault(ExceptionsDebugOptionsDefaults.IncludeMonitorExceptions);
         }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Controllers/DiagController.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
         [HttpGet("collectionrules/{collectionRuleName}", Name = nameof(GetCollectionRuleDetailedDescription))]
         [ProducesWithProblemDetails(ContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(CollectionRuleDetailedDescription), StatusCodes.Status200OK)]
-        public Task<ActionResult<CollectionRuleDetailedDescription>> GetCollectionRuleDetailedDescription(
+        public Task<ActionResult<CollectionRuleDetailedDescription?>> GetCollectionRuleDetailedDescription(
             string collectionRuleName,
             [FromQuery]
             int? pid = null,
@@ -556,7 +556,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Controllers
             [FromQuery]
             string? name = null)
         {
-            return InvokeForProcess<CollectionRuleDetailedDescription>(processInfo =>
+            return InvokeForProcess<CollectionRuleDetailedDescription?>(processInfo =>
             {
                 return _collectionRuleService.GetCollectionRuleDetailedDescription(collectionRuleName, processInfo.EndpointInfo);
             },

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DiagProcessFilter.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return false;
         }
 
-        private bool Compare(string value)
+        private bool Compare(string? value)
         {
             if (MatchType == DiagProcessFilterMatchType.Exact)
             {
@@ -174,12 +174,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             return false;
         }
 
-        private bool ExactCompare(string value)
+        private bool ExactCompare(string? value)
         {
             return string.Equals(Value, value, StringComparison.OrdinalIgnoreCase);
         }
 
-        private bool ContainsCompare(string value)
+        private bool ContainsCompare(string? value)
         {
             return value?.IndexOf(Value, StringComparison.OrdinalIgnoreCase) > -1;
         }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionInstance.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
 {
-    internal record class ExceptionInstance(ulong Id, string TypeName, string ModuleName, string Message, DateTime Timestamp, CallStack CallStack, ulong[] InnerExceptionIds, string ActivityId, ActivityIdFormat ActivityIdFormat)
+    internal record class ExceptionInstance(ulong Id, string TypeName, string ModuleName, string Message, DateTime Timestamp, CallStack? CallStack, ulong[] InnerExceptionIds, string ActivityId, ActivityIdFormat ActivityIdFormat)
         : IExceptionInstance
     {
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Exceptions/ExceptionsSettingsFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Exceptions
     /// </summary>
     internal static class ExceptionsSettingsFactory
     {
-        public static ExceptionsConfigurationSettings ConvertExceptionsConfiguration(ExceptionsConfiguration configuration)
+        public static ExceptionsConfigurationSettings ConvertExceptionsConfiguration(ExceptionsConfiguration? configuration)
         {
             ExceptionsConfigurationSettings configurationSettings = new();
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ICollectionRuleService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ICollectionRuleService.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         Dictionary<string, CollectionRuleDescription> GetCollectionRulesDescriptions(IEndpointInfo endpointInfo);
 
-        CollectionRuleDetailedDescription GetCollectionRuleDetailedDescription(string collectionRuleName, IEndpointInfo endpointInfo);
+        CollectionRuleDetailedDescription? GetCollectionRuleDetailedDescription(string collectionRuleName, IEndpointInfo endpointInfo);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/IDiagnosticServices.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
     {
         IEndpointInfo EndpointInfo { get; }
 
-        string CommandLine { get; }
+        string? CommandLine { get; }
 
-        public string OperatingSystem { get; }
+        public string? OperatingSystem { get; }
 
-        public string ProcessArchitecture { get; }
+        public string? ProcessArchitecture { get; }
 
         string ProcessName { get; }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ITraceOperationFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ITraceOperationFactory.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             TimeSpan duration,
             string providerName,
             string eventName,
-            IDictionary<string, string> payloadFilter);
+            IDictionary<string, string>? payloadFilter);
     }
 }

--- a/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
+++ b/src/Tests/CollectionRuleActions.UnitTests/ActionListExecutorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Moq;
 using System;
 using System.Reflection;
 using System.Threading;
@@ -29,6 +30,16 @@ namespace CollectionRuleActions.UnitTests
         private readonly ITestOutputHelper _outputHelper;
 
         private const string DefaultRuleName = nameof(ActionListExecutorTests);
+
+        private static Microsoft.Diagnostics.Monitoring.WebApi.IProcessInfo CreateTestProcess()
+        {
+            Mock<Microsoft.Diagnostics.Monitoring.WebApi.IProcessInfo> mockProcessInfo = new();
+            mockProcessInfo
+                .Setup(p => p.EndpointInfo)
+                .Returns(Mock.Of<Microsoft.Diagnostics.Monitoring.WebApi.IEndpointInfo>);
+
+            return mockProcessInfo.Object;
+        }
 
         public ActionListExecutorTests(ITestOutputHelper outputHelper)
         {
@@ -54,7 +65,7 @@ namespace CollectionRuleActions.UnitTests
                 ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
                 TimeProvider timeProvider = host.Services.GetRequiredService<TimeProvider>();
 
-                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, timeProvider);
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, CreateTestProcess(), logger, timeProvider);
 
                 int callbackCount = 0;
                 Action startCallback = () => callbackCount++;
@@ -95,7 +106,7 @@ namespace CollectionRuleActions.UnitTests
                 ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
                 TimeProvider timeProvider = host.Services.GetRequiredService<TimeProvider>();
 
-                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, timeProvider);
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, CreateTestProcess(), logger, timeProvider);
 
                 int callbackCount = 0;
                 Action startCallback = () => callbackCount++;
@@ -141,7 +152,7 @@ namespace CollectionRuleActions.UnitTests
                 ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
                 TimeProvider timeProvider = host.Services.GetRequiredService<TimeProvider>();
 
-                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, timeProvider);
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, CreateTestProcess(), logger, timeProvider);
 
                 int callbackCount = 0;
                 Action startCallback = () => callbackCount++;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="..\..\Tools\dotnet-monitor\LoggingEventIds.cs" Link="LoggingEventIds.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\OutputFormat.cs" Link="Options\OutputFormat.cs" />
     <Compile Include="..\..\Tools\dotnet-monitor\RootOptions.cs" Link="Options\RootOptions.cs" />
+    <Compile Include="..\..\Tools\dotnet-monitor\ConvertUtils.cs" Link="ConvertUtils.cs" />
     <Compile Include="..\Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon\ExecuteActionTestHelper.cs" Link="ExecuteActionTestHelper.cs" />
     <Compile Include="..\Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon\Options\CollectionRuleOptionsExtensions.cs" Link="Options\CollectionRuleOptionsExtensions.cs" />
   </ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ActionDependencyAnalyzerTests.cs
@@ -107,7 +107,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
                 TimeProvider timeProvider = host.Services.GetRequiredService<TimeProvider>();
 
-                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, timeProvider);
+                Guid instanceId = Guid.NewGuid();
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, new TestProcessInfo(instanceId), logger, timeProvider);
 
                 int callbackCount = 0;
                 Action startCallback = () => callbackCount++;
@@ -200,7 +201,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
                 ILogger<CollectionRuleService> logger = host.Services.GetRequiredService<ILogger<CollectionRuleService>>();
                 TimeProvider timeProvider = host.Services.GetRequiredService<TimeProvider>();
 
-                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, null, logger, timeProvider);
+                Guid instanceId = Guid.NewGuid();
+                CollectionRuleContext context = new(DefaultRuleName, ruleOptions, new TestProcessInfo(instanceId), logger, timeProvider);
 
                 ActionOptionsDependencyAnalyzer analyzer = ActionOptionsDependencyAnalyzer.Create(context);
                 analyzer.GetActionDependencies(1);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/EgressExtensibilityTests.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             HostBuilderSettings settings = new()
             {
                 SharedConfigDirectory = sharedConfigDir.FullName,
-                UserConfigDirectory = userConfigDir.FullName
+                UserConfigDirectory = userConfigDir.FullName,
+                ContentRootDirectory = AppContext.BaseDirectory
             };
 
             IHost host = TestHostHelper.CreateHost(_outputHelper, rootOptions => { }, host => { }, settings: settings);
@@ -61,7 +62,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             HostBuilderSettings settings = new()
             {
                 SharedConfigDirectory = sharedConfigDir.FullName,
-                UserConfigDirectory = userConfigDir.FullName
+                UserConfigDirectory = userConfigDir.FullName,
+                ContentRootDirectory = AppContext.BaseDirectory
             };
 
             IEgressExtension extension = FindEgressExtension(configDirectory, settings);
@@ -96,7 +98,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             HostBuilderSettings settings = new()
             {
                 SharedConfigDirectory = sharedConfigDir.FullName,
-                UserConfigDirectory = userConfigDir.FullName
+                UserConfigDirectory = userConfigDir.FullName,
+                ContentRootDirectory = AppContext.BaseDirectory
             };
 
             EgressExtension extension = (EgressExtension)FindEgressExtension(ConfigDirectory.UserConfigDirectory, settings);

--- a/src/Tools/dotnet-monitor/ActivityExtensions.cs
+++ b/src/Tools/dotnet-monitor/ActivityExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ActivityExtensions
     {
-        public static string GetSpanId(this Activity activity)
+        public static string? GetSpanId(this Activity activity)
         {
             switch (activity.IdFormat)
             {
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return string.Empty;
         }
 
-        public static string GetParentId(this Activity activity)
+        public static string? GetParentId(this Activity activity)
         {
             switch (activity.IdFormat)
             {
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return string.Empty;
         }
 
-        public static string GetTraceId(this Activity activity)
+        public static string? GetTraceId(this Activity activity)
         {
             switch (activity.IdFormat)
             {

--- a/src/Tools/dotnet-monitor/AddressListenResults.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResults.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         /// </summary>
         private bool Listen(KestrelServerOptions options, string url, bool isAuthEnabled)
         {
-            BindingAddress address = null;
+            BindingAddress? address = null;
             try
             {
                 address = BindingAddress.Parse(url);
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     options.ListenLocalhost(address.Port, configureListenOptions);
                 }
-                else if (IPAddress.TryParse(address.Host, out IPAddress ipAddress))
+                else if (IPAddress.TryParse(address.Host, out IPAddress? ipAddress))
                 {
                     options.Listen(ipAddress, address.Port, configureListenOptions);
                 }

--- a/src/Tools/dotnet-monitor/AddressListenResultsStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/AddressListenResultsStartupLogger.cs
@@ -29,9 +29,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _logger = logger;
             _server = server;
 
+#nullable disable
             _applicationStartedRegistration = lifetime.ApplicationStarted.Register(
                 l => ((AddressListenResultsStartupLogger)l).OnStarted(),
                 this);
+#nullable restore
         }
 
         public void Dispose()
@@ -52,6 +54,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
+#nullable disable
         private void OnStarted()
         {
             IServerAddressesFeature serverAddresses = _server.Features.Get<IServerAddressesFeature>();
@@ -69,5 +72,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 _logger.BoundMetricsAddress(metricAddress);
             }
         }
+#nullable restore
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerChangeTokenSource.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
         IDisposable
     {
         private readonly IOptionsMonitor<MonitorApiKeyConfiguration> _optionsMonitor;
-        private readonly IDisposable _changeRegistration;
+        private readonly IDisposable? _changeRegistration;
 
         private ConfigurationReloadToken _reloadToken = new ConfigurationReloadToken();
 
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 
         public void Dispose()
         {
-            _changeRegistration.Dispose();
+            _changeRegistration?.Dispose();
         }
 
         private void OnReload(MonitorApiKeyConfiguration options)

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/JwtBearerPostConfigure.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
             _apiKeyConfig = apiKeyConfig;
         }
 
-        public void PostConfigure(string name, JwtBearerOptions options)
+        public void PostConfigure(string? name, JwtBearerOptions options)
         {
             MonitorApiKeyConfiguration configSnapshot = _apiKeyConfig.CurrentValue;
-            if (!configSnapshot.Configured || configSnapshot.ValidationErrors.Any())
+            if (!configSnapshot.Configured || configSnapshot.ValidationErrors?.Any() == true)
             {
 #if NET8_0_OR_GREATER
                 // https://github.com/aspnet/Announcements/issues/508
@@ -37,7 +37,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
                 return;
             }
 
+#nullable disable
             options.ConfigureApiKeyTokenValidation(configSnapshot.PublicKey, configSnapshot.Issuer);
+#nullable restore
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyAuthConfigurator.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyAuthConfigurator.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 {
     internal sealed class MonitorApiKeyAuthConfigurator : IAuthenticationConfigurator
     {
-        private readonly GeneratedJwtKey _pinnedJwtKey;
+        private readonly GeneratedJwtKey? _pinnedJwtKey;
         private readonly bool _enableNegotiation;
 
 
-        public MonitorApiKeyAuthConfigurator(GeneratedJwtKey pinnedJwtKey = null)
+        public MonitorApiKeyAuthConfigurator(GeneratedJwtKey? pinnedJwtKey = null)
         {
             _pinnedJwtKey = pinnedJwtKey;
 

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyChangeTokenSource.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyChangeTokenSource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
         IDisposable
     {
         private readonly IOptionsMonitor<MonitorApiKeyOptions> _optionsMonitor;
-        private readonly IDisposable _changeRegistration;
+        private readonly IDisposable? _changeRegistration;
 
         private ConfigurationReloadToken _reloadToken = new ConfigurationReloadToken();
 
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 
         public void Dispose()
         {
-            _changeRegistration.Dispose();
+            _changeRegistration?.Dispose();
         }
 
         private void OnReload(MonitorApiKeyOptions options)

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyConfiguration.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyConfiguration.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
     internal class MonitorApiKeyConfiguration : AuthenticationSchemeOptions
     {
         public bool Configured { get; set; }
-        public string Subject { get; set; }
-        public SecurityKey PublicKey { get; set; }
-        public IEnumerable<ValidationResult> ValidationErrors { get; set; }
-        public string Issuer { get; set; }
+        public string? Subject { get; set; }
+        public SecurityKey? PublicKey { get; set; }
+        public IEnumerable<ValidationResult>? ValidationErrors { get; set; }
+        public string? Issuer { get; set; }
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyConfigurationObserver.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyConfigurationObserver.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
         private readonly ILogger<MonitorApiKeyConfigurationObserver> _logger;
         private readonly IOptionsMonitor<MonitorApiKeyConfiguration> _options;
 
-        private IDisposable _changeRegistration;
+        private IDisposable? _changeRegistration;
 
         public MonitorApiKeyConfigurationObserver(
             ILogger<MonitorApiKeyConfigurationObserver> logger,

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyPostConfigure.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/MonitorApiKeyPostConfigure.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
             _apiKeyOptions = apiKeyOptions;
         }
 
-        public void PostConfigure(string name, MonitorApiKeyConfiguration options)
+        public void PostConfigure(string? name, MonitorApiKeyConfiguration options)
         {
             MonitorApiKeyOptions sourceOptions = _apiKeyOptions.CurrentValue;
 
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
                 errors,
                 validateAllProperties: true);
 
-            string jwkJson = null;
+            string? jwkJson = null;
             try
             {
                 jwkJson = Base64UrlEncoder.Decode(sourceOptions.PublicKey);
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
                         new string[] { nameof(MonitorApiKeyOptions.PublicKey) }));
             }
 
-            JsonWebKey jwk = null;
+            JsonWebKey? jwk = null;
             if (!string.IsNullOrEmpty(jwkJson))
             {
                 try

--- a/src/Tools/dotnet-monitor/Auth/ApiKey/RejectAllSecurityValidator.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKey/RejectAllSecurityValidator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.ApiKey
 
         public bool CanReadToken(string securityToken) => true;
 
-        public ClaimsPrincipal ValidateToken(string securityToken, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
+        public ClaimsPrincipal ValidateToken(string securityToken, TokenValidationParameters validationParameters, out SecurityToken? validatedToken)
         {
             validatedToken = null;
             throw new InvalidOperationException(Strings.ErrorMessage_ApiKeyNotConfigured);

--- a/src/Tools/dotnet-monitor/Auth/AuthConfiguratorFactory.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthConfiguratorFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth
                     return new NoAuthConfigurator();
 
                 case StartupAuthenticationMode.TemporaryKey:
-                    if (context.Properties.TryGetValue(typeof(GeneratedJwtKey), out object generatedJwtKeyObject))
+                    if (context.Properties.TryGetValue(typeof(GeneratedJwtKey), out object? generatedJwtKeyObject))
                     {
                         if (generatedJwtKeyObject is GeneratedJwtKey generatedJwtKey)
                         {
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth
             }
         }
 
-        private static void ValidateAuthConfigSection<T>(T options, string configurationPath)
+        private static void ValidateAuthConfigSection<T>(T options, string configurationPath) where T : notnull
         {
             List<ValidationResult> results = new();
             if (!Validator.TryValidateObject(options, new ValidationContext(options), results, validateAllProperties: true))

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionListExecutor.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 {
                     KeyValueLogScope actionScope = new();
                     actionScope.AddCollectionRuleAction(actionOption.Type, actionIndex);
-                    using IDisposable actionScopeRegistration = _logger.BeginScope(actionScope);
+                    using IDisposable? actionScopeRegistration = _logger.BeginScope(actionScope);
 
                     _logger.CollectionRuleActionStarted(context.Name, actionOption.Type);
 
@@ -91,8 +91,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                                 ));
                         }
 
-                        object newSettings = dependencyAnalyzer.SubstituteOptionValues(actionResults, actionIndex, actionOption.Settings);
-                        ICollectionRuleAction action = factory.Create(context.ProcessInfo, newSettings);
+                        object? newSettings = dependencyAnalyzer.SubstituteOptionValues(actionResults, actionIndex, actionOption.Settings);
+                        ICollectionRuleAction? action = factory.Create(context.ProcessInfo, newSettings);
 
                         try
                         {
@@ -158,7 +158,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         }
 
         private async Task WaitForCompletion(CollectionRuleContext context,
-            Action startCallback,
+            Action? startCallback,
             IDictionary<string, CollectionRuleActionResult> allResults,
             ICollectionRuleAction action,
             CollectionRuleActionOptions actionOption,
@@ -178,7 +178,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         }
 
         private async Task WaitForCompletion(CollectionRuleContext context,
-            Action startCallback,
+            Action? startCallback,
             IDictionary<string, CollectionRuleActionResult> allResults,
             ActionCompletionEntry entry,
             CancellationToken cancellationToken)

--- a/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/ActionOptionsDependencyAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -35,7 +36,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         private readonly ConfigurationTokenParser _tokenParser;
 
         //Use action index instead of name, since it's possible for an unnamed action to have named dependencies.
+#nullable disable
         private Dictionary<int, Dictionary<string, PropertyDependency>> _dependencies;
+#nullable restore
 
         private sealed class PropertyDependency
         {
@@ -87,6 +90,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             _tokenParser = tokenParser ?? throw new ArgumentNullException(nameof(tokenParser));
         }
 
+#nullable disable
         public IList<CollectionRuleActionOptions> GetActionDependencies(int actionIndex)
         {
             if (_dependencies.TryGetValue(actionIndex, out Dictionary<string, PropertyDependency> properties))
@@ -106,19 +110,21 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             }
             return Array.Empty<CollectionRuleActionOptions>();
         }
+#nullable restore
 
-        public object SubstituteOptionValues(IDictionary<string, CollectionRuleActionResult> actionResults, int actionIndex, object settings)
+        public object? SubstituteOptionValues(IDictionary<string, CollectionRuleActionResult> actionResults, int actionIndex, object? settings)
         {
             //Attempt to substitute context properties.
-            object originalSettings = settings;
+            object? originalSettings = settings;
 
-            if (_dependencies.TryGetValue(actionIndex, out Dictionary<string, PropertyDependency> properties) && (properties.Count > 0))
+            if (_dependencies.TryGetValue(actionIndex, out Dictionary<string, PropertyDependency>? properties) && (properties.Count > 0))
             {
                 if (!_tokenParser.TryCloneSettings(originalSettings, ref settings))
                 {
                     return settings;
                 }
 
+#nullable disable
                 foreach ((_, PropertyDependency property) in properties)
                 {
                     StringBuilder builder = property.ActionDependencies.Any() ? new() : null;
@@ -150,16 +156,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                         property.Property.SetValue(settings, builder.ToString());
                     }
                 }
+#nullable restore
             }
-            string commandLine = _ruleContext.EndpointInfo?.CommandLine ?? string.Empty;
+            string? commandLine = _ruleContext.EndpointInfo.CommandLine;
 
             settings = _tokenParser.SubstituteOptionValues(settings, new TokenContext
             {
                 CloneOnSubstitution = ReferenceEquals(originalSettings, settings),
-                RuntimeId = _ruleContext.EndpointInfo?.RuntimeInstanceCookie ?? Guid.Empty,
-                ProcessId = _ruleContext.EndpointInfo?.ProcessId ?? 0,
-                CommandLine = commandLine,
-                ProcessName = _ruleContext.ProcessInfo?.ProcessName ?? string.Empty
+                RuntimeId = _ruleContext.EndpointInfo.RuntimeInstanceCookie,
+                ProcessId = _ruleContext.EndpointInfo.ProcessId,
+                CommandLine = commandLine ?? string.Empty,
+                ProcessName = _ruleContext.ProcessInfo.ProcessName ?? string.Empty
             });
 
             return settings;
@@ -167,6 +174,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
 
 
+#nullable disable
         private void EnsureDependencies()
         {
             if (_dependencies == null)
@@ -179,22 +187,23 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
                 }
             }
         }
+#nullable restore
 
         private void EnsureDependencies(CollectionRuleActionOptions options, int actionIndex)
         {
             foreach (PropertyInfo property in GetDependencyPropertiesFromSettings(options))
             {
-                string originalValue = (string)property.GetValue(options.Settings);
-                string newValue = originalValue;
+                string? originalValue = (string?)property.GetValue(options.Settings);
                 if (string.IsNullOrEmpty(originalValue))
                 {
                     continue;
                 }
+                string newValue = originalValue;
 
                 int foundIndex;
                 int startIndex = 0;
 
-                PropertyDependency propertyDependency = null;
+                PropertyDependency? propertyDependency = null;
 
                 while ((foundIndex = newValue.IndexOf(ActionReferencePrefix, startIndex, StringComparison.OrdinalIgnoreCase)) >= 0)
                 {
@@ -208,7 +217,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
                     string actionAndResult = newValue[(foundIndex + ActionReferencePrefix.Length)..suffixIndex];
 
-                    if (!GetActionResultReference(actionAndResult, actionIndex, out CollectionRuleActionOptions dependencyOptions, out string actionResultName))
+                    if (!GetActionResultReference(actionAndResult, actionIndex, out CollectionRuleActionOptions? dependencyOptions, out string? actionResultName))
                     {
                         continue;
                     }
@@ -223,12 +232,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         private PropertyDependency GetOrCreateDependency(int actionIndex, PropertyInfo propertyInfo, string originalValue)
         {
-            if (!_dependencies.TryGetValue(actionIndex, out Dictionary<string, PropertyDependency> properties))
+            if (!_dependencies.TryGetValue(actionIndex, out Dictionary<string, PropertyDependency>? properties))
             {
                 properties = new Dictionary<string, PropertyDependency>(StringComparer.Ordinal);
                 _dependencies.Add(actionIndex, properties);
             }
-            if (!properties.TryGetValue(propertyInfo.Name, out PropertyDependency dependency))
+            if (!properties.TryGetValue(propertyInfo.Name, out PropertyDependency? dependency))
             {
                 dependency = new PropertyDependency(propertyInfo, originalValue);
                 properties.Add(propertyInfo.Name, dependency);
@@ -237,7 +246,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         }
 
         private bool GetActionResultReference(string actionReference, int actionIndex,
-            out CollectionRuleActionOptions action, out string actionResultName)
+            [NotNullWhen(true)] out CollectionRuleActionOptions? action, [NotNullWhen(true)] out string? actionResultName)
         {
             action = null;
             actionResultName = null;
@@ -257,7 +266,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             }
 
             //We only check previous actions for our dependencies.
-            CollectionRuleActionOptions dependencyOptions = _ruleContext.Options.Actions.Take(actionIndex)
+            CollectionRuleActionOptions? dependencyOptions = _ruleContext.Options.Actions?.Take(actionIndex)
                 .FirstOrDefault(a => string.Equals(a.Name, name, StringComparison.Ordinal));
 
             if (dependencyOptions == null)

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectDumpAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectDumpAction.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 _dumpOperationFactory = serviceProvider.GetRequiredService<IDumpOperationFactory>();
             }
 
-            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
             {
                 DumpType dumpType = Options.Type.GetValueOrDefault(CollectDumpOptionsDefaults.Type);
                 string egressProvider = Options.Egress;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectExceptionsAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectExceptionsAction.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _operationFactory = ServiceProvider.GetRequiredService<IExceptionsOperationFactory>();
         }
 
-        protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+        protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
         {
             KeyValueLogScope scope = Utils.CreateArtifactScope(Utils.ArtifactType_Exceptions, EndpointInfo);
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectGCDumpAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectGCDumpAction.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 _operationFactory = serviceProvider.GetRequiredService<IGCDumpOperationFactory>();
             }
 
-            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
             {
                 KeyValueLogScope scope = Utils.CreateArtifactScope(Utils.ArtifactType_GCDump, EndpointInfo);
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLiveMetricsAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLiveMetricsAction.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 _metricsOptions = serviceProvider.GetRequiredService<IOptionsMonitor<MetricsOptions>>();
             }
 
-            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
             {
                 MetricsPipelineSettings settings;
                 if (Options.HasCustomConfiguration())

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLogsAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectLogsAction.cs
@@ -45,12 +45,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             {
             }
 
-            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
             {
                 TimeSpan duration = Options.Duration.GetValueOrDefault(TimeSpan.Parse(CollectLogsOptionsDefaults.Duration));
                 bool useAppFilters = Options.UseAppFilters.GetValueOrDefault(CollectLogsOptionsDefaults.UseAppFilters);
                 LogLevel defaultLevel = Options.DefaultLevel.GetValueOrDefault(CollectLogsOptionsDefaults.DefaultLevel);
-                Dictionary<string, LogLevel?> filterSpecs = Options.FilterSpecs;
+                Dictionary<string, LogLevel?>? filterSpecs = Options.FilterSpecs;
                 string egressProvider = Options.Egress;
                 LogFormat logFormat = Options.Format.GetValueOrDefault(CollectLogsOptionsDefaults.Format);
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectStacksAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectStacksAction.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _operationFactory = serviceProvider.GetRequiredService<IStacksOperationFactory>();
         }
 
-        protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+        protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
         {
             KeyValueLogScope scope = Utils.CreateArtifactScope(Utils.ArtifactType_Stacks, EndpointInfo);
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectTraceAction.cs
@@ -47,14 +47,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 _counterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<GlobalCounterOptions>>();
             }
 
-            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata)
+            protected override EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata)
             {
                 TimeSpan duration = Options.Duration.GetValueOrDefault(TimeSpan.Parse(CollectTraceOptionsDefaults.Duration));
                 string egressProvider = Options.Egress;
 
                 MonitoringSourceConfiguration configuration;
 
-                TraceEventFilter stoppingEvent = null;
+                TraceEventFilter? stoppingEvent = null;
 
                 if (Options.Profile.HasValue)
                 {
@@ -63,7 +63,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 }
                 else
                 {
+#nullable disable
                     EventPipeProvider[] optionsProviders = Options.Providers.ToArray();
+#nullable restore
                     bool requestRundown = Options.RequestRundown.GetValueOrDefault(CollectTraceOptionsDefaults.RequestRundown);
                     int bufferSizeMegabytes = Options.BufferSizeMegabytes.GetValueOrDefault(CollectTraceOptionsDefaults.BufferSizeMegabytes);
                     configuration = TraceUtilities.GetTraceConfiguration(optionsProviders, requestRundown, bufferSizeMegabytes);

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionBase.cs
@@ -16,10 +16,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         private readonly CancellationTokenSource _disposalTokenSource = new();
         private readonly TaskCompletionSource _startCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+#nullable disable
         private Task<CollectionRuleActionResult> _completionTask;
+#nullable restore
         private long _disposedState;
 
-        protected IEndpointInfo EndpointInfo => ProcessInfo?.EndpointInfo;
+        protected IEndpointInfo EndpointInfo => ProcessInfo.EndpointInfo;
 
         protected IProcessInfo ProcessInfo { get; }
 
@@ -53,7 +55,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _disposalTokenSource.Dispose();
         }
 
-        public async Task StartAsync(CollectionRuleMetadata collectionRuleMetadata, CancellationToken token)
+        public async Task StartAsync(CollectionRuleMetadata? collectionRuleMetadata, CancellationToken token)
         {
             ThrowIfDisposed();
 
@@ -82,7 +84,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
 
         private async Task<CollectionRuleActionResult> ExecuteAsync(
-            CollectionRuleMetadata collectionRuleMetadata,
+            CollectionRuleMetadata? collectionRuleMetadata,
             CancellationToken token)
         {
             try
@@ -108,7 +110,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         }
 
         protected abstract Task<CollectionRuleActionResult> ExecuteCoreAsync(
-            CollectionRuleMetadata collectionRuleMetadata,
+            CollectionRuleMetadata? collectionRuleMetadata,
             CancellationToken token);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionFactoryProxy.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             _factory = factory;
         }
 
+#nullable disable
         /// <inheritdoc/>
         public ICollectionRuleAction Create(IProcessInfo processInfo, object options)
         {
@@ -33,5 +34,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
 
             return _factory.Create(processInfo, typedOptions);
         }
+#nullable restore
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleActionOperations.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleEgressActionBase.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/CollectionRuleEgressActionBase.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             EgressOperationStore = ServiceProvider.GetRequiredService<IEgressOperationStore>();
         }
 
-        protected abstract EgressOperation CreateArtifactOperation(CollectionRuleMetadata collectionRuleMetadata);
+        protected abstract EgressOperation CreateArtifactOperation(CollectionRuleMetadata? collectionRuleMetadata);
 
-        protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(CollectionRuleMetadata collectionRuleMetadata, CancellationToken token)
+        protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(CollectionRuleMetadata? collectionRuleMetadata, CancellationToken token)
         {
             EgressOperation egressOperation = CreateArtifactOperation(collectionRuleMetadata);
             Task<ExecutionResult<EgressResult>> executeTask = EgressOperationStore.ExecuteOperation(egressOperation);

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ExecuteAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ExecuteAction.cs
@@ -40,11 +40,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             }
 
             protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
-                CollectionRuleMetadata collectionRuleMetadata,
+                CollectionRuleMetadata? collectionRuleMetadata,
                 CancellationToken token)
             {
                 string path = Options.Path;
-                string arguments = Options.Arguments;
+                string? arguments = Options.Arguments;
                 bool IgnoreExitCode = Options.IgnoreExitCode.GetValueOrDefault(ExecuteOptionsDefaults.IgnoreExitCode);
 
                 ValidateFilePath(path);
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
                 // May want to capture stdout and stderr and return as part of the result in the future
                 using Process process = new Process();
 
-                process.StartInfo = new ProcessStartInfo(path, arguments);
+                process.StartInfo = new ProcessStartInfo(path, arguments ?? string.Empty);
                 process.StartInfo.RedirectStandardOutput = true;
 
                 process.EnableRaisingEvents = true;

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/GetEnvironmentVariableAction.cs
@@ -53,14 +53,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             }
 
             protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
-                CollectionRuleMetadata collectionRuleMetadata,
+                CollectionRuleMetadata? collectionRuleMetadata,
                 CancellationToken token)
             {
                 DiagnosticsClient client = new DiagnosticsClient(EndpointInfo.Endpoint);
 
                 _logger.GettingEnvironmentVariable(_options.Name, EndpointInfo.ProcessId);
                 Dictionary<string, string> envBlock = await client.GetProcessEnvironmentAsync(token);
-                if (!envBlock.TryGetValue(Options.Name, out string value))
+                if (!envBlock.TryGetValue(Options.Name, out string? value))
                 {
                     throw new InvalidOperationException(
                             string.Format(

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionFactoryProxy.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
         /// Executes the underlying action with the specified parameters, verifying
         /// that the passed options are of the correct type.
         /// </summary>
-        ICollectionRuleAction Create(IProcessInfo endpointInfo, object options);
+        ICollectionRuleAction Create(IProcessInfo endpointInfo, object? options);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/ICollectionRuleActionOperations.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/LoadProfilerAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/LoadProfilerAction.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             }
 
             protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
-                CollectionRuleMetadata collectionRuleMetadata,
+                CollectionRuleMetadata? collectionRuleMetadata,
                 CancellationToken token)
             {
                 DiagnosticsClient client = new DiagnosticsClient(EndpointInfo.Endpoint);

--- a/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Actions/SetEnvironmentVariableAction.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions
             }
 
             protected override async Task<CollectionRuleActionResult> ExecuteCoreAsync(
-                CollectionRuleMetadata collectionRuleMetadata,
+                CollectionRuleMetadata? collectionRuleMetadata,
                 CancellationToken token)
             {
                 DiagnosticsClient client = new DiagnosticsClient(EndpointInfo.Endpoint);

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContainer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         public List<CollectionRulePipeline> Pipelines { get; set; } = new();
 
         private long _disposalState;
-        private CancellationTokenSource _shutdownTokenSource;
+        private CancellationTokenSource? _shutdownTokenSource;
 
         public CollectionRuleContainer(
             IServiceProvider serviceProvider,
@@ -139,7 +139,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             // executing the ApplyRules method.
             using CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(token);
 
-            TaskCompletionSource<object> startedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> startedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // Start running the rule and wrap running task
             // in a safe awaitable task so that shutdown isn't
@@ -164,37 +164,35 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         /// </remarks>
         private async Task RunRuleAsync(
             string ruleName,
-            TaskCompletionSource<object> startedSource,
+            TaskCompletionSource<object?> startedSource,
             CancellationToken token)
         {
             KeyValueLogScope scope = new();
             scope.AddCollectionRuleEndpointInfo(_processInfo.EndpointInfo);
             scope.AddCollectionRuleName(ruleName);
-            using IDisposable loggerScope = _logger.BeginScope(scope);
+            using IDisposable? loggerScope = _logger.BeginScope(scope);
 
+#nullable disable
             using CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
                 _shutdownTokenSource.Token,
                 token);
-
+#nullable restore
             try
             {
                 CollectionRuleOptions options = _optionsMonitor.Get(ruleName);
 
-                if (null != options.Filters)
+                DiagProcessFilter filter = DiagProcessFilter.FromConfiguration(options.Filters);
+
+                if (!filter.Filters.All(f => f.MatchFilter(_processInfo)))
                 {
-                    DiagProcessFilter filter = DiagProcessFilter.FromConfiguration(options.Filters);
+                    // Collection rule filter does not match target process
+                    _logger.CollectionRuleUnmatchedFilters(ruleName);
 
-                    if (!filter.Filters.All(f => f.MatchFilter(_processInfo)))
-                    {
-                        // Collection rule filter does not match target process
-                        _logger.CollectionRuleUnmatchedFilters(ruleName);
+                    // Signal rule has "started" in order to not block
+                    // resumption of the runtime instance.
+                    startedSource.TrySetResult(null);
 
-                        // Signal rule has "started" in order to not block
-                        // resumption of the runtime instance.
-                        startedSource.TrySetResult(null);
-
-                        return;
-                    }
+                    return;
                 }
 
                 _logger.CollectionRuleStarted(ruleName);
@@ -242,7 +240,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             }
         }
 
-        private static bool TrySetCanceledAndReturnTrue(OperationCanceledException ex, TaskCompletionSource<object> source)
+        private static bool TrySetCanceledAndReturnTrue(OperationCanceledException ex, TaskCompletionSource<object?> source)
         {
             // Always attempt to cancel the completion source
             source.TrySetCanceled(ex.CancellationToken);
@@ -251,7 +249,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             return true;
         }
 
-        private bool LogExceptionAndReturnFalse(Exception ex, TaskCompletionSource<object> source, string ruleName)
+        private bool LogExceptionAndReturnFalse(Exception ex, TaskCompletionSource<object?> source, string ruleName)
         {
             // Log failure
             _logger.CollectionRuleFailed(ruleName, ex);

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleContext.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 {
     internal class CollectionRuleContext
     {
-        public CollectionRuleContext(string name, CollectionRuleOptions options, IProcessInfo processInfo, ILogger logger, TimeProvider timeProvider, Action throttledCallback = null)
+        public CollectionRuleContext(string name, CollectionRuleOptions options, IProcessInfo processInfo, ILogger logger, TimeProvider timeProvider, Action? throttledCallback = null)
         {
             // TODO: Allow null processInfo to allow tests to pass, but this should be provided by
             // tests since it will be required by all aspects in the future. For example, the ActionListExecutor
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         public IProcessInfo ProcessInfo { get; }
 
-        public IEndpointInfo EndpointInfo => ProcessInfo?.EndpointInfo;
+        public IEndpointInfo EndpointInfo => ProcessInfo.EndpointInfo;
 
         public ILogger Logger { get; }
 
@@ -37,6 +37,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
 
         public string Name { get; }
 
-        public Action ThrottledCallback { get; }
+        public Action? ThrottledCallback { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/CollectionRuleService.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             IEndpointInfo endpointInfo,
             CancellationToken token)
         {
-            CollectionRuleContainer container;
+            CollectionRuleContainer? container;
             lock (_containersMap)
             {
                 if (!_containersMap.Remove(endpointInfo, out container))
@@ -263,7 +263,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
         {
             Dictionary<string, CollectionRuleDescription> collectionRulesDescriptions = new();
 
-            if (_containersMap.TryGetValue(endpointInfo, out CollectionRuleContainer container))
+            if (_containersMap.TryGetValue(endpointInfo, out CollectionRuleContainer? container))
             {
                 container.Pipelines.ForEach(pipeline => collectionRulesDescriptions.Add(pipeline.Context.Name, GetCollectionRuleDescription(pipeline)));
             }
@@ -271,9 +271,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules
             return collectionRulesDescriptions;
         }
 
-        public CollectionRuleDetailedDescription GetCollectionRuleDetailedDescription(string collectionRuleName, IEndpointInfo endpointInfo)
+        public CollectionRuleDetailedDescription? GetCollectionRuleDetailedDescription(string collectionRuleName, IEndpointInfo endpointInfo)
         {
-            if (_containersMap.TryGetValue(endpointInfo, out CollectionRuleContainer container))
+            if (_containersMap.TryGetValue(endpointInfo, out CollectionRuleContainer? container))
             {
                 IEnumerable<CollectionRulePipeline> pipelines = container.Pipelines.Where(pipeline => pipeline.Context.Name.Equals(collectionRuleName));
 

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleConfigureNamedOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
             _configurationProvider = configurationProvider;
         }
 
+#nullable disable
         public void Configure(string name, CollectionRuleOptions options)
         {
             IConfigurationSection ruleSection = _configurationProvider.GetCollectionRuleSection(name);
@@ -27,6 +28,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
                 ruleSection.Bind(options);
             }
         }
+#nullable restore
 
         public void Configure(CollectionRuleOptions options)
         {

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulePostConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulePostConfigureNamedOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Actions;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerDescriptor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRuleTriggerDescriptor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
 
         public Type FactoryType => typeof(TFactory);
 
-        public Type OptionsType => null;
+        public Type? OptionsType => null;
 
         public string TriggerName { get; }
     }

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/CollectionRulesConfigurationProvider.cs
@@ -55,6 +55,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
 
         public IConfigurationSection Configuration => _section;
 
-        public event EventHandler RulesChanged;
+        public event EventHandler? RulesChanged;
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerDescriptor.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/ICollectionRuleTriggerDescriptor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
     {
         Type FactoryType { get; }
 
-        Type OptionsType { get; }
+        Type? OptionsType { get; }
 
         string TriggerName { get; }
     }

--- a/src/Tools/dotnet-monitor/CollectionRules/Configuration/TemplatesConfigureNamedOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Configuration/TemplatesConfigureNamedOptions.cs
@@ -28,29 +28,35 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration
             _configuration = configuration;
         }
 
-        public void PostConfigure(string name, TemplateOptions options)
+        public void PostConfigure(string? name, TemplateOptions options)
         {
             IConfigurationSection collectionRuleActionsSection = _configuration.GetSection(collectionRuleActionsPath);
 
-            foreach (string key in options.CollectionRuleActions.Keys)
+            if (options.CollectionRuleActions != null)
             {
-                IConfigurationSection actionSection = collectionRuleActionsSection.GetSection(key);
-
-                if (actionSection.Exists())
+                foreach (string key in options.CollectionRuleActions.Keys)
                 {
-                    CollectionRuleBindingHelper.BindActionSettings(actionSection, options.CollectionRuleActions[key], _actionOperations);
+                    IConfigurationSection actionSection = collectionRuleActionsSection.GetSection(key);
+
+                    if (actionSection.Exists())
+                    {
+                        CollectionRuleBindingHelper.BindActionSettings(actionSection, options.CollectionRuleActions[key], _actionOperations);
+                    }
                 }
             }
 
             IConfigurationSection collectionRuleTriggersSection = _configuration.GetSection(collectionRuleTriggersPath);
 
-            foreach (string key in options.CollectionRuleTriggers.Keys)
+            if (options.CollectionRuleTriggers != null)
             {
-                IConfigurationSection triggerSection = collectionRuleTriggersSection.GetSection(key);
-
-                if (triggerSection.Exists())
+                foreach (string key in options.CollectionRuleTriggers.Keys)
                 {
-                    CollectionRuleBindingHelper.BindTriggerSettings(triggerSection, options.CollectionRuleTriggers[key], _triggerOperations);
+                    IConfigurationSection triggerSection = collectionRuleTriggersSection.GetSection(key);
+
+                    if (triggerSection.Exists())
+                    {
+                        CollectionRuleBindingHelper.BindTriggerSettings(triggerSection, options.CollectionRuleTriggers[key], _triggerOperations);
+                    }
                 }
             }
         }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/CollectLogsOptions.Validate.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
                 // Validate that the category is not null and that the level is a valid level value.
                 foreach ((string category, LogLevel? level) in FilterSpecs)
                 {
-                    ValidationResult result = requiredAttribute.GetValidationResult(category, filterSpecsContext);
-                    if (result != ValidationResult.Success)
+                    ValidationResult? result = requiredAttribute.GetValidationResult(category, filterSpecsContext);
+                    if (!result.IsSuccess())
                     {
                         results.Add(result);
                     }
 
                     result = enumValidationAttribute.GetValidationResult(level, filterSpecsContext);
-                    if (result != ValidationResult.Success)
+                    if (!result.IsSuccess())
                     {
                         results.Add(result);
                     }

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/RequiredGuidAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/RequiredGuidAttribute.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
                         name);
         }
 
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             if (!(value is Guid))
             {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ValidateEgressProviderAttribute.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/Actions/ValidateEgressProviderAttribute.cs
@@ -12,8 +12,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions
     internal sealed class ValidateEgressProviderAttribute :
         ValidationAttribute
     {
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
+            if (!(value is string))
+            {
+                return new ValidationResult(
+                    FormatErrorMessage(validationContext.DisplayName));
+            }
+
             string egressProvider = (string)value;
 
             IEgressService egressService = validationContext.GetRequiredService<IEgressService>();

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.Validate.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/CollectionRuleOptions.Validate.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/DefaultCollectionRulePostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/DefaultCollectionRulePostConfigureOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
             _defaultOptions = defaultOptions;
         }
 
-        public void PostConfigure(string name, CollectionRuleOptions options)
+        public void PostConfigure(string? name, CollectionRuleOptions options)
         {
             ConfigureEgress(options);
             ConfigureLimits(options);
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 
         private void ConfigureEgress(CollectionRuleOptions options)
         {
-            CollectionRuleActionDefaultsOptions actionDefaults = _defaultOptions.CurrentValue.Actions;
+            CollectionRuleActionDefaultsOptions? actionDefaults = _defaultOptions.CurrentValue.Actions;
 
             if (actionDefaults == null)
             {
@@ -45,7 +45,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
                 {
                     if (string.IsNullOrEmpty(egressProviderProperties.Egress))
                     {
+#nullable disable
                         egressProviderProperties.Egress = actionDefaults.Egress;
+#nullable restore
                     }
                 }
             }
@@ -53,7 +55,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 
         private void ConfigureLimits(CollectionRuleOptions options)
         {
-            CollectionRuleLimitsDefaultsOptions limitsDefaults = _defaultOptions.CurrentValue.Limits;
+            CollectionRuleLimitsDefaultsOptions? limitsDefaults = _defaultOptions.CurrentValue.Limits;
 
             if (limitsDefaults == null)
             {
@@ -90,7 +92,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 
         private void ConfigureRequestCounts(CollectionRuleOptions options)
         {
-            CollectionRuleTriggerDefaultsOptions triggerDefaults = _defaultOptions.CurrentValue.Triggers;
+            CollectionRuleTriggerDefaultsOptions? triggerDefaults = _defaultOptions.CurrentValue.Triggers;
 
             if (triggerDefaults == null)
             {
@@ -111,7 +113,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 
         private void ConfigureResponseCounts(CollectionRuleOptions options)
         {
-            CollectionRuleTriggerDefaultsOptions triggerDefaults = _defaultOptions.CurrentValue.Triggers;
+            CollectionRuleTriggerDefaultsOptions? triggerDefaults = _defaultOptions.CurrentValue.Triggers;
 
             if (triggerDefaults == null)
             {
@@ -132,7 +134,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
 
         private void ConfigureSlidingWindowDurations(CollectionRuleOptions options)
         {
-            CollectionRuleTriggerDefaultsOptions triggerDefaults = _defaultOptions.CurrentValue.Triggers;
+            CollectionRuleTriggerDefaultsOptions? triggerDefaults = _defaultOptions.CurrentValue.Triggers;
 
             if (triggerDefaults == null)
             {

--- a/src/Tools/dotnet-monitor/CollectionRules/Options/ValidationHelper.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Options/ValidationHelper.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
             }
         }
 
+#nullable disable
         public static bool TryValidateOptions(Type optionsType, object options, ValidationContext validationContext, ICollection<ValidationResult> results)
         {
             RequiredAttribute requiredAttribute = new();
@@ -58,5 +59,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options
                 return false;
             }
         }
+#nullable restore
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerFactoryProxy.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
         }
 
         /// <inheritdoc/>
-        public ICollectionRuleTrigger Create(IEndpointInfo endpointInfo, Action callback, object options)
+        public ICollectionRuleTrigger Create(IEndpointInfo endpointInfo, Action callback, object? options)
         {
             return _factory.Create(endpointInfo, callback);
         }
@@ -48,6 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
             _factory = factory;
         }
 
+#nullable disable
         /// <inheritdoc/>
         public ICollectionRuleTrigger Create(IEndpointInfo endpointInfo, Action callback, object options)
         {
@@ -60,5 +61,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
 
             return _factory.Create(endpointInfo, callback, typedOptions);
         }
+#nullable restore
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/CollectionRuleTriggerOperations.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerFactoryProxy.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerFactoryProxy.cs
@@ -21,6 +21,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
         /// Executes the underlying factory with the specified parameters, verifying
         /// that the passed options are of the correct type.
         /// </summary>
-        ICollectionRuleTrigger Create(IEndpointInfo endpointInfo, Action callback, object options);
+        ICollectionRuleTrigger Create(IEndpointInfo endpointInfo, Action callback, object? options);
     }
 }

--- a/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerOperations.cs
+++ b/src/Tools/dotnet-monitor/CollectionRules/Triggers/ICollectionRuleTriggerOperations.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Triggers
         /// </summary>
         bool TryValidateOptions(
             string triggerName,
-            object options,
+            object? options,
             ValidationContext validationContext,
             ICollection<ValidationResult> results);
     }

--- a/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/CollectCommandHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
 {
     internal static class CollectCommandHandler
     {
-        public static async Task<int> Invoke(CancellationToken token, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, FileInfo configurationFilePath, bool exitOnStdinDisconnect)
+        public static async Task<int> Invoke(CancellationToken token, string[]? urls, string[]? metricUrls, bool metrics, string? diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, FileInfo? configurationFilePath, bool exitOnStdinDisconnect)
         {
             try
             {
@@ -154,7 +154,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             })
             .ConfigureContainer((HostBuilderContext context, IServiceCollection services) =>
             {
-                ServerUrlsBlockingConfigurationManager manager =
+                ServerUrlsBlockingConfigurationManager? manager =
                     context.Properties[typeof(ServerUrlsBlockingConfigurationManager)] as ServerUrlsBlockingConfigurationManager;
                 Debug.Assert(null != manager, $"Expected {typeof(ServerUrlsBlockingConfigurationManager).FullName} to be a {typeof(HostBuilderContext).FullName} property.");
                 if (null != manager)

--- a/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/ConfigShowCommandHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         // Although the "noHttpEgress" parameter is unused, it keeps the entire command parameter set a superset
         // of the "collect" command so that users can take the same arguments from "collect" and use it on "config show"
         // to get the same configuration without telling them to drop specific command line arguments.
-        public static void Invoke(string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, FileInfo configurationFilePath, ConfigDisplayLevel level, bool showSources)
+        public static void Invoke(string[]? urls, string[]? metricUrls, bool metrics, string? diagnosticPort, bool noAuth, bool tempApiKey, bool noHttpEgress, FileInfo? configurationFilePath, ConfigDisplayLevel level, bool showSources)
         {
             Stream stream = Console.OpenStandardOutput();
 
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
             Write(stream, urls, metricUrls, metrics, diagnosticPort, noAuth, tempApiKey, configurationFilePath, level, showSources);
         }
 
-        public static void Write(Stream stream, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth, bool tempApiKey, FileInfo configurationFilePath, ConfigDisplayLevel level, bool showSources)
+        public static void Write(Stream stream, string[]? urls, string[]? metricUrls, bool metrics, string? diagnosticPort, bool noAuth, bool tempApiKey, FileInfo? configurationFilePath, ConfigDisplayLevel level, bool showSources)
         {
             StartupAuthenticationMode startupAuthMode = HostBuilderHelper.GetStartupAuthenticationMode(noAuth, tempApiKey);
             HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(urls, metricUrls, metrics, diagnosticPort, startupAuthMode, configurationFilePath);

--- a/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/Commands/GenerateApiKeyCommandHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
                         {
                             // Create configuration from object model.
                             MemoryConfigurationSource source = new();
-                            source.InitialData = opts.ToConfigurationValues();
+                            source.InitialData = (IDictionary<string, string?>)opts.ToConfigurationValues(); // Cast the values as nullable, since they are reference types we can safely do this.
                             ConfigurationBuilder builder = new();
                             builder.Add(source);
                             IConfigurationRoot configuration = builder.Build();
@@ -141,8 +141,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Commands
         /// </remarks>
         internal class MachineOutputFormat
         {
-            public AuthenticationOptions Authentication { get; set; }
-            public string AuthorizationHeader { get; set; }
+            public required AuthenticationOptions Authentication { get; set; }
+            public required string AuthorizationHeader { get; set; }
         }
     }
 }

--- a/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 #if UNITTEST
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 #endif
@@ -62,11 +64,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             foreach (var key in dictionary.Keys)
             {
-                object value = dictionary[key];
+                object? value = dictionary[key];
 
                 if (null != value)
                 {
-                    string keyString = Convert.ToString(key, CultureInfo.InvariantCulture);
+                    string keyString = ConvertUtils.ToString(key, CultureInfo.InvariantCulture);
                     MapValue(
                         value,
                         FormattableString.Invariant($"{prefix}{keyString}"),
@@ -80,7 +82,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             for (int index = 0; index < list.Count; index++)
             {
-                object value = list[index];
+                object? value = list[index];
                 if (null != value)
                 {
                     MapValue(
@@ -107,7 +109,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
-        private static void MapValue(object value, string valueName, string separator, IDictionary<string, string> map)
+        private static void MapValue(object? value, string valueName, string separator, IDictionary<string, string> map)
         {
             if (null != value)
             {
@@ -120,7 +122,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     map.Add(
                         valueName,
-                        Convert.ToString(value, CultureInfo.InvariantCulture));
+                        ConvertUtils.ToString(value, CultureInfo.InvariantCulture));
                 }
                 else
                 {

--- a/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Configuration;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 #if !NET7_0_OR_GREATER
 using System.Reflection;
@@ -11,7 +12,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ConfigurationExtensions
     {
-        public static bool TryGetProvider(this IConfigurationBuilder builder, string key, out IConfigurationProvider provider)
+        public static bool TryGetProvider(this IConfigurationBuilder builder, string key, [NotNullWhen(true)] out IConfigurationProvider? provider)
         {
             foreach (IConfigurationSource source in builder.Sources.Reverse())
             {
@@ -27,7 +28,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return false;
         }
 
-        public static bool TryGetProviderAndValue(this IConfiguration configuration, string key, out IConfigurationProvider provider, out string value)
+        public static bool TryGetProviderAndValue(this IConfiguration configuration, string key, [NotNullWhen(true)] out IConfigurationProvider? provider, out string? value)
         {
             if (configuration is IConfigurationRoot configurationRoot)
             {
@@ -39,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return false;
         }
 
-        public static bool TryGetProviderAndValue(this IConfigurationRoot configurationRoot, string key, out IConfigurationProvider provider, out string value)
+        public static bool TryGetProviderAndValue(this IConfigurationRoot configurationRoot, string key, [NotNullWhen(true)] out IConfigurationProvider? provider, out string? value)
         {
             foreach (IConfigurationProvider candidate in configurationRoot.Providers.Reverse())
             {

--- a/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationJsonWriter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal sealed class ConfigurationJsonWriter : IDisposable
     {
         private readonly Utf8JsonWriter _writer;
-        private IConfiguration _configuration;
+        private IConfiguration? _configuration;
         public ConfigurationJsonWriter(Stream outputStream)
         {
             JsonWriterOptions options = new() { Indented = true };
@@ -39,17 +39,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             using (new JsonObjectContext(_writer))
             {
                 ProcessChildSection(configuration, WebHostDefaults.ServerUrlsKey, skipNotPresent, showSources: showSources);
-                IConfigurationSection kestrel = ProcessChildSection(configuration, "Kestrel", skipNotPresent, includeChildSections: false, showSources: showSources);
+                IConfigurationSection? kestrel = ProcessChildSection(configuration, "Kestrel", skipNotPresent, includeChildSections: false, showSources: showSources);
                 if (kestrel != null)
                 {
                     using (new JsonObjectContext(_writer))
                     {
-                        IConfigurationSection certificates = ProcessChildSection(kestrel, "Certificates", skipNotPresent, includeChildSections: false, showSources: showSources);
+                        IConfigurationSection? certificates = ProcessChildSection(kestrel, "Certificates", skipNotPresent, includeChildSections: false, showSources: showSources);
                         if (certificates != null)
                         {
                             using (new JsonObjectContext(_writer))
                             {
-                                IConfigurationSection defaultCert = ProcessChildSection(certificates, "Default", skipNotPresent, includeChildSections: false, showSources: showSources);
+                                IConfigurationSection? defaultCert = ProcessChildSection(certificates, "Default", skipNotPresent, includeChildSections: false, showSources: showSources);
                                 if (defaultCert != null)
                                 {
                                     using (new JsonObjectContext(_writer))
@@ -84,12 +84,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
                 else
                 {
-                    IConfigurationSection auth = ProcessChildSection(configuration, ConfigurationKeys.Authentication, skipNotPresent, includeChildSections: false, showSources: showSources);
+                    IConfigurationSection? auth = ProcessChildSection(configuration, ConfigurationKeys.Authentication, skipNotPresent, includeChildSections: false, showSources: showSources);
                     if (null != auth)
                     {
                         using (new JsonObjectContext(_writer))
                         {
-                            IConfigurationSection monitorApiKey = ProcessChildSection(auth, ConfigurationKeys.MonitorApiKey, skipNotPresent, includeChildSections: false, showSources: showSources);
+                            IConfigurationSection? monitorApiKey = ProcessChildSection(auth, ConfigurationKeys.MonitorApiKey, skipNotPresent, includeChildSections: false, showSources: showSources);
                             if (null != monitorApiKey)
                             {
                                 using (new JsonObjectContext(_writer))
@@ -102,11 +102,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                             }
 
                             // No sensitive information
-                            IConfigurationSection azureAd = ProcessChildSection(auth, ConfigurationKeys.AzureAd, skipNotPresent, includeChildSections: true, showSources: showSources);
+                            IConfigurationSection? azureAd = ProcessChildSection(auth, ConfigurationKeys.AzureAd, skipNotPresent, includeChildSections: true, showSources: showSources);
                         }
                     }
 
-                    IConfigurationSection egress = ProcessChildSection(configuration, ConfigurationKeys.Egress, skipNotPresent, includeChildSections: false, showSources: showSources);
+                    IConfigurationSection? egress = ProcessChildSection(configuration, ConfigurationKeys.Egress, skipNotPresent, includeChildSections: false, showSources: showSources);
                     if (egress != null)
                     {
                         using (new JsonObjectContext(_writer))
@@ -123,13 +123,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IList<string> processedSectionPaths = new List<string>();
 
             // Redact all the properties since they could include secrets such as storage keys
-            IConfigurationSection propertiesSection = ProcessChildSection(egress, ConfigurationKeys.Egress_Properties, skipNotPresent, includeChildSections: true, redact: true, showSources: showSources);
+            IConfigurationSection? propertiesSection = ProcessChildSection(egress, ConfigurationKeys.Egress_Properties, skipNotPresent, includeChildSections: true, redact: true, showSources: showSources);
             if (null != propertiesSection)
             {
                 processedSectionPaths.Add(propertiesSection.Path);
             }
 
-            IConfigurationSection fileSystemProviderSection = ProcessChildSection(egress, EgressProviderTypes.FileSystem, skipNotPresent, includeChildSections: false, showSources: showSources);
+            IConfigurationSection? fileSystemProviderSection = ProcessChildSection(egress, EgressProviderTypes.FileSystem, skipNotPresent, includeChildSections: false, showSources: showSources);
             if (fileSystemProviderSection != null)
             {
                 processedSectionPaths.Add(fileSystemProviderSection.Path);
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
-        private IConfigurationSection ProcessChildSection(IConfiguration parentSection, string key, bool skipNotPresent, bool includeChildSections = true, bool redact = false, bool showSources = false)
+        private IConfigurationSection? ProcessChildSection(IConfiguration parentSection, string key, bool skipNotPresent, bool includeChildSections = true, bool redact = false, bool showSources = false)
         {
             IConfigurationSection section = parentSection.GetSection(key);
             if (!section.Exists())
@@ -238,16 +238,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
             }
         }
-
+#nullable disable
         private string GetConfigurationProvider(IConfigurationSection section, bool showSources)
         {
             if (showSources && _configuration.TryGetProviderAndValue(section.Path, out IConfigurationProvider provider, out _))
             {
                 return provider.ToString();
             }
-
             return string.Empty;
         }
+#nullable restore
 
         private static bool CanWriteChildren(IConfigurationSection section, IEnumerable<IConfigurationSection> children)
         {
@@ -259,9 +259,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return children.Any();
         }
 
-        private void WriteValue(string value, bool redact)
+        private void WriteValue(string? value, bool redact)
         {
-            string valueToWrite = redact ? Strings.Placeholder_Redacted : value;
+            string? valueToWrite = redact ? Strings.Placeholder_Redacted : value;
 
             _writer.WriteStringValue(valueToWrite);
         }

--- a/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
@@ -50,13 +50,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _logger = logger;
         }
 
-        public object SubstituteOptionValues(object originalSettings, TokenContext context)
+        public object? SubstituteOptionValues(object? originalSettings, TokenContext context)
         {
-            object settings = originalSettings;
+            object? settings = originalSettings;
 
             foreach (PropertyInfo propertyInfo in GetPropertiesFromSettings(settings))
             {
-                string originalPropertyValue = (string)propertyInfo.GetValue(settings);
+                string? originalPropertyValue = (string?)propertyInfo.GetValue(settings);
                 if (string.IsNullOrEmpty(originalPropertyValue))
                 {
                     continue;
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return settings;
         }
 
-        public bool TryCloneSettings(object originalSettings, ref object settings)
+        public bool TryCloneSettings(object? originalSettings, ref object? settings)
         {
             if (originalSettings == null)
             {
@@ -97,7 +97,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
                 else
                 {
+#nullable disable
                     _logger.ActionSettingsTokenizationNotSupported(settings.GetType().FullName);
+#nullable restore
                     settings = originalSettings;
                     return false;
                 }
@@ -105,7 +107,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return true;
         }
 
-        public static IEnumerable<PropertyInfo> GetPropertiesFromSettings(object settings, Predicate<PropertyInfo> predicate = null) =>
+        public static IEnumerable<PropertyInfo> GetPropertiesFromSettings(object? settings, Predicate<PropertyInfo>? predicate = null) =>
             settings?.GetType()
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.PropertyType == typeof(string) && (predicate?.Invoke(p) ?? true)) ??

--- a/src/Tools/dotnet-monitor/ConvertUtils.cs
+++ b/src/Tools/dotnet-monitor/ConvertUtils.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+
+namespace Microsoft.Diagnostics.Tools.Monitor;
+
+internal static class ConvertUtils
+{
+    public static string ToString(object value, IFormatProvider? provider)
+    {
+        return Convert.ToString(value, provider)!; // Since value is not null this will never return null.
+    }
+}

--- a/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DataAnnotationValidateOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
@@ -24,7 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _serviceProvider = serviceProvider;
         }
 
-        public ValidateOptionsResult Validate(string name, TOptions options)
+        public ValidateOptionsResult Validate(string? name, TOptions options)
         {
             ValidationContext validationContext = new(options, _serviceProvider, null);
             ICollection<ValidationResult> results = new Collection<ValidationResult>();
@@ -35,7 +37,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     if (ValidationResult.Success != result)
                     {
+#nullable disable
                         failures.Add(result.ErrorMessage);
+#nullable restore
                     }
                 }
 

--- a/src/Tools/dotnet-monitor/DiagnosticLifetimeBackgroundService.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticLifetimeBackgroundService.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         IDiagnosticLifetimeService,
         IAsyncDisposable
     {
-        private Task _executingTask;
+        private Task? _executingTask;
         private object _executionLock = new object();
-        private CancellationTokenSource _stoppingSource;
+        private CancellationTokenSource? _stoppingSource;
 
         public virtual ValueTask DisposeAsync()
         {
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
 
             // Signal to the execution that it should stop.
-            _stoppingSource.SafeCancel();
+            _stoppingSource?.SafeCancel();
 
             // Safe await the execution regardless of the completion type,
             // but allow cancelling waiting for it to finish.

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortPostConfigureOptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _storageOptions = storageOptions;
         }
 
-        public void PostConfigure(string name, DiagnosticPortOptions options)
+        public void PostConfigure(string? name, DiagnosticPortOptions options)
         {
             IConfigurationSection diagPortSection = _configuration.GetSection(nameof(RootOptions.DiagnosticPort));
 

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortStartupLogger.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _options = options.Value;
         }
 
+#nullable disable
         public void Log()
         {
             switch (_options.GetConnectionMode())
@@ -48,5 +49,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     break;
             }
         }
+#nullable restore
     }
 }

--- a/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortValidateOptions.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticPort/DiagnosticPortValidateOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal class DiagnosticPortValidateOptions :
         IValidateOptions<DiagnosticPortOptions>
     {
-        public ValidateOptionsResult Validate(string name, DiagnosticPortOptions options)
+        public ValidateOptionsResult Validate(string? name, DiagnosticPortOptions options)
         {
             var failures = new List<string>();
 

--- a/src/Tools/dotnet-monitor/DisposableHelper.cs
+++ b/src/Tools/dotnet-monitor/DisposableHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,7 +62,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         /// Calls <see cref="IDisposable.Dispose"/> on object if object
         /// implements <see cref="IDisposable"/> interface.
         /// </summary>
-        public static void Dispose(object obj)
+        public static void Dispose(object? obj)
         {
             if (obj is IDisposable disposable)
             {
@@ -72,7 +74,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         /// Checks if the object implements <see cref="IAsyncDisposable"/>
         /// or <see cref="IDisposable"/> and calls the corresponding dispose method.
         /// </summary>
-        public static async ValueTask DisposeAsync(object obj)
+        public static async ValueTask DisposeAsync(object? obj)
         {
             if (obj is IAsyncDisposable asyncDisposable)
             {

--- a/src/Tools/dotnet-monitor/DotNetHost.Unix.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.Unix.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -20,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             public string ExecutableName => ExecutableRootName;
 
-            public bool TryGetDefaultInstallationDirectory(out string dotnetRoot)
+            public bool TryGetDefaultInstallationDirectory([NotNullWhen(true)] out string? dotnetRoot)
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
@@ -38,13 +39,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 return false;
             }
 
-            public bool TryGetSelfRegisteredDirectory(out string dotnetRoot)
+            public bool TryGetSelfRegisteredDirectory([NotNullWhen(true)] out string? dotnetRoot)
             {
                 return TryReadFileFirstLine(CurrentArchInstallationFilePath, out dotnetRoot) ||
                     TryReadFileFirstLine(InstallationFilePath, out dotnetRoot);
             }
 
-            private static bool TryReadFileFirstLine(string filePath, out string content)
+            private static bool TryReadFileFirstLine(string filePath, [NotNullWhen(true)] out string? content)
             {
                 try
                 {

--- a/src/Tools/dotnet-monitor/DotNetHost.Windows.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
@@ -12,14 +13,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             public string ExecutableName => FormattableString.Invariant($"{ExecutableRootName}.exe");
 
-            public bool TryGetDefaultInstallationDirectory(out string dotnetRoot)
+            public bool TryGetDefaultInstallationDirectory([NotNullWhen(true)] out string? dotnetRoot)
             {
                 // CONSIDER: Account for emulation (emulated path would be under ".\x64\")
                 dotnetRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), InstallationDirectoryName);
                 return true;
             }
 
-            public bool TryGetSelfRegisteredDirectory(out string dotnetRoot)
+            public bool TryGetSelfRegisteredDirectory([NotNullWhen(true)] out string? dotnetRoot)
             {
                 // CONSIDER: Lookup dotnet installation from registry
                 dotnetRoot = null;

--- a/src/Tools/dotnet-monitor/DotNetHost.cs
+++ b/src/Tools/dotnet-monitor/DotNetHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -27,7 +28,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private static string GetPath()
         {
             // If current executable is already dotnet, return its path
-            string executablePath = Environment.ProcessPath;
+            string? executablePath = Environment.ProcessPath;
             if (!string.IsNullOrEmpty(executablePath) &&
                 executablePath.EndsWith(Helper.ExecutableName, StringComparison.OrdinalIgnoreCase))
             {
@@ -39,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             // Get dotnet root from environment variable
             // TODO: check architecture specific environment variables (e.g. *_X86, *_X64, *_ARM64)
-            string dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            string? dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
 
             if (string.IsNullOrEmpty(dotnetRoot) &&
                 !Helper.TryGetSelfRegisteredDirectory(out dotnetRoot) &&
@@ -58,9 +59,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private interface IDotNetHostHelper
         {
-            bool TryGetSelfRegisteredDirectory(out string dotnetRoot);
+            bool TryGetSelfRegisteredDirectory([NotNullWhen(true)] out string? dotnetRoot);
 
-            bool TryGetDefaultInstallationDirectory(out string dotnetRoot);
+            bool TryGetDefaultInstallationDirectory([NotNullWhen(true)] out string? dotnetRoot);
 
             string ExecutableName { get; }
         }

--- a/src/Tools/dotnet-monitor/DynamicNamedOptionsCache.cs
+++ b/src/Tools/dotnet-monitor/DynamicNamedOptionsCache.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Extensions.Options;
 using System;
 using System.Diagnostics;

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigurationProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-monitor/Egress/EgressArtifactSettings.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressArtifactSettings.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Tools/dotnet-monitor/Egress/EgressProviderSource.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressProviderSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
         private readonly ILogger _logger;
         private readonly IDictionary<string, string> _providerNameToTypeMap;
         public IReadOnlyCollection<string> ProviderNames { get; set; } = new List<string>();
-        public event EventHandler ProvidersChanged;
+        public event EventHandler? ProvidersChanged;
 
         public EgressProviderSource(
             IEgressConfigurationProvider configurationProvider,
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
 
         public IEgressExtension GetEgressProvider(string name)
         {
-            if (!_providerNameToTypeMap.TryGetValue(name, out string providerType))
+            if (!_providerNameToTypeMap.TryGetValue(name, out string? providerType))
             {
                 throw new EgressException(string.Format(CultureInfo.CurrentCulture, Strings.ErrorMessage_EgressProviderDoesNotExist, name));
             }
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
                 foreach (IConfigurationSection optionsSection in typeSection.GetChildren())
                 {
                     string providerName = optionsSection.Key;
-                    if (_providerNameToTypeMap.TryGetValue(providerName, out string existingProviderType))
+                    if (_providerNameToTypeMap.TryGetValue(providerName, out string? existingProviderType))
                     {
                         _logger.DuplicateEgressProviderIgnored(providerName, providerType, existingProviderType);
                     }

--- a/src/Tools/dotnet-monitor/Egress/EgressService.cs
+++ b/src/Tools/dotnet-monitor/Egress/EgressService.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/Extension/EgressArtifactResult.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/EgressArtifactResult.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using System.Diagnostics;
 

--- a/src/Tools/dotnet-monitor/Egress/Extension/EgressExtension.OutputParser.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/EgressExtension.OutputParser.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Tools/dotnet-monitor/Egress/Extension/EgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/EgressExtension.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration;
 using Microsoft.Diagnostics.Tools.Monitor.Extensibility;
 using Microsoft.Extensions.Configuration;

--- a/src/Tools/dotnet-monitor/Egress/Extension/ExtensionEgressPayload.cs
+++ b/src/Tools/dotnet-monitor/Egress/Extension/ExtensionEgressPayload.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressExtension.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
                     WrapException(() => Directory.CreateDirectory(options.IntermediateDirectoryPath));
                 }
 
-                string intermediateFilePath = null;
+                string? intermediateFilePath = null;
                 try
                 {
                     int remainingAttempts = 10;
@@ -92,7 +92,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
                     }
                     catch (Exception ex)
                     {
-                        _logger.IntermediateFileDeletionFailed(intermediateFilePath, ex);
+                        if (intermediateFilePath != null)
+                        {
+                            _logger.IntermediateFileDeletionFailed(intermediateFilePath, ex);
+                        }
                     }
                 }
             }

--- a/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ClientEndpointInfoSource.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             CancellationToken timeoutToken = timeoutTokenSource.Token;
             CancellationToken linkedToken = linkedTokenSource.Token;
 
-            var endpointInfoTasks = new List<Task<EndpointInfo>>();
+            var endpointInfoTasks = new List<Task<EndpointInfo?>>();
             // Run the EndpointInfo creation parallel. The call to FromProcessId sends
             // a GetProcessInfo command to the runtime instance to get additional information.
             foreach (int pid in DiagnosticsClient.GetPublishedProcesses())
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
             await Task.WhenAll(endpointInfoTasks);
 
-            return endpointInfoTasks.Where(t => t.Result != null).Select(t => t.Result);
+            return endpointInfoTasks.Where(t => t.Result != null).Select(t => t.Result).Cast<IEndpointInfo>();
         }
     }
 }

--- a/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/EndpointInfo.cs
@@ -5,6 +5,7 @@ using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             var client = new DiagnosticsClient(processId);
 
-            ProcessInfo processInfo = null;
+            ProcessInfo? processInfo = null;
             try
             {
                 // Primary motivation is to get the runtime instance cookie in order to
@@ -36,7 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 // Runtime didn't respond within client timeout.
             }
 
-            _ = TryParseVersion(processInfo?.ClrProductVersionString, out Version runtimeVersion);
+            _ = TryParseVersion(processInfo?.ClrProductVersionString, out Version? runtimeVersion);
 
             // CONSIDER: Generate a runtime instance identifier based on the pipe name
             // for .NET Core 3.1 e.g. pid + disambiguator in GUID form.
@@ -59,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             var client = new DiagnosticsClient(info.Endpoint);
 
-            ProcessInfo processInfo = null;
+            ProcessInfo? processInfo = null;
             try
             {
                 // Primary motivation is to keep parity with the FromProcessId implementation,
@@ -79,7 +80,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 // Runtime didn't respond within client timeout.
             }
 
-            _ = TryParseVersion(processInfo?.ClrProductVersionString, out Version runtimeVersion);
+            _ = TryParseVersion(processInfo?.ClrProductVersionString, out Version? runtimeVersion);
 
             return new EndpointInfo()
             {
@@ -94,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             };
         }
 
-        private static bool TryParseVersion(string versionString, out Version version)
+        private static bool TryParseVersion(string? versionString, [NotNullWhen(true)] out Version? version)
         {
             version = null;
             if (string.IsNullOrEmpty(versionString))
@@ -122,21 +123,25 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return Version.TryParse(noMetadataVersion[..prereleaseIndex], out version);
         }
 
+#nullable disable
         public override IpcEndpoint Endpoint { get; protected set; }
+#nullable restore
 
         public override int ProcessId { get; protected set; }
 
         public override Guid RuntimeInstanceCookie { get; protected set; }
 
-        public override string CommandLine { get; protected set; }
+        public override string? CommandLine { get; protected set; }
 
-        public override string OperatingSystem { get; protected set; }
+        public override string? OperatingSystem { get; protected set; }
 
-        public override string ProcessArchitecture { get; protected set; }
+        public override string? ProcessArchitecture { get; protected set; }
 
-        public override Version RuntimeVersion { get; protected set; }
+        public override Version? RuntimeVersion { get; protected set; }
 
+#nullable disable
         public override IServiceProvider ServiceProvider { get; protected set; }
+#nullable restore
 
         internal string DebuggerDisplay => FormattableString.Invariant($"PID={ProcessId}, Cookie={RuntimeInstanceCookie}");
     }

--- a/src/Tools/dotnet-monitor/EndpointInfo/ScopedEndpointInfo.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ScopedEndpointInfo.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class ScopedEndpointInfo : IEndpointInfo
     {
+#nullable disable
         private IEndpointInfo _endpointInfo;
+#nullable restore
 
         public void Set(IEndpointInfo endpointInfo)
         {
@@ -20,13 +22,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public Guid RuntimeInstanceCookie => _endpointInfo.RuntimeInstanceCookie;
 
-        public string CommandLine => _endpointInfo.CommandLine;
+        public string? CommandLine => _endpointInfo.CommandLine;
 
-        public string OperatingSystem => _endpointInfo.OperatingSystem;
+        public string? OperatingSystem => _endpointInfo.OperatingSystem;
 
-        public string ProcessArchitecture => _endpointInfo.ProcessArchitecture;
+        public string? ProcessArchitecture => _endpointInfo.ProcessArchitecture;
 
-        public Version RuntimeVersion => _endpointInfo.RuntimeVersion;
+        public Version? RuntimeVersion => _endpointInfo.RuntimeVersion;
 
         IpcEndpoint IEndpointInfo.Endpoint => _endpointInfo.Endpoint;
 

--- a/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
+++ b/src/Tools/dotnet-monitor/EndpointInfo/ServerEndpointInfoSource.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipelineNameCache.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/EventExceptionsPipelineNameCache.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             throwingMethodId = 0;
             ilOffset = 0;
 
-            if (!_exceptionGroupMap.TryGetValue(groupId, out ExceptionGroup identifier))
+            if (!_exceptionGroupMap.TryGetValue(groupId, out ExceptionGroup? identifier))
                 return false;
 
             exceptionClassId = identifier.ClassId;
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             methodId = 0;
             ilOffset = 0;
 
-            if (!_stackFrames.TryGetValue(stackFrameId, out StackFrameInstance instance))
+            if (!_stackFrames.TryGetValue(stackFrameId, out StackFrameInstance? instance))
                 return false;
 
             methodId = instance.MethodId;

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             {
                 if (priorInstances.TryGetValue(
                         currentInstance.InnerExceptionIds[0],
-                        out IExceptionInstance primaryInnerInstance))
+                        out IExceptionInstance? primaryInnerInstance))
                 {
                     await WriteTextInnerException(writer, primaryInnerInstance, 0, priorInstances);
 
@@ -333,7 +333,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 {
                     if (priorInstances.TryGetValue(
                         currentInstance.InnerExceptionIds[index],
-                        out IExceptionInstance secondaryInnerInstance))
+                        out IExceptionInstance? secondaryInnerInstance))
                     {
                         await WriteTextInnerException(writer, secondaryInnerInstance, index, priorInstances);
                     }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         public void RemoveExceptionInstance(ulong exceptionId)
         {
-            ExceptionInstance removedInstance = null;
+            ExceptionInstance? removedInstance = null;
 
             lock (_instances)
             {
@@ -145,7 +145,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 // it in the future, with either periodic retry OR registering a callback system for the missing IDs.
                 if (entry.Cache.TryGetExceptionGroup(entry.GroupId, out ulong exceptionClassId, out _, out _))
                 {
-                    string exceptionTypeName;
+                    string? exceptionTypeName;
                     if (!_exceptionTypeNameMap.TryGetValue(exceptionClassId, out exceptionTypeName))
                     {
                         _builder.Clear();
@@ -154,12 +154,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                     }
 
                     string moduleName = string.Empty;
-                    if (entry.Cache.NameCache.ClassData.TryGetValue(exceptionClassId, out ClassData exceptionClassData))
+                    if (entry.Cache.NameCache.ClassData.TryGetValue(exceptionClassId, out ClassData? exceptionClassData))
                     {
                         moduleName = NameFormatter.GetModuleName(entry.Cache.NameCache, exceptionClassData.ModuleId);
                     }
 
-                    CallStackModel callStack = GenerateCallStack(entry.StackFrameIds, entry.Cache, entry.ThreadId);
+                    CallStackModel? callStack = GenerateCallStack(entry.StackFrameIds, entry.Cache, entry.ThreadId);
 
                     ExceptionInstance instance = new(
                         entry.ExceptionId,
@@ -196,7 +196,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             }
         }
 
-        internal static CallStackModel GenerateCallStack(ulong[] stackFrameIds, IExceptionsNameCache cache, int threadId)
+        internal static CallStackModel? GenerateCallStack(ulong[] stackFrameIds, IExceptionsNameCache cache, int threadId)
         {
             // Exceptions without stack frames were not thrown; do not create a call stack object,
             // which makes it clear that this exception was not thrown.

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStoreLimitsCallback.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStoreLimitsCallback.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             // Make sure all of the inner exceptions are no longer top-level exceptions.
             foreach (ulong innerExceptionId in instance.InnerExceptionIds)
             {
-                if (_outerExceptionMap.TryGetValue(innerExceptionId, out List<ulong> outerExceptions))
+                if (_outerExceptionMap.TryGetValue(innerExceptionId, out List<ulong>? outerExceptions))
                 {
                     outerExceptions.Add(instance.Id);
                 }
@@ -65,9 +65,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             // exceptions that are not shared with any current top-level exception.
             if (_topLevelExceptions.Count > _topLevelLimit)
             {
-                LinkedListNode<ulong> lastNode = _topLevelExceptions.Last;
+                // The linked list is guaranteed to have an entry due to the above check and constraints on _topLevelLimit
+                LinkedListNode<ulong> lastNode = _topLevelExceptions.Last!;
                 _topLevelExceptions.RemoveLast();
-
                 RemoveIfNoOuterExceptions(lastNode.Value);
             }
         }
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
         {
             // Remove the exception if it no longer belongs to any other exception in the store
             // as an inner exception.
-            if (_outerExceptionMap.TryGetValue(exceptionId, out List<ulong> outerExceptionIds))
+            if (_outerExceptionMap.TryGetValue(exceptionId, out List<ulong>? outerExceptionIds))
             {
                 if (outerExceptionIds.Count == 0)
                 {
@@ -85,11 +85,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
                     // Check the inner exceptions of this exception, decouple them from this exception,
                     // and remove them if they are not shared with any current top-level exception.
-                    if (_innerExceptionMap.Remove(exceptionId, out List<ulong> innerExceptionIds))
+                    if (_innerExceptionMap.Remove(exceptionId, out List<ulong>? innerExceptionIds))
                     {
                         foreach (ulong innerExceptionId in innerExceptionIds)
                         {
-                            if (_outerExceptionMap.TryGetValue(innerExceptionId, out List<ulong> innerOuterExceptionIds))
+                            if (_outerExceptionMap.TryGetValue(innerExceptionId, out List<ulong>? innerOuterExceptionIds))
                             {
                                 innerOuterExceptionIds.Remove(exceptionId);
                             }

--- a/src/Tools/dotnet-monitor/Extensibility/ExtensionManifest.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/ExtensionManifest.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;

--- a/src/Tools/dotnet-monitor/Extensibility/FolderExtensionRepository.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/FolderExtensionRepository.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Diagnostics.Tools.Monitor.Egress.Extension;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;

--- a/src/Tools/dotnet-monitor/Extensibility/WellKnownExtensionRepository.cs
+++ b/src/Tools/dotnet-monitor/Extensibility/WellKnownExtensionRepository.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static IHostBuilder CreateHostBuilder(HostBuilderSettings settings)
         {
-            string aspnetUrls = string.Empty;
+            string? aspnetUrls = string.Empty;
             ServerUrlsBlockingConfigurationManager manager = new();
             manager.IsBlocking = true;
 
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     //in Kubernetes.
                     //We get around this by watching the target folder of the symlink instead.
                     //See https://github.com/kubernetes/kubernetes/master/pkg/volume/util/atomic_writer.go
-                    string path = settings.SharedConfigDirectory;
+                    string? path = settings.SharedConfigDirectory;
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInfo.IsInKubernetes)
                     {
                         string symlinkTarget = Path.Combine(settings.SharedConfigDirectory, "..data");
@@ -78,7 +78,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     builder.AddEnvironmentVariables(ToolIdentifiers.StandardPrefix);
 
                     // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources
-                    FileInfo userFilePath = settings.UserProvidedConfigFilePath;
+                    FileInfo? userFilePath = settings.UserProvidedConfigFilePath;
 
                     if (null != userFilePath)
                     {
@@ -146,6 +146,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                         // Unblock reading of the Urls option from configuration, read it, and block it again so that Kestrel
                         // is unable to read this option when it starts.
+#nullable disable
                         manager.IsBlocking = false;
                         string[] urls = ConfigurationHelper.SplitValue(context.Configuration[WebHostDefaults.ServerUrlsKey]);
                         manager.IsBlocking = true;
@@ -155,7 +156,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                         string metricHostingUrls = metricsOptions.Endpoints;
                         string[] metricUrls = ConfigurationHelper.SplitValue(metricHostingUrls);
-
+#nullable restore
                         //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
                         options.Configure(context.Configuration.GetSection("Kestrel")).Load();
 
@@ -175,7 +176,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     // Restore the Urls option to the configuration provider that originally provided the value
                     // before it was cleared during the IWebHostBuilder configuration callback.
                     if (!string.IsNullOrEmpty(aspnetUrls) &&
-                        builder.TryGetProvider(WebHostDefaults.ServerUrlsKey, out IConfigurationProvider provider))
+                        builder.TryGetProvider(WebHostDefaults.ServerUrlsKey, out IConfigurationProvider? provider))
                     {
                         provider.Set(WebHostDefaults.ServerUrlsKey, aspnetUrls);
                     }
@@ -237,7 +238,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static void ConfigureMetricsDefaults(IConfigurationBuilder builder)
         {
-            builder.AddInMemoryCollection(new Dictionary<string, string>
+            builder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.MetricCount)), MetricsOptionsDefaults.MetricCount.ToString()},
                 {ConfigurationPath.Combine(ConfigurationKeys.Metrics, nameof(MetricsOptions.IncludeDefaultProviders)), MetricsOptionsDefaults.IncludeDefaultProviders.ToString()}
@@ -246,7 +247,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static void ConfigureGlobalMetricsDefaults(IConfigurationBuilder builder)
         {
-            builder.AddInMemoryCollection(new Dictionary<string, string>
+            builder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 {ConfigurationPath.Combine(ConfigurationKeys.GlobalCounter, nameof(GlobalCounterOptions.IntervalSeconds)), GlobalCounterOptionsDefaults.IntervalSeconds.ToString() }
             });

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
@@ -42,34 +42,34 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "." + ProductFolderName) :
                     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ProductFolderName));
 
-        public string[] Urls { get; set; }
+        public string[]? Urls { get; set; }
 
-        public string[] MetricsUrls { get; set; }
+        public string[]? MetricsUrls { get; set; }
 
         public bool EnableMetrics { get; set; }
 
-        public string DiagnosticPort { get; set; }
+        public string? DiagnosticPort { get; set; }
 
         public StartupAuthenticationMode AuthenticationMode { get; set; }
 
-        public string ContentRootDirectory { get; set; }
+        public required string ContentRootDirectory { get; set; }
 
-        public string SharedConfigDirectory { get; set; }
+        public required string SharedConfigDirectory { get; set; }
 
-        public string UserConfigDirectory { get; set; }
+        public required string UserConfigDirectory { get; set; }
 
-        public FileInfo UserProvidedConfigFilePath { get; set; }
+        public FileInfo? UserProvidedConfigFilePath { get; set; }
 
         /// <summary>
         /// Create settings for dotnet-monitor hosting.
         /// </summary>
         public static HostBuilderSettings CreateMonitor(
-            string[] urls,
-            string[] metricUrls,
+            string[]? urls,
+            string[]? metricUrls,
             bool metrics,
-            string diagnosticPort,
+            string? diagnosticPort,
             StartupAuthenticationMode startupAuthMode,
-            FileInfo userProvidedConfigFilePath)
+            FileInfo? userProvidedConfigFilePath)
         {
             return new HostBuilderSettings()
             {

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderStartupLogger.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderStartupLogger.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public void Log()
         {
-            if (_builderContext.Properties.TryGetValue(HostBuilderResults.ResultKey, out object resultsObject))
+            if (_builderContext.Properties.TryGetValue(HostBuilderResults.ResultKey, out object? resultsObject))
             {
                 if (resultsObject is HostBuilderResults hostBuilderResults)
                 {

--- a/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationProvider.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/ServerUrlsBlockingConfigurationProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.Tools.Monitor
 {
@@ -17,13 +18,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _manager = manager;
         }
 
-        public override void Set(string key, string value)
+        public override void Set(string key, string? value)
         {
             // Overridden to prevent set of data since this provider does not
             // provide any real data from any source.
         }
 
-        public override bool TryGet(string key, out string value)
+        public override bool TryGet(string key, [NotNullWhen(true)] out string? value)
         {
             // Block reading of the Urls option if the manager says to block. This will prevent other
             // configuration providers that were configured at a lower priority from providing their

--- a/src/Tools/dotnet-monitor/InProcessFeatures/InProcessPostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/InProcessFeatures/InProcessPostConfigureOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             _enabledByDefault = enabledByDefault;
         }
 
-        void IPostConfigureOptions<T>.PostConfigure(string name, T options)
+        void IPostConfigureOptions<T>.PostConfigure(string? name, T options)
         {
             InProcessFeatureOptionsBinder.BindEnabled(
                 options,

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryInitializer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
                 // Go through each directory and validate the existing files are exactly the same as expected
                 // or create new files if they do not exist. Hold onto the file handles to prevent modification
                 // of the shared files while they are being offered for use in target applications.
-                while (subDirectories.TryDequeue(out string subDirectory))
+                while (subDirectories.TryDequeue(out string? subDirectory))
                 {
                     DirectoryInfo sourceDir = new(Path.Combine(sharedLibrarySourceDir.FullName, subDirectory));
                     DirectoryInfo targetDir = Directory.CreateDirectory(Path.Combine(_pathProvider.TargetPath, subDirectory));

--- a/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryPathProvider.cs
+++ b/src/Tools/dotnet-monitor/LibrarySharing/DefaultSharedLibraryPathProvider.cs
@@ -14,10 +14,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
         /// <summary>
         /// Provides libraries from the 'shared' folder under the .NET Monitor installation.
         /// </summary>
+        #nullable disable
         public DefaultSharedLibraryPathProvider(IOptions<StorageOptions> _storageOptions)
             : this(Path.Combine(AppContext.BaseDirectory, "shared"), ComputeTargetPath(_storageOptions))
         {
         }
+#nullable restore
 
         public DefaultSharedLibraryPathProvider(string sourcePath, string targetPath)
         {
@@ -25,13 +27,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor.LibrarySharing
             TargetPath = targetPath;
         }
 
-        private static string ComputeTargetPath(IOptions<StorageOptions> options)
+        private static string? ComputeTargetPath(IOptions<StorageOptions> options)
         {
-            string rootPath = options.Value.SharedLibraryPath;
+            string? rootPath = options.Value.SharedLibraryPath;
             if (string.IsNullOrEmpty(rootPath))
                 return null;
 
-            string expectedVersion = Assembly.GetExecutingAssembly().GetInformationalVersionString();
+            string? expectedVersion = Assembly.GetExecutingAssembly()?.GetInformationalVersionString();
+            if (expectedVersion == null)
+                return null;
+
             // Remove '+' and commit hash from version string
             int hashSeparatorIndex = expectedVersion.IndexOf('+');
             if (hashSeparatorIndex > 0)

--- a/src/Tools/dotnet-monitor/LoggingEventIds.cs
+++ b/src/Tools/dotnet-monitor/LoggingEventIds.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -119,7 +121,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public static EventId EventId(this LoggingEventIds enumVal)
         {
-            string name = Enum.GetName(typeof(LoggingEventIds), enumVal);
+            string? name = Enum.GetName(typeof(LoggingEventIds), enumVal);
             int id = enumVal.Id();
             return new EventId(id, name);
         }

--- a/src/Tools/dotnet-monitor/LoggingExtensions.cs
+++ b/src/Tools/dotnet-monitor/LoggingExtensions.cs
@@ -14,361 +14,361 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class LoggingExtensions
     {
-        private static readonly Action<ILogger, string, Exception> _egressProviderInvalidOptions =
+        private static readonly Action<ILogger, string, Exception?> _egressProviderInvalidOptions =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.EgressProviderInvalidOptions.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_EgressProviderInvalidOptions);
 
-        private static readonly Action<ILogger, int, Exception> _egressCopyActionStreamToEgressStream =
+        private static readonly Action<ILogger, int, Exception?> _egressCopyActionStreamToEgressStream =
             LoggerMessage.Define<int>(
                 eventId: LoggingEventIds.EgressCopyActionStreamToEgressStream.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_EgressCopyActionStreamToEgressStream);
 
-        private static readonly Action<ILogger, string, string, Exception> _egressProviderOptionsValidationFailure =
+        private static readonly Action<ILogger, string, string, Exception?> _egressProviderOptionsValidationFailure =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.EgressProviderOptionsValidationFailure.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_EgressProviderOptionsValidationError);
 
-        private static readonly Action<ILogger, string, Exception> _egressProviderInvokeStreamAction =
+        private static readonly Action<ILogger, string, Exception?> _egressProviderInvokeStreamAction =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.EgressProviderInvokeStreamAction.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_EgressProviderInvokeStreamAction);
 
-        private static readonly Action<ILogger, string, string, Exception> _egressProviderSavedStream =
+        private static readonly Action<ILogger, string, string, Exception?> _egressProviderSavedStream =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.EgressProviderSavedStream.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_EgressProviderSavedStream);
 
-        private static readonly Action<ILogger, Exception> _noAuthentication =
+        private static readonly Action<ILogger, Exception?> _noAuthentication =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.NoAuthentication.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_NoAuthentication);
 
-        private static readonly Action<ILogger, Exception> _insecureAuthenticationConfiguration =
+        private static readonly Action<ILogger, Exception?> _insecureAuthenticationConfiguration =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.InsecureAuthenticationConfiguration.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_InsecureAuthenticationConfiguration);
 
-        private static readonly Action<ILogger, string, Exception> _unableToListenToAddress =
+        private static readonly Action<ILogger, string, Exception?> _unableToListenToAddress =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.UnableToListenToAddress.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_UnableToListenToAddress);
 
-        private static readonly Action<ILogger, string, Exception> _boundDefaultAddress =
+        private static readonly Action<ILogger, string, Exception?> _boundDefaultAddress =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.BoundDefaultAddress.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_BoundDefaultAddress);
 
-        private static readonly Action<ILogger, string, Exception> _boundMetricsAddress =
+        private static readonly Action<ILogger, string, Exception?> _boundMetricsAddress =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.BoundMetricsAddress.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_BoundMetricsAddress);
 
-        private static readonly Action<ILogger, string, Exception> _optionsValidationFailure =
+        private static readonly Action<ILogger, string, Exception?> _optionsValidationFailure =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.OptionsValidationFailure.EventId(),
                 logLevel: LogLevel.Critical,
                 formatString: Strings.LogFormatString_OptionsValidationFailure);
 
-        private static readonly Action<ILogger, Exception> _runningElevated =
+        private static readonly Action<ILogger, Exception?> _runningElevated =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.RunningElevated.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_RunningElevated);
 
-        private static readonly Action<ILogger, Exception> _disabledNegotiateWhileElevated =
+        private static readonly Action<ILogger, Exception?> _disabledNegotiateWhileElevated =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.DisabledNegotiateWhileElevated.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DisabledNegotiateWhileElevated);
 
-        private static readonly Action<ILogger, string, string, Exception> _apiKeyValidationFailure =
+        private static readonly Action<ILogger, string, string, Exception?> _apiKeyValidationFailure =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.ApiKeyValidationFailure.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ApiKeyValidationFailure);
 
-        private static readonly Action<ILogger, string, string, string, string, Exception> _logTempKey =
+        private static readonly Action<ILogger, string, string, string, string, Exception?> _logTempKey =
             LoggerMessage.Define<string, string, string, string>(
                 eventId: LoggingEventIds.LogTempApiKey.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_LogTempApiKey);
 
-        private static readonly Action<ILogger, string, string, string, Exception> _duplicateEgressProviderIgnored =
+        private static readonly Action<ILogger, string, string, string, Exception?> _duplicateEgressProviderIgnored =
             LoggerMessage.Define<string, string, string>(
                 eventId: LoggingEventIds.DuplicateEgressProviderIgnored.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateEgressProviderIgnored);
 
-        private static readonly Action<ILogger, string, Exception> _apiKeyAuthenticationOptionsValidated =
+        private static readonly Action<ILogger, string, Exception?> _apiKeyAuthenticationOptionsValidated =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ApiKeyAuthenticationOptionsValidated.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ApiKeyAuthenticationOptionsValidated);
 
-        private static readonly Action<ILogger, string, Exception> _notifyPrivateKey =
+        private static readonly Action<ILogger, string, Exception?> _notifyPrivateKey =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.NotifyPrivateKey.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_NotifyPrivateKey);
 
-        private static readonly Action<ILogger, string, Exception> _duplicateCollectionRuleActionIgnored =
+        private static readonly Action<ILogger, string, Exception?> _duplicateCollectionRuleActionIgnored =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.DuplicateCollectionRuleActionIgnored.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateCollectionRuleActionIgnored);
 
-        private static readonly Action<ILogger, string, Exception> _duplicateCollectionRuleTriggerIgnored =
+        private static readonly Action<ILogger, string, Exception?> _duplicateCollectionRuleTriggerIgnored =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.DuplicateCollectionRuleTriggerIgnored.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DuplicateCollectionRuleTriggerIgnored);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleStarted =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleStarted =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleStarted);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleFailed =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleFailed =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleFailed.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_CollectionRuleFailed);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleCompleted =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleCompleted =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleCompleted);
 
-        private static readonly Action<ILogger, Exception> _collectionRulesStarted =
+        private static readonly Action<ILogger, Exception?> _collectionRulesStarted =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.CollectionRulesStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStarted);
 
-        private static readonly Action<ILogger, string, string, Exception> _collectionRuleActionStarted =
+        private static readonly Action<ILogger, string, string, Exception?> _collectionRuleActionStarted =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.CollectionRuleActionStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionStarted);
 
-        private static readonly Action<ILogger, string, string, Exception> _collectionRuleActionCompleted =
+        private static readonly Action<ILogger, string, string, Exception?> _collectionRuleActionCompleted =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.CollectionRuleActionCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionCompleted);
 
-        private static readonly Action<ILogger, string, string, Exception> _collectionRuleTriggerStarted =
+        private static readonly Action<ILogger, string, string, Exception?> _collectionRuleTriggerStarted =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.CollectionRuleTriggerStarted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleTriggerStarted);
 
-        private static readonly Action<ILogger, string, string, Exception> _collectionRuleTriggerCompleted =
+        private static readonly Action<ILogger, string, string, Exception?> _collectionRuleTriggerCompleted =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.CollectionRuleTriggerCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleTriggerCompleted);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleActionsThrottled =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleActionsThrottled =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleActionsThrottled.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_CollectionRuleActionsThrottled);
 
-        private static readonly Action<ILogger, string, string, Exception> _collectionRuleActionFailed =
+        private static readonly Action<ILogger, string, string, Exception?> _collectionRuleActionFailed =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.CollectionRuleActionFailed.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_CollectionRuleActionFailed);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleActionsCompleted =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleActionsCompleted =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleActionsCompleted.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleActionsCompleted);
 
-        private static readonly Action<ILogger, Exception> _collectionRulesStarting =
+        private static readonly Action<ILogger, Exception?> _collectionRulesStarting =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.CollectionRulesStarting.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStarting);
 
-        private static readonly Action<ILogger, int, Exception> _diagnosticRequestCancelled =
+        private static readonly Action<ILogger, int, Exception?> _diagnosticRequestCancelled =
             LoggerMessage.Define<int>(
                 eventId: LoggingEventIds.DiagnosticRequestCancelled.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DiagnosticRequestCancelled);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleUnmatchedFilters =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleUnmatchedFilters =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleUnmatchedFilters.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleUnmatchedFilters);
 
-        private static readonly Action<ILogger, Exception> _collectionRuleConfigurationChanged =
+        private static readonly Action<ILogger, Exception?> _collectionRuleConfigurationChanged =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.CollectionRuleConfigurationChanged.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleConfigurationChanged);
 
-        private static readonly Action<ILogger, Exception> _collectionRulesStopping =
+        private static readonly Action<ILogger, Exception?> _collectionRulesStopping =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.CollectionRulesStopping.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStopping);
 
-        private static readonly Action<ILogger, Exception> _collectionRulesStopped =
+        private static readonly Action<ILogger, Exception?> _collectionRulesStopped =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.CollectionRulesStopped.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRulesStopped);
 
-        private static readonly Action<ILogger, string, Exception> _collectionRuleCancelled =
+        private static readonly Action<ILogger, string, Exception?> _collectionRuleCancelled =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.CollectionRuleCancelled.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_CollectionRuleCancelled);
 
-        private static readonly Action<ILogger, int, Exception> _diagnosticRequestFailed =
+        private static readonly Action<ILogger, int, Exception?> _diagnosticRequestFailed =
             LoggerMessage.Define<int>(
                 eventId: LoggingEventIds.DiagnosticRequestFailed.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_DiagnosticRequestFailed);
 
-        private static readonly Action<ILogger, string, string, Exception> _invalidActionReferenceToken =
+        private static readonly Action<ILogger, string, string, Exception?> _invalidActionReferenceToken =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.InvalidActionReferenceToken.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_InvalidToken);
 
-        private static readonly Action<ILogger, string, Exception> _invalidActionReference =
+        private static readonly Action<ILogger, string, Exception?> _invalidActionReference =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.InvalidActionReference.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_InvalidActionReference);
 
-        private static readonly Action<ILogger, string, Exception> _invalidActionResultReference =
+        private static readonly Action<ILogger, string, Exception?> _invalidActionResultReference =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.InvalidActionResultReference.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_InvalidActionResultReference);
 
-        private static readonly Action<ILogger, string, Exception> _actionSettingsTokenizationNotSupported =
+        private static readonly Action<ILogger, string, Exception?> _actionSettingsTokenizationNotSupported =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ActionSettingsTokenizationNotSupported.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_ActionSettingsTokenizationNotSupported);
 
-        private static readonly Action<ILogger, string, Exception> _endpointTimeout =
+        private static readonly Action<ILogger, string, Exception?> _endpointTimeout =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.EndpointTimeout.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_EndpointTimeout);
 
-        private static readonly Action<ILogger, Guid, string, int, Exception> _loadingProfiler =
+        private static readonly Action<ILogger, Guid, string, int, Exception?> _loadingProfiler =
             LoggerMessage.Define<Guid, string, int>(
                 eventId: LoggingEventIds.LoadingProfiler.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_LoadingProfiler);
 
-        private static readonly Action<ILogger, string, int, Exception> _setEnvironmentVariable =
+        private static readonly Action<ILogger, string, int, Exception?> _setEnvironmentVariable =
             LoggerMessage.Define<string, int>(
                 eventId: LoggingEventIds.SetEnvironmentVariable.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_SetEnvironmentVariable);
 
-        private static readonly Action<ILogger, string, int, Exception> _getEnvironmentVariable =
+        private static readonly Action<ILogger, string, int, Exception?> _getEnvironmentVariable =
             LoggerMessage.Define<string, int>(
                 eventId: LoggingEventIds.GetEnvironmentVariable.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_GetEnvironmentVariable);
 
-        private static readonly Action<ILogger, string, Exception> _monitorApiKeyNotConfigured =
+        private static readonly Action<ILogger, string, Exception?> _monitorApiKeyNotConfigured =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.MonitorApiKeyNotConfigured.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ApiKeyNotConfigured);
 
-        private static readonly Action<ILogger, string, Exception> _experienceSurvey =
+        private static readonly Action<ILogger, string, Exception?> _experienceSurvey =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExperienceSurvey.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ExperienceSurvey);
 
-        private static readonly Action<ILogger, Exception> _diagnosticPortNotInListenModeForCollectionRules =
+        private static readonly Action<ILogger, Exception?> _diagnosticPortNotInListenModeForCollectionRules =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.DiagnosticPortNotInListenModeForCollectionRules.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DiagnosticPortNotInListenModeForCollectionRules);
 
-        private static readonly Action<ILogger, string, Exception> _extensionProbeStart =
+        private static readonly Action<ILogger, string, Exception?> _extensionProbeStart =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExtensionProbeStart.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ExtensionProbeStart);
 
-        private static readonly Action<ILogger, string, string, Exception> _extensionProbeSucceeded =
+        private static readonly Action<ILogger, string, string, Exception?> _extensionProbeSucceeded =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.ExtensionProbeSucceeded.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ExtensionProbeSucceeded);
 
-        private static readonly Action<ILogger, string, Exception> _extensionProbeFailed =
+        private static readonly Action<ILogger, string, Exception?> _extensionProbeFailed =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExtensionProbeFailed.EventId(),
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_ExtensionProbeFailed);
 
-        private static readonly Action<ILogger, string, Exception> _extensionStarting =
+        private static readonly Action<ILogger, string, Exception?> _extensionStarting =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExtensionStarting.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ExtensionStarting);
 
-        private static readonly Action<ILogger, string, int, Exception> _extensionConfigured =
+        private static readonly Action<ILogger, string, int, Exception?> _extensionConfigured =
             LoggerMessage.Define<string, int>(
                 eventId: LoggingEventIds.ExtensionConfigured.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ExtensionConfigured);
 
-        private static readonly Action<ILogger, int, Exception> _extensionEgressPayloadCompleted =
+        private static readonly Action<ILogger, int, Exception?> _extensionEgressPayloadCompleted =
             LoggerMessage.Define<int>(
                 eventId: LoggingEventIds.ExtensionEgressPayloadCompleted.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ExtensionEgressPayloadCompleted);
 
-        private static readonly Action<ILogger, int, int, Exception> _extensionExited =
+        private static readonly Action<ILogger, int, int, Exception?> _extensionExited =
             LoggerMessage.Define<int, int>(
                 eventId: LoggingEventIds.ExtensionExited.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_ExtensionExited);
 
-        private static readonly Action<ILogger, int, string, Exception> _extensionOutputMessage =
+        private static readonly Action<ILogger, int, string, Exception?> _extensionOutputMessage =
             LoggerMessage.Define<int, string>(
                 eventId: LoggingEventIds.ExtensionOutputMessage.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ExtensionOutputMessage);
 
-        private static readonly Action<ILogger, int, string, Exception> _extensionErrorMessage =
+        private static readonly Action<ILogger, int, string, Exception?> _extensionErrorMessage =
             LoggerMessage.Define<int, string>(
                 eventId: LoggingEventIds.ExtensionErrorMessage.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ExtensionErrorMessage);
 
-        private static readonly Action<ILogger, string, string, string, Exception> _extensionNotOfType =
+        private static readonly Action<ILogger, string, string, string, Exception?> _extensionNotOfType =
             LoggerMessage.Define<string, string, string>(
                 eventId: LoggingEventIds.ExtensionNotOfType.EventId(),
                 logLevel: LogLevel.Error,
@@ -380,7 +380,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_ExtensionManifestNotParsable);
 
-        private static readonly Action<ILogger, int, string, string, Exception> _extensionMalformedOutput =
+        private static readonly Action<ILogger, int, string, string, Exception?> _extensionMalformedOutput =
             LoggerMessage.Define<int, string, string>(
                 eventId: LoggingEventIds.ExtensionMalformedOutput.EventId(),
                 logLevel: LogLevel.Error,
@@ -404,7 +404,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_IntermediateFileDeletionFailed);
 
-        private static readonly Action<ILogger, string, Exception> _diagnosticPortDeleteAttempt =
+        private static readonly Action<ILogger, string, Exception?> _diagnosticPortDeleteAttempt =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.DiagnosticPortDeleteAttempt.EventId(),
                 logLevel: LogLevel.Warning,
@@ -416,7 +416,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_DiagnosticPortDeleteFailed);
 
-        private static readonly Action<ILogger, string, Exception> _diagnosticPortAlteredWhileInUse =
+        private static readonly Action<ILogger, string, Exception?> _diagnosticPortAlteredWhileInUse =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.DiagnosticPortAlteredWhileInUse.EventId(),
                 logLevel: LogLevel.Warning,
@@ -440,37 +440,37 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_UnableToApplyProfiler);
 
-        private static readonly Action<ILogger, string, Exception> _sharedlibraryPath =
+        private static readonly Action<ILogger, string, Exception?> _sharedlibraryPath =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.SharedLibraryPath.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_SharedLibraryPath);
 
-        private static readonly Action<ILogger, Exception> _connectionModeConnect =
+        private static readonly Action<ILogger, Exception?> _connectionModeConnect =
             LoggerMessage.Define(
                 eventId: LoggingEventIds.ConnectionModeConnect.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ConnectionModeConnect);
 
-        private static readonly Action<ILogger, string, Exception> _connectionModeListen =
+        private static readonly Action<ILogger, string, Exception?> _connectionModeListen =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ConnectionModeListen.EventId(),
                 logLevel: LogLevel.Information,
                 formatString: Strings.LogFormatString_ConnectionModeListen);
 
-        private static readonly Action<ILogger, string, Exception> _experimentalFeatureEnabled =
+        private static readonly Action<ILogger, string, Exception?> _experimentalFeatureEnabled =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.ExperimentalFeatureEnabled.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_ExperimentalFeatureEnabled);
 
-        private static readonly Action<ILogger, string, Exception> _startCollectArtifact =
+        private static readonly Action<ILogger, string, Exception?> _startCollectArtifact =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.StartCollectArtifact.EventId(),
                 logLevel: LogLevel.Debug,
                 formatString: Strings.LogFormatString_StartCollectArtifact);
 
-        private static readonly Action<ILogger, int, string, string, Exception> _startupHookInstructions =
+        private static readonly Action<ILogger, int, string, string, Exception?> _startupHookInstructions =
             LoggerMessage.Define<int, string, string>(
                 eventId: LoggingEventIds.StartupHookInstructions.EventId(),
                 logLevel: LogLevel.Warning,
@@ -482,13 +482,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 logLevel: LogLevel.Error,
                 formatString: Strings.LogFormatString_UnableToWatchForDisconnect);
 
-        private static readonly Action<ILogger, string, Exception> _egressProviderTypeNotExist =
+        private static readonly Action<ILogger, string, Exception?> _egressProviderTypeNotExist =
             LoggerMessage.Define<string>(
                 eventId: LoggingEventIds.EgressProviderTypeNotExist.EventId(),
                 logLevel: LogLevel.Warning,
                 formatString: Strings.LogFormatString_EgressProviderTypeNotExist);
 
-        private static readonly Action<ILogger, string, string, Exception> _profilerRuntimeIdentifier =
+        private static readonly Action<ILogger, string, string, Exception?> _profilerRuntimeIdentifier =
             LoggerMessage.Define<string, string>(
                 eventId: LoggingEventIds.ProfilerRuntimeIdentifier.EventId(),
                 logLevel: LogLevel.Debug,
@@ -588,7 +588,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             foreach (ValidationResult error in errors)
             {
+#nullable disable
                 _apiKeyValidationFailure(logger, ConfigurationKeys.MonitorApiKey, error.ErrorMessage, null);
+#nullable restore
             }
         }
 

--- a/src/Tools/dotnet-monitor/MetricsPortsProvider.cs
+++ b/src/Tools/dotnet-monitor/MetricsPortsProvider.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal class MetricsPortsProvider : IMetricsPortsProvider
     {
         private readonly AddressListenResults _results;
+#nullable disable
         private readonly IServerAddressesFeature _serverAddresses;
+#nullable restore
 
         public MetricsPortsProvider(AddressListenResults results, IServer server)
         {

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -94,20 +94,20 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 
             IDictionary<string, string> env = await client.GetProcessEnvironmentAsync(token);
 
-            if (!env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.ManagedMessaging, out string isManagedMessagingAvailable) ||
+            if (!env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.ManagedMessaging, out string? isManagedMessagingAvailable) ||
                 !ToolIdentifiers.IsEnvVarValueEnabled(isManagedMessagingAvailable))
             {
                 throw getNotAvailableException(Strings.ParameterCapturingNotAvailable_Reason_ManagedMessagingDidNotLoad);
             }
 
-            if (!env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.StartupHook, out string isStartupHookAvailable) ||
+            if (!env.TryGetValue(InProcessFeaturesIdentifiers.EnvironmentVariables.AvailableInfrastructure.StartupHook, out string? isStartupHookAvailable) ||
                 !ToolIdentifiers.IsEnvVarValueEnabled(isStartupHookAvailable))
             {
                 throw getNotAvailableException(Strings.ParameterCapturingNotAvailable_Reason_StartupHookDidNotLoad);
             }
 
             const string EditAndContinueEnvName = "COMPLUS_ForceEnc";
-            if (env.TryGetValue(EditAndContinueEnvName, out string editAndContinueEnvValue) &&
+            if (env.TryGetValue(EditAndContinueEnvName, out string? editAndContinueEnvValue) &&
                 ToolIdentifiers.IsEnvVarValueEnabled(editAndContinueEnvValue))
             {
                 // Having Enc enabled results in methods belonging to debug modules to silently fail being instrumented.
@@ -180,7 +180,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             }
         }
 
-        private void OnStartedCapturing(object sender, Guid requestId)
+        private void OnStartedCapturing(object? sender, Guid requestId)
         {
             if (requestId != _requestId)
             {
@@ -190,7 +190,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             _ = _capturingStartedCompletionSource.TrySetResult();
         }
 
-        private void OnStoppedCapturing(object sender, Guid requestId)
+        private void OnStoppedCapturing(object? sender, Guid requestId)
         {
             if (requestId != _requestId)
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             _ = _capturingStoppedCompletionSource.TrySetResult();
         }
 
-        private void OnCapturingFailed(object sender, CapturingFailedArgs args)
+        private void OnCapturingFailed(object? sender, CapturingFailedArgs args)
         {
             if (args.RequestId != _requestId)
             {
@@ -222,7 +222,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             _ = _capturingStartedCompletionSource.TrySetException(ex);
         }
 
-        private void OnServiceStateUpdate(object sender, ServiceStateUpdateArgs args)
+        private void OnServiceStateUpdate(object? sender, ServiceStateUpdateArgs args)
         {
             Exception ex;
             switch (args.ServiceState)
@@ -241,7 +241,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             _ = _capturingStoppedCompletionSource.TrySetException(ex);
         }
 
-        private void OnUnknownRequestId(object sender, Guid requestId)
+        private void OnUnknownRequestId(object? sender, Guid requestId)
         {
             if (requestId != _requestId)
             {

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -20,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             return _capturedParameters.TryAdd(captureId, new CapturedParameters(activityId, activityIdFormat, threadId, capturedDateTime, methodName, methodTypeName, methodModuleName));
         }
 
-        public bool TryFinalizeParameters(Guid captureId, out ICapturedParameters? capturedParameters)
+        public bool TryFinalizeParameters(Guid captureId, [NotNullWhen(true)] out ICapturedParameters? capturedParameters)
         {
             if (_capturedParameters.Remove(captureId, out CapturedParameters? captured))
             {

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersWriter.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersWriter.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 
             while (await _parameters.Reader.WaitToReadAsync(_cancellationToken))
             {
-                if (_parameters.Reader.TryRead(out ICapturedParameters parameter))
+                if (_parameters.Reader.TryRead(out ICapturedParameters? parameter))
                 {
                     await _formatter.WriteParameters(parameter, _cancellationToken);
                 }

--- a/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
@@ -19,15 +19,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 {
     internal sealed class CapturingFailedArgs
     {
-        public Guid RequestId { get; set; }
-        public ParameterCapturingEvents.CapturingFailedReason Reason { get; set; }
-        public string Details { get; set; }
+        public required Guid RequestId { get; set; }
+        public required ParameterCapturingEvents.CapturingFailedReason Reason { get; set; }
+        public required string Details { get; set; }
     }
 
     internal sealed class ServiceStateUpdateArgs
     {
-        public ParameterCapturingEvents.ServiceState ServiceState { get; set; }
-        public string Details { get; set; }
+        public required ParameterCapturingEvents.ServiceState ServiceState { get; set; }
+        public required string Details { get; set; }
     }
 
     internal sealed class EventParameterCapturingPipeline : EventSourcePipeline<EventParameterCapturingPipelineSettings>
@@ -65,19 +65,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                 case "Capturing/Start":
                     {
                         Guid requestId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturingActivityPayload.RequestId);
-                        Settings.OnStartedCapturing.Invoke(this, requestId);
+                        Settings.OnStartedCapturing?.Invoke(this, requestId);
                         break;
                     }
                 case "Capturing/Stop":
                     {
                         Guid requestId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturingActivityPayload.RequestId);
-                        Settings.OnStoppedCapturing.Invoke(this, requestId);
+                        Settings.OnStoppedCapturing?.Invoke(this, requestId);
                         break;
                     }
                 case "UnknownRequestId":
                     {
                         Guid requestId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.UnknownRequestIdPayload.RequestId);
-                        Settings.OnUnknownRequestId.Invoke(this, requestId);
+                        Settings.OnUnknownRequestId?.Invoke(this, requestId);
                         break;
                     }
                 case "FailedToCapture":
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                         ParameterCapturingEvents.CapturingFailedReason reason = traceEvent.GetPayload<ParameterCapturingEvents.CapturingFailedReason>(ParameterCapturingEvents.CapturingFailedPayloads.Reason);
                         string details = traceEvent.GetPayload<string>(ParameterCapturingEvents.CapturingFailedPayloads.Details);
 
-                        Settings.OnCapturingFailed.Invoke(this, new CapturingFailedArgs()
+                        Settings.OnCapturingFailed?.Invoke(this, new CapturingFailedArgs()
                         {
                             RequestId = requestId,
                             Reason = reason,
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                     {
                         ParameterCapturingEvents.ServiceState state = traceEvent.GetPayload<ParameterCapturingEvents.ServiceState>(ParameterCapturingEvents.ServiceStatePayload.State);
                         string details = traceEvent.GetPayload<string>(ParameterCapturingEvents.ServiceStatePayload.Details);
-                        Settings.OnServiceStateUpdate.Invoke(this, new ServiceStateUpdateArgs()
+                        Settings.OnServiceStateUpdate?.Invoke(this, new ServiceStateUpdateArgs()
                         {
                             ServiceState = state,
                             Details = details
@@ -166,9 +166,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                         Guid requestId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturedParametersStopPayloads.RequestId);
                         Guid captureId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturedParametersStopPayloads.CaptureId);
 
-                        if (_parameterBuilder.TryFinalizeParameters(captureId, out ICapturedParameters capturedParameters))
+                        if (_parameterBuilder.TryFinalizeParameters(captureId, out ICapturedParameters? capturedParameters))
                         {
-                            Settings.OnParametersCaptured.Invoke(this, capturedParameters);
+                            Settings.OnParametersCaptured?.Invoke(this, capturedParameters);
                         }
                         break;
                     }
@@ -189,14 +189,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
 
     internal sealed class EventParameterCapturingPipelineSettings : EventSourcePipelineSettings
     {
-        public EventHandler<Guid> OnStartedCapturing;
-        public EventHandler<Guid> OnStoppedCapturing;
-        public EventHandler<Guid> OnUnknownRequestId;
+        public EventHandler<Guid>? OnStartedCapturing;
+        public EventHandler<Guid>? OnStoppedCapturing;
+        public EventHandler<Guid>? OnUnknownRequestId;
 
-        public EventHandler<CapturingFailedArgs> OnCapturingFailed;
-        public EventHandler<ServiceStateUpdateArgs> OnServiceStateUpdate;
+        public EventHandler<CapturingFailedArgs>? OnCapturingFailed;
+        public EventHandler<ServiceStateUpdateArgs>? OnServiceStateUpdate;
 
-        public EventHandler<ICapturedParameters> OnParametersCaptured;
+        public EventHandler<ICapturedParameters>? OnParametersCaptured;
 
         public EventParameterCapturingPipelineSettings()
         {

--- a/src/Tools/dotnet-monitor/PipelineArtifactOperation.cs
+++ b/src/Tools/dotnet-monitor/PipelineArtifactOperation.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private readonly string _artifactType;
         private readonly TaskCompletionSource _startCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private Func<CancellationToken, Task> _stopFunc;
+        private Func<CancellationToken, Task>? _stopFunc;
 
         protected OperationTrackerService OperationTrackerService { get; }
 
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
                 _stopFunc = pipeline.StopAsync;
 
-                using IDisposable trackerRegistration = Register ? OperationTrackerService.Register(EndpointInfo) : null;
+                using IDisposable? trackerRegistration = Register ? OperationTrackerService.Register(EndpointInfo) : null;
 
                 Task runTask = await StartPipelineAsync(pipeline, token);
 

--- a/src/Tools/dotnet-monitor/Profiler/ProfilerService.cs
+++ b/src/Tools/dotnet-monitor/Profiler/ProfilerService.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
                 // and where to provide any additional files to dotnet-monitor.
                 // CONSIDER: Include the runtime instance identifier in the path in order to keep
                 // target processes assets separated from one another.
-                string defaultSharedPath = _storageOptions.Value.DefaultSharedPath;
+                string? defaultSharedPath = _storageOptions.Value.DefaultSharedPath;
                 if (!string.IsNullOrEmpty(defaultSharedPath))
                 {
                     // Create sharing directory in case it doesn't exist.
@@ -115,7 +115,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
             Dictionary<string, string> env = await client.GetProcessEnvironmentAsync(cancellationToken);
 
             string runtimeIdentifierSource = RuntimeIdentifierSource.ProcessEnvironment;
-            if (!env.TryGetValue(ToolIdentifiers.EnvironmentVariables.RuntimeIdentifier, out string runtimeIdentifier))
+            if (!env.TryGetValue(ToolIdentifiers.EnvironmentVariables.RuntimeIdentifier, out string? runtimeIdentifier))
             {
                 ProcessInfo processInfo = await client.GetProcessInfoAsync(cancellationToken);
 
@@ -210,6 +210,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
             return profilerFileInfo;
         }
 
+#nullable disable
         private async Task ApplyNotifyOnlyProfilerAsync(DiagnosticsClient client, IFileProvider nativeFileProvider, CancellationToken cancellationToken)
         {
             IFileInfo profilerFileInfo = GetProfilerFileInfo(ProfilerIdentifiers.NotifyOnlyProfiler.LibraryRootFileName, nativeFileProvider);
@@ -231,6 +232,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Profiler
                 ProfilerIdentifiers.MutatingProfiler.Clsid.Guid,
                 cancellationToken);
         }
+#nullable restore
 
         private async Task ApplyProfilerCoreAsync(DiagnosticsClient client, string physicalPath, string moduleEnvVarName, Guid clsid, CancellationToken cancellationToken)
         {

--- a/src/Tools/dotnet-monitor/RuntimeInfo.cs
+++ b/src/Tools/dotnet-monitor/RuntimeInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             get
             {
-                string enableDiagnostics = Environment.GetEnvironmentVariable("COMPlus_EnableDiagnostics");
+                string? enableDiagnostics = Environment.GetEnvironmentVariable("COMPlus_EnableDiagnostics");
                 return string.IsNullOrEmpty(enableDiagnostics) || !"0".Equals(enableDiagnostics, StringComparison.Ordinal);
             }
         }

--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookApplicator.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookApplicator.cs
@@ -48,13 +48,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
                 return true;
             }
 
-#nullable disable
             if (_endpointInfo.RuntimeVersion?.Major < 8)
             {
+#nullable disable
                 _logger.StartupHookInstructions(_endpointInfo.ProcessId, fileInfo.Name, fileInfo.PhysicalPath);
+#nullable restore
                 return false;
             }
-#nullable restore
 
             return await ApplyUsingDiagnosticClientAsync(fileInfo, client, token);
         }

--- a/src/Tools/dotnet-monitor/StartupHook/StartupHookApplicator.cs
+++ b/src/Tools/dotnet-monitor/StartupHook/StartupHookApplicator.cs
@@ -48,14 +48,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
                 return true;
             }
 
-
-            if (_endpointInfo.RuntimeVersion.Major < 8)
+#nullable disable
+            if (_endpointInfo.RuntimeVersion?.Major < 8)
             {
                 _logger.StartupHookInstructions(_endpointInfo.ProcessId, fileInfo.Name, fileInfo.PhysicalPath);
                 return false;
             }
+#nullable restore
 
-            return await ApplyUsingDiagnosticClientAsync(fileInfo, _endpointInfo, client, token);
+            return await ApplyUsingDiagnosticClientAsync(fileInfo, client, token);
         }
 
         private async Task<IFileInfo> GetFileInfoAsync(string tfm, string fileName, CancellationToken token)
@@ -66,10 +67,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor.StartupHook
         }
 
         private static bool IsEnvironmentConfiguredForStartupHook(IFileInfo fileInfo, IDictionary<string, string> env)
-            => env.TryGetValue(ToolIdentifiers.EnvironmentVariables.StartupHooks, out string startupHookPaths) &&
+            => env.TryGetValue(ToolIdentifiers.EnvironmentVariables.StartupHooks, out string? startupHookPaths) &&
             startupHookPaths?.Contains(fileInfo.Name, StringComparison.OrdinalIgnoreCase) == true;
 
-        private async Task<bool> ApplyUsingDiagnosticClientAsync(IFileInfo fileInfo, IEndpointInfo endpointInfo, DiagnosticsClient client, CancellationToken token)
+        private async Task<bool> ApplyUsingDiagnosticClientAsync(IFileInfo fileInfo, DiagnosticsClient client, CancellationToken token)
         {
             try
             {

--- a/src/Tools/dotnet-monitor/StoragePostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/StoragePostConfigureOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private const string DefaultSharedPathDumpsFolderName = "dumps";
         private const string DefaultSharedPathLibrariesFolderName = "libs";
 
-        void IPostConfigureOptions<StorageOptions>.PostConfigure(string name, StorageOptions options)
+        void IPostConfigureOptions<StorageOptions>.PostConfigure(string? name, StorageOptions options)
         {
             if (string.IsNullOrEmpty(options.DumpTempFolder))
             {

--- a/src/Tools/dotnet-monitor/Swagger/Filters/UnauthorizedResponseOperationFilter.cs
+++ b/src/Tools/dotnet-monitor/Swagger/Filters/UnauthorizedResponseOperationFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger.Filters
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            if (operation.Responses.TryGetValue(StatusCodeStrings.Status401Unauthorized, out OpenApiResponse unauthorizedResponse))
+            if (operation.Responses.TryGetValue(StatusCodeStrings.Status401Unauthorized, out OpenApiResponse? unauthorizedResponse))
             {
                 unauthorizedResponse.Content.Clear();
                 unauthorizedResponse.Reference = new OpenApiReference()

--- a/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/Swagger/SwaggerGenOptionsExtensions.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Swagger
             options.OperationFilter<UnauthorizedResponseOperationFilter>();
 
             string documentationFile = $"{typeof(DiagController).Assembly.GetName().Name}.xml";
+#nullable disable
             options.IncludeXmlComments(() => new XPathDocument(Assembly.GetExecutingAssembly().GetManifestResourceStream(documentationFile)));
-
+#nullable restore
             // Make sure TimeSpan is represented as a string instead of a full object type
             options.MapType<TimeSpan>(() => new OpenApiSchema() { Type = "string", Format = "time-span", Example = new OpenApiString("00:00:30") });
         }

--- a/src/Tools/dotnet-monitor/TestAssemblies.cs
+++ b/src/Tools/dotnet-monitor/TestAssemblies.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Hosting;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -20,6 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private const string TestHostingStartupAssemblyName = "Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup";
         private const string TestStartupHookAssemblyName = "Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook";
 
+#nullable disable
         [Conditional("DEBUG")]
         public static void SimulateStartupHook()
         {
@@ -42,6 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
             }
         }
+#nullable restore
 
         [Conditional("DEBUG")]
         public static void AddHostingStartup(IWebHostBuilder builder)
@@ -64,10 +67,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
         }
 
-        private static bool TryComputeBuildOutputAssemblyPath(string assemblyName, out string path)
+        private static bool TryComputeBuildOutputAssemblyPath(string assemblyName, [NotNullWhen(true)] out string? path)
         {
             Assembly thisAssembly = Assembly.GetExecutingAssembly();
-            string thisAssemblyName = thisAssembly.GetName().Name;
+            string? thisAssemblyName = thisAssembly.GetName()?.Name;
+            if (thisAssemblyName == null)
+            {
+                path = null;
+                return false;
+            }
+
             string separator = Path.DirectorySeparatorChar + ArtifactsDirectoryName + Path.DirectorySeparatorChar;
             int artifactsIndex = AppContext.BaseDirectory.IndexOf(separator);
             if (artifactsIndex != -1)

--- a/src/Tools/dotnet-monitor/Trace/TraceOperation.cs
+++ b/src/Tools/dotnet-monitor/Trace/TraceOperation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal sealed class TraceOperation : AbstractTraceOperation
     {
-        private readonly TaskCompletionSource<object> _eventStreamAvailableCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _eventStreamAvailableCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public TraceOperation(IEndpointInfo endpointInfo, EventTracePipelineSettings settings, OperationTrackerService trackerService, ILogger logger)
             : base(endpointInfo, settings, trackerService, logger) { }

--- a/src/Tools/dotnet-monitor/Trace/TraceOperationFactory.cs
+++ b/src/Tools/dotnet-monitor/Trace/TraceOperationFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return new TraceOperation(endpointInfo, settings, _operationTrackerService, _logger);
         }
 
-        public IArtifactOperation Create(IEndpointInfo endpointInfo, MonitoringSourceConfiguration configuration, TimeSpan duration, string providerName, string eventName, IDictionary<string, string> payloadFilter)
+        public IArtifactOperation Create(IEndpointInfo endpointInfo, MonitoringSourceConfiguration configuration, TimeSpan duration, string providerName, string eventName, IDictionary<string, string>? payloadFilter)
         {
             EventTracePipelineSettings settings = new()
             {

--- a/src/Tools/dotnet-monitor/Trace/TraceUntilEventOperation.cs
+++ b/src/Tools/dotnet-monitor/Trace/TraceUntilEventOperation.cs
@@ -16,17 +16,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         private readonly string _providerName;
         private readonly string _eventName;
-        private readonly IDictionary<string, string> _payloadFilter;
+        private readonly IDictionary<string, string>? _payloadFilter;
 
-        private readonly TaskCompletionSource<object> _eventStreamAvailableCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource<object> _stoppingEventHitSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _eventStreamAvailableCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _stoppingEventHitSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public TraceUntilEventOperation(
             IEndpointInfo endpointInfo,
             EventTracePipelineSettings settings,
             string providerName,
             string eventName,
-            IDictionary<string, string> payloadFilter,
+            IDictionary<string, string>? payloadFilter,
             OperationTrackerService trackerService,
             ILogger logger)
             : base(endpointInfo, settings, trackerService, logger)
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return new EventTracePipeline(client, _settings,
                 async (eventStream, token) =>
                 {
-                    _eventStreamAvailableCompletionSource?.TrySetResult(null);
+                    _eventStreamAvailableCompletionSource.TrySetResult(null);
 
                     await using EventMonitor eventMonitor = new(
                         _providerName,

--- a/src/Tools/dotnet-monitor/ValidationResultExtensions.cs
+++ b/src/Tools/dotnet-monitor/ValidationResultExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public static bool IsSuccess([NotNullWhen(false)] this ValidationResult? result)
         {
+            // ValidationResult.Success is null, and a null value indicates there are no validation errors.
             return result == ValidationResult.Success;
         }
     }

--- a/src/Tools/dotnet-monitor/ValidationResultExtensions.cs
+++ b/src/Tools/dotnet-monitor/ValidationResultExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static class ValidationResultExtensions
+    {
+        public static bool IsSuccess([NotNullWhen(false)] this ValidationResult? result)
+        {
+            return result == ValidationResult.Success;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -8,6 +8,7 @@
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
###### Summary

Enable nullable aware context for `dotnet-monitor`.  Just like https://github.com/dotnet/dotnet-monitor/pull/6924 this PR only contains no/low risk changes. If you see anything that you feel like could introduce a regression or is non-trivial, leave a comment and I'll pull out those changes.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
