### PR TITLE
Replace COMPlus with DOTNET prefix

### DIFF
--- a/documentation/learningPath/aks.md
+++ b/documentation/learningPath/aks.md
@@ -42,7 +42,7 @@ ENV \
     # Unset ASPNETCORE_HTTP_PORTS from aspnet base image (.NET 8+)
     ASPNETCORE_HTTP_PORTS= \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
-    COMPlus_EnableDiagnostics=0 \
+    DOTNET_EnableDiagnostics=0 \
     # Default Filter
     DefaultProcess__Filters__0__Key=ProcessId \
     DefaultProcess__Filters__0__Value=1 \

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DumpTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DumpTestUtilities.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     public static class DumpTestUtilities
     {
-        public const string EnableElfDumpOnMacOS = "COMPlus_DbgEnableElfDumpOnMacOS";
+        public const string EnableElfDumpOnMacOS = "DOTNET_DbgEnableElfDumpOnMacOS";
 
         public static async Task ValidateDump(bool expectElfDump, Stream dumpStream)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             _runner.Arguments = fullScenarioName;
 
             // Enable diagnostics in case it is disabled via inheriting test environment.
-            _adapter.Environment.Add("COMPlus_EnableDiagnostics", "1");
+            _adapter.Environment.Add("DOTNET_EnableDiagnostics", "1");
 
             if (ConnectionMode == DiagnosticPortConnectionMode.Connect)
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             _runner.Arguments = string.Join(" ", argsList);
 
             // Disable diagnostics on tool
-            _adapter.Environment.Add("COMPlus_EnableDiagnostics", "0");
+            _adapter.Environment.Add("DOTNET_EnableDiagnostics", "0");
             // Console output in JSON for easy parsing
             _adapter.Environment.Add("Logging__Console__FormatterName", "json");
             // Enable Information on ASP.NET Core logs for better ability to diagnose issues.

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -106,8 +106,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                 throw getNotAvailableException(Strings.ParameterCapturingNotAvailable_Reason_StartupHookDidNotLoad);
             }
 
-            const string EditAndContinueEnvName = "COMPLUS_ForceEnc";
-            if (env.TryGetValue(EditAndContinueEnvName, out string? editAndContinueEnvValue) &&
+            if ((env.TryGetValue("DOTNET_ForceEnc", out string? editAndContinueEnvValue) || env.TryGetValue("COMPlus_ForceEnc", out editAndContinueEnvValue)) &&
                 ToolIdentifiers.IsEnvVarValueEnabled(editAndContinueEnvValue))
             {
                 // Having Enc enabled results in methods belonging to debug modules to silently fail being instrumented.

--- a/src/Tools/dotnet-monitor/RuntimeInfo.cs
+++ b/src/Tools/dotnet-monitor/RuntimeInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             get
             {
-                string? enableDiagnostics = Environment.GetEnvironmentVariable("COMPlus_EnableDiagnostics");
+                string? enableDiagnostics = Environment.GetEnvironmentVariable("DOTNET_EnableDiagnostics") ?? Environment.GetEnvironmentVariable("COMPlus_EnableDiagnostics");
                 return string.IsNullOrEmpty(enableDiagnostics) || !"0".Equals(enableDiagnostics, StringComparison.Ordinal);
             }
         }


### PR DESCRIPTION
The configuration system in coreclr and mono started supporting `DOTNET_` prefix in net6.0. Using `DOTNET_` is preferred because [it has precedence](https://github.com/dotnet/runtime/blob/a3d1e1cdb61a65b64246dee45998f2701c8987b8/src/coreclr/inc/clrconfignocache.h#L81) over `COMPlus_`.

This matches the behavior by prioritizing DOTNET_ prefix and moving COMPlus_ to fallback in product code. Tests are using the new prefix.