### PR TITLE
Update Learning Path Staleness Check (Pt. 2)

### DIFF
--- a/.github/actions/learning-path-staleness-check/index.js
+++ b/.github/actions/learning-path-staleness-check/index.js
@@ -168,7 +168,7 @@ function ValidateLinks(learningPathContents, repoURLToSearch, modifiedPRFiles, l
         UpdateManuallyReview(fileName, link, learningPathFile, learningPathLineNumber);
         continue
       }
-      const headContentLines = headContent.toString().split("\n");
+      const headContentLines = headContent.toString().split("\n").map(line => line.trim());
 
       if (!linkHasLineNumber) { continue; }
       const oldLineNumber = Number(link.substring(linePrefixIndex + linePrefix.length, link.length));
@@ -185,6 +185,9 @@ function ValidateLinks(learningPathContents, repoURLToSearch, modifiedPRFiles, l
       {
         const newLineNumberLast = headContentLines.lastIndexOf(prevContentLines[oldLineNumber - 1].trim()) + 1;
         const newLineNumberFirst = headContentLines.indexOf(prevContentLines[oldLineNumber - 1].trim()) + 1;
+
+        console.log("New line number last: " + newLineNumberLast);
+        console.log("New line number last: " + newLineNumberFirst);
 
         if (newLineNumberLast === 0 || newLineNumberFirst === 0 || newLineNumberLast !== newLineNumberFirst) // Multiple matches found in the file, or no matches found
         {

--- a/.github/actions/learning-path-staleness-check/index.js
+++ b/.github/actions/learning-path-staleness-check/index.js
@@ -186,9 +186,6 @@ function ValidateLinks(learningPathContents, repoURLToSearch, modifiedPRFiles, l
         const newLineNumberLast = headContentLines.lastIndexOf(prevContentLines[oldLineNumber - 1].trim()) + 1;
         const newLineNumberFirst = headContentLines.indexOf(prevContentLines[oldLineNumber - 1].trim()) + 1;
 
-        console.log("New line number last: " + newLineNumberLast);
-        console.log("New line number last: " + newLineNumberFirst);
-
         if (newLineNumberLast === 0 || newLineNumberFirst === 0 || newLineNumberLast !== newLineNumberFirst) // Multiple matches found in the file, or no matches found
         {
           UpdateManuallyReview(fileName, link, learningPathFile, learningPathLineNumber, oldLineNumber);

--- a/.github/workflows/check-learning-path-links.yml
+++ b/.github/workflows/check-learning-path-links.yml
@@ -8,7 +8,6 @@ permissions: {}
   
 jobs:
   check-learning-path-links:
-    if: github.repository == 'dotnet/dotnet-monitor'
     name: 'Check Learning Path Links'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/check-learning-path-links.yml
+++ b/.github/workflows/check-learning-path-links.yml
@@ -8,6 +8,7 @@ permissions: {}
   
 jobs:
   check-learning-path-links:
+    if: github.repository == 'dotnet/dotnet-monitor'
     name: 'Check Learning Path Links'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
###### Summary

Follows https://github.com/dotnet/dotnet-monitor/pull/7383 - I think my diagnosis was correct, but it wasn't a complete fix. I tried this change in my fork and it appeared to resolve the problem: https://github.com/kkeirstead/dotnet-monitor/pull/413. I'll run the automation again and confirm things look right before merging the learning path update.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
