### PR TITLE
Only run x64 Helix tests in public

### DIFF
--- a/eng/pipelines/dotnet-monitor-cg.yml
+++ b/eng/pipelines/dotnet-monitor-cg.yml
@@ -37,7 +37,6 @@ extends:
       - template: /eng/pipelines/jobs/platform-matrix.yml@self
         parameters:
           jobTemplate: /eng/pipelines/jobs/build-binaries.yml@self
-          includeArm64: true
           jobParameters:
             disableComponentGovernance: false
             disableSbom: true

--- a/eng/pipelines/dotnet-monitor-codeql.yml
+++ b/eng/pipelines/dotnet-monitor-codeql.yml
@@ -2,7 +2,7 @@ variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 - name: _TeamName
   value: DotNetCore
-    
+
 trigger: none
 
 schedules:
@@ -32,6 +32,5 @@ extends:
       - template: /eng/pipelines/jobs/platform-matrix.yml@self
         parameters:
           jobTemplate: /eng/pipelines/jobs/build-codeql.yml@self
-          includeArm64: true
           jobParameters:
             enableTsa: ${{ parameters.enableTsa }}

--- a/eng/pipelines/dotnet-monitor-official.yml
+++ b/eng/pipelines/dotnet-monitor-official.yml
@@ -78,15 +78,15 @@ extends:
         # Generate a TPN for only the dotnet-monitor project
         - template: /eng/pipelines/jobs/tpn.yml@self
 
-      # Build and (optionally) test binaries
+      # Build binaries
       - template: /eng/pipelines/jobs/platform-matrix.yml@self
         parameters:
           jobTemplate: /eng/pipelines/jobs/build-binaries.yml@self
-          includeArm64: ${{ or(ne(variables['System.TeamProject'], 'public'), eq(parameters.useHelix, 'true')) }}
           jobParameters:
             publishBinaries: true
             publishArtifacts: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
 
+      # (Optionally) Test binaries
       - ${{ if ne(parameters.testGroup, 'None') }}:
         - template: /eng/pipelines/jobs/platform-matrix.yml@self
           parameters:
@@ -109,7 +109,6 @@ extends:
         - template: /eng/pipelines/jobs/platform-matrix.yml@self
           parameters:
             jobTemplate: /eng/pipelines/jobs/build-archive.yml@self
-            includeArm64: true
 # This stage creates NuGet packages and generates the BAR manifests
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - stage: PackSignPublish

--- a/eng/pipelines/dotnet-monitor-public.yml
+++ b/eng/pipelines/dotnet-monitor-public.yml
@@ -52,7 +52,6 @@ extends:
       - template: /eng/pipelines/jobs/platform-matrix.yml@self
         parameters:
           jobTemplate: /eng/pipelines/jobs/build-binaries.yml@self
-          includeArm64: true
           includeDebug: true
           jobParameters:
             publishBinaries: true
@@ -63,7 +62,8 @@ extends:
         - template: /eng/pipelines/jobs/platform-matrix.yml@self
           parameters:
             jobTemplate: /eng/pipelines/jobs/test-binaries.yml@self
-            includeArm64: true
+            includeArm64: false
+            includeX86: false
             jobParameters:
               testGroup: ${{ parameters.testGroup }}
               useHelix: true

--- a/eng/pipelines/jobs/platform-matrix.yml
+++ b/eng/pipelines/jobs/platform-matrix.yml
@@ -8,7 +8,9 @@ parameters:
   # Determines if debug configurations should be included
   includeDebug: false
   # Determines if ARM64 architectures should be included
-  includeArm64: false
+  includeArm64: true
+  # Determines if X86 architectures should be included
+  includeX86: true
 
 jobs:
 - ${{ if eq(parameters.includeDebug, 'true') }}:
@@ -24,13 +26,14 @@ jobs:
     configuration: Release
     targetRid: win-x64
     ${{ insert }}: ${{ parameters.jobParameters }}
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    osGroup: Windows
-    configuration: Release
-    architecture: x86
-    targetRid: win-x86
-    ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if eq(parameters.includeX86, 'true') }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osGroup: Windows
+      configuration: Release
+      architecture: x86
+      targetRid: win-x86
+      ${{ insert }}: ${{ parameters.jobParameters }}
 - ${{ if eq(parameters.includeArm64, 'true') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:


### PR DESCRIPTION
###### Summary

The public builds will only run x64 tests (binaries for all architectures are still built). The internal builds will still build and test all architectures.

Internal validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2631743&view=results

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
