### PR TITLE
Remove CBL Mariner helix queue

### DIFF
--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -79,10 +79,6 @@
                                Condition="'$(HelixArchitecture)' == 'x64'">
       <TestRunName>Debian 12 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
     </HelixAvailableTargetQueue>
-    <HelixAvailableTargetQueue Include="ubuntu.2204.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64"
-                               Condition="'$(HelixArchitecture)' == 'x64'">
-      <TestRunName>Mariner 2.0 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
-    </HelixAvailableTargetQueue>
     <HelixAvailableTargetQueue Include="ubuntu.2204.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64"
                                Condition="'$(HelixArchitecture)' == 'x64'">
       <TestRunName>Ubuntu 20.04 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>


### PR DESCRIPTION
###### Summary

CBL Mariner 2.0 will not be an available image for .NET 9; let's remove the Helix queue for CBL Mariner 2.0 to lighten the Linux x64 test job.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
