### PR TITLE
[feature/9.x] Force `System.Text.Json` Update

### DIFF
--- a/eng/dependabot/net9.0/Versions.props
+++ b/eng/dependabot/net9.0/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
-    <SystemTextJson90Version>9.0.0-rc.1.24431.7</SystemTextJson90Version>
+    <SystemTextJson90Version>9.0.0-rc.2.24473.5</SystemTextJson90Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
###### Summary

Dependabot won't automatically update preview versions, so manually update `System.Text.Json` to unblock other changes. This should only need to be done once, as the next release will be GA.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
