### PR TITLE
Use `JsonSerializer` to serialize exception data

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/Activity.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/Activity.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
+{
+    public class Activity
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("idFormat")]
+        public ActivityIdFormat IdFormat { get; set; } = ActivityIdFormat.Unknown;
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/Activity.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/Activity.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public string Id { get; set; } = string.Empty;
 
         [JsonPropertyName("idFormat")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public ActivityIdFormat IdFormat { get; set; } = ActivityIdFormat.Unknown;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -15,6 +15,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         [JsonPropertyName("methodToken")]
         public uint MethodToken { get; set; }
 
+        [JsonPropertyName("parameterTypes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IList<string>? FullParameterTypes { get; set; }
+
+        [JsonIgnore]
+        internal IList<string>? SimpleParameterTypes { get; set; }
+
         [JsonPropertyName("typeName")]
         public string TypeName { get; set; } = string.Empty;
 
@@ -30,11 +37,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         [JsonIgnore]
         internal IList<string> FullGenericArgTypes { get; set; } = new List<string>();
 
-        [JsonIgnore]
-        internal IList<string> SimpleParameterTypes { get; set; } = new List<string>();
-
-        [JsonIgnore]
-        internal IList<string> FullParameterTypes { get; set; } = new List<string>();
         //TODO Bring this back once we have a relative il offset value.
         //[JsonPropertyName("offset")]
         //public ulong Offset { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
                 NameFormatter.BuildGenericArgTypes(builder, FullGenericArgTypes);
                 return builder.ToString();
             }
-            // Only intended for use test code.
+            // Only intended for test code.
             set
             {
                 MethodName = NameFormatter.RemoveGenericArgTypes(value, out string[] genericArgTypes);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Diagnostics.Monitoring.WebApi.Stacks;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
@@ -10,7 +12,24 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
     public class CallStackFrame
     {
         [JsonPropertyName("methodName")]
-        public string MethodName { get; set; } = string.Empty;
+        public string MethodNameWithGenericArgTypes
+        {
+            get
+            {
+                StringBuilder builder = new(MethodName);
+                NameFormatter.BuildGenericArgTypes(builder, FullGenericArgTypes);
+                return builder.ToString();
+            }
+            // Only intended for use test code.
+            set
+            {
+                MethodName = NameFormatter.RemoveGenericArgTypes(value, out string[] genericArgTypes);
+                FullGenericArgTypes = genericArgTypes;
+            }
+        }
+
+        [JsonIgnore]
+        internal string MethodName { get; set; } = string.Empty;
 
         [JsonPropertyName("methodToken")]
         public uint MethodToken { get; set; }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
+{
+    public class ExceptionInstance
+    {
+        [JsonPropertyName("id")]
+        public ulong Id { get; set; }
+
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        [JsonPropertyName("typeName")]
+        public string TypeName { get; set; } = string.Empty;
+
+        [JsonPropertyName("moduleName")]
+        public string ModuleName { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonPropertyName("activity")]
+        public Activity? Activity { get; set; }
+
+        [JsonPropertyName("innerExceptions")]
+        public InnerExceptionId[] InnerExceptionIds { get; set; } = [];
+
+        [JsonPropertyName("stack")]
+        public CallStack? CallStack { get; set; }
+    }
+
+    public class Activity
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("idFormat")]
+        public ActivityIdFormat IdFormat { get; set; } = ActivityIdFormat.Unknown;
+    }
+
+    public class InnerExceptionId
+    {
+        public static implicit operator InnerExceptionId(ulong id)
+            => new InnerExceptionId()
+            {
+                Id = id,
+            };
+
+        [JsonPropertyName("id")]
+        public ulong Id { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
@@ -36,15 +36,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public CallStack? CallStack { get; set; }
     }
 
-    public class Activity
-    {
-        [JsonPropertyName("id")]
-        public string Id { get; set; } = string.Empty;
-
-        [JsonPropertyName("idFormat")]
-        public ActivityIdFormat IdFormat { get; set; } = ActivityIdFormat.Unknown;
-    }
-
     public class InnerExceptionId
     {
         public static implicit operator InnerExceptionId(ulong id)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Models

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 
     public class InnerExceptionId
     {
-        public static implicit operator InnerExceptionId(ulong id)
+        public static explicit operator InnerExceptionId(ulong id)
             => new InnerExceptionId()
             {
                 Id = id,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/ExceptionInstance.cs
@@ -25,12 +25,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         public string Message { get; set; } = string.Empty;
 
         [JsonPropertyName("activity")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Activity? Activity { get; set; }
 
         [JsonPropertyName("innerExceptions")]
         public InnerExceptionId[] InnerExceptionIds { get; set; } = [];
 
         [JsonPropertyName("stack")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public CallStack? CallStack { get; set; }
     }
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 
             foreach (CallStack stack in stackResult.Stacks)
             {
-                stackResultModel.Stacks.Add(StackUtilities.TranslateCallStackToModel(stack, cache));
+                stackResultModel.Stacks.Add(StackUtilities.TranslateCallStackToModel(stack, cache, parameterTypesSupported: false));
             }
 
             await JsonSerializer.SerializeAsync(OutputStream, stackResultModel, cancellationToken: token);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/JsonStacksFormatter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 
             foreach (CallStack stack in stackResult.Stacks)
             {
-                stackResultModel.Stacks.Add(StackUtilities.TranslateCallStackToModel(stack, cache, parameterTypesSupported: false));
+                stackResultModel.Stacks.Add(StackUtilities.TranslateCallStackToModel(stack, cache, ensureParameterTypeFieldsNotNull: false));
             }
 
             await JsonSerializer.SerializeAsync(OutputStream, stackResultModel, cancellationToken: token);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameFormatter.cs
@@ -130,7 +130,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
         public static string RemoveGenericArgTypes(string name, out string[] genericArgTypes)
         {
             int genericsStartIndex = name.IndexOf(GenericStart);
-            if (genericsStartIndex == -1)
+            // Not found or an annotated frame
+            if (genericsStartIndex <= 0)
             {
                 genericArgTypes = [];
                 return name;

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/NameFormatter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -124,6 +125,25 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
         public static void BuildGenericArgTypes(StringBuilder builder, IList<string> typeNames)
         {
             WriteTypeNamesList(builder, typeNames, GenericStart, GenericEnd, GenericSeparator);
+        }
+
+        public static string RemoveGenericArgTypes(string name, out string[] genericArgTypes)
+        {
+            int genericsStartIndex = name.IndexOf(GenericStart);
+            if (genericsStartIndex == -1)
+            {
+                genericArgTypes = [];
+                return name;
+            }
+
+            int genericEndIndex = name.IndexOf(GenericEnd);
+            if (genericEndIndex != name.Length - 1)
+            {
+                throw new InvalidOperationException("Malformed name");
+            }
+
+            genericArgTypes = name[(genericsStartIndex + 1)..genericEndIndex].Split(GenericSeparator);
+            return name[..genericsStartIndex];
         }
 
         public static void BuildMethodParameterTypes(StringBuilder builder, IList<string> typeNames)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
     internal static class StackUtilities
     {
-        public static Models.CallStack TranslateCallStackToModel(CallStack stack, NameCache cache, bool parameterTypesSupported = true)
+        public static Models.CallStack TranslateCallStackToModel(CallStack stack, NameCache cache, bool ensureParameterTypeFieldsNotNull = true)
         {
             Models.CallStack stackModel = new Models.CallStack();
             stackModel.ThreadId = stack.ThreadId;
@@ -25,21 +25,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             foreach (CallStackFrame frame in stack.Frames)
             {
-                var frameModel = CreateFrameModel(frame, cache);
-
-                if (parameterTypesSupported)
-                {
-                    frameModel.SimpleParameterTypes ??= [];
-                    frameModel.FullParameterTypes ??= [];
-                }
-
+                var frameModel = CreateFrameModel(frame, cache, ensureParameterTypeFieldsNotNull);
                 stackModel.Frames.Add(frameModel);
             }
 
             return stackModel;
         }
 
-        internal static Models.CallStackFrame CreateFrameModel(CallStackFrame frame, NameCache cache)
+        internal static Models.CallStackFrame CreateFrameModel(CallStackFrame frame, NameCache cache, bool ensureParameterTypeFieldsNotNull)
         {
             var builder = new StringBuilder();
 
@@ -51,7 +44,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 //TODO Bring this back once we have a useful offset value
                 //Offset = frame.Offset,
                 ModuleName = NameFormatter.UnknownModule,
-                ModuleVersionId = Guid.Empty
+                ModuleVersionId = Guid.Empty,
+
+                SimpleParameterTypes = ensureParameterTypeFieldsNotNull ? [] : null,
+                FullParameterTypes = ensureParameterTypeFieldsNotNull ? [] : null,
             };
             if (frame.FunctionId == 0)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
     internal static class StackUtilities
     {
-        public static Models.CallStack TranslateCallStackToModel(CallStack stack, NameCache cache, bool methodNameIncludesGenericParameters = true)
+        public static Models.CallStack TranslateCallStackToModel(CallStack stack, NameCache cache, bool methodNameIncludesGenericParameters = true, bool parameterTypesSupported = true)
         {
             Models.CallStack stackModel = new Models.CallStack();
             stackModel.ThreadId = stack.ThreadId;
@@ -27,6 +27,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             foreach (CallStackFrame frame in stack.Frames)
             {
                 var frameModel = CreateFrameModel(frame, cache);
+
+                if (parameterTypesSupported)
+                {
+                    frameModel.SimpleParameterTypes ??= [];
+                    frameModel.FullParameterTypes ??= [];
+                }
+
                 if (methodNameIncludesGenericParameters)
                 {
                     builder.Append(frameModel.MethodName);

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Utilities/StackUtilities.cs
@@ -17,13 +17,12 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
     internal static class StackUtilities
     {
-        public static Models.CallStack TranslateCallStackToModel(CallStack stack, NameCache cache, bool methodNameIncludesGenericParameters = true, bool parameterTypesSupported = true)
+        public static Models.CallStack TranslateCallStackToModel(CallStack stack, NameCache cache, bool parameterTypesSupported = true)
         {
             Models.CallStack stackModel = new Models.CallStack();
             stackModel.ThreadId = stack.ThreadId;
             stackModel.ThreadName = stack.ThreadName;
 
-            StringBuilder builder = new();
             foreach (CallStackFrame frame in stack.Frames)
             {
                 var frameModel = CreateFrameModel(frame, cache);
@@ -34,13 +33,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     frameModel.FullParameterTypes ??= [];
                 }
 
-                if (methodNameIncludesGenericParameters)
-                {
-                    builder.Append(frameModel.MethodName);
-                    NameFormatter.BuildGenericArgTypes(builder, frameModel.FullGenericArgTypes);
-                    frameModel.MethodName = builder.ToString();
-                    builder.Clear();
-                }
                 stackModel.Frames.Add(frameModel);
             }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -154,7 +154,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Assert.Equal(expectedFrames.Length, actualFrames.Count);
             for (int i = 0; i < expectedFrames.Length; i++)
             {
-                Assert.True(AreFramesEqual(expectedFrames[i], actualFrames[i]));
+                var expected = expectedFrames[i];
+                var actual = actualFrames[i];
+                if (!AreFramesEqual(expected, actual))
+                {
+                    Assert.Fail("WHOO");
+                }
             }
         }
 
@@ -565,19 +570,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 {
                     ModuleName = ExpectedModule,
                     TypeName = ExpectedClass,
-                    MethodName = ExpectedCallbackFunction,
+                    MethodNameWithGenericArgTypes = ExpectedCallbackFunction,
                 },
                 new WebApi.Models.CallStackFrame
                 {
                     ModuleName = NativeFrame,
                     TypeName = NativeFrame,
-                    MethodName = NativeFrame,
+                    MethodNameWithGenericArgTypes = NativeFrame,
                 },
                 new WebApi.Models.CallStackFrame
                 {
                     ModuleName = ExpectedModule,
                     TypeName = ExpectedClass,
-                    MethodName = ExpectedFunction,
+                    MethodNameWithGenericArgTypes = ExpectedFunction,
                 }
             };
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -154,12 +154,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             Assert.Equal(expectedFrames.Length, actualFrames.Count);
             for (int i = 0; i < expectedFrames.Length; i++)
             {
-                var expected = expectedFrames[i];
-                var actual = actualFrames[i];
-                if (!AreFramesEqual(expected, actual))
-                {
-                    Assert.Fail("WHOO");
-                }
+                Assert.True(AreFramesEqual(expectedFrames[i], actualFrames[i]));
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Models/CallStackResultsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Models/CallStackResultsTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.Models
 
         [Theory]
         [InlineData("Test", "Test")]
+        [InlineData("[NativeFrame]", "[NativeFrame]")]
         [InlineData("Test[System.String]", "Test", "System.String")]
         [InlineData("Test[System.String,System.Object]", "Test", "System.String", "System.Object")]
         public void MethodNameWithGenericArgTypes_Set(string serializedName, string expectedMethodName, params string[] expectedGenericArgTypes)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Models/CallStackResultsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Models/CallStackResultsTests.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.WebApi.Models;
+using System;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.Models
+{
+    public class CallStackResultsTests
+    {
+        [Theory]
+        [InlineData("Test", "Test")]
+        [InlineData("Test[System.String]", "Test", "System.String")]
+        [InlineData("Test[System.String,System.Object]", "Test", "System.String", "System.Object")]
+        public void MethodNameWithGenericArgTypes_Get(string expectedName, string methodName, params string[] genericArgTypes)
+        {
+            CallStackFrame frame = new()
+            {
+                MethodName = methodName,
+                FullGenericArgTypes = genericArgTypes
+            };
+
+            Assert.Equal(expectedName, frame.MethodNameWithGenericArgTypes);
+        }
+
+        [Theory]
+        [InlineData("Test", "Test")]
+        [InlineData("Test[System.String]", "Test", "System.String")]
+        [InlineData("Test[System.String,System.Object]", "Test", "System.String", "System.Object")]
+        public void MethodNameWithGenericArgTypes_Set(string serializedName, string expectedMethodName, params string[] expectedGenericArgTypes)
+        {
+            CallStackFrame frame = new()
+            {
+                MethodNameWithGenericArgTypes = serializedName
+            };
+
+            Assert.Equal(expectedMethodName, frame.MethodName);
+            Assert.Equal(expectedGenericArgTypes, frame.FullGenericArgTypes);
+        }
+
+        [Theory]
+        [InlineData("Test[")]
+        [InlineData("Test[System.String,System.Object")]
+        public void MethodNameWithGenericArgTypes_Set_InvalidInput_Throws(string serializedName)
+        {
+            CallStackFrame frame = new();
+            Assert.Throws<InvalidOperationException>(() => frame.MethodNameWithGenericArgTypes = serializedName);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Operation/EgressOperationStoreTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Operation/EgressOperationStoreTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.Operation
             // Assert
             Exception hitException = await exceptionHit.Task.WaitAsync(CommonTestTimeouts.GeneralTimeout);
             Assert.NotNull(hitException);
-            Assert.Equal(Models.OperationState.Stopping, store.GetOperationStatus(operationId).Status);
+            Assert.Equal(WebApi.Models.OperationState.Stopping, store.GetOperationStatus(operationId).Status);
         }
 
         [Fact(Skip = "Flaky")]
@@ -96,14 +96,14 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.Operation
 
             Guid operationId = await store.AddOperation(mockOperation.Object, AllowOperationKey);
             store.StopOperation(operationId, (ex) => { });
-            Assert.Equal(Models.OperationState.Stopping, store.GetOperationStatus(operationId).Status);
+            Assert.Equal(WebApi.Models.OperationState.Stopping, store.GetOperationStatus(operationId).Status);
 
             // Act
             store.CancelOperation(operationId);
 
             // Assert
             await stopCancelled.Task.WaitAsync(CommonTestTimeouts.GeneralTimeout);
-            Assert.Equal(Models.OperationState.Cancelled, store.GetOperationStatus(operationId).Status);
+            Assert.Equal(WebApi.Models.OperationState.Cancelled, store.GetOperationStatus(operationId).Status);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                     await writer.WriteAsync(builder);
                     builder.Clear();
 
-                    NameFormatter.BuildMethodParameterTypes(builder, frame.SimpleParameterTypes);
+                    NameFormatter.BuildMethodParameterTypes(builder, frame.SimpleParameterTypes ?? []);
                     await writer.WriteAsync(builder);
                     builder.Clear();
                 }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -15,6 +15,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Utils = Microsoft.Diagnostics.Monitoring.WebApi.Utilities;
+using Models = Microsoft.Diagnostics.Monitoring.WebApi.Models;
 using NameFormatter = Microsoft.Diagnostics.Monitoring.WebApi.Stacks.NameFormatter;
 
 namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
@@ -25,9 +26,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
 
         private static byte[] JsonSequenceRecordSeparator = new byte[] { 0x1E };
 
-        private const char GenericSeparator = ',';
-        private const char GenericStart = '[';
-        private const char GenericEnd = ']';
 
         private readonly ExceptionsConfigurationSettings _configuration;
         private readonly IEndpointInfo _endpointInfo;
@@ -141,80 +139,27 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 await stream.WriteAsync(JsonSequenceRecordSeparator, token);
             }
 
-            // Make sure dotnet-monitor is self-consistent with other features that print type and stack information.
-            // For example, the stacks and exceptions features should print structured stack traces exactly the same way.
-            // CONSIDER: Investigate if other tools have "standard" formats for printing structured stacks and exceptions.
-            await using (Utf8JsonWriter writer = new(stream, new JsonWriterOptions() { Indented = false }))
+            Models.ExceptionInstance model = new()
             {
-                writer.WriteStartObject();
-                writer.WriteNumber("id", instance.Id);
-                // Writes the timestamp in ISO 8601 format
-                writer.WriteString("timestamp", instance.Timestamp);
-                writer.WriteString("typeName", instance.TypeName);
-                writer.WriteString("moduleName", instance.ModuleName);
-                writer.WriteString("message", instance.Message);
+                Id = instance.Id,
+                Timestamp = instance.Timestamp,
+                TypeName = instance.TypeName,
+                ModuleName = instance.ModuleName,
+                Message = instance.Message,
+                InnerExceptionIds = Array.ConvertAll(instance.InnerExceptionIds, id => (InnerExceptionId)id),
+                CallStack = instance.CallStack,
+            };
 
-                if (IncludeActivityId(instance))
+            if (IncludeActivityId(instance))
+            {
+                model.Activity = new()
                 {
-                    writer.WriteStartObject("activity");
-                    writer.WriteString("id", instance.ActivityId);
-                    writer.WriteString("idFormat", instance.ActivityIdFormat.ToString("G"));
-                    writer.WriteEndObject();
-                }
-
-                writer.WriteStartArray("innerExceptions");
-                foreach (ulong innerExceptionId in instance.InnerExceptionIds)
-                {
-                    writer.WriteStartObject();
-                    writer.WriteNumber("id", innerExceptionId);
-                    writer.WriteEndObject();
-                }
-                writer.WriteEndArray();
-
-                if (null != instance.CallStack)
-                {
-                    writer.WriteStartObject("stack");
-                    writer.WriteNumber("threadId", instance.CallStack.ThreadId);
-                    writer.WriteString("threadName", instance.CallStack.ThreadName);
-
-                    writer.WriteStartArray("frames");
-
-                    StringBuilder builder = new StringBuilder();
-
-                    foreach (var frame in instance.CallStack.Frames)
-                    {
-                        writer.WriteStartObject();
-
-                        string assembledMethodName = frame.MethodName;
-                        if (frame.FullGenericArgTypes.Count > 0)
-                        {
-                            builder.Clear();
-                            builder.Append(GenericStart);
-                            builder.Append(string.Join(GenericSeparator, frame.FullGenericArgTypes));
-                            builder.Append(GenericEnd);
-                            assembledMethodName += builder.ToString();
-                        }
-                        writer.WriteString("methodName", assembledMethodName);
-                        writer.WriteNumber("methodToken", frame.MethodToken);
-                        writer.WriteStartArray("parameterTypes");
-                        foreach (string parameterType in frame.FullParameterTypes)
-                        {
-                            writer.WriteStringValue(parameterType);
-                        }
-                        writer.WriteEndArray(); // end parameterTypes
-                        writer.WriteString("typeName", frame.TypeName);
-                        writer.WriteString("moduleName", frame.ModuleName);
-                        writer.WriteString("moduleVersionId", frame.ModuleVersionId.ToString("D"));
-
-                        writer.WriteEndObject();
-                    }
-
-                    writer.WriteEndArray(); // end frames
-                    writer.WriteEndObject(); // end callStack
-                }
-
-                writer.WriteEndObject(); // end.
+                    Id = instance.ActivityId,
+                    IdFormat = instance.ActivityIdFormat
+                };
             }
+
+            await JsonSerializer.SerializeAsync(stream, model, cancellationToken: token);
 
             await stream.WriteAsync(JsonRecordDelimiter, token);
         }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsStore.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                 }
             }
 
-            return StackUtilities.TranslateCallStackToModel(callStack, cache.NameCache, methodNameIncludesGenericParameters: false);
+            return StackUtilities.TranslateCallStackToModel(callStack, cache.NameCache);
         }
 
         private sealed class ExceptionInstanceEntry


### PR DESCRIPTION
###### Summary

Switch over to using `JsonSerializer` to serialize our exception data instead of manually serializing. This will make it less likely for us to accidentally introduce bugs here, standardize with our other features, and also make writing more complex json tests for `/exceptions` easier.

**This PR does not change the API surface**.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
