### PR TITLE
Revert "Fixup package version (#7411)"

### DIFF
--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -137,7 +137,7 @@
     <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp70Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
-    <AdditionalDotNetPackage Include="$(VSRedistCommonAspNetCoreSharedFrameworkx6480Version)">
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp80Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
   </ItemGroup>


### PR DESCRIPTION
###### Summary

This reverts commit edfddd9acb43f9e8478c96dcd5104e6062a9c96a.

The use of the `VSRedistCommonAspNetCoreSharedFrameworkx6480Version` is causing incompatibilities with the runtime versions that are updated via dependabot. Reverting back to `MicrosoftAspNetCoreApp80Version` to restore the compatible versions. This is how it is set in every other branch.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
