### PR TITLE
Get non-base64 runtime feed token for Helix

### DIFF
--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -117,6 +117,12 @@ jobs:
               -DestinationFolder "$(HelixNodejsPayloadPath)"
             displayName: Hydrate Node.js Installation Non-Linux
 
+      # Populate dotnetbuilds-internal-container-read-token for Helix
+      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+        parameters:
+          outputVariableName: 'dotnetbuilds-internal-container-read-token'
+          base64Encode: false
+
     - ${{ else }}:
       - ${{ if ne(parameters.osGroup, 'Windows') }}:
         - task: NodeTool@0
@@ -144,12 +150,6 @@ jobs:
       - ${{ if eq(parameters.osGroup, 'Linux_Musl') }}:
         - script: echo "##vso[task.prependpath]/usr/share/node/bin"
           displayName: Add Azurite to PATH
-
-      # Populate dotnetbuilds-internal-container-read-token
-      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
-        parameters:
-          outputVariableName: 'dotnetbuilds-internal-container-read-token'
-          base64Encode: false
 
     ${{ if eq(parameters.useHelix, 'true')}}:
       buildArgs: >-

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -145,6 +145,12 @@ jobs:
         - script: echo "##vso[task.prependpath]/usr/share/node/bin"
           displayName: Add Azurite to PATH
 
+      # Populate dotnetbuilds-internal-container-read-token
+      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+        parameters:
+          outputVariableName: 'dotnetbuilds-internal-container-read-token'
+          base64Encode: false
+
     ${{ if eq(parameters.useHelix, 'true')}}:
       buildArgs: >-
         -test


### PR DESCRIPTION
###### Summary

In #6892, the repository switched to using federated service connections and generating feed tokens on demand. One spot that was missed was the Helix test runs, which required a non-base64 runtime feed token. Add the pipeline step to generate this token and set it on the expected variable.

This is targeting `release/9.x` directly and will be backported to all other branches after approval and validation.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2527864&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
