### PR TITLE
Fix AcquireBuild usage in compliance pipeline

### DIFF
--- a/eng/pipelines/dotnet-monitor-compliance.yml
+++ b/eng/pipelines/dotnet-monitor-compliance.yml
@@ -61,40 +61,18 @@ extends:
               -TaskVariableName 'BuildMajorMinorVersion'
               -MajorMinorOnly
 
-        # Populate dotnetbuilds-internal-container-read-token
-        - template: /eng/common/templates-official/steps/get-delegation-sas.yml
-          parameters:
-            federatedServiceConnection: 'dotnetbuilds-internal-read'
-            outputVariableName: 'dotnetbuilds-internal-checksums-container-read-token'
-            expiryInHours: 1
-            base64Encode: false
-            storageAccount: dotnetbuilds
-            container: internal-checksums
-            permissions: rl
-
-        # Populate dotnetbuilds-internal-container-read-token
-        - template: /eng/common/templates-official/steps/get-delegation-sas.yml
-          parameters:
-            federatedServiceConnection: 'dotnetbuilds-internal-read'
-            outputVariableName: 'dotnetbuilds-internal-container-read-token'
-            expiryInHours: 1
-            base64Encode: false
-            storageAccount: dotnetbuilds
-            container: internal
-            permissions: rl
-
         # Only scan the files that are being shipped; use the same gathering procedure
         # that the asset staging process uses.
-        - task: PowerShell@2
+        - task: AzureCLI@2
           displayName: 'Download Build Assets'
           inputs:
-            targetType: filePath
-            filePath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
+            azureSubscription: 'DotNetStaging'
+            scriptType: ps
+            scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
             arguments: >-
               -BarBuildId "$(BuildBarId)"
               -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
               -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
-              -SasSuffixes "$(dotnetbuilds-internal-checksums-container-read-token),$(dotnetbuilds-internal-container-read-token)"
               -ReleaseVersion "$(BuildVersion)"
               -Separated $False
             workingDirectory: '$(Build.Repository.LocalPath)'


### PR DESCRIPTION
###### Summary

This is the same treatment applied to the storage account staging stage (https://github.com/dotnet/dotnet-monitor/pull/7410) but applied to the compliance pipeline. This fixes an issue where the compliance pipeline is unable to download the build.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
