### PR TITLE
[release/8.0] Get build data using darc instead of maestro web api

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -62,22 +62,24 @@ extends:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: Get Release Version
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
             arguments: >-
               -BarId $(BarId)
-              -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'ReleaseVersion'
         
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: Get Build Version
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
             arguments: >-
               -BarId $(BarId)
-              -MaestroToken $(MaestroAccessToken)
               -TaskVariableName 'BuildVersion'
 
         - powershell: |
@@ -140,22 +142,24 @@ extends:
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-              - task: PowerShell@2
+              - task: AzureCLI@2
                 displayName: Get Release Version
                 inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
+                  azureSubscription: "Darc: Maestro Production"
+                  scriptType: ps
+                  scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetReleaseVersion.ps1
                   arguments: >-
                     -BarId $(BarId)
-                    -MaestroToken $(MaestroAccessToken)
                     -TaskVariableName 'ReleaseVersion'
 
-              - task: PowerShell@2
+              - task: AzureCLI@2
                 displayName: Get Build Version
                 inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+                  azureSubscription: "Darc: Maestro Production"
+                  scriptType: ps
+                  scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
                   arguments: >-
                     -BarId $(BarId)
-                    -MaestroToken $(MaestroAccessToken)
                     -TaskVariableName 'BuildVersion'
 
               - powershell: Install-PackageProvider -Name NuGet -Force -Scope CurrentUser

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -39,13 +39,14 @@ stages:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/release/'))) }}:
       - template: /eng/common/templates-official/post-build/setup-maestro-vars.yml@self
 
-      - task: PowerShell@2
+      - task: AzureCLI@2
         displayName: Get Build Version
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
+          azureSubscription: "Darc: Maestro Production"
+          scriptType: ps
+          scriptPath: $(Build.SourcesDirectory)/eng/release/Scripts/GetBuildVersion.ps1
           arguments: >-
             -BarId $(BARBuildId)
-            -MaestroToken $(MaestroAccessToken)
             -TaskVariableName 'BuildVersion'
 
       # Populate dotnetbuilds-internal-container-read-token

--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -1,31 +1,26 @@
 [CmdletBinding()]
 Param(
     [Parameter(Mandatory=$true)][string] $BarId,
-    [Parameter(Mandatory=$true)][string] $MaestroToken,
-    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
-    [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2020-02-20',
-    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null
+    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro.dot.net',
+    [Parameter(Mandatory=$false)][string] $TaskVariableName = $null,
+    [Parameter(Mandatory=$false)][string] $DarcVersion = $null
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-[array]$releaseData = Invoke-RestMethod `
-    -Uri "$MaestroApiEndPoint/api/assets?buildId=$BarId&api-version=$MaestroApiVersion" `
-    -Method 'GET' `
-    -Headers @{ 'accept' = 'application/json'; 'Authorization' = "Bearer $MaestroToken" }
+$buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
+    -BarId $BarId `
+    -MaestroApiEndPoint $MaestroApiEndPoint `
+    -DarcVersion $DarcVersion
 
-Write-Verbose 'ReleaseData:'
-$releaseDataJson = $releaseData | ConvertTo-Json
-Write-Verbose $releaseDataJson
+[array]$matchingData = $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping }
 
-[array]$matchingData = $releaseData | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping -ieq 'true' }
-
-if ($matchingData.Length -ne 1) {
+if (!$matchingData -or $matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'
 }
 
-$version = $matchingData[0].Version
+$version = $matchingData[0].version
 
 Write-Verbose "Build Version: $version"
 

--- a/eng/release/Scripts/GetDarcBuild.ps1
+++ b/eng/release/Scripts/GetDarcBuild.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][string] $BarId,
+    [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro.dot.net',
+    [Parameter(Mandatory=$false)][string] $DarcVersion = $null
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ci = $true
+$darc = $null
+try {
+    $darc = (Get-Command darc).Source
+}
+catch {
+    . $PSScriptRoot\..\..\common\tools.ps1
+    $darc = Get-Darc $DarcVersion
+}
+
+[string]$buildDataJson = & $darc get-build `
+    --id "$BarId" `
+    --extended `
+    --output-format json `
+    --bar-uri "$MaestroApiEndPoint" `
+    --ci
+
+Write-Verbose 'BuildData:'
+Write-Verbose $buildDataJson
+$buildData = $buildDataJson | ConvertFrom-Json
+
+if (!$buildData -or $buildData.Length -ne 1) {
+    Write-Error 'Unable to obtain build data.'
+}
+
+Write-Output  $buildData[0]


### PR DESCRIPTION
###### Summary

Manual backport of #7174 to `release/8.0`; there was minor merge conflicts in some of the files due to drift and the compliance pipeline doesn't exist in 8.0

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
