### PR TITLE
Update documentation around `/stacks` and `parameterTypes`

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -33,7 +33,7 @@ First Available: 8.0 Preview 7
 |---|---|---|
 | `methodName` | string | Name of the method for this frame. This includes generic parameters. |
 | `methodToken` | int | TypeDef token for the method. |
-| `parameterTypes` | string[] | Array of parameter types. Empty array if none. |
+| `parameterTypes` | string[] | Array of parameter types. Empty array if none. Field does not exist when this information is not available. |
 | `typeName` | string | Name of the class for this frame. This includes generic parameters. |
 | `moduleName` | string | Name of the module for this frame. |
 | `moduleVersionId` | guid | Unique identifier used to distinguish between two versions of the same module. An empty value: `00000000-0000-0000-0000-000000000000`. |

--- a/documentation/api/stacks.md
+++ b/documentation/api/stacks.md
@@ -42,6 +42,9 @@ Allowed schemes:
 
 ## Responses
 
+> [!NOTE]
+> Parameter type information is not available through this feature. The `parameterTypes` field of [CallStackFrame](definitions.md#callstackframe) is omitted.
+
 | Name | Type | Description | Content Type |
 |---|---|---|---|
 | 200 OK | [CallStackResult](definitions.md#callstackresult) | Callstacks for all managed threads in the process. | `application/json` |
@@ -79,7 +82,6 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
         {
             "methodName": "GetQueuedCompletionStatus",
             "methodToken": 100663634,
-            "parameterTypes": [],
             "typeName": "Interop\u002BKernel32",
             "moduleName": "System.Private.CoreLib.dll",
             "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606"
@@ -87,11 +89,6 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
         {
             "methodName": "WaitForSignal",
             "methodToken": 100663639,
-            "parameterTypes": [
-                "System.Threading.ExecutionContext",
-                "System.Threading.ContextCallback",
-                "System.Object"
-            ],
             "typeName": "System.Threading.LowLevelLifoSemaphore",
             "moduleName": "System.Private.CoreLib.dll",
             "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606"
@@ -99,7 +96,6 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
         {
             "methodName": "Wait",
             "methodToken": 100663643,
-            "parameterTypes": [],
             "typeName": "System.Threading.LowLevelLifoSemaphore",
             "moduleName": "System.Private.CoreLib.dll",
             "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606"


### PR DESCRIPTION
###### Summary

Our documentation stated that parameter type information is collected as part of the `/stacks` feature -- this isn't the case. Update our documentation.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
