### PR TITLE
Skip CG for version 6 branches

### DIFF
--- a/eng/pipelines/dotnet-monitor-cg.yml
+++ b/eng/pipelines/dotnet-monitor-cg.yml
@@ -8,6 +8,10 @@ schedules:
     - shipped/v7.3
     - shipped/v7.2
     - shipped/v7.1
+    - shipped/v6.3
+    - shipped/v6.2
+    - shipped/v6.1
+    - shipped/v6.0
   always: true
 
 trigger: none


### PR DESCRIPTION
###### Summary

With .NET Monitor 6 at end-of-life, we can skip scanning the 6.X shipped branches for component governance.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
