### PR TITLE
Limit managed entry point assembly tests to net8.0 and higher

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/CollectionRuleTests.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 });
         }
 
+#if NET8_0_OR_GREATER
         /// <summary>
         /// Validates that a startup rule will execute and complete without action beyond
         /// discovering the target process.
@@ -110,6 +111,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     ruleCompletedTask = runner.WaitForCollectionRuleCompleteAsync(DefaultRuleName);
                 });
         }
+#endif
 
         /// <summary>
         /// Validates that a non-startup rule will complete when it has an action limit specified
@@ -289,6 +291,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 });
         }
 
+#if NET8_0_OR_GREATER
         /// <summary>
         /// Validates that a collection rule with a managed entry point assembly name filter can be matched to the
         /// target process.
@@ -350,6 +353,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     filteredTask = runner.WaitForCollectionRuleUnmatchedFiltersAsync(DefaultRuleName);
                 });
         }
+#endif
 
         /// <summary>
         /// Validates that a change in the collection rule configuration is detected and applied correctly.


### PR DESCRIPTION
###### Summary

Managed entry point assembly name is only available on .NET 8 and higher. Exclude the functional tests from the lower TFMs.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
