### PR TITLE
Skip flaky `BackgroundService` test

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/BackgroundService/BackgroundServiceTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.StartupHook.UnitTests/BackgroundService/BackgroundServiceTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.ExecutingTask);
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky, the background service only waits up to 1 second when stopping")]
         public async Task Stop_WaitsForTheBackgroundTask()
         {
             // Arrange


### PR DESCRIPTION
###### Summary

Skip the flaky `Stop_WaitsForTheBackgroundTask` test. The test is flaky because the background service only waits up to 1 second when stopping for the executing task. On a resource constrained system this test is more likely to fail.

Example failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=843507&view=ms.vss-test-web.build-test-results-tab&runId=21880890&resultId=100088&paneView=debug

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
