### PR TITLE
[feature/9.x] Use official diagnostic releases

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <!--
       This should be set to true for official releases.
     -->
-    <UseMicrosoftDiagnosticsMonitoringShippedVersion>false</UseMicrosoftDiagnosticsMonitoringShippedVersion>
+    <UseMicrosoftDiagnosticsMonitoringShippedVersion>true</UseMicrosoftDiagnosticsMonitoringShippedVersion>
   </PropertyGroup>
   <PropertyGroup Label="Testing">
     <XUnitCoreSettingsFile>$(MSBuildThisFileDirectory)xunit.runner.json</XUnitCoreSettingsFile>


### PR DESCRIPTION
###### Summary

Switch `feature/9.x` to use official diagnostic releases as we don't need anything from the nightly builds for 9.0 GA.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
