### PR TITLE
Update Alpine version for Helix runs

### DIFF
--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -92,14 +92,14 @@
   <!-- Linux musl libc queues -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform(Linux)) and $(PackageRid.Contains(musl))">
     <!-- linux-musl-arm64 -->
-    <HelixAvailableTargetQueue Include="ubuntu.2204.armarch$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-helix-arm64v8"
+    <HelixAvailableTargetQueue Include="ubuntu.2204.armarch$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-helix-arm64v8"
                                Condition="'$(HelixArchitecture)' == 'arm64'">
-      <TestRunName>Alpine 3.17 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+      <TestRunName>Alpine 3.20 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
     </HelixAvailableTargetQueue>
     <!-- linux-musl-x64 -->
-    <HelixAvailableTargetQueue Include="ubuntu.2204.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-helix-amd64"
+    <HelixAvailableTargetQueue Include="ubuntu.2204.amd64$(QueueSuffix)@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-helix-amd64"
                                Condition="'$(HelixArchitecture)' == 'x64'">
-      <TestRunName>Alpine 3.17 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
+      <TestRunName>Alpine 3.20 $(HelixArchitecture) $(HelixConfiguration)</TestRunName>
     </HelixAvailableTargetQueue>
   </ItemGroup>
 


### PR DESCRIPTION
###### Summary

Migrate off of unsupported Helix image to newer Alpine version. Using 3.20 should be supported for over a year from now according to https://alpinelinux.org/releases/

closes #7787 