### PR TITLE
Add internal build access to pack and sign jobs

### DIFF
--- a/eng/pipelines/jobs/pack-sign-publish.yml
+++ b/eng/pipelines/jobs/pack-sign-publish.yml
@@ -15,6 +15,15 @@ jobs:
     variables:
     - _BuildConfig: Release
     - _SignType: real
+    - group: DotNet-MSRC-Storage
+    - _InternalBuildArgs: ''
+    - _InternalInstallArgs: >-
+        -RuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet
+        -RuntimeSourceFeedKey $(dotnetclimsrc-read-sas-token-base64)
+    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - _InternalBuildArgs: >-
+          /p:TeamName=$(_TeamName)
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     steps:
     - task: DownloadPipelineArtifact@2
       displayName: Download Binaries
@@ -31,13 +40,20 @@ jobs:
       inputs:
         artifactName: 'THIRD-PARTY-NOTICES'
         targetPath: '$(Build.SourcesDirectory)'
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+      env:
+        Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - script: >-
         $(Build.SourcesDirectory)/eng/cipacksignpublish.cmd
-        /p:TeamName=$(_TeamName)
-        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
         /p:DotNetSignType=real
         /p:DotNetPublishUsingPipelines=true
         /p:ThirdPartyNoticesFilePath='$(Build.SourcesDirectory)/$(_TPNFile)'
+        $(_InternalInstallArgs)
+        $(_InternalBuildArgs)
       displayName: Pack, Sign, and Publish
     # Intentionally copying file as "dotnet-monitor.nupkg.buildversion" for back compat
     - task: powershell@2

--- a/eng/pipelines/jobs/sign-binaries.yml
+++ b/eng/pipelines/jobs/sign-binaries.yml
@@ -15,6 +15,16 @@ jobs:
     variables:
     - _BuildConfig: ${{ parameters.configuration }}
     - _SignType: real
+    - group: DotNet-MSRC-Storage
+    - _InternalBuildArgs: ''
+    - _InternalInstallArgs: >-
+        -RuntimeSourceFeed https://dotnetclimsrc.blob.core.windows.net/dotnet
+        -RuntimeSourceFeedKey $(dotnetclimsrc-read-sas-token-base64)
+
+    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - _InternalBuildArgs: >-
+          /p:TeamName=$(_TeamName)
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -22,6 +32,14 @@ jobs:
       inputs:
         artifactName: Build_Published_${{ parameters.configuration }}
         targetPath: '$(Build.SourcesDirectory)/artifacts'
+
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+      env:
+        Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
     - script: >-
         $(Build.SourcesDirectory)/restore.cmd
@@ -32,10 +50,10 @@ jobs:
         -sign
         -nobl
         /bl:'$(Build.SourcesDirectory)\artifacts\log\Release\SignBinaries.binlog'
-        /p:TeamName=$(_TeamName)
-        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
         /p:DotNetSignType=real
         /p:SignAllBinaries=true
+        $(_InternalInstallArgs)
+        $(_InternalBuildArgs)
       displayName: Sign
 
     - task: CopyFiles@2


### PR DESCRIPTION
###### Summary

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2551971&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
