### PR TITLE
Update Learning Path Staleness Check

### DIFF
--- a/.github/actions/learning-path-staleness-check/index.js
+++ b/.github/actions/learning-path-staleness-check/index.js
@@ -24,7 +24,7 @@ function UpdateModifiedFiles(fileName, path, learningPathFile)
 {
   modifiedFilesUrlToFileName[path] = fileName;
 
-  modifiedFilesPathToLearningPathFile[path] = modifiedFilesPathToLearningPathFile[path] ? modifiedFilesPathToLearningPathFile[path] : new Set();;
+  modifiedFilesPathToLearningPathFile[path] = modifiedFilesPathToLearningPathFile[path] ? modifiedFilesPathToLearningPathFile[path] : new Set();
   modifiedFilesPathToLearningPathFile[path].add(learningPathFile);
 
   modifiedFiles = new Set();
@@ -183,10 +183,10 @@ function ValidateLinks(learningPathContents, repoURLToSearch, modifiedPRFiles, l
       }
       else if (headContentLines.length < oldLineNumber || prevContentLines[oldLineNumber - 1].trim() !== headContentLines[oldLineNumber - 1].trim())
       {
-        const newLineNumberLast = headContentLines.lastIndexOf(prevContentLines[oldLineNumber - 1]) + 1;
-        const newLineNumberFirst = headContentLines.indexOf(prevContentLines[oldLineNumber - 1]) + 1;
+        const newLineNumberLast = headContentLines.lastIndexOf(prevContentLines[oldLineNumber - 1].trim()) + 1;
+        const newLineNumberFirst = headContentLines.indexOf(prevContentLines[oldLineNumber - 1].trim()) + 1;
 
-        if (newLineNumberLast !== newLineNumberFirst) // Multiple matches found in the file
+        if (newLineNumberLast === 0 || newLineNumberFirst === 0 || newLineNumberLast !== newLineNumberFirst) // Multiple matches found in the file, or no matches found
         {
           UpdateManuallyReview(fileName, link, learningPathFile, learningPathLineNumber, oldLineNumber);
         }


### PR DESCRIPTION
###### Summary

I did some looking around, and I think I figured out why the learning path automation is broken. This hasn't been tested, so I'd like to check it in, run the automation, and then iterate if needed - the changes are pretty minimal and pertain only to the automation.

There are two slight bugs that I'm trying to address: the first is that if a line is no longer present in the file, the `newLineNumberFirst` and `newLineNumberLast` in theory are the same (0), in which case we try to apply a suggestion when we shouldn't (in `AssembleOutput`, we check if there's a value for `newLineNumber`, which in JS if the value is 0 this would be false). The second is that we aren't trimming the `prevContentLines`, which could cause issues for changes in tabbing.

The error being thrown was occurring when attempting to apply suggestions - it was looking for the `->` separator, but for a few files that didn't have a suggestion, there was no separator - causing it to fail. It might also make sense to add some extra handling around that so it doesn't crash and burn, but I first wanted to validate my hypothesis before doing that.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
