### PR TITLE
[Nullable Context] Proposal for better null-state static analysis with `IPostConfigureOptions`

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionUtils.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionUtils.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Diagnostics.Monitoring.Options
 {
     internal static class OptionUtils
     {
-        public static void ThrowIfNotConfigured<T>([DoesNotReturnIf(false)] bool IsValid)
+        public static void ThrowIfNotConfigured<T>([DoesNotReturnIf(false)] bool isConfigured)
         {
-            if (!IsValid)
+            if (!isConfigured)
             {
                 throw new InvalidOperationException(string.Format(
                     CultureInfo.InvariantCulture,

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionUtils.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionUtils.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.Monitoring.Options
+{
+    internal static class OptionUtils
+    {
+        public static void ThrowIfNotConfigured<T>([DoesNotReturnIf(false)] bool IsValid)
+        {
+            if (!IsValid)
+            {
+                throw new InvalidOperationException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    OptionsDisplayStrings.ErrorMessage_OptionNotConfigured,
+                    nameof(T)));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -1568,6 +1568,15 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;{0} option was not configured correctly..
+        /// </summary>
+        public static string ErrorMessage_OptionNotConfigured {
+            get {
+                return ResourceManager.GetString("ErrorMessage_OptionNotConfigured", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The field {0} must be a status code or status code range between 1xx and 5xx. E.g. 200, 400-500..
         /// </summary>
         public static string ErrorMessage_StatusCodesRegularExpressionDoesNotMatch {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -1568,7 +1568,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;{0} option was not configured correctly..
+        ///   Looks up a localized string similar to The &apos;{0}&apos; option was not configured correctly..
         /// </summary>
         public static string ErrorMessage_OptionNotConfigured {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -774,6 +774,6 @@
     <comment>The description provided for the Issuer parameter on MonitorApiKeyOptions.</comment>
   </data>
   <data name="ErrorMessage_OptionNotConfigured" xml:space="preserve">
-    <value>The '{0} option was not configured correctly.</value>
+    <value>The '{0}' option was not configured correctly.</value>
   </data>
 </root>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -773,4 +773,7 @@
     <value>The expected value of the 'iss' or Issuer field in the JWT (JSON Web Token).</value>
     <comment>The description provided for the Issuer parameter on MonitorApiKeyOptions.</comment>
   </data>
+  <data name="ErrorMessage_OptionNotConfigured" xml:space="preserve">
+    <value>The '{0} option was not configured correctly.</value>
+  </data>
 </root>

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsUtils.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsUtils.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 
 namespace Microsoft.Diagnostics.Monitoring.Options
 {
-    internal static class OptionUtils
+    internal static class OptionsUtils
     {
         public static void ThrowIfNotConfigured<T>([DoesNotReturnIf(false)] bool isConfigured)
         {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         internal bool Configured
         {
-            [MemberNotNullWhen(true, nameof(DefaultSharedPath), nameof(DumpTempFolder), nameof(SharedLibraryPath))]
+            [MemberNotNullWhen(true, nameof(DumpTempFolder), nameof(SharedLibraryPath))]
             get;
             set;
         }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Diagnostics.Monitoring.Options;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi
 {
@@ -18,10 +18,17 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_StorageOptions_DumpTempFolder))]
         public string? DumpTempFolder { get; set; }
 
-        [Experimental]
+        [Options.Experimental]
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_StorageOptions_SharedLibraryPath))]
         public string? SharedLibraryPath { get; set; }
+
+        internal bool Configured
+        {
+            [MemberNotNullWhen(true, nameof(DefaultSharedPath), nameof(DumpTempFolder), nameof(SharedLibraryPath))]
+            get;
+            set;
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/StorageOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         internal bool Configured
         {
-            [MemberNotNullWhen(true, nameof(DumpTempFolder), nameof(SharedLibraryPath))]
+            [MemberNotNullWhen(true, nameof(DumpTempFolder))]
             get;
             set;
         }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.Options;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Options;
 using System;
@@ -36,8 +37,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 throw new ArgumentNullException(nameof(endpointInfo));
             }
 
-            // Guaranteed to not be null by StoragePostConfigureOptions.PostConfigure.
-            string dumpTempFolder = _storageOptions.CurrentValue.DumpTempFolder!;
+            StorageOptions options = _storageOptions.CurrentValue;
+            OptionUtils.ThrowIfNotConfigured<StorageOptions>(options.Configured);
+
+            string dumpTempFolder = options.DumpTempFolder;
 
             // Ensure folder exists before issue command.
             if (!Directory.Exists(dumpTempFolder))

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/DumpService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
 
             StorageOptions options = _storageOptions.CurrentValue;
-            OptionUtils.ThrowIfNotConfigured<StorageOptions>(options.Configured);
+            OptionsUtils.ThrowIfNotConfigured<StorageOptions>(options.Configured);
 
             string dumpTempFolder = options.DumpTempFolder;
 

--- a/src/Tools/dotnet-monitor/StoragePostConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/StoragePostConfigureOptions.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     options.SharedLibraryPath = Path.Combine(options.DefaultSharedPath, DefaultSharedPathLibrariesFolderName);
                 }
             }
+
+            options.Configured = true;
         }
     }
 }


### PR DESCRIPTION
###### Summary

This PR is a proposal for how we can have better null-state static analysis when dealing with our Options classes the rely on `IPostConfigureOptions` to set default values.

(Also partially addresses #6929)

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
