### PR TITLE
Hide frames with `StackTraceHiddenAttribute` from `/exceptions` and `/stacks`

### DIFF
--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -37,7 +37,7 @@ First Available: 8.0 Preview 7
 | `typeName` | string | Name of the class for this frame. This includes generic parameters. |
 | `moduleName` | string | Name of the module for this frame. |
 | `moduleVersionId` | guid | Unique identifier used to distinguish between two versions of the same module. An empty value: `00000000-0000-0000-0000-000000000000`. |
-| `hidden`| bool |(9.0 RC2+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
+| `hidden`| bool |(9.0+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
 
 ## CallStackResult
 

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -37,6 +37,7 @@ First Available: 8.0 Preview 7
 | `typeName` | string | Name of the class for this frame. This includes generic parameters. |
 | `moduleName` | string | Name of the module for this frame. |
 | `moduleVersionId` | guid | Unique identifier used to distinguish between two versions of the same module. An empty value: `00000000-0000-0000-0000-000000000000`. |
+| `hidden`| bool |(9.0 RC2+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
 
 ## CallStackResult
 

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -37,7 +37,7 @@ First Available: 8.0 Preview 7
 | `typeName` | string | Name of the class for this frame. This includes generic parameters. |
 | `moduleName` | string | Name of the module for this frame. |
 | `moduleVersionId` | guid | Unique identifier used to distinguish between two versions of the same module. An empty value: `00000000-0000-0000-0000-000000000000`. |
-| `hidden`| bool |(9.0+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
+| `hidden`| bool |(8.1+ and 9.0 GA+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
 
 ## CallStackResult
 

--- a/documentation/api/definitions.md
+++ b/documentation/api/definitions.md
@@ -37,7 +37,7 @@ First Available: 8.0 Preview 7
 | `typeName` | string | Name of the class for this frame. This includes generic parameters. |
 | `moduleName` | string | Name of the module for this frame. |
 | `moduleVersionId` | guid | Unique identifier used to distinguish between two versions of the same module. An empty value: `00000000-0000-0000-0000-000000000000`. |
-| `hidden`| bool |(8.1+ and 9.0 GA+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
+| `hidden`| bool |(8.1+ and 9.0+) Whether this frame has the [StackTraceHiddenAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) and should be omitted from stack trace text. |
 
 ## CallStackResult
 

--- a/documentation/api/exceptions.md
+++ b/documentation/api/exceptions.md
@@ -91,8 +91,6 @@ System.InvalidOperationException: Operation is not valid due to the current stat
 First chance exception at 2023-07-13T21:46:18.7530773Z
 System.ObjectDisposedException: Cannot access a disposed object.
 Object name: 'System.Net.Sockets.NetworkStream'.
-   at System.ThrowHelper.ThrowObjectDisposedException(System.Object)
-   at System.ObjectDisposedException.ThrowIf(System.Boolean,System.Object)
    at System.Net.Sockets.NetworkStream.ReadAsync(System.Memory`1[[System.Byte, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][System.Byte],System.Threading.CancellationToken)
    at System.Net.Http.HttpConnection+<<EnsureReadAheadTaskHasStarted>g__ReadAheadWithZeroByteReadAsync|43_0>d.MoveNext()
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1+TResult,System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1+TStateMachine].ExecutionContextCallback(System.Object)
@@ -140,7 +138,8 @@ Content-Type: application/x-ndjson
         "parameterTypes": [],
         "typeName": "WebApplication3.Pages.IndexModel\u002B\u003CGetData\u003Ed__3",
         "moduleName": "WebApplication3.dll",
-        "moduleVersionId": "bf769014-c2e2-496a-93b7-76fbbcd04be5"
+        "moduleVersionId": "bf769014-c2e2-496a-93b7-76fbbcd04be5",
+        "hidden": false
       },
       ... // see stacks.md
     ]
@@ -165,7 +164,8 @@ Content-Type: application/x-ndjson
         ],
         "typeName": "System.ThrowHelper",
         "moduleName": "System.Private.CoreLib.dll",
-        "moduleVersionId": "bf769014-c2e2-496a-93b7-76fbbcd04be5"
+        "moduleVersionId": "bf769014-c2e2-496a-93b7-76fbbcd04be5",
+        "hidden": true
       },
       ... // see stacks.md
     ]

--- a/documentation/api/stacks.md
+++ b/documentation/api/stacks.md
@@ -82,7 +82,8 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
             "parameterTypes": [],
             "typeName": "Interop\u002BKernel32",
             "moduleName": "System.Private.CoreLib.dll",
-            "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606"
+            "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606",
+            "hidden": false
         },
         {
             "methodName": "WaitForSignal",
@@ -94,7 +95,8 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
             ],
             "typeName": "System.Threading.LowLevelLifoSemaphore",
             "moduleName": "System.Private.CoreLib.dll",
-            "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606"
+            "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606",
+            "hidden": false
         },
         {
             "methodName": "Wait",
@@ -102,7 +104,8 @@ Location: localhost:52323/operations/67f07e40-5cca-4709-9062-26302c484f18
             "parameterTypes": [],
             "typeName": "System.Threading.LowLevelLifoSemaphore",
             "moduleName": "System.Private.CoreLib.dll",
-            "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606"
+            "moduleVersionId": "194ddabd-a802-4520-90ef-854e2f1cd606",
+            "hidden": false
         }
     ]
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 {
-    [DebuggerDisplay("{ModuleName}!{TypeName}.{MethodName}")]
+    [DebuggerDisplay("{ModuleName,nq}!{TypeName,nq}.{MethodName,nq}")]
     public class CallStackFrame
     {
         [JsonPropertyName("methodName")]

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
         [JsonPropertyName("moduleVersionId")]
         public Guid ModuleVersionId { get; set; }
 
+        [JsonPropertyName("hidden")]
+        public bool Hidden { get; set; }
+
         [JsonIgnore]
         internal IList<string> SimpleGenericArgTypes { get; set; } = new List<string>();
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CallStackResults.cs
@@ -4,11 +4,13 @@
 using Microsoft.Diagnostics.Monitoring.WebApi.Stacks;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 {
+    [DebuggerDisplay("{ModuleName}!{TypeName}.{MethodName}")]
     public class CallStackFrame
     {
         [JsonPropertyName("methodName")]

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/SpeedScopeStacksFormatter.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                     }
                     else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData? functionData))
                     {
+                        if (StackUtilities.ShouldHideFunctionFromStackTrace(cache, functionData))
+                        {
+                            continue;
+                        }
+
                         if (!functionToSharedFrameMap.TryGetValue(frame.FunctionId, out int mapping))
                         {
                             // Note this may imply some duplicate frames because we use FunctionId as a unique identifier for a frame,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Stacks/TextStacksFormatter.cs
@@ -29,8 +29,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
                 {
                     builder.Clear();
                     builder.Append(Indent);
-                    BuildFrame(builder, stackResult.NameCache, frame);
-                    await writer.WriteLineAsync(builder, token);
+                    if (BuildFrame(builder, stackResult.NameCache, frame))
+                    {
+                        await writer.WriteLineAsync(builder, token);
+                    }
                 }
                 await writer.WriteLineAsync();
             }
@@ -42,7 +44,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
 #endif
         }
 
-        private static void BuildFrame(StringBuilder builder, NameCache cache, CallStackFrame frame)
+        /// <returns>True if the frame should be included in the stack trace.</returns>
+        private static bool BuildFrame(StringBuilder builder, NameCache cache, CallStackFrame frame)
         {
             if (frame.FunctionId == 0)
             {
@@ -50,6 +53,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             }
             else if (cache.FunctionData.TryGetValue(frame.FunctionId, out FunctionData? functionData))
             {
+                if (StackUtilities.ShouldHideFunctionFromStackTrace(cache, functionData))
+                {
+                    return false;
+                }
+
                 builder.Append(NameFormatter.GetModuleName(cache, functionData.ModuleId));
                 builder.Append(ModuleSeparator);
                 NameFormatter.BuildTypeName(builder, cache, functionData);
@@ -61,6 +69,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Stacks
             {
                 builder.Append(UnknownFunction);
             }
+
+            return true;
         }
     }
 }

--- a/src/Profilers/CommonMonitorProfiler/CommonUtilities/TypeNameUtilities.cpp
+++ b/src/Profilers/CommonMonitorProfiler/CommonUtilities/TypeNameUtilities.cpp
@@ -86,7 +86,7 @@ HRESULT TypeNameUtilities::GetFunctionInfo(NameCache& nameCache, FunctionID id, 
 
     IfFailRet(GetModuleInfo(nameCache, moduleId));
 
-    bool stackTraceHidden = ShouldHideFromStackTrace(moduleId, classToken);
+    bool stackTraceHidden = ShouldHideFromStackTrace(moduleId, token);
 
     nameCache.AddFunctionData(moduleId, id, tstring(funcName), classId, token, classToken, typeArgs, typeArgsCount, stackTraceHidden);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestAppScenarios.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 public const string EclipsingExceptionFromMethodCall = nameof(EclipsingExceptionFromMethodCall);
                 public const string AggregateException = nameof(AggregateException);
                 public const string ReflectionTypeLoadException = nameof(ReflectionTypeLoadException);
+                public const string HiddenFramesExceptionCommand = nameof(HiddenFramesExceptionCommand);
             }
 
             public static class Commands

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
@@ -944,7 +944,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 CallStackFrame actualFrame = exception.CallStack.Frames[i];
 
                 //
-                // TODO: We don't currently check method tokens / mvids.
+                // TODO: We don't currently check method tokens / mvid.
                 // This is tested by ExceptionsJsonTest. If/when that test is updated to use this method,
                 // we should resolve this todo. Until then the coverage is unnecessary so keep things simple.
                 //

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
@@ -754,7 +754,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         [MemberData(nameof(ProfilerHelper.GetArchitecture), MemberType = typeof(ProfilerHelper))]
         public async Task Exceptions_HideHiddenFrames_Text(Architecture targetArchitecture)
         {
-            const string DoWorkEntryPointMethod = $"{nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkEntryPoint)}(Action)";
+            const string HiddenMethodsParameterTypes = "(Action)";
+
             await ScenarioRunner.SingleTarget(
                 _outputHelper,
                 _httpClientFactory,
@@ -770,8 +771,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         [
                             new ExceptionFrame(FrameTypeName, FrameMethodName, [SimpleFrameParameterType, SimpleFrameParameterType]),
                             new ExceptionFrame(FrameTypeName, FrameMethodName, []),
-                            new ExceptionFrame(typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName, DoWorkEntryPointMethod, []),
-                            new ExceptionFrame(FrameTypeName, nameof(ExceptionsScenario.ThrowExceptionWithHiddenFrames), []),
+                            new ExceptionFrame(typeof(HiddenFrameTestMethods).FullName, $"{nameof(HiddenFrameTestMethods.ExitPoint)}{HiddenMethodsParameterTypes}", []),
+                            new ExceptionFrame(typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName, $"{nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkFromVisibleDerivedClass)}{HiddenMethodsParameterTypes}", []),
+                            new ExceptionFrame(typeof(HiddenFrameTestMethods).FullName, $"{nameof(HiddenFrameTestMethods.EntryPoint)}{HiddenMethodsParameterTypes}", []),
                         ]);
                 },
                 configureApp: runner =>
@@ -815,6 +817,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         {
                             TypeName = typeof(HiddenFrameTestMethods).FullName,
                             ModuleName = UnitTestAppModule,
+                            MethodName = nameof(HiddenFrameTestMethods.ExitPoint),
+                            FullParameterTypes = [typeof(Action).FullName],
+                        },
+                        new()
+                        {
+                            TypeName = typeof(HiddenFrameTestMethods).FullName,
+                            ModuleName = UnitTestAppModule,
                             MethodName = nameof(HiddenFrameTestMethods.DoWorkFromHiddenMethod),
                             FullParameterTypes = [typeof(Action).FullName],
                             Hidden = true
@@ -831,15 +840,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         {
                             TypeName = typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName,
                             ModuleName = UnitTestAppModule,
-                            MethodName = nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkEntryPoint),
+                            MethodName = nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkFromVisibleDerivedClass),
                             FullParameterTypes = [typeof(Action).FullName],
                         },
                         new()
                         {
-                            TypeName = FrameTypeName,
+                            TypeName = typeof(HiddenFrameTestMethods).FullName,
                             ModuleName = UnitTestAppModule,
-                            MethodName = nameof(ExceptionsScenario.ThrowExceptionWithHiddenFrames),
-                        },
+                            MethodName = nameof(HiddenFrameTestMethods.EntryPoint),
+                            FullParameterTypes = [typeof(Action).FullName],
+                        }
                     ]
                 }
             };

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
@@ -916,6 +916,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             List<ExceptionInstance> exceptions = DeserializeJsonExceptions();
             ExceptionInstance exception = Assert.Single(exceptions);
 
+            // We don't check all properties (e.g. timestamp or thread information)
             Assert.Equal(expectedException.ModuleName, exception.ModuleName);
             Assert.Equal(expectedException.TypeName, exception.TypeName);
             Assert.Equal(expectedException.Message, exception.Message);
@@ -923,6 +924,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             if (expectedException.CallStack == null)
             {
+                Assert.Null(exception.CallStack);
                 return;
             }
 
@@ -941,6 +943,11 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 CallStackFrame expectedFrame = expectedException.CallStack.Frames[i];
                 CallStackFrame actualFrame = exception.CallStack.Frames[i];
 
+                //
+                // TODO: We don't currently check method tokens / mvids.
+                // This is tested by ExceptionsJsonTest. If/when that test is updated to use this method,
+                // we should resolve this todo. Until then the coverage is unnecessary so keep things simple.
+                //
                 Assert.Equal(expectedFrame.ModuleName, actualFrame.ModuleName);
                 Assert.Equal(expectedFrame.TypeName, actualFrame.TypeName);
                 Assert.Equal(expectedFrame.MethodName, actualFrame.MethodName);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
@@ -956,15 +956,13 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         private List<ExceptionInstance> DeserializeJsonExceptions()
         {
             List<ExceptionInstance> exceptions = [];
-            JsonSerializerOptions options = new();
-            //options.Converters.Add(new JsonStringEnumConverter());
 
             using StringReader reader = new StringReader(exceptionsResult);
 
             string line;
             while (null != (line = reader.ReadLine()))
             {
-                exceptions.Add(JsonSerializer.Deserialize<ExceptionInstance>(line, options));
+                exceptions.Add(JsonSerializer.Deserialize<ExceptionInstance>(line));
             }
             return exceptions;
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
@@ -899,7 +899,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             int lineIndex = 2;
 
             Assert.True(exceptionsLines.Length - lineIndex >= topFrames.Count, "Not enough frames");
-            foreach(ExceptionFrame expectedFrame in topFrames)
+            foreach (ExceptionFrame expectedFrame in topFrames)
             {
                 string parametersString = string.Empty;
                 if (expectedFrame.ParameterTypes.Count > 0)

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ExceptionsTests.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
     [Collection(DefaultCollectionFixture.Name)]
     public class ExceptionsTests
     {
+        private record class ExceptionFrame(string TypeName, string MethodName, List<string> ParameterTypes);
+
         private const string FrameTypeName = "Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.ExceptionsScenario";
         private const string FrameMethodName = "ThrowAndCatchInvalidOperationException";
         private const string FrameParameterType = "System.Boolean";
@@ -886,8 +888,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 Assert.Contains(exceptionType, exceptionsResult);
             }
         }
-
-        private record class ExceptionFrame(string TypeName, string MethodName, List<string> ParameterTypes);
 
         private void ValidateSingleExceptionText(string exceptionType, string exceptionMessage, List<ExceptionFrame> topFrames)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -576,12 +576,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     ModuleName = ExpectedModule,
                     TypeName = typeof(HiddenFrameTestMethods).FullName,
                     MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.DoWorkFromHiddenMethod),
+                    Hidden = true,
                 },
                 new WebApi.Models.CallStackFrame
                 {
                     ModuleName = ExpectedModule,
                     TypeName = typeof(HiddenFrameTestMethods.BaseHiddenClass).FullName,
                     MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.BaseHiddenClass.DoWorkFromHiddenBaseClass),
+                    Hidden = true
                 },
                 new WebApi.Models.CallStackFrame
                 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -207,10 +207,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 FormatFrame(ExpectedModule, ExpectedClass, ExpectedFunction)
                 ];
 
-            int[] indicies = framesToFind.Select(frame => result.Shared.Frames.FindIndex(f => f.Name == frame)).ToArray();
-            Assert.DoesNotContain(-1, indicies);
+            int[] indices = framesToFind.Select(frame => result.Shared.Frames.FindIndex(f => f.Name == frame)).ToArray();
+            Assert.DoesNotContain(-1, indices);
 
-            WebApi.Models.ProfileEvent[] expectedFrames = ExpectedSpeedscopeFrames(indicies);
+            WebApi.Models.ProfileEvent[] expectedFrames = ExpectedSpeedscopeFrames(indices);
             (WebApi.Models.Profile stack, IList<WebApi.Models.ProfileEvent> actualFrames) = GetActualFrames(result, framesToFind[0], framesToFind.Length);
 
             Assert.NotNull(stack);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -198,14 +198,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             WebApi.Models.SpeedscopeResult result = await JsonSerializer.DeserializeAsync<WebApi.Models.SpeedscopeResult>(holder.Stream);
 
-            string[] framesToFind = [
-            FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.ExitPoint)),
+            string[] framesToFind =
+            [
+                FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.ExitPoint)),
                 FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName, nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkFromVisibleDerivedClass)),
                 FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.EntryPoint)),
                 FormatFrame(ExpectedModule, ExpectedClass, ExpectedCallbackFunction),
                 NativeFrame,
                 FormatFrame(ExpectedModule, ExpectedClass, ExpectedFunction)
-                ];
+            ];
 
             int[] indices = framesToFind.Select(frame => result.Shared.Frames.FindIndex(f => f.Name == frame)).ToArray();
             Assert.DoesNotContain(-1, indices);
@@ -556,7 +557,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         }
 
         private static WebApi.Models.ProfileEvent[] ExpectedSpeedscopeFrames(int[] indices)
-            => indices.Select((i) => new WebApi.Models.ProfileEvent {
+            => indices.Select((i) => new WebApi.Models.ProfileEvent
+            {
                 Frame = i,
                 At = 0.0,
                 Type = WebApi.Models.ProfileEventType.O

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -41,13 +41,19 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         private const string NativeFrame = "[NativeFrame]";
         private const string ExpectedThreadName = "TestThread";
 
-        private static MethodInfo GetMethodInfo(string methodName)
+        private static MethodInfo GetMethodInfo(string typeName, string methodName)
         {
-            // Strip off any generic type information.
-            if (methodName.Contains('['))
+            static void removeGenericInformation(ref string name)
             {
-                methodName = methodName[..methodName.IndexOf('[')];
+                if (name.Contains('['))
+                {
+                    name = name[..name.IndexOf('[')];
+                }
             }
+
+            // Strip off any generic type information.
+            removeGenericInformation(ref typeName);
+            removeGenericInformation(ref methodName);
 
             // Return null on pseudo frames (e.g. [NativeFrame])
             if (methodName.Length == 0)
@@ -55,7 +61,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 return null;
             }
 
-            return typeof(Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios.StacksWorker.StacksWorkerNested<int>).GetMethod(methodName);
+            Type typeMatch = typeof(StacksWorker).Module.GetType(typeName);
+            Assert.NotNull(typeMatch);
+
+            return typeMatch.GetMethod(methodName);
         }
 
         public StacksTests(ITestOutputHelper outputHelper, ServiceProviderFixture serviceProviderFixture)
@@ -189,14 +198,20 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             WebApi.Models.SpeedscopeResult result = await JsonSerializer.DeserializeAsync<WebApi.Models.SpeedscopeResult>(holder.Stream);
 
-            int bottomIndex = result.Shared.Frames.FindIndex(f => f.Name == FormatFrame(ExpectedModule, ExpectedClass, ExpectedFunction));
-            Assert.NotEqual(-1, bottomIndex);
-            string topFrameName = FormatFrame(ExpectedModule, ExpectedClass, ExpectedCallbackFunction);
-            int topIndex = result.Shared.Frames.FindIndex(f => f.Name == topFrameName);
-            Assert.NotEqual(-1, topIndex);
+            string[] framesToFind = [
+            FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.ExitPoint)),
+                FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName, nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkFromVisibleDerivedClass)),
+                FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.EntryPoint)),
+                FormatFrame(ExpectedModule, ExpectedClass, ExpectedCallbackFunction),
+                NativeFrame,
+                FormatFrame(ExpectedModule, ExpectedClass, ExpectedFunction)
+                ];
 
-            WebApi.Models.ProfileEvent[] expectedFrames = ExpectedSpeedscopeFrames(topIndex, bottomIndex);
-            (WebApi.Models.Profile stack, IList<WebApi.Models.ProfileEvent> actualFrames) = GetActualFrames(result, topFrameName, 3);
+            int[] indicies = framesToFind.Select(frame => result.Shared.Frames.FindIndex(f => f.Name == frame)).ToArray();
+            Assert.DoesNotContain(-1, indicies);
+
+            WebApi.Models.ProfileEvent[] expectedFrames = ExpectedSpeedscopeFrames(indicies);
+            (WebApi.Models.Profile stack, IList<WebApi.Models.ProfileEvent> actualFrames) = GetActualFrames(result, framesToFind[0], framesToFind.Length);
 
             Assert.NotNull(stack);
 
@@ -475,7 +490,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
         private static bool AreFramesEqual(WebApi.Models.CallStackFrame expected, WebApi.Models.CallStackFrame actual)
         {
-            MethodInfo expectedMethodInfo = GetMethodInfo(expected.MethodName);
+            MethodInfo expectedMethodInfo = GetMethodInfo(expected.TypeName, expected.MethodName);
 
             return (expected.ModuleName == actual.ModuleName) &&
                 (expected.TypeName == actual.TypeName) &&
@@ -540,28 +555,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
             return (null, actualFrames);
         }
 
-        private static WebApi.Models.ProfileEvent[] ExpectedSpeedscopeFrames(int topFrameIndex, int bottomFrameIndex) => new WebApi.Models.ProfileEvent[]
-        {
-            new WebApi.Models.ProfileEvent
-            {
-                Frame = topFrameIndex,
+        private static WebApi.Models.ProfileEvent[] ExpectedSpeedscopeFrames(int[] indices)
+            => indices.Select((i) => new WebApi.Models.ProfileEvent {
+                Frame = i,
                 At = 0.0,
                 Type = WebApi.Models.ProfileEventType.O
-            },
-            new WebApi.Models.ProfileEvent
-            {
-                Frame = 0,
-                At = 0.0,
-                Type = WebApi.Models.ProfileEventType.O
-            },
-            new WebApi.Models.ProfileEvent
-            {
-                Frame = bottomFrameIndex,
-                At = 0.0,
-                Type = WebApi.Models.ProfileEventType.O
-            },
-
-        };
+            }).ToArray();
 
         private static WebApi.Models.CallStackFrame[] ExpectedFrames() => new WebApi.Models.CallStackFrame[]
             {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/StacksTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Fixtures;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.HttpApi;
 using Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners;
+using Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -90,6 +91,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             string[] expectedFrames =
             {
+                FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.ExitPoint)),
+                FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName, nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkFromVisibleDerivedClass)),
+                FormatFrame(ExpectedModule, typeof(HiddenFrameTestMethods).FullName, nameof(HiddenFrameTestMethods.EntryPoint)),
                 FormatFrame(ExpectedModule, ExpectedClass, ExpectedCallbackFunction),
                 NativeFrame,
                 FormatFrame(ExpectedModule, ExpectedClass, ExpectedTextFunction),
@@ -561,6 +565,36 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
         private static WebApi.Models.CallStackFrame[] ExpectedFrames() => new WebApi.Models.CallStackFrame[]
             {
+                new WebApi.Models.CallStackFrame
+                {
+                    ModuleName = ExpectedModule,
+                    TypeName = typeof(HiddenFrameTestMethods).FullName,
+                    MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.ExitPoint),
+                },
+                new WebApi.Models.CallStackFrame
+                {
+                    ModuleName = ExpectedModule,
+                    TypeName = typeof(HiddenFrameTestMethods).FullName,
+                    MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.DoWorkFromHiddenMethod),
+                },
+                new WebApi.Models.CallStackFrame
+                {
+                    ModuleName = ExpectedModule,
+                    TypeName = typeof(HiddenFrameTestMethods.BaseHiddenClass).FullName,
+                    MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.BaseHiddenClass.DoWorkFromHiddenBaseClass),
+                },
+                new WebApi.Models.CallStackFrame
+                {
+                    ModuleName = ExpectedModule,
+                    TypeName = typeof(HiddenFrameTestMethods.PartiallyVisibleClass).FullName,
+                    MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.PartiallyVisibleClass.DoWorkFromVisibleDerivedClass),
+                },
+                new WebApi.Models.CallStackFrame
+                {
+                    ModuleName = ExpectedModule,
+                    TypeName = typeof(HiddenFrameTestMethods).FullName,
+                    MethodNameWithGenericArgTypes = nameof(HiddenFrameTestMethods.EntryPoint),
+                },
                 new WebApi.Models.CallStackFrame
                 {
                     ModuleName = ExpectedModule,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                 await ScenarioHelpers.WaitForCommandAsync(TestAppScenarios.Exceptions.Commands.Begin, logger);
                 try
                 {
-                    ThrowExceptionWithHiddenMethodFrame();
+                    ThrowExceptionWithHiddenFrames();
                 }
                 catch (Exception)
                 {
@@ -399,10 +399,16 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowExceptionWithHiddenMethodFrame()
+        private static void ThrowExceptionWithHiddenFrames()
         {
             PartiallyVisibleClass partiallyVisibleClass = new();
-            partiallyVisibleClass.ThrowException();
+            partiallyVisibleClass.DoWork(ThrowAndCatchInvalidOperationException);
+        }
+
+        [StackTraceHidden]
+        private static void DoWorkFromHiddenMethod(Action work)
+        {
+            work();
         }
 
         [StackTraceHidden]
@@ -410,10 +416,10 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         {
 #pragma warning disable CA1822 // Mark members as static
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public void ThrowExceptionFromBaseClass()
+            public void DoWorkFromHiddenBaseClass(Action work)
 #pragma warning restore CA1822 // Mark members as static
             {
-                ThrowAndCatchInvalidOperationException();
+                DoWorkFromHiddenMethod(work);
             }
         }
 
@@ -421,9 +427,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         {
             // StackTraceHidden attributes are not inherited
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public void ThrowException()
+            public void DoWork(Action work)
             {
-                ThrowExceptionFromBaseClass();
+                DoWorkFromHiddenBaseClass(work);
             }
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -4,7 +4,6 @@
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using System;
 using System.CommandLine;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -399,39 +398,12 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowExceptionWithHiddenFrames()
+        internal static void ThrowExceptionWithHiddenFrames()
         {
-            PartiallyVisibleClass partiallyVisibleClass = new();
-            partiallyVisibleClass.DoWork(ThrowAndCatchInvalidOperationException);
+            HiddenFrameTestMethods.PartiallyVisibleClass partiallyVisibleClass = new();
+            partiallyVisibleClass.DoWorkEntryPoint(ThrowAndCatchInvalidOperationException);
         }
 
-        [StackTraceHidden]
-        private static void DoWorkFromHiddenMethod(Action work)
-        {
-            work();
-        }
-
-        [StackTraceHidden]
-        private abstract class BaseHiddenClass
-        {
-#pragma warning disable CA1822 // Mark members as static
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void DoWorkFromHiddenBaseClass(Action work)
-#pragma warning restore CA1822 // Mark members as static
-            {
-                DoWorkFromHiddenMethod(work);
-            }
-        }
-
-        private class PartiallyVisibleClass : BaseHiddenClass
-        {
-            // StackTraceHidden attributes are not inherited
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void DoWork(Action work)
-            {
-                DoWorkFromHiddenBaseClass(work);
-            }
-        }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowAndCatchInvalidOperationException()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/ExceptionsScenario.cs
@@ -398,10 +398,9 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static void ThrowExceptionWithHiddenFrames()
+        private static void ThrowExceptionWithHiddenFrames()
         {
-            HiddenFrameTestMethods.PartiallyVisibleClass partiallyVisibleClass = new();
-            partiallyVisibleClass.DoWorkEntryPoint(ThrowAndCatchInvalidOperationException);
+            HiddenFrameTestMethods.EntryPoint(ThrowAndCatchInvalidOperationException);
         }
 
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/HiddenFrameTestMethods.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/HiddenFrameTestMethods.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
+{
+    internal static class HiddenFrameTestMethods
+    {
+        /// <summary>
+        /// Entry point to test frame visibility
+        /// </summary>
+        public class PartiallyVisibleClass : BaseHiddenClass
+        {
+            // StackTraceHidden attributes are not inherited
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void DoWorkEntryPoint(Action work)
+            {
+                DoWorkFromHiddenBaseClass(work);
+            }
+        }
+
+        [StackTraceHidden]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void DoWorkFromHiddenMethod(Action work)
+        {
+            work();
+        }
+
+        [StackTraceHidden]
+        public abstract class BaseHiddenClass
+        {
+#pragma warning disable CA1822 // Mark members as static
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void DoWorkFromHiddenBaseClass(Action work)
+#pragma warning restore CA1822 // Mark members as static
+            {
+                DoWorkFromHiddenMethod(work);
+            }
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/HiddenFrameTestMethods.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/HiddenFrameTestMethods.cs
@@ -9,24 +9,26 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
 {
     internal static class HiddenFrameTestMethods
     {
-        /// <summary>
-        /// Entry point to test frame visibility
-        /// </summary>
-        public class PartiallyVisibleClass : BaseHiddenClass
+        // We keep the entry and exit points visible so they act as sentinel frames
+        // when checking output that excludes hidden frames.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void EntryPoint(Action work)
         {
-            // StackTraceHidden attributes are not inherited
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void DoWorkEntryPoint(Action work)
-            {
-                DoWorkFromHiddenBaseClass(work);
-            }
+            PartiallyVisibleClass partiallyVisibleClass = new();
+            partiallyVisibleClass.DoWorkFromVisibleDerivedClass(work);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ExitPoint(Action work)
+        {
+            work();
         }
 
         [StackTraceHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void DoWorkFromHiddenMethod(Action work)
         {
-            work();
+            ExitPoint(work);
         }
 
         [StackTraceHidden]
@@ -38,6 +40,16 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
 #pragma warning restore CA1822 // Mark members as static
             {
                 DoWorkFromHiddenMethod(work);
+            }
+        }
+
+        public class PartiallyVisibleClass : BaseHiddenClass
+        {
+            // StackTraceHidden attributes are not inherited
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void DoWorkFromVisibleDerivedClass(Action work)
+            {
+                DoWorkFromHiddenBaseClass(work);
             }
         }
     }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
 
             public void Callback()
             {
-                HiddenFrameTestMethods.PartiallyVisibleClass partiallyVisibleClass = new();
-                partiallyVisibleClass.DoWorkEntryPoint(() =>
+                HiddenFrameTestMethods.EntryPoint(() =>
                 {
                     using EventSource eventSource = new EventSource("StackScenario");
                     using EventCounter eventCounter = new EventCounter("Ready", eventSource);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/StacksWorker.cs
@@ -23,10 +23,14 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
 
             public void Callback()
             {
-                using EventSource eventSource = new EventSource("StackScenario");
-                using EventCounter eventCounter = new EventCounter("Ready", eventSource);
-                eventCounter.WriteMetric(1.0);
-                _handle.WaitOne();
+                HiddenFrameTestMethods.PartiallyVisibleClass partiallyVisibleClass = new();
+                partiallyVisibleClass.DoWorkEntryPoint(() =>
+                {
+                    using EventSource eventSource = new EventSource("StackScenario");
+                    using EventCounter eventCounter = new EventCounter("Ready", eventSource);
+                    eventCounter.WriteMetric(1.0);
+                    _handle.WaitOne();
+                });
             }
         }
 

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -205,6 +205,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
                         writer.WriteString("typeName", frame.TypeName);
                         writer.WriteString("moduleName", frame.ModuleName);
                         writer.WriteString("moduleVersionId", frame.ModuleVersionId.ToString("D"));
+                        writer.WriteBoolean("hidden", frame.Hidden);
 
                         writer.WriteEndObject();
                     }

--- a/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
+++ b/src/Tools/dotnet-monitor/Exceptions/ExceptionsOperation.cs
@@ -312,6 +312,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Exceptions
             {
                 foreach (CallStackFrame frame in currentInstance.CallStack.Frames)
                 {
+                    if (frame.Hidden)
+                    {
+                        continue;
+                    }
+
                     await writer.WriteLineAsync();
                     await writer.WriteAsync("   at ");
                     await writer.WriteAsync(frame.TypeName);


### PR DESCRIPTION
###### Summary

When frames (via their function or declaring type) contain [`StackTraceHiddenAttribute`](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) they are now hidden from text stack traces. When retrieving json stack traces, they are still included but are identified by a new `hidden` field.


The bulk of this PR is updating our `/exceptions` and `/stacks` functional tests + test infrastructure. Also fix a bug with how our profiler identified hidden functions.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Hide frames with [`StackTraceHiddenAttribute`](https://learn.microsoft.com/dotnet/api/system.diagnostics.stacktracehiddenattribute) from `/exceptions` and `/stacks`. When retrieving json data these frames are still included but are identified by a new `hidden` field.