### PR TITLE
Move System.Text.Json into runtime-dependencies group

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -49,9 +49,6 @@ updates:
         - "version-update:semver-major"
         - "version-update:semver-minor"
 #@ end
-      - dependency-name: System.Text.Json
-        update-types:
-        - "version-update:semver-major"
       - dependency-name: "Moq"
     commit-message:
       prefix: #@ commit_prefix
@@ -89,5 +86,6 @@ updates:
         patterns:
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.App.Runtime.*"
+          - "System.Text.Json"
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
-  - dependency-name: System.Text.Json
-    update-types:
-    - version-update:semver-major
   - dependency-name: Moq
   commit-message:
     prefix: '[main] '
@@ -53,6 +50,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -69,6 +67,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -85,6 +84,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
   schedule:
@@ -94,9 +94,6 @@ updates:
   - dependency-name: Microsoft.Extensions.*
     update-types:
     - version-update:semver-major
-  - dependency-name: System.Text.Json
-    update-types:
-    - version-update:semver-major
   - dependency-name: Moq
   commit-message:
     prefix: '[release/8.0] '
@@ -133,6 +130,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
   schedule:
@@ -149,6 +147,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
   schedule:
@@ -165,6 +164,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
   schedule:
@@ -178,9 +178,6 @@ updates:
     update-types:
     - version-update:semver-major
     - version-update:semver-minor
-  - dependency-name: System.Text.Json
-    update-types:
-    - version-update:semver-major
   - dependency-name: Moq
   commit-message:
     prefix: '[release/6.x] '
@@ -217,6 +214,7 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
   schedule:
@@ -233,3 +231,4 @@ updates:
       patterns:
       - Microsoft.Extensions.*
       - Microsoft.NETCore.App.Runtime.*
+      - System.Text.Json

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -11,6 +11,7 @@
     <MicrosoftExtensionsLoggingConsole80Version>8.0.0</MicrosoftExtensionsLoggingConsole80Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp80Version>8.0.8</MicrosoftNETCoreApp80Version>
+    <!-- System.Text.Json -->
     <SystemTextJson80Version>8.0.4</SystemTextJson80Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
###### Summary

The System.Text.Json dependency is part of the TFM dependabot version source, so it should be removed from the independent package group and into the TFM package group. Additionally, add it to the runtime-dependencies group since it is produced by dotnet/runtime and would update with simultaneously with similar dependencies.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
