### PR TITLE
Generate dSAS for dotnetcli account

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -173,6 +173,15 @@ extends:
               - powershell: Install-Module Az.Storage -Force -Scope CurrentUser -AllowClobber -Verbose -RequiredVersion 5.10.1
                 displayName: Install Az.Storage Module 5.10.1
 
+              - template: /eng/common/templates/steps/get-delegation-sas.yml
+                parameters:
+                  federatedServiceConnection: 'DotNetRelease-PME'
+                  outputVariableName: 'DotNetCliDelegationSasTokenBase64'
+                  base64Encode: true
+                  storageAccount: 'dotnetcli'
+                  container: 'dotnet'
+                  permissions: 'racwl'
+
               - task: AzureCLI@2
                 displayName: Publish Assets
                 inputs:
@@ -192,8 +201,11 @@ extends:
                     -BuildVersion $(BuildVersion)
                     -ReleaseVersion $(ReleaseVersion)
                     -DestinationAccountName $(DestinationAccountName)
+                    -DestinationSasTokenBase64 $Env:DestinationSasTokenBase64
                     -ChecksumsAccountName $(ChecksumsAccountName)
                     -WhatIf:${{ format('${0}', parameters.IsDryRun) }}
+                env:
+                  DestinationSasTokenBase64: $(DotNetCliDelegationSasTokenBase64)
 
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: Publish Logs


### PR DESCRIPTION
###### Summary

These changes update the release pipeline to use dSAS token for accessing the `dotnetcli` storage account so that files can be transferred to it from `dotnetstage` storage account. These changes were used for the .NET Monitor November 2024 releases.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
