### PR TITLE
[release/8.0] Replace COMPlus with DOTNET prefix

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DumpTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/DumpTestUtilities.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 {
     public static class DumpTestUtilities
     {
-        public const string EnableElfDumpOnMacOS = "COMPlus_DbgEnableElfDumpOnMacOS";
+        public const string EnableElfDumpOnMacOS = "DOTNET_DbgEnableElfDumpOnMacOS";
 
         public static async Task ValidateDump(bool expectElfDump, Stream dumpStream)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/Runners/AppRunner.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon.Runners
             _runner.Arguments = fullScenarioName;
 
             // Enable diagnostics in case it is disabled via inheriting test environment.
-            _adapter.Environment.Add("COMPlus_EnableDiagnostics", "1");
+            _adapter.Environment.Add("DOTNET_EnableDiagnostics", "1");
 
             if (ConnectionMode == DiagnosticPortConnectionMode.Connect)
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             _runner.Arguments = string.Join(" ", argsList);
 
             // Disable diagnostics on tool
-            _adapter.Environment.Add("COMPlus_EnableDiagnostics", "0");
+            _adapter.Environment.Add("DOTNET_EnableDiagnostics", "0");
             // Console output in JSON for easy parsing
             _adapter.Environment.Add("Logging__Console__FormatterName", "json");
             // Enable Information on ASP.NET Core logs for better ability to diagnose issues.

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CaptureParametersOperation.cs
@@ -88,8 +88,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                 throw getNotAvailableException(Strings.ParameterCapturingNotAvailable_Reason_HostingStartupDidNotLoad);
             }
 
-            const string EditAndContinueEnvName = "COMPLUS_ForceEnc";
-            if (env.TryGetValue(EditAndContinueEnvName, out string editAndContinueEnvValue) &&
+            if ((env.TryGetValue("DOTNET_ForceEnc", out string editAndContinueEnvValue) || env.TryGetValue("COMPlus_ForceEnc", out editAndContinueEnvValue)) &&
                 ToolIdentifiers.IsEnvVarValueEnabled(editAndContinueEnvValue))
             {
                 // Having Enc enabled results in methods belonging to debug modules to silently fail being instrumented.

--- a/src/Tools/dotnet-monitor/RuntimeInfo.cs
+++ b/src/Tools/dotnet-monitor/RuntimeInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             get
             {
-                string enableDiagnostics = Environment.GetEnvironmentVariable("COMPlus_EnableDiagnostics");
+                string enableDiagnostics = Environment.GetEnvironmentVariable("DOTNET_EnableDiagnostics") ?? Environment.GetEnvironmentVariable("COMPlus_EnableDiagnostics");
                 return string.IsNullOrEmpty(enableDiagnostics) || !"0".Equals(enableDiagnostics, StringComparison.Ordinal);
             }
         }


### PR DESCRIPTION
###### Summary

Manual backport of #7434 to `release/8.0`; only difference is the removal of nullability operators since that was not applied to `release/8.0`.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
