### PR TITLE
Increase token expiration and retry until compatible token

### DIFF
--- a/eng/common/core-templates/steps/get-delegation-sas.yml
+++ b/eng/common/core-templates/steps/get-delegation-sas.yml
@@ -28,15 +28,20 @@ steps:
     scriptType: 'pscore'
     scriptLocation: 'inlineScript'
     inlineScript: |
-      # Calculate the expiration of the SAS token and convert to UTC
-      $expiry = (Get-Date).AddHours(${{ parameters.expiryInHours }}).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+      # Temporarily work around a helix issue where SAS tokens with / in them will cause incorrect downloads
+      # of correlation payloads. See https://github.com/dotnet/dnceng/issues/3484
+      $sas = ""
+      do {
+        # Calculate the expiration of the SAS token and convert to UTC
+        $expiry = (Get-Date).AddHours(${{ parameters.expiryInHours }}).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
-      $sas = az storage container generate-sas --account-name ${{ parameters.storageAccount }} --name ${{ parameters.container }} --permissions ${{ parameters.permissions }} --expiry $expiry --auth-mode login --as-user -o tsv
+        $sas = az storage container generate-sas --account-name ${{ parameters.storageAccount }} --name ${{ parameters.container }} --permissions ${{ parameters.permissions }} --expiry $expiry --auth-mode login --as-user -o tsv
 
-      if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to generate SAS token."
-        exit 1
-      }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to generate SAS token."
+          exit 1
+        }
+      } while($sas.IndexOf('/') -ne -1)
 
       if ('${{ parameters.base64Encode }}' -eq 'true') {
         $sas = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($sas))

--- a/eng/pipelines/jobs/test-binaries.yml
+++ b/eng/pipelines/jobs/test-binaries.yml
@@ -118,10 +118,11 @@ jobs:
             displayName: Hydrate Node.js Installation Non-Linux
 
       # Populate dotnetbuilds-internal-container-read-token for Helix
-      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+      - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
         parameters:
           outputVariableName: 'dotnetbuilds-internal-container-read-token'
           base64Encode: false
+          expiryInHours: 2 # Match the job timeout; Helix can take a long time to process tests depending on queue depth
 
     - ${{ else }}:
       - ${{ if ne(parameters.osGroup, 'Windows') }}:


### PR DESCRIPTION
###### Summary

- Increase the token expiration for Helix runs. The test job allows Helix up to 2 hours since it can take some time to wait in the Helix queues before tests are run. Don't want the token to expire before the tests get a chance to run.
- Update the get-delegation-sas yaml to retry getting a token if it contains a forward slash. Tokens with forward slashes seem to trip up Helix and cause it to not download the correlation payload. Similar workarounds have been employed elsewhere: https://github.com/dotnet/aspnetcore/blob/release/6.0/eng/common/templates-official/steps/get-delegation-sas.yml#L34

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2528027&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
