### PR TITLE
[release/6.x] Manually Backport `preparerelease.yml` 

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -20,7 +20,6 @@ stages:
       - group: DotNet-Diagnostics-Storage
       - group: DotNet-DotNetStage-Storage
       - group: Release-Pipeline
-      - group: DotNetBuilds storage account read tokens
     steps:
     - task: UseDotNet@2
       displayName: 'Use .NET 6'
@@ -48,6 +47,28 @@ stages:
             -BarId $(BARBuildId)
             -MaestroToken $(MaestroAccessToken)
             -TaskVariableName 'BuildVersion'
+
+      # Populate dotnetbuilds-internal-container-read-token
+      - template: /eng/common/templates-official/steps/get-delegation-sas.yml
+        parameters:
+          federatedServiceConnection: 'dotnetbuilds-internal-read'
+          outputVariableName: 'dotnetbuilds-internal-checksums-container-read-token'
+          expiryInHours: 1
+          base64Encode: false
+          storageAccount: dotnetbuilds
+          container: internal-checksums
+          permissions: rl
+
+      # Populate dotnetbuilds-internal-container-read-token
+      - template: /eng/common/templates-official/steps/get-delegation-sas.yml
+        parameters:
+          federatedServiceConnection: 'dotnetbuilds-internal-read'
+          outputVariableName: 'dotnetbuilds-internal-container-read-token'
+          expiryInHours: 1
+          base64Encode: false
+          storageAccount: dotnetbuilds
+          container: internal
+          permissions: rl
 
       - task: AzureCLI@2
         displayName: 'Download Build Assets'


### PR DESCRIPTION
###### Summary

Manually porting `preparerelease.yml` from https://github.com/dotnet/dotnet-monitor/pull/6892 to address staging issue.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
