### PR TITLE
Get build data using darc instead of maestro web api

### DIFF
--- a/eng/pipelines/dotnet-monitor-compliance.yml
+++ b/eng/pipelines/dotnet-monitor-compliance.yml
@@ -40,22 +40,24 @@ extends:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: 'Get Build Version (Full)'
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
             arguments: >-
               -BarId $(BuildBarId)
-              -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'BuildVersion'
 
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: 'Get Build Version (Major.Minor)'
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
             arguments: >-
               -BarId $(BuildBarId)
-              -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'BuildMajorMinorVersion'
               -MajorMinorOnly
 

--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -62,22 +62,24 @@ extends:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: Get Release Version
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
             arguments: >-
               -BarId $(BarId)
-              -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'ReleaseVersion'
 
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: Get Build Version
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
             arguments: >-
               -BarId $(BarId)
-              -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'BuildVersion'
 
         - powershell: |
@@ -145,22 +147,24 @@ extends:
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-              - task: PowerShell@2
+              - task: AzureCLI@2
                 displayName: Get Release Version
                 inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
+                  azureSubscription: "Darc: Maestro Production"
+                  scriptType: ps
+                  scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
                   arguments: >-
                     -BarId $(BarId)
-                    -MaestroToken $(MaestroAccessToken)
                     -TaskVariableName 'ReleaseVersion'
 
-              - task: PowerShell@2
+              - task: AzureCLI@2
                 displayName: Get Build Version
                 inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+                  azureSubscription: "Darc: Maestro Production"
+                  scriptType: ps
+                  scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
                   arguments: >-
                     -BarId $(BarId)
-                    -MaestroToken $(MaestroAccessToken)
                     -TaskVariableName 'BuildVersion'
 
               - powershell: Install-PackageProvider -Name NuGet -Force -Scope CurrentUser

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -39,13 +39,14 @@ stages:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:
       - template: /eng/common/templates-official/post-build/setup-maestro-vars.yml@self
 
-      - task: PowerShell@2
+      - task: AzureCLI@2
         displayName: Get Build Version
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+          azureSubscription: "Darc: Maestro Production"
+          scriptType: ps
+          scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
           arguments: >-
             -BarId $(BARBuildId)
-            -MaestroToken $(MaestroAccessToken)
             -TaskVariableName 'BuildVersion'
 
       # Populate dotnetbuilds-internal-container-read-token

--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -10,32 +10,12 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-$ci = $true
-$darc = $null
-try {
-    $darc = (Get-Command darc).Source
-}
-catch {
-    . $PSScriptRoot\..\..\common\tools.ps1
-    $darc = Get-Darc $DarcVersion
-}
+$buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
+    -BarId $BarId `
+    -MaestroApiEndPoint $MaestroApiEndPoint `
+    -DarcVersion $DarcVersion
 
-[string]$buildDataJson = & $darc get-build `
-    --id "$BarId" `
-    --extended `
-    --output-format json `
-    --bar-uri "$MaestroApiEndPoint" `
-    --ci
-
-Write-Verbose 'BuildData:'
-Write-Verbose $buildDataJson
-$buildData = $buildDataJson | ConvertFrom-Json
-
-if ($buildData.Length -ne 1) {
-    Write-Error 'Unable to obtain build data.'
-}
-
-[array]$matchingData = $buildData[0].assets | Where-Object { $_.name -match 'MergedManifest.xml$' }
+[array]$matchingData = $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' }
 
 if ($matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'

--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -15,9 +15,9 @@ $buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
     -MaestroApiEndPoint $MaestroApiEndPoint `
     -DarcVersion $DarcVersion
 
-[array]$matchingData = $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' }
+[array]$matchingData = $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping }
 
-if ($matchingData.Length -ne 1) {
+if (!$matchingData -or $matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'
 }
 

--- a/eng/release/Scripts/GetDarcBuild.ps1
+++ b/eng/release/Scripts/GetDarcBuild.ps1
@@ -29,7 +29,7 @@ Write-Verbose 'BuildData:'
 Write-Verbose $buildDataJson
 $buildData = $buildDataJson | ConvertFrom-Json
 
-if ($buildData.Length -ne 1) {
+if (!$buildData -or $buildData.Length -ne 1) {
     Write-Error 'Unable to obtain build data.'
 }
 

--- a/eng/release/Scripts/GetDarcBuild.ps1
+++ b/eng/release/Scripts/GetDarcBuild.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][string] $BarId,
+    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro.dot.net',
+    [Parameter(Mandatory=$false)][string] $DarcVersion = $null
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ci = $true
+$darc = $null
+try {
+    $darc = (Get-Command darc).Source
+}
+catch {
+    . $PSScriptRoot\..\..\common\tools.ps1
+    $darc = Get-Darc $DarcVersion
+}
+
+[string]$buildDataJson = & $darc get-build `
+    --id "$BarId" `
+    --extended `
+    --output-format json `
+    --bar-uri "$MaestroApiEndPoint" `
+    --ci
+
+Write-Verbose 'BuildData:'
+Write-Verbose $buildDataJson
+$buildData = $buildDataJson | ConvertFrom-Json
+
+if ($buildData.Length -ne 1) {
+    Write-Error 'Unable to obtain build data.'
+}
+
+Write-Output  $buildData[0]

--- a/eng/release/Scripts/GetReleaseVersion.ps1
+++ b/eng/release/Scripts/GetReleaseVersion.ps1
@@ -10,32 +10,12 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-$ci = $true
-$darc = $null
-try {
-    $darc = (Get-Command darc).Source
-}
-catch {
-    . $PSScriptRoot\..\..\common\tools.ps1
-    $darc = Get-Darc $DarcVersion
-}
+$buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
+    -BarId $BarId `
+    -MaestroApiEndPoint $MaestroApiEndPoint `
+    -DarcVersion $DarcVersion
 
-[string]$buildDataJson = & $darc get-build `
-    --id "$BarId" `
-    --extended `
-    --output-format json `
-    --bar-uri "$MaestroApiEndPoint" `
-    --ci
-
-Write-Verbose 'BuildData:'
-Write-Verbose $buildDataJson
-$buildData = $buildDataJson | ConvertFrom-Json
-
-if ($buildData.Length -ne 1) {
-    Write-Error 'Unable to obtain build data.'
-}
-
-[array]$matchingData = $buildData[0].assets | Where-Object { $_.name -match '^dotnet-monitor$' }
+[array]$matchingData = $buildData.assets | Where-Object { $_.name -match '^dotnet-monitor$' }
 
 if ($matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain release version'

--- a/eng/release/Scripts/GetReleaseVersion.ps1
+++ b/eng/release/Scripts/GetReleaseVersion.ps1
@@ -17,7 +17,7 @@ $buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
 
 [array]$matchingData = $buildData.assets | Where-Object { $_.name -match '^dotnet-monitor$' }
 
-if ($matchingData.Length -ne 1) {
+if (!$matchingData -or $matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain release version'
 }
 

--- a/eng/release/Scripts/GetReleaseVersion.ps1
+++ b/eng/release/Scripts/GetReleaseVersion.ps1
@@ -1,30 +1,47 @@
 [CmdletBinding()]
 Param(
     [Parameter(Mandatory=$true)][string] $BarId,
-    [Parameter(Mandatory=$true)][string] $MaestroToken,
-    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
-    [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2020-02-20',
+    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro.dot.net',
     [Parameter(Mandatory=$false)][string] $TaskVariableName = $null,
+    [Parameter(Mandatory=$false)][string] $DarcVersion = $null,
     [Parameter(Mandatory=$false)][switch] $IncludeV
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-[array]$releaseData = Invoke-RestMethod `
-    -Uri "$MaestroApiEndPoint/api/assets?buildId=$BarId&name=dotnet-monitor&api-version=$MaestroApiVersion" `
-    -Method 'GET' `
-    -Headers @{ 'accept' = 'application/json'; 'Authorization' = "Bearer $MaestroToken" }
+$ci = $true
+$darc = $null
+try {
+    $darc = (Get-Command darc).Source
+}
+catch {
+    . $PSScriptRoot\..\..\common\tools.ps1
+    $darc = Get-Darc $DarcVersion
+}
 
-Write-Verbose 'ReleaseData:'
-$releaseDataJson = $releaseData | ConvertTo-Json
-Write-Verbose $releaseDataJson
+[string]$buildDataJson = & $darc get-build `
+    --id "$BarId" `
+    --extended `
+    --output-format json `
+    --bar-uri "$MaestroApiEndPoint" `
+    --ci
 
-if ($releaseData.Length -ne 1) {
+Write-Verbose 'BuildData:'
+Write-Verbose $buildDataJson
+$buildData = $buildDataJson | ConvertFrom-Json
+
+if ($buildData.Length -ne 1) {
+    Write-Error 'Unable to obtain build data.'
+}
+
+[array]$matchingData = $buildData[0].assets | Where-Object { $_.name -match '^dotnet-monitor$' }
+
+if ($matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain release version'
 }
 
-$version = $releaseData[0].Version
+$version = $matchingData[0].version
 if ($IncludeV) {
     $version = "v$version"
 }


### PR DESCRIPTION
###### Summary

- Convert GetBuildVersion.ps1 and GetReleaseVersion.ps1 scripts to use `darc` instead of Maestro web api.
- Switch from PowerShell to AzureCLI pipeline task to use the "Darc: Maestro Production" service connection.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2519875&view=logs&j=9c2ccffd-8e7d-5b34-ccf9-d3f1053322e9&t=3f1d8db9-f809-50a5-55bc-cc845894472c
The validation build demonstrates that the GetBuildVersion.ps1 script works as expected. The remainder of the job failed due to the "Publish Using Darc" job not actually publishing bits. I will perform further testing once the changes are merged.

Closes #7079 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
