### PR TITLE
[Docs] Add the `GcCollect` option to TraceProfile in documentation

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -554,6 +554,7 @@ Enumeration that describes the type of diagnostic trace to capture. Each profile
 | `Http` | Tracks ASP[]().NET request handling and HttpClient requests. |
 | `Logs` | Tracks log events emitted at the `Debug` [log level](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventlevel) or higher. |
 | `Metrics` | Tracks [event counters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/available-counters) from the `System.Runtime`, `Microsoft.AspNetCore.Hosting`, and `Grpc.AspNetCore.Server` event sources. |
+| `GcCollect` | Tracks only garbage collection events, same as the `gc-collect` profile for `dotnet-trace`. |
 
 ## ValidationProblemDetails
 


### PR DESCRIPTION
###### Summary
Support for the `GcCollect` option was added for trace profiles in https://github.com/dotnet/dotnet-monitor/pull/6348, however, the documentation was never updated. This just updates the docs with similar information to the release note/PR


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
