### PR TITLE
Prevent native obj files from being uploaded to build artifact

### DIFF
--- a/eng/pipelines/jobs/build-binaries.yml
+++ b/eng/pipelines/jobs/build-binaries.yml
@@ -107,6 +107,12 @@ jobs:
           inputs:
             SourceFolder: '$(Build.SourcesDirectory)/artifacts/obj'
             TargetFolder: '$(Build.ArtifactStagingDirectory)/unified/obj'
+        - task: DeleteFiles@1
+          displayName: Delete Native files (obj)
+          inputs:
+            SourceFolder: '$(Build.ArtifactStagingDirectory)/unified/obj/win-x64.Release'
+            Contents: '*'
+            RemoveSourceFolder: true
         - task: CopyFiles@2
           displayName: Gather Artifacts (pub)
           inputs:


### PR DESCRIPTION
###### Summary

CMake places a lot of binaries under the `obj/win-x64.Release` output folder during build. Some of the scanning tools flag some of these binaries as not being compliant (e.g. needing to add EnableControlFlowGuard to CompilerIdC.exe). The repository doesn't ship those binaries. To avoid being flagged, delete the `obj/win-x64.Release` folder before uploading it as a build artifact; it is not necessary for downstream consumers of the build.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2635369

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
