### PR TITLE
[feature/9.x] Require setting `TenantId` when configuring `AzureAd` authentication

### DIFF
--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -463,6 +463,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "TenantId",
         "ClientId",
         "RequiredRole"
       ],
@@ -477,12 +478,9 @@
           "default": "https://login.microsoftonline.com"
         },
         "TenantId": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "The tenant id of the Azure Active Directory tenant, or its tenant domain.",
-          "default": "organizations"
+          "type": "string",
+          "description": "The tenant id of the Azure Active Directory tenant.",
+          "minLength": 1
         },
         "ClientId": {
           "type": "string",

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptions.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_AzureAdOptions_TenantId))]
-        [DefaultValue(AzureAdOptionsDefaults.DefaultTenantId)]
-        public string? TenantId { get; set; }
+        [Required]
+        public string TenantId { get; set; } = string.Empty;
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptionsDefaults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptionsDefaults.cs
@@ -6,6 +6,5 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal static class AzureAdOptionsDefaults
     {
         public const string DefaultInstance = "https://login.microsoftonline.com";
-        public const string DefaultTenantId = "organizations";
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptionsExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/AzureAdOptionsExtensions.cs
@@ -12,11 +12,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             return options.Instance ?? new Uri(AzureAdOptionsDefaults.DefaultInstance);
         }
 
-        public static string GetTenantId(this AzureAdOptions options)
-        {
-            return options.TenantId ?? AzureAdOptionsDefaults.DefaultTenantId;
-        }
-
         public static Uri GetAppIdUri(this AzureAdOptions options)
         {
             return options.AppIdUri ?? new Uri(FormattableString.Invariant($"api://{options.ClientId}"));

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.Designer.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The tenant id of the Azure Active Directory tenant, or its tenant domain..
+        ///   Looks up a localized string similar to The tenant id of the Azure Active Directory tenant..
         /// </summary>
         public static string DisplayAttributeDescription_AzureAdOptions_TenantId {
             get {

--- a/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
+++ b/src/Microsoft.Diagnostics.Monitoring.Options/OptionsDisplayStrings.resx
@@ -713,7 +713,7 @@
     <comment>The description provided for the RequiredRole parameter on AzureAdOptions.</comment>
   </data>
   <data name="DisplayAttributeDescription_AzureAdOptions_TenantId" xml:space="preserve">
-    <value>The tenant id of the Azure Active Directory tenant, or its tenant domain.</value>
+    <value>The tenant id of the Azure Active Directory tenant.</value>
     <comment>The description provided for the TenantId parameter on AzureAdOptions.</comment>
   </data>
   <data name="ErrorMessage_MultipleAuthenticationModesSpecified" xml:space="preserve">

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/AzureAdOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/AzureAdOptionsTests.cs
@@ -17,25 +17,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Options
         {
             return new AzureAdOptions
             {
+                TenantId = Guid.NewGuid().ToString("D"),
                 ClientId = Guid.NewGuid().ToString("D"),
                 RequiredRole = Guid.NewGuid().ToString("D")
             };
-        }
-
-        [Fact]
-        public void AzureAdOptions_Supports_GuidTenantId()
-        {
-            // Arrange
-            AzureAdOptions options = GetDefaultOptions();
-            options.TenantId = Guid.NewGuid().ToString("D");
-
-            List<ValidationResult> results = new();
-
-            // Act
-            bool isValid = Validator.TryValidateObject(options, new(options), results, validateAllProperties: true);
-
-            // Assert
-            Assert.True(isValid);
         }
 
         [Fact]
@@ -45,6 +30,24 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Options
             AzureAdOptions options = GetDefaultOptions();
 
             options.RequiredRole = null;
+
+            List<ValidationResult> results = new();
+
+            // Act
+            bool isValid = Validator.TryValidateObject(options, new(options), results, validateAllProperties: true);
+
+            // Assert
+            Assert.False(isValid);
+            Assert.Single(results);
+        }
+
+        [Fact]
+        public void AzureAdOptions_Requires_TenantId()
+        {
+            // Arrange
+            AzureAdOptions options = GetDefaultOptions();
+
+            options.TenantId = null;
 
             List<ValidationResult> results = new();
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/AzureAdOptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Options/AzureAdOptionsTests.cs
@@ -39,22 +39,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests.Options
         }
 
         [Fact]
-        public void AzureAdOptions_Supports_DomainTenantId()
-        {
-            // Arrange
-            AzureAdOptions options = GetDefaultOptions();
-            options.TenantId = "common";
-
-            List<ValidationResult> results = new();
-
-            // Act
-            bool isValid = Validator.TryValidateObject(options, new(options), results, validateAllProperties: true);
-
-            // Assert
-            Assert.True(isValid);
-        }
-
-        [Fact]
         public void AzureAdOptions_Requires_Role()
         {
             // Arrange

--- a/src/Tools/dotnet-monitor/Auth/AzureAd/AzureAdAuthConfigurator.cs
+++ b/src/Tools/dotnet-monitor/Auth/AzureAd/AzureAdAuthConfigurator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.AzureAd
                     configureMicrosoftIdentityOptions: options =>
                     {
                         options.Instance = _azureAdOptions.GetInstance().ToString();
-                        options.TenantId = _azureAdOptions.GetTenantId();
+                        options.TenantId = _azureAdOptions.TenantId;
                         options.ClientId = _azureAdOptions.ClientId;
                     }
                 );
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Auth.AzureAd
         {
             const string OAuth2SecurityDefinitionName = "OAuth2";
 
-            Uri baseEndpoint = new Uri(_azureAdOptions.GetInstance(), FormattableString.Invariant($"{_azureAdOptions.GetTenantId()}/oauth2/v2.0/"));
+            Uri baseEndpoint = new Uri(_azureAdOptions.GetInstance(), FormattableString.Invariant($"{_azureAdOptions.TenantId}/oauth2/v2.0/"));
 
             options.AddSecurityDefinition(OAuth2SecurityDefinitionName, new OpenApiSecurityScheme
             {


### PR DESCRIPTION
###### Summary

Require setting the `TenantId` property with no default option. Documentation updates will be made in a separate PR targeting `main`.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
The `TenantId` property is now required when configuring `AzureAd` authentication.