### PR TITLE
Fix excluded branches in CG pipeline

### DIFF
--- a/eng/pipelines/dotnet-monitor-cg.yml
+++ b/eng/pipelines/dotnet-monitor-cg.yml
@@ -5,9 +5,9 @@ schedules:
     include:
     - shipped/*
     exclude:
-    - shipped/7.3
-    - shipped/7.2
-    - shipped/7.1
+    - shipped/v7.3
+    - shipped/v7.2
+    - shipped/v7.1
   always: true
 
 trigger: none


### PR DESCRIPTION
###### Summary

The excluded branches were not correctly specified (they were missing the `v` in the version). This update should actually exclude the branches from being scanned for component governance issues.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
