### PR TITLE
Update Azure Linux tag names

### DIFF
--- a/eng/pipelines/templates/pipeline-template.yml
+++ b/eng/pipelines/templates/pipeline-template.yml
@@ -27,13 +27,13 @@ extends:
   parameters:
     containers:
       build_linux_amd64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net8.0
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-amd64
       build_linux_arm64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm64-net8.0
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64
       build_linux_musl_amd64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-alpine-net8.0
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-amd64-alpine
       build_linux_musl_arm64_cross:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm64-alpine-net8.0
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64-alpine
       helix_linux_amd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04
       helix_linux_musl_amd64:


### PR DESCRIPTION
Updating the naming scheme for these images, see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1176.