### PR TITLE
Fix net8.0 dependabot Packages.props

### DIFF
--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -13,6 +13,6 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreApp80Version)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJson80Version) />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJson80Version)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
###### Summary

A double quote is missing from the System.Text.Json PackageReference Version property.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
