### PR TITLE
Updated metrics store

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
         private static bool IsMeter(ICounterPayload payload) =>
             payload switch
             {
-                GaugePayload or PercentilePayload or CounterEndedPayload or RatePayload => true,
+                GaugePayload or PercentilePayload or CounterEndedPayload or RatePayload or AggregatePercentilePayload or UpDownCounterPayload => true,
                 _ => false
             };
 


### PR DESCRIPTION
###### Summary

Replaces the backport https://github.com/dotnet/dotnet-monitor/pull/7744 - just updates `IsMeter` without the tests for custom tags that don't pertain to 8.0.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->

###### Release Notes Entry

Fixed bug where `Histogram/UpDownCounter` were not correctly treated as meters.