### PR TITLE
Update DefaultProcessConfigurationTests for managed entry point assembly

### DIFF
--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/DefaultProcessConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/DefaultProcessConfigurationTests.cs
@@ -71,6 +71,13 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests
                 Value = "arg1"
             };
 
+            var filterDescriptorManagedEntryPointAssemblyName = new ProcessFilterDescriptor
+            {
+                Key = ProcessFilterKey.ManagedEntryPointAssemblyName,
+                MatchType = ProcessFilterType.Exact,
+                Value = "MyApp"
+            };
+
             var filter = CreateFilterEntry(filterDescriptorPid);
             ValidateProcessFilter(DiagProcessFilterCriteria.ProcessId, filterDescriptorPid.Value, filter);
 
@@ -90,14 +97,24 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests
             filter = CreateFilterEntry(filterDescriptorCommandContains);
             ValidateProcessFilter(DiagProcessFilterCriteria.CommandLine, filterDescriptorCommandContains.Value, DiagProcessFilterMatchType.Contains, filter);
 
+            filter = CreateFilterEntry(filterDescriptorManagedEntryPointAssemblyName);
+            ValidateProcessFilter(DiagProcessFilterCriteria.ManagedEntryPointAssemblyName, filterDescriptorManagedEntryPointAssemblyName.Value, filter);
+
             //This filter doesn't make any sense but we are just testing that we can combine multiple filters
-            var options = CreateOptions(filterDescriptorPid, filterDescriptorName, filterDescriptorNameContains, filterDescriptorCommand, filterDescriptorCommandContains);
+            var options = CreateOptions(
+                filterDescriptorPid,
+                filterDescriptorName,
+                filterDescriptorNameContains,
+                filterDescriptorCommand,
+                filterDescriptorCommandContains,
+                filterDescriptorManagedEntryPointAssemblyName);
 
             ValidateProcessFilter(DiagProcessFilterCriteria.ProcessId, filterDescriptorPid.Value, options.Filters[0]);
             ValidateProcessFilter(DiagProcessFilterCriteria.ProcessName, filterDescriptorName.Value, options.Filters[1]);
             ValidateProcessFilter(DiagProcessFilterCriteria.ProcessName, filterDescriptorNameContains.Value, DiagProcessFilterMatchType.Contains, options.Filters[2]);
             ValidateProcessFilter(DiagProcessFilterCriteria.CommandLine, filterDescriptorCommand.Value, options.Filters[3]);
             ValidateProcessFilter(DiagProcessFilterCriteria.CommandLine, filterDescriptorCommandContains.Value, DiagProcessFilterMatchType.Contains, options.Filters[4]);
+            ValidateProcessFilter(DiagProcessFilterCriteria.ManagedEntryPointAssemblyName, filterDescriptorManagedEntryPointAssemblyName.Value, options.Filters[5]);
         }
 
         [Fact]
@@ -115,6 +132,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi.UnitTests
                 DiagProcessFilterCriteria.RuntimeId,
                 DiagProcessFilterCriteria.CommandLine,
                 DiagProcessFilterCriteria.ProcessName,
+                DiagProcessFilterCriteria.ManagedEntryPointAssemblyName
             };
 
             Assert.Equal(expectedValues.Length, actualValues.Length);


### PR DESCRIPTION
###### Summary

Some more test failure fixes due to addition of the managed entry point assembly. These tests seem to not run in PR but only run in CI, which I'll investigate separately to get them to run in PR.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
