### PR TITLE
Update async usage to conform to analyzer rules

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -47,14 +47,14 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
         /// is the same that is generated from the dotnet-monitor binaries.
         /// </summary>
         [Fact]
-        public async Task BaselineDifferenceTest()
+        public async Task BaselineDifferenceTestAsync()
         {
             using FileStream stream = await GenerateDocumentAsync();
             using StreamReader reader = new(stream);
 
             // Renormalize line endings due to git checkout normalizing to the operating system preference.
             string baselineContent = File.ReadAllText(OpenApiBaselinePath).Replace("\r\n", "\n");
-            string generatedContent = reader.ReadToEnd();
+            string generatedContent = await reader.ReadToEndAsync();
 
             bool equal = string.Equals(baselineContent, generatedContent, StringComparison.Ordinal);
             if (!equal)
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
         /// Test that the generated OpenAPI document is valid.
         /// </summary>
         [Fact]
-        public async Task GeneratedIsValidTest()
+        public async Task GeneratedIsValidTestAsync()
         {
             using FileStream stream = await GenerateDocumentAsync();
 


### PR DESCRIPTION
###### Summary

As seen in PRs such as #7234, new analyzers are failing the name of some async methods and requiring the use of aysnc methods over sync methods within async contexts.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
