### PR TITLE
Fix Helix ASP.NET 9.0 version

### DIFF
--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -136,7 +136,7 @@
     <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp80Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
-    <AdditionalDotNetPackage Include="$(VSRedistCommonAspNetCoreSharedFrameworkx6490Version)">
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp90Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
   </ItemGroup>


### PR DESCRIPTION
###### Summary

The Helix runner should install the same ASP.NET Core version for which the tests are built. Use the same version variable when specifying the ASP.NET Core additional package for .NET 9.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
