### PR TITLE
Add transient failure retry to `SharedConcurrencyLimitTest`

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/RetryUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/RetryUtilities.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             }
         }
 
-        public static async Task RetryAsync(Func<Task> func, Func<Exception, bool> shouldRetry, ITestOutputHelper outputHelper, int maxRetryCount = 3)
+        public static async Task<T> RetryAsync<T>(Func<Task<T>> func, Func<Exception, bool> shouldRetry, ITestOutputHelper outputHelper, int maxRetryCount = 3)
         {
             int attemptIteration = 0;
             while (true)
@@ -36,13 +36,19 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 outputHelper.WriteLine("===== Attempt #{0} =====", attemptIteration);
                 try
                 {
-                    await func();
-                    break;
+                    return await func();
                 }
                 catch (Exception ex) when (attemptIteration < maxRetryCount && shouldRetry(ex))
                 {
                 }
             }
         }
+
+        public static async Task RetryAsync(Func<Task> func, Func<Exception, bool> shouldRetry, ITestOutputHelper outputHelper, int maxRetryCount = 3)
+            => await RetryAsync<object>(async () =>
+            {
+                await func();
+                return null;
+            }, shouldRetry, outputHelper, maxRetryCount);
     }
 }


### PR DESCRIPTION
###### Summary

`SharedConcurrencyLimitTest` has been extremely flaky recently. The issue appears to be from the fact that:
1. We're running on a resource constrained system.
1. This test runs multiple concurrent traces (3), while also triggering cancellations. This is somewhat intensive inside the test environment.
1. Because of the above 2 reasons, the test app fails its responsiveness check (in Connect mode, taking longer than 3 seconds to respond) when doing additional API calls, causing a test failure.

To fix it, add retry to our API calls in these tests when it appears that the process has failed its liveliness check. For now I've only introduced this retry logic to `EgressTests`. If we find other tests are facing this same issue we can consider moving this retry logic further down inside of our api client.

Alternatively, the [new pruning algorithm](https://github.com/dotnet/dotnet-monitor/pull/7571) in listen mode should prevent this issue. Once it's out of its experimental phase, we can consider moving these tests over to `Listen` mode to leverage the new algorithm and removing the retries.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
