### PR TITLE
Add .NET 9 dependabot updates

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -8,6 +8,7 @@
 #! to the list of TFMs that the major version uses for build and test.
 #@ def getTfms():
 #@   return {
+#@     "9": [ "net9.0", "net8.0", "net7.0", "net6.0" ],
 #@     "8": [ "net8.0", "net7.0", "net6.0" ],
 #@     "6": [ "net6.0", "netcoreapp3.1" ]
 #@   }
@@ -18,6 +19,7 @@
 #@ def getBranches():
 #@   return [
 #@     struct.encode({"name": "main", "majorVersion": "8"}),
+#@     struct.encode({"name": "feature/9.x", "majorVersion": "9"}),
 #@     struct.encode({"name": "release/8.0", "majorVersion": "8"}),
 #@     struct.encode({"name": "release/6.x", "majorVersion": "6"}),
 #@   ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,103 @@ updates:
   directory: /eng/dependabot/independent
   schedule:
     interval: daily
+  target-branch: feature/9.x
+  ignore:
+  - dependency-name: Microsoft.Extensions.*
+    update-types:
+    - version-update:semver-major
+  - dependency-name: Moq
+  commit-message:
+    prefix: '[feature/9.x] '
+  groups:
+    azure-sdk-dependencies:
+      patterns:
+      - Azure.Core
+      - Azure.Identity
+      - Azure.Storage.*
+    identity-dependencies:
+      patterns:
+      - Microsoft.Identity.*
+      - Microsoft.IdentityModel.*
+- package-ecosystem: nuget
+  directory: /eng/dependabot/nuget.org
+  schedule:
+    interval: daily
+  target-branch: feature/9.x
+  commit-message:
+    prefix: '[feature/9.x] '
+- package-ecosystem: nuget
+  directory: /eng/dependabot/net9.0
+  schedule:
+    interval: daily
+  target-branch: feature/9.x
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[feature/9.x] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Text.Json
+- package-ecosystem: nuget
+  directory: /eng/dependabot/net8.0
+  schedule:
+    interval: daily
+  target-branch: feature/9.x
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[feature/9.x] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Text.Json
+- package-ecosystem: nuget
+  directory: /eng/dependabot/net7.0
+  schedule:
+    interval: daily
+  target-branch: feature/9.x
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[feature/9.x] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Text.Json
+- package-ecosystem: nuget
+  directory: /eng/dependabot/net6.0
+  schedule:
+    interval: daily
+  target-branch: feature/9.x
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[feature/9.x] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Text.Json
+- package-ecosystem: nuget
+  directory: /eng/dependabot/independent
+  schedule:
+    interval: daily
   target-branch: release/8.0
   ignore:
   - dependency-name: Microsoft.Extensions.*


### PR DESCRIPTION
###### Summary

Manual backport of #7579 to main branch. The dependabot update descriptions need to be in the main branch.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
