### PR TITLE
Disable EOL check for test projects

### DIFF
--- a/src/Tests/Directory.Builds.props
+++ b/src/Tests/Directory.Builds.props
@@ -1,0 +1,11 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props"/>
+  <!--
+    Some test projects build for target frameworks that are no longer in support.
+    This is intentional so that test coverage for downlevel versions is maintained.
+    Suppress the EOL target framework check for test projects.
+  -->
+  <PropertyGroup>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
###### Summary

Newer SDK versions are failing build due to the existence of the `net7.0` target framework being used in the test applications. Use of the EOL target frameworks for testing is desired for some time after EOL has occurred, so the check should be suppressed for the test projects. The removal of EOL target frameworks can be done separately when it is no longer necessary to test with them.

Unblocks #7704 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
