### PR TITLE
Fix runtime framework package version name

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -85,7 +85,7 @@ updates:
       runtime-dependencies:
         patterns:
           - "Microsoft.Extensions.*"
-          - "Microsoft.NETCore.DotNetHost.*"
+          - "Microsoft.NETCore.DotNetHost"
           - "System.Text.Json"
 #@ end
 #@ end

--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -85,7 +85,7 @@ updates:
       runtime-dependencies:
         patterns:
           - "Microsoft.Extensions.*"
-          - "Microsoft.NETCore.App.Runtime.*"
+          - "Microsoft.NETCore.DotNetHost.*"
           - "System.Text.Json"
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
@@ -66,7 +66,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
@@ -83,7 +83,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -129,7 +129,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
@@ -146,7 +146,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
@@ -163,7 +163,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -213,7 +213,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
@@ -230,5 +230,5 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.App.Runtime.*
+      - Microsoft.NETCore.DotNetHost.*
       - System.Text.Json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
@@ -66,7 +66,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
@@ -83,7 +83,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -129,7 +129,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net7.0
@@ -146,7 +146,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net6.0
@@ -163,7 +163,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -213,7 +213,7 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/netcoreapp3.1
@@ -230,5 +230,5 @@ updates:
     runtime-dependencies:
       patterns:
       - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost.*
+      - Microsoft.NETCore.DotNetHost
       - System.Text.Json


### PR DESCRIPTION
###### Summary

The repository uses `Microsoft.NETCore.DotNetHost` to determine the latest runtime version since `Microsoft.NETCore.App.Runtime.*` are platform packages and cannot be used as PackageReferences. Fix the package name in the update group so that it is updated together with the other runtime dependent packages.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
