### PR TITLE
Move Azure.Identity to azure-sdk-dependencies group

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -55,10 +55,10 @@ updates:
       azure-sdk-dependencies:
         patterns:
           - "Azure.Core"
+          - "Azure.Identity"
           - "Azure.Storage.*"
       identity-dependencies:
         patterns:
-          - "Azure.Identity"
           - "Microsoft.Identity.*"
           - "Microsoft.IdentityModel.*"
   - package-ecosystem: "nuget"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,10 @@ updates:
     azure-sdk-dependencies:
       patterns:
       - Azure.Core
+      - Azure.Identity
       - Azure.Storage.*
     identity-dependencies:
       patterns:
-      - Azure.Identity
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
@@ -98,10 +98,10 @@ updates:
     azure-sdk-dependencies:
       patterns:
       - Azure.Core
+      - Azure.Identity
       - Azure.Storage.*
     identity-dependencies:
       patterns:
-      - Azure.Identity
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
 - package-ecosystem: nuget
@@ -179,10 +179,10 @@ updates:
     azure-sdk-dependencies:
       patterns:
       - Azure.Core
+      - Azure.Identity
       - Azure.Storage.*
     identity-dependencies:
       patterns:
-      - Azure.Identity
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
 - package-ecosystem: nuget


### PR DESCRIPTION
###### Summary

The `Azure.Identity` package should be updated with the rest of the Azure SDK dependencies since it is released with the other Azure SDK packages.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
