### PR TITLE
Update MacOS build pool to OSX 15

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -70,7 +70,7 @@ jobs:
     ${{ if in(parameters.osGroup, 'MacOS') }}:
       pool:
         name: Azure Pipelines
-        vmImage: macos-12
+        vmImage: macos-15
         os: macOS
 
     ${{ if ne(parameters.container, '') }}:


### PR DESCRIPTION
###### Summary

Update the MacOS build pool to OSX 15. The built binaries should still be runnable on 10.14+ for x64 and 11.0+ for arm64 because CMAKE_OSX_DEPLOYMENT_TARGET is specified.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
