### PR TITLE
Use dotnet-public net9.0 versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,12 +72,11 @@
   <PropertyGroup Label="Runtime Versions">
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <MicrosoftNETCoreApp50Version>5.0.17</MicrosoftNETCoreApp50Version>
-    <MicrosoftNETCoreApp90Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp90Version>
     <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftNETCoreApp70Version)</MicrosoftAspNetCoreApp70Version>
     <MicrosoftAspNetCoreApp80Version>$(MicrosoftNETCoreApp80Version)</MicrosoftAspNetCoreApp80Version>
-    <MicrosoftAspNetCoreApp90Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp90Version>
+    <MicrosoftAspNetCoreApp90Version>$(MicrosoftNETCoreApp90Version)</MicrosoftAspNetCoreApp90Version>
   </PropertyGroup>
   <PropertyGroup Label="SDK Versions">
     <!-- Use a non-final versioned sentinel package for installation of specific SDK version. -->
@@ -118,10 +117,10 @@
   <PropertyGroup Label=".NET 9 Dependent" Condition=" '$(TargetFramework)' == 'net9.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp90Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp90Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp90Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp90Version)</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp90Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp90Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftExtensionsConfigurationAbstractions90Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging90Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions90Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole90Version)</MicrosoftExtensionsLoggingConsoleVersion>
     <SystemTextJsonVersion>$(SystemTextJson90Version)</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">

--- a/eng/dependabot/net9.0/Packages.props
+++ b/eng/dependabot/net9.0/Packages.props
@@ -3,6 +3,16 @@
     Packages in this file have versions updated periodically by Dependabot specifically for .NET 9.
   -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions90Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging90Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions90Version)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsole90Version)" />
+    <!--
+      We want to update "Microsoft.NETCore.App.Runtime.*" but those packages are considered platform packages and cannot be added
+      as a package reference. Use Microsoft.NETCore.DotNetAppHost instead which is released in lockstep with the runtime packages and
+      with the same version number.
+    -->
+    <PackageReference Include="Microsoft.NETCore.DotNetAppHost" Version="$(MicrosoftNETCoreApp90Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson90Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net9.0/Versions.props
+++ b/eng/dependabot/net9.0/Versions.props
@@ -1,6 +1,17 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
+    <!-- Microsoft.Extensions.Configuration.Abstractions -->
+    <MicrosoftExtensionsConfigurationAbstractions90Version>9.0.1</MicrosoftExtensionsConfigurationAbstractions90Version>
+    <!-- Microsoft.Extensions.Logging -->
+    <MicrosoftExtensionsLogging90Version>9.0.1</MicrosoftExtensionsLogging90Version>
+    <!-- Microsoft.Extensions.Logging.Abstractions -->
+    <MicrosoftExtensionsLoggingAbstractions90Version>9.0.1</MicrosoftExtensionsLoggingAbstractions90Version>
+    <!-- Microsoft.Extensions.Logging.Console -->
+    <MicrosoftExtensionsLoggingConsole90Version>9.0.1</MicrosoftExtensionsLoggingConsole90Version>
+    <!-- Microsoft.NETCore.App -->
+    <MicrosoftNETCoreApp90Version>9.0.1</MicrosoftNETCoreApp90Version>
+    <!-- System.Text.Json -->
     <SystemTextJson90Version>9.0.0</SystemTextJson90Version>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -6,25 +6,25 @@
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(MicrosoftAspNetCoreApp70Version)",
         "$(MicrosoftAspNetCoreApp80Version)",
-        "$(VSRedistCommonAspNetCoreSharedFrameworkx6490Version)"
+        "$(MicrosoftAspNetCoreApp90Version)"
       ],
       "aspnetcore/x86": [
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(MicrosoftAspNetCoreApp70Version)",
         "$(MicrosoftAspNetCoreApp80Version)",
-        "$(VSRedistCommonAspNetCoreSharedFrameworkx6490Version)"
+        "$(MicrosoftAspNetCoreApp90Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp60Version)",
         "$(MicrosoftNETCoreApp70Version)",
         "$(MicrosoftNETCoreApp80Version)",
-        "$(VSRedistCommonNetCoreSharedFrameworkx6490Version)"
+        "$(MicrosoftNETCoreApp90Version)"
       ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreApp60Version)",
         "$(MicrosoftNETCoreApp70Version)",
         "$(MicrosoftNETCoreApp80Version)",
-        "$(VSRedistCommonNetCoreSharedFrameworkx6490Version)"
+        "$(MicrosoftNETCoreApp90Version)"
       ]
     }
   },


### PR DESCRIPTION
###### Summary

Switch .NET 9 dependencies to those found in the dotnet-public feed instead of using dependency flow.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
