### PR TITLE
Add `MVID` and `MethodToken` To Parameters

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
             string? methodDeclaringTypeName,
             ResolvedParameterInfo[] parameters,
             uint methodToken,
-            Guid mvid
+            Guid moduleVersionId
             )
         {
             Activity? currentActivity = Activity.Current;
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
                     methodModuleName,
                     methodDeclaringTypeName ?? string.Empty,
                     methodToken,
-                    mvid);
+                    moduleVersionId);
 
                 foreach (ResolvedParameterInfo param in parameters)
                 {

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/AsyncParameterCapturingEventSource.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
             string methodName,
             string methodModuleName,
             string? methodDeclaringTypeName,
-            ResolvedParameterInfo[] parameters
+            ResolvedParameterInfo[] parameters,
+            uint methodToken,
+            Guid mvid
             )
         {
             Activity? currentActivity = Activity.Current;
@@ -81,7 +83,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
                     currentThreadId,
                     methodName,
                     methodModuleName,
-                    methodDeclaringTypeName ?? string.Empty);
+                    methodDeclaringTypeName ?? string.Empty,
+                    methodToken,
+                    mvid);
 
                 foreach (ResolvedParameterInfo param in parameters)
                 {

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
             string methodModuleName,
             string methodDeclaringTypeName,
             uint methodToken,
-            Guid mvid
+            Guid moduleVersionId
             )
         {
             Span<EventData> data = stackalloc EventData[10];
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
             SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodModuleName], pinnedMethodModuleName);
             SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodDeclaringTypeName], pinnedMethodDeclaringTypeName);
             SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodToken], methodToken);
-            SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.Mvid], mvid);
+            SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.ModuleVersionId], moduleVersionId);
 
             WriteEventWithFlushing(ParameterCapturingEvents.EventIds.ParametersCapturedStart, data);
         }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/Eventing/ParameterCapturingEventSource.cs
@@ -123,10 +123,12 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
             int managedThreadId,
             string methodName,
             string methodModuleName,
-            string methodDeclaringTypeName
+            string methodDeclaringTypeName,
+            uint methodToken,
+            Guid mvid
             )
         {
-            Span<EventData> data = stackalloc EventData[8];
+            Span<EventData> data = stackalloc EventData[10];
 
             using PinnedData pinnedActivityId = PinnedData.Create(activityId);
             using PinnedData pinnedMethodName = PinnedData.Create(methodName);
@@ -141,6 +143,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Eventi
             SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodName], pinnedMethodName);
             SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodModuleName], pinnedMethodModuleName);
             SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodDeclaringTypeName], pinnedMethodDeclaringTypeName);
+            SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.MethodToken], methodToken);
+            SetValue(ref data[ParameterCapturingEvents.CapturedParametersStartPayloads.Mvid], mvid);
 
             WriteEventWithFlushing(ParameterCapturingEvents.EventIds.ParametersCapturedStart, data);
         }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/FunctionProbes/EventSourceEmittingProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/FunctionProbes/EventSourceEmittingProbes.cs
@@ -86,7 +86,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Functi
                 instrumentedMethod.MethodSignature.MethodName,
                 instrumentedMethod.MethodSignature.ModuleName,
                 instrumentedMethod.MethodSignature.TypeName,
-                resolvedArgs);
+                resolvedArgs,
+                Convert.ToUInt32(instrumentedMethod.Method.MetadataToken),
+                instrumentedMethod.Method.Module.ModuleVersionId
+            );
 
             return true;
         }

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/FunctionProbes/EventSourceEmittingProbes.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/FunctionProbes/EventSourceEmittingProbes.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing.Functi
                 instrumentedMethod.MethodSignature.ModuleName,
                 instrumentedMethod.MethodSignature.TypeName,
                 resolvedArgs,
-                Convert.ToUInt32(instrumentedMethod.Method.MetadataToken),
-                instrumentedMethod.Method.Module.ModuleVersionId
+                Convert.ToUInt32(instrumentedMethod.MethodSignature.MethodToken),
+                instrumentedMethod.MethodSignature.ModuleVersionId
             );
 
             return true;

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/MethodSignature.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/MethodSignature.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing
 
         public string MethodName { get; } = GetMethodName(method);
 
-        public string? MethodDefToken { get; } = method.MetadataToken.ToString();
+        public int MethodToken { get; } = method.MetadataToken;
 
-        public Guid Mvid { get; } = method.Module.ModuleVersionId;
+        public Guid ModuleVersionId { get; } = method.Module.ModuleVersionId;
 
         public IReadOnlyList<ParameterSignature> Parameters { get; } = EmitParameters(method);
 

--- a/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/MethodSignature.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.StartupHook/ParameterCapturing/MethodSignature.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Diagnostics.Monitoring.StartupHook.ParameterCapturing
 
         public string MethodName { get; } = GetMethodName(method);
 
+        public string? MethodDefToken { get; } = method.MetadataToken.ToString();
+
+        public Guid Mvid { get; } = method.Module.ModuleVersionId;
+
         public IReadOnlyList<ParameterSignature> Parameters { get; } = EmitParameters(method);
 
         private static string GetMethodName(MethodInfo method)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CapturedParametersResults.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Models/CapturedParametersResults.cs
@@ -64,5 +64,11 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.Models
 
         [JsonPropertyName("parameters")]
         public IList<CapturedParameter> Parameters { get; init; } = [];
+
+        [JsonPropertyName("methodToken")]
+        public required uint MethodToken { get; init; }
+
+        [JsonPropertyName("moduleVersionId")]
+        public required Guid ModuleVersionId { get; init; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersFormatter.cs
@@ -65,7 +65,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
                 TypeModuleName = param.TypeModuleName,
                 Value = param.Value,
                 EvalFailReason = param.EvalFailReason
-            }).ToList()
+            }).ToList(),
+            MethodToken = capture.MethodToken,
+            ModuleVersionId = capture.ModuleVersionId
         };
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
         {
             StringBuilder builder = new();
 
-            builder.AppendLine(FormattableString.Invariant($"[{capture.CapturedDateTime}][thread {capture.ThreadId}] {GetValueOrUnknown(capture.ActivityId)}[format: {capture.ActivityIdFormat}][moduleVersionId: {capture.ModuleVersionId}][methodToken: {capture.MethodToken}"));
+            builder.AppendLine(FormattableString.Invariant($"[{capture.CapturedDateTime}][thread {capture.ThreadId}] {GetValueOrUnknown(capture.ActivityId)}[format: {capture.ActivityIdFormat}][methodToken: {capture.MethodToken}][moduleVersionId: {capture.ModuleVersionId}]"));
             builder.AppendLine(FormattableString.Invariant($"{Indent}{GetValueOrUnknown(capture.ModuleName)}!{GetValueOrUnknown(capture.TypeName)}.{GetValueOrUnknown(capture.MethodName)}("));
 
             foreach (CapturedParameter parameter in capture.Parameters)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/CapturedParametersTextFormatter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
         {
             StringBuilder builder = new();
 
-            builder.AppendLine(FormattableString.Invariant($"[{capture.CapturedDateTime}][thread {capture.ThreadId}] {GetValueOrUnknown(capture.ActivityId)}[format: {capture.ActivityIdFormat}]"));
+            builder.AppendLine(FormattableString.Invariant($"[{capture.CapturedDateTime}][thread {capture.ThreadId}] {GetValueOrUnknown(capture.ActivityId)}[format: {capture.ActivityIdFormat}][moduleVersionId: {capture.ModuleVersionId}][methodToken: {capture.MethodToken}"));
             builder.AppendLine(FormattableString.Invariant($"{Indent}{GetValueOrUnknown(capture.ModuleName)}!{GetValueOrUnknown(capture.TypeName)}.{GetValueOrUnknown(capture.MethodName)}("));
 
             foreach (CapturedParameter parameter in capture.Parameters)

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ICapturedParameters.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/ParameterCapturing/ICapturedParameters.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.ParameterCapturing
 
         string MethodName { get; }
 
+        public uint MethodToken { get; }
+
+        public Guid ModuleVersionId { get; }
+
         IReadOnlyList<ParameterInfo> Parameters { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParameters.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParameters.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
     {
         private readonly List<ParameterInfo> _parameters = [];
 
-        public CapturedParameters(string? activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName)
+        public CapturedParameters(string? activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName, uint methodToken, Guid moduleVersionId)
         {
             ActivityId = activityId;
             ActivityIdFormat = activityIdFormat;
@@ -23,6 +23,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             TypeName = methodTypeName;
             ModuleName = methodModuleName;
             CapturedDateTime = capturedDateTime;
+            MethodToken = methodToken;
+            ModuleVersionId = moduleVersionId;
         }
 
         public void AddParameter(ParameterInfo parameter)
@@ -45,5 +47,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
         public IReadOnlyList<ParameterInfo> Parameters => _parameters;
 
         public DateTime CapturedDateTime { get; }
+
+        public uint MethodToken { get; }
+
+        public Guid ModuleVersionId { get; }
     }
 }

--- a/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/CapturedParametersBuilder.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
     {
         private readonly Dictionary<Guid, CapturedParameters> _capturedParameters = new();
 
-        public bool TryStartNewCaptureResponse(Guid captureId, string? activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName)
+        public bool TryStartNewCaptureResponse(Guid captureId, string? activityId, ActivityIdFormat activityIdFormat, int threadId, DateTime capturedDateTime, string methodName, string methodTypeName, string methodModuleName, uint methodToken, Guid moduleVersionId)
         {
-            return _capturedParameters.TryAdd(captureId, new CapturedParameters(activityId, activityIdFormat, threadId, capturedDateTime, methodName, methodTypeName, methodModuleName));
+            return _capturedParameters.TryAdd(captureId, new CapturedParameters(activityId, activityIdFormat, threadId, capturedDateTime, methodName, methodTypeName, methodModuleName, methodToken, moduleVersionId));
         }
 
         public bool TryFinalizeParameters(Guid captureId, [NotNullWhen(true)] out ICapturedParameters? capturedParameters)

--- a/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
@@ -115,6 +115,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                         string methodName = traceEvent.GetPayload<string>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodName);
                         string methodModuleName = traceEvent.GetPayload<string>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodModuleName);
                         string methodDeclaringTypeName = traceEvent.GetPayload<string>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodDeclaringTypeName);
+                        uint methodToken = traceEvent.GetPayload<uint>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodToken);
+                        Guid moduleVersionId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturedParametersStartPayloads.Mvid);
 
                         _ = _parameterBuilder.TryStartNewCaptureResponse(
                                 captureId,
@@ -124,7 +126,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                                 traceEvent.TimeStamp,
                                 methodName: methodName,
                                 methodTypeName: methodDeclaringTypeName,
-                                methodModuleName: methodModuleName);
+                                methodModuleName: methodModuleName,
+                                methodToken: methodToken,
+                                moduleVersionId: moduleVersionId);
 
                         break;
                     }

--- a/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/EventParameterCapturingPipeline.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
                         string methodModuleName = traceEvent.GetPayload<string>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodModuleName);
                         string methodDeclaringTypeName = traceEvent.GetPayload<string>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodDeclaringTypeName);
                         uint methodToken = traceEvent.GetPayload<uint>(ParameterCapturingEvents.CapturedParametersStartPayloads.MethodToken);
-                        Guid moduleVersionId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturedParametersStartPayloads.Mvid);
+                        Guid moduleVersionId = traceEvent.GetPayload<Guid>(ParameterCapturingEvents.CapturedParametersStartPayloads.ModuleVersionId);
 
                         _ = _parameterBuilder.TryStartNewCaptureResponse(
                                 captureId,

--- a/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             public const int MethodModuleName = 6;
             public const int MethodDeclaringTypeName = 7;
             public const int MethodToken = 8;
-            public const int Mvid = 9;
+            public const int ModuleVersionId = 9;
         }
 
         public static class CapturedParametersStopPayloads

--- a/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
+++ b/src/Tools/dotnet-monitor/ParameterCapturing/ParameterCapturingEvents.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor.ParameterCapturing
             public const int MethodName = 5;
             public const int MethodModuleName = 6;
             public const int MethodDeclaringTypeName = 7;
+            public const int MethodToken = 8;
+            public const int Mvid = 9;
         }
 
         public static class CapturedParametersStopPayloads


### PR DESCRIPTION
###### Summary

Added `MVID` and `MethodToken` to Parameter Capture output.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry

Added `ModuleVersionId` and `MethodToken` Fields to Parameter Capture Output