### PR TITLE
.NET 10 build and OpenAPI generation update

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,7 +20,8 @@
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
-    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
+    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "dotnet-monitor",
     "version": "1.0"
@@ -187,14 +187,7 @@
             "in": "query",
             "description": "The type of dump to capture.",
             "schema": {
-              "enum": [
-                "Full",
-                "Mini",
-                "WithHeap",
-                "Triage"
-              ],
-              "type": "string",
-              "default": "WithHeap"
+              "$ref": "#/components/schemas/DumpType"
             }
           },
           {
@@ -358,15 +351,7 @@
             "in": "query",
             "description": "The profiles enabled for the trace session.",
             "schema": {
-              "enum": [
-                "Cpu",
-                "Http",
-                "Logs",
-                "Metrics",
-                "GcCollect"
-              ],
-              "type": "string",
-              "default": "Cpu, Http, Metrics, GcCollect"
+              "$ref": "#/components/schemas/TraceProfile"
             }
           },
           {
@@ -1666,8 +1651,8 @@
             "maximum": 2147483647,
             "minimum": 1,
             "type": "integer",
-            "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -1680,8 +1665,8 @@
           },
           "stateReason": {
             "type": "string",
-            "description": "Human-readable explanation for the current state of the collection rule.",
-            "nullable": true
+            "nullable": true,
+            "description": "Human-readable explanation for the current state of the collection rule."
           }
         },
         "additionalProperties": false
@@ -1706,23 +1691,23 @@
           },
           "actionCountSlidingWindowDurationLimit": {
             "type": "string",
+            "nullable": true,
             "description": "The sliding window duration in which the actionCountLimit is the maximum number of occurrences (as defined by Limits).",
             "format": "time-span",
-            "nullable": true,
             "example": "00:00:30"
           },
           "slidingWindowDurationCountdown": {
             "type": "string",
+            "nullable": true,
             "description": "The amount of time that needs to pass before the slidingWindowOccurrences drops below the actionCountLimit",
             "format": "time-span",
-            "nullable": true,
             "example": "00:00:30"
           },
           "ruleFinishedCountdown": {
             "type": "string",
+            "nullable": true,
             "description": "The amount of time that needs to pass before the rule is finished",
             "format": "time-span",
-            "nullable": true,
             "example": "00:00:30"
           },
           "state": {
@@ -1730,8 +1715,8 @@
           },
           "stateReason": {
             "type": "string",
-            "description": "Human-readable explanation for the current state of the collection rule.",
-            "nullable": true
+            "nullable": true,
+            "description": "Human-readable explanation for the current state of the collection rule."
           }
         },
         "additionalProperties": false
@@ -1760,32 +1745,42 @@
         "properties": {
           "version": {
             "type": "string",
-            "description": "The dotnet monitor version.",
-            "nullable": true
+            "nullable": true,
+            "description": "The dotnet monitor version."
           },
           "runtimeVersion": {
             "type": "string",
-            "description": "The dotnet runtime version.",
-            "nullable": true
+            "nullable": true,
+            "description": "The dotnet runtime version."
           },
           "diagnosticPortMode": {
             "$ref": "#/components/schemas/DiagnosticPortConnectionMode"
           },
           "diagnosticPortName": {
             "type": "string",
-            "description": "The name of the named pipe or unix domain socket to use for connecting to the diagnostic server.",
-            "nullable": true
+            "nullable": true,
+            "description": "The name of the named pipe or unix domain socket to use for connecting to the diagnostic server."
           },
           "capabilities": {
             "type": "array",
+            "nullable": true,
             "items": {
               "$ref": "#/components/schemas/MonitorCapability"
             },
-            "description": "The capabilities provided by dotnet-monitor.",
-            "nullable": true
+            "description": "The capabilities provided by dotnet-monitor."
           }
         },
         "additionalProperties": false
+      },
+      "DumpType": {
+        "enum": [
+          "Full",
+          "Mini",
+          "WithHeap",
+          "Triage"
+        ],
+        "type": "string",
+        "default": "WithHeap"
       },
       "EventLevel": {
         "enum": [
@@ -1806,17 +1801,17 @@
           },
           "providers": {
             "type": "array",
+            "nullable": true,
             "items": {
               "$ref": "#/components/schemas/EventMetricsProvider"
-            },
-            "nullable": true
+            }
           },
           "meters": {
             "type": "array",
+            "nullable": true,
             "items": {
               "$ref": "#/components/schemas/EventMetricsMeter"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false
@@ -1833,10 +1828,10 @@
           },
           "instrumentNames": {
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false
@@ -1853,10 +1848,10 @@
           },
           "counterNames": {
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false
@@ -1905,10 +1900,10 @@
           },
           "arguments": {
             "type": "object",
+            "nullable": true,
             "additionalProperties": {
               "type": "string"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false
@@ -1940,17 +1935,17 @@
         "properties": {
           "include": {
             "type": "array",
+            "nullable": true,
             "items": {
               "$ref": "#/components/schemas/ExceptionFilter"
-            },
-            "nullable": true
+            }
           },
           "exclude": {
             "type": "array",
+            "nullable": true,
             "items": {
               "$ref": "#/components/schemas/ExceptionFilter"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false
@@ -1978,11 +1973,11 @@
           },
           "filterSpecs": {
             "type": "object",
+            "nullable": true,
             "additionalProperties": {
-              "$ref": "#/components/schemas/LogLevel"
+              "$ref": "#/components/schemas/NullableOfLogLevel"
             },
-            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property.",
-            "nullable": true
+            "description": "The logger categories and levels at which logs are collected. Setting the log level to null will have logs collected from the corresponding category at the level set in the LogLevel property."
           },
           "useAppFilters": {
             "type": "boolean",
@@ -2031,8 +2026,22 @@
         },
         "additionalProperties": false
       },
+      "NullableOfLogLevel": {
+        "enum": [
+          "Trace",
+          "Debug",
+          "Information",
+          "Warning",
+          "Error",
+          "Critical",
+          "None"
+        ],
+        "type": "string",
+        "nullable": true
+      },
       "OperationError": {
         "type": "object",
+        "nullable": true,
         "properties": {
           "code": {
             "type": "string",
@@ -2043,11 +2052,11 @@
             "nullable": true
           }
         },
-        "additionalProperties": false,
-        "nullable": true
+        "additionalProperties": false
       },
       "OperationProcessInfo": {
         "type": "object",
+        "nullable": true,
         "properties": {
           "pid": {
             "type": "integer",
@@ -2063,8 +2072,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "Represents the details of a given process used in an operation.",
-        "nullable": true
+        "description": "Represents the details of a given process used in an operation."
       },
       "OperationState": {
         "enum": [
@@ -2111,10 +2119,10 @@
           "tags": {
             "uniqueItems": true,
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false,
@@ -2147,10 +2155,10 @@
           "tags": {
             "uniqueItems": true,
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": false,
@@ -2169,8 +2177,8 @@
           },
           "status": {
             "type": "integer",
-            "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "format": "int32"
           },
           "detail": {
             "type": "string",
@@ -2238,6 +2246,17 @@
         },
         "additionalProperties": false
       },
+      "TraceProfile": {
+        "enum": [
+          "Cpu",
+          "Http",
+          "Logs",
+          "Metrics",
+          "GcCollect"
+        ],
+        "type": "string",
+        "default": "Cpu, Http, Metrics, GcCollect"
+      },
       "ValidationProblemDetails": {
         "type": "object",
         "properties": {
@@ -2251,8 +2270,8 @@
           },
           "status": {
             "type": "integer",
-            "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "format": "int32"
           },
           "detail": {
             "type": "string",
@@ -2264,13 +2283,13 @@
           },
           "errors": {
             "type": "object",
+            "nullable": true,
             "additionalProperties": {
               "type": "array",
               "items": {
                 "type": "string"
               }
-            },
-            "nullable": true
+            }
           }
         },
         "additionalProperties": { }

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- These properties are shared among the Arcade build infrastructure as well as individual project build. -->
   <PropertyGroup>
-    <LatestTargetFramework>net9.0</LatestTargetFramework>
+    <LatestTargetFramework>net10.0</LatestTargetFramework>
     <LatestToolTargetFramework>$(LatestTargetFramework)</LatestToolTargetFramework>
     <ArtifactsNonShippingBundlesDir>$(ArtifactsDir)bundles\$(Configuration)\NonShipping\</ArtifactsNonShippingBundlesDir>
   </PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,8 +1,8 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="9.0.1" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>4442a188f9200a57635373dcd640893c0e8dcc78</Sha>
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="10.0.0-preview.3.25172.1" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.10.0">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>de35e2b0a0d8d5d1e307907983a6838da1092898</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="9.0.0-preview.25155.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
@@ -46,21 +46,21 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>b1037b7cc1ef0b00a9032f19a83b074a00c9a4b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="9.0.1" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>c8acea22626efab11c13778c028975acdc34678f</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="10.0.0-preview.3.25171.5" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.10.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>0a33e18a0bccc10a0c4646dbf5b0fc70cbb3aa44</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.9.0" Version="9.0.1-rtm.24610.9" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>4442a188f9200a57635373dcd640893c0e8dcc78</Sha>
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.10.0" Version="10.0.0-preview.3.25172.1" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.10.0">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>de35e2b0a0d8d5d1e307907983a6838da1092898</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0" Version="9.0.200-rtm.25073.13">
+    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.10.0" Version="10.0.100-preview.3.25178.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>843734df45746db9cbb4d2f5db721ae53f4c959f</Sha>
+      <Sha>f1136b96aa547132927220cea7207e22ce0f59e1</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.1-servicing.24610.10" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>c8acea22626efab11c13778c028975acdc34678f</Sha>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.10.0" Version="10.0.0-preview.3.25171.5" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.10.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>0a33e18a0bccc10a0c4646dbf5b0fc70cbb3aa44</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,9 +27,9 @@
     <!-- The TFMs of the dotnet-monitor tool.  -->
     <ToolTargetFrameworks>$(LatestTargetFramework)</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
-    <TestTargetFrameworks>net6.0;net7.0;net8.0;$(LatestTargetFramework)</TestTargetFrameworks>
+    <TestTargetFrameworks>net6.0;net7.0;net8.0;net9.0;$(LatestTargetFramework)</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
-    <SchemaTargetFramework>net9.0</SchemaTargetFramework>
+    <SchemaTargetFramework>net10.0</SchemaTargetFramework>
   </PropertyGroup>
   <PropertyGroup Label="Arcade">
     <UsingToolXliff>false</UsingToolXliff>
@@ -52,8 +52,8 @@
     <MicrosoftDotNetCodeAnalysisVersion>10.0.0-beta.25177.3</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.25177.3</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/aspnetcore references -->
-    <MicrosoftAspNetCoreAppRuntimewinx64Version>9.0.1</MicrosoftAspNetCoreAppRuntimewinx64Version>
-    <VSRedistCommonAspNetCoreSharedFrameworkx6490Version>9.0.1-rtm.24610.9</VSRedistCommonAspNetCoreSharedFrameworkx6490Version>
+    <MicrosoftAspNetCoreAppRuntimewinx64Version>10.0.0-preview.3.25172.1</MicrosoftAspNetCoreAppRuntimewinx64Version>
+    <VSRedistCommonAspNetCoreSharedFrameworkx64100Version>10.0.0-preview.3.25172.1</VSRedistCommonAspNetCoreSharedFrameworkx64100Version>
     <!-- dotnet/command-line-api references -->
     <SystemCommandLineVersion>2.0.0-beta5.25170.1</SystemCommandLineVersion>
     <!-- dotnet/diagnostics references -->
@@ -62,10 +62,10 @@
     <!-- dotnet/roslyn-analyzers -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>9.0.0-preview.25076.3</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- dotnet/runtime references -->
-    <MicrosoftNETCoreAppRuntimewinx64Version>9.0.1</MicrosoftNETCoreAppRuntimewinx64Version>
-    <VSRedistCommonNetCoreSharedFrameworkx6490Version>9.0.1-servicing.24610.10</VSRedistCommonNetCoreSharedFrameworkx6490Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0-preview.3.25171.5</MicrosoftNETCoreAppRuntimewinx64Version>
+    <VSRedistCommonNetCoreSharedFrameworkx64100Version>10.0.0-preview.3.25171.5</VSRedistCommonNetCoreSharedFrameworkx64100Version>
     <!-- dotnet/sdk references -->
-    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.200-rtm.25073.13</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
+    <VSRedistCommonNetCoreSdkPlaceholderx64100Version>10.0.100-preview.2.25164.34</VSRedistCommonNetCoreSdkPlaceholderx64100Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.615501</MicrosoftFileFormatsVersion>
   </PropertyGroup>
@@ -77,10 +77,12 @@
     <MicrosoftAspNetCoreApp70Version>$(MicrosoftNETCoreApp70Version)</MicrosoftAspNetCoreApp70Version>
     <MicrosoftAspNetCoreApp80Version>$(MicrosoftNETCoreApp80Version)</MicrosoftAspNetCoreApp80Version>
     <MicrosoftAspNetCoreApp90Version>$(MicrosoftNETCoreApp90Version)</MicrosoftAspNetCoreApp90Version>
+    <MicrosoftNETCoreApp100Version>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreApp100Version>
+    <MicrosoftAspNetCoreApp100Version>$(MicrosoftAspNetCoreAppRuntimewinx64Version)</MicrosoftAspNetCoreApp100Version>
   </PropertyGroup>
   <PropertyGroup Label="SDK Versions">
     <!-- Use a non-final versioned sentinel package for installation of specific SDK version. -->
-    <InstallableSdkVersion>$(VSRedistCommonNetCoreSdkPlaceholderx6490Version)</InstallableSdkVersion>
+    <InstallableSdkVersion>$(VSRedistCommonNetCoreSdkPlaceholderx64100Version)</InstallableSdkVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dev Workflow">
     <!-- These versions are not used directly. For Dev workflows, nuget requires these to properly follow
@@ -123,6 +125,16 @@
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole90Version)</MicrosoftExtensionsLoggingConsoleVersion>
     <SystemTextJsonVersion>$(SystemTextJson90Version)</SystemTextJsonVersion>
     <MicrosoftAspNetCoreOpenApiVersion>$(MicrosoftAspNetCoreApp90Version)</MicrosoftAspNetCoreOpenApiVersion>
+  </PropertyGroup>
+  <PropertyGroup Label=".NET 10 Dependent" Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp100Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp100Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>$(MicrosoftNETCoreApp100Version)</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftNETCoreApp100Version)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftNETCoreApp100Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftNETCoreApp100Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemTextJsonVersion>$(MicrosoftNETCoreApp100Version)</SystemTextJsonVersion>
+    <MicrosoftAspNetCoreOpenApiVersion>$(MicrosoftAspNetCoreApp100Version)</MicrosoftAspNetCoreOpenApiVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">
     <MicrosoftDiagnosticsMonitoringLibraryVersion>$(MicrosoftDiagnosticsMonitoringShippedVersion)</MicrosoftDiagnosticsMonitoringLibraryVersion>

--- a/eng/helix/Helix.proj
+++ b/eng/helix/Helix.proj
@@ -139,6 +139,9 @@
     <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp90Version)">
       <PackageType>aspnetcore-runtime</PackageType>
     </AdditionalDotNetPackage>
+    <AdditionalDotNetPackage Include="$(MicrosoftAspNetCoreApp100Version)">
+      <PackageType>aspnetcore-runtime</PackageType>
+    </AdditionalDotNetPackage>
   </ItemGroup>
 
   <!-- Correlation Paylod: Node -->

--- a/global.json
+++ b/global.json
@@ -1,30 +1,34 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.3.25167.3",
+    "dotnet": "10.0.100-preview.3.25178.6",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(MicrosoftAspNetCoreApp70Version)",
         "$(MicrosoftAspNetCoreApp80Version)",
-        "$(MicrosoftAspNetCoreApp90Version)"
+        "$(MicrosoftAspNetCoreApp90Version)",
+        "$(MicrosoftAspNetCoreApp100Version)"
       ],
       "aspnetcore/x86": [
         "$(MicrosoftAspNetCoreApp60Version)",
         "$(MicrosoftAspNetCoreApp70Version)",
         "$(MicrosoftAspNetCoreApp80Version)",
-        "$(MicrosoftAspNetCoreApp90Version)"
+        "$(MicrosoftAspNetCoreApp90Version)",
+        "$(MicrosoftAspNetCoreApp100Version)"
       ],
       "dotnet": [
         "$(MicrosoftNETCoreApp60Version)",
         "$(MicrosoftNETCoreApp70Version)",
         "$(MicrosoftNETCoreApp80Version)",
-        "$(MicrosoftNETCoreApp90Version)"
+        "$(MicrosoftNETCoreApp90Version)",
+        "$(MicrosoftNETCoreApp100Version)"
       ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreApp60Version)",
         "$(MicrosoftNETCoreApp70Version)",
         "$(MicrosoftNETCoreApp80Version)",
-        "$(MicrosoftNETCoreApp90Version)"
+        "$(MicrosoftNETCoreApp90Version)",
+        "$(MicrosoftNETCoreApp100Version)"
       ]
     }
   },

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -119,6 +119,14 @@
         <Version>$(MicrosoftAspNetCoreApp90Version)</Version>
       </_TestRuntimeFramework>
     </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+      <_TestRuntimeFramework Include="@(RuntimeFramework)" Condition=" '%(Identity)' == 'Microsoft.NETCore.App' ">
+        <Version>$(MicrosoftNETCoreApp100Version)</Version>
+      </_TestRuntimeFramework>
+      <_TestRuntimeFramework Include="@(RuntimeFramework)" Condition=" '%(Identity)' == 'Microsoft.AspNetCore.App' ">
+        <Version>$(MicrosoftAspNetCoreApp100Version)</Version>
+      </_TestRuntimeFramework>
+    </ItemGroup>
     <ItemGroup>
       <_TestRuntimeFramework Include="@(RuntimeFramework)" Condition=" '%(Identity)' != 'Microsoft.NETCore.App' and '%(Identity)' != 'Microsoft.AspNetCore.App' " />
     </ItemGroup>
@@ -136,6 +144,18 @@
                                        IsSelfContained="$(SelfContained)"
                                        WriteIncludedFrameworks="$(_WriteIncludedFrameworks)"
                                        AlwaysIncludeCoreFramework="$(AlwaysIncludeCoreFrameworkInRuntimeConfig)" />
+  </Target>
+
+  <!-- Disable openapi generation based on XML comments, as this produces invalid
+       generated code for doc comments with quotes: https://github.com/dotnet/aspnetcore/issues/60783 -->
+  <Target Name="DisableCompileTimeOpenApiXmlGenerator"
+          BeforeTargets="CoreCompile"
+          Condition="'$(DisableCompileTimeOpenApiXmlGenerator)' == 'true'">
+    <Error Text="Set 'GeneratePathProperty=true' on the Microsoft.AspNetCore.OpenApi package reference."
+           Condition="'$(PkgMicrosoft_AspNetCore_OpenApi)' == ''" />
+    <ItemGroup>
+      <Analyzer Remove="$(PkgMicrosoft_AspNetCore_OpenApi)\analyzers\dotnet\cs\Microsoft.AspNetCore.OpenApi.SourceGenerators.dll" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectionRuleActions.UnitTests.csproj
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectionRuleActions.UnitTests.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" GeneratePathProperty="true" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Diagnostics.Monitoring.Options\Microsoft.Diagnostics.Monitoring.Options.csproj" />

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests/SchemaGenerationTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Monitoring.ConfigurationSchema.UnitTests
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 SchemaGeneratorName,
-                TargetFrameworkMoniker.Net90);
+                TargetFrameworkMoniker.Net100);
 
         public SchemaGenerationTests(ITestOutputHelper outputHelper)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
             Path.Combine(Path.GetDirectoryName(CurrentExecutingAssemblyPath), OpenApiBaselineName);
 
         private static readonly string OpenApiGenPath =
-            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), OpenApiGenName, TargetFrameworkMoniker.Net90);
+            AssemblyHelper.GetAssemblyArtifactBinPath(Assembly.GetExecutingAssembly(), OpenApiGenName, TargetFrameworkMoniker.Net100);
 
         private readonly ITestOutputHelper _outputHelper;
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Program.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
         {
             var serviceType = Type.GetType("Microsoft.AspNetCore.OpenApi.OpenApiDocumentService, Microsoft.AspNetCore.OpenApi", throwOnError: true)!;
             return serviceProvider.GetRequiredKeyedService(serviceType, "v1")!;
-
         }
 
         private static async Task<OpenApiDocument> GetOpenApiDocument(IHost host)
@@ -69,7 +68,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen
             var documentService = GetDocumentService(host.Services);
             var methodInfo = documentService.GetType().GetMethod("GetOpenApiDocumentAsync", BindingFlags.Public | BindingFlags.Instance)!;
 
-            object result = methodInfo.Invoke(documentService, new object?[] { host.Services, default(CancellationToken) })!;
+            object result = methodInfo.Invoke(documentService, new object?[] { host.Services, null, default(CancellationToken) })!;
 
             return await (Task<OpenApiDocument>)result;
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/GenerateDotNetHost.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
-  <!-- 
+  <!--
     DotNetHostGeneratedFileName, GenerateDotNetHostSourceFile, and InjectDotNetHostSourceFile are used for injecting the value of the
     Microsoft.NETCore.App version into csharp code so that it can be used by testing harnesses for running tests under a specific
     runtime version. This specifically allows tests to run on a version of the runtime besides whatever was included with Arcade's SDK.
@@ -14,12 +14,14 @@
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net7.0'">$(MicrosoftNETCoreApp70Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net8.0'">$(MicrosoftNETCoreApp80Version)</NetCoreAppVersion>
     <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net9.0'">$(MicrosoftNETCoreApp90Version)</NetCoreAppVersion>
+    <NetCoreAppVersion Condition="'$(TargetFramework)' == 'net10.0'">$(MicrosoftNETCoreApp100Version)</NetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftAspNetCoreApp31Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net5.0'">$(MicrosoftAspNetCoreApp50Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net6.0'">$(MicrosoftAspNetCoreApp60Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net7.0'">$(MicrosoftAspNetCoreApp70Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net8.0'">$(MicrosoftAspNetCoreApp80Version)</AspNetCoreAppVersion>
     <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net9.0'">$(MicrosoftAspNetCoreApp90Version)</AspNetCoreAppVersion>
+    <AspNetCoreAppVersion Condition="'$(TargetFramework)' == 'net10.0'">$(MicrosoftAspNetCoreApp100Version)</AspNetCoreAppVersion>
   </PropertyGroup>
 
   <Target Name="GenerateDotNetHostSourceFile" Inputs="$(VersionsPropsPath)" Outputs="$(DotNetHostGeneratedFileName)">
@@ -33,12 +35,14 @@
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp70Version$', '$(MicrosoftNETCoreApp70Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp80Version$', '$(MicrosoftNETCoreApp80Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp90Version$', '$(MicrosoftNETCoreApp90Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftNetCoreApp100Version$', '$(MicrosoftNETCoreApp100Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp31Version$', '$(MicrosoftAspNetCoreApp31Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp50Version$', '$(MicrosoftAspNetCoreApp50Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp60Version$', '$(MicrosoftAspNetCoreApp60Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp70Version$', '$(MicrosoftAspNetCoreApp70Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp80Version$', '$(MicrosoftAspNetCoreApp80Version)'))</TransformedContent>
       <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp90Version$', '$(MicrosoftAspNetCoreApp90Version)'))</TransformedContent>
+      <TransformedContent>$(TransformedContent.Replace('$MicrosoftAspNetCoreApp100Version$', '$(MicrosoftAspNetCoreApp100Version)'))</TransformedContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(DotNetHostGeneratedFileName)" Overwrite="true" Lines="$(TransformedContent)" WriteOnlyWhenDifferent="true" />
   </Target>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMoniker.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         Net60,
         Net70,
         Net80,
-        Net90
+        Net90,
+        Net100
     }
 
     public static partial class TargetFrameworkMonikerExtensions
@@ -34,6 +35,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return "net8.0";
                 case TargetFrameworkMoniker.Net90:
                     return "net9.0";
+                case TargetFrameworkMoniker.Net100:
+                    return "net10.0";
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -44,7 +47,9 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         }
 
         public const TargetFrameworkMoniker CurrentTargetFrameworkMoniker =
-#if NET9_0
+#if NET10_0
+            TargetFrameworkMoniker.Net100;
+#elif NET9_0
             TargetFrameworkMoniker.Net90;
 #elif NET8_0
             TargetFrameworkMoniker.Net80;

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerExtensions.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TargetFrameworkMonikerExtensions.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return TestDotNetHost.AspNetCore80VersionString;
                 case TargetFrameworkMoniker.Net90:
                     return TestDotNetHost.AspNetCore90VersionString;
+                case TargetFrameworkMoniker.Net100:
+                    return TestDotNetHost.AspNetCore100VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }
@@ -53,6 +55,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     return TestDotNetHost.NetCore80VersionString;
                 case TargetFrameworkMoniker.Net90:
                     return TestDotNetHost.NetCore90VersionString;
+                case TargetFrameworkMoniker.Net100:
+                    return TestDotNetHost.NetCore100VersionString;
             }
             throw CreateUnsupportedException(moniker);
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs
@@ -90,6 +90,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                 return TargetFrameworkMoniker.Net80;
 #elif NET9_0
                 return TargetFrameworkMoniker.Net90;
+#elif NET10_0
+                return TargetFrameworkMoniker.Net100;
 #endif
             }
         }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs.template
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/TestDotNetHost.cs.template
@@ -16,6 +16,7 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly string NetCore70VersionString = "$MicrosoftNetCoreApp70Version$";
         public static readonly string NetCore80VersionString = "$MicrosoftNetCoreApp80Version$";
         public static readonly string NetCore90VersionString = "$MicrosoftNetCoreApp90Version$";
+        public static readonly string NetCore100VersionString = "$MicrosoftNetCoreApp100Version$";
 
         public static readonly string AspNetCore31VersionString = "$MicrosoftAspNetCoreApp31Version$";
         public static readonly string AspNetCore50VersionString = "$MicrosoftAspNetCoreApp50Version$";
@@ -23,5 +24,6 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public static readonly string AspNetCore70VersionString = "$MicrosoftAspNetCoreApp70Version$";
         public static readonly string AspNetCore80VersionString = "$MicrosoftAspNetCoreApp80Version$";
         public static readonly string AspNetCore90VersionString = "$MicrosoftAspNetCoreApp90Version$";
+        public static readonly string AspNetCore100VersionString = "$MicrosoftAspNetCoreApp100Version$";
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/InfoTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     Assert.NotNull(info.Version); // Not sure of how to get Dotnet Monitor version from within tests...
                     Assert.True(Version.TryParse(info.RuntimeVersion, out Version runtimeVersion), "Unable to parse version from RuntimeVersion property.");
 
-                    Version currentAspNetVersion = TargetFrameworkMoniker.Net90.GetAspNetCoreFrameworkVersion();
+                    Version currentAspNetVersion = TargetFrameworkMoniker.Net100.GetAspNetCoreFrameworkVersion();
                     Assert.Equal(currentAspNetVersion.Major, runtimeVersion.Major);
                     Assert.Equal(currentAspNetVersion.Minor, runtimeVersion.Minor);
                     Assert.Equal(currentAspNetVersion.Revision, runtimeVersion.Revision);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -102,7 +102,7 @@
     <ProjectReference Include="..\..\Tools\dotnet-monitor\dotnet-monitor.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      <SetTargetFramework>TargetFramework=net9.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net10.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.TestCommon\Microsoft.Diagnostics.Monitoring.TestCommon.csproj" />
     <ProjectReference Include="..\Microsoft.Diagnostics.Monitoring.UnitTestApp\Microsoft.Diagnostics.Monitoring.UnitTestApp.csproj" />

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -68,14 +68,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 "dotnet-monitor",
-                TargetFrameworkMoniker.Net90
+                TargetFrameworkMoniker.Net100
                 );
 
         private static string TestStartupHookPath =>
             AssemblyHelper.GetAssemblyArtifactBinPath(
                 Assembly.GetExecutingAssembly(),
                 TestStartupHookAssemblyName,
-                TargetFrameworkMoniker.Net90
+                TargetFrameworkMoniker.Net100
                 );
 
         private string SharedConfigDirectoryPath =>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/ActionTestsHelper.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
                     || tfm == TargetFrameworkMoniker.Net60
                     || tfm == TargetFrameworkMoniker.Net70
                     || tfm == TargetFrameworkMoniker.Net80
-                    || tfm == TargetFrameworkMoniker.Net90)
+                    || tfm == TargetFrameworkMoniker.Net90
+                    || tfm == TargetFrameworkMoniker.Net100)
                 {
                     yield return new object[] { tfm, DumpType.WithHeap };
                     yield return new object[] { tfm, DumpType.Triage };

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" GeneratePathProperty="true" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/CollectionRulePipelineTests.cs
@@ -578,11 +578,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             yield return new object[] { TargetFrameworkMoniker.Net70 };
             yield return new object[] { TargetFrameworkMoniker.Net80 };
             yield return new object[] { TargetFrameworkMoniker.Net90 };
+            yield return new object[] { TargetFrameworkMoniker.Net100 };
         }
 
         public static IEnumerable<object[]> GetCurrentTfm()
         {
-            yield return new object[] { TargetFrameworkMoniker.Net90 };
+            yield return new object[] { TargetFrameworkMoniker.Net100 };
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" GeneratePathProperty="true" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/BadRequestResponseDocumentTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/BadRequestResponseDocumentTransformer.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Models.References;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,17 +26,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
                 ContentTypes.ApplicationProblemJson,
                 new OpenApiMediaType()
                 {
-                    Schema = new OpenApiSchema()
-                    {
-                        Reference = new OpenApiReference()
-                        {
-                            Id = nameof(ValidationProblemDetails),
-                            Type = ReferenceType.Schema
-                        }
-                    }
+                    Schema = new OpenApiSchemaReference(nameof(ValidationProblemDetails))
                 });
 
-            (openApiDoc.Components ??= new OpenApiComponents()).Responses.Add(
+            OpenApiComponents components = openApiDoc.Components ??= new OpenApiComponents();
+            IDictionary<string, IOpenApiResponse> responses = components.Responses ??= new OpenApiResponses();
+            responses.Add(
                 ResponseNames.BadRequestResponse,
                 unauthorizedResponse);
 

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/BadRequestResponseOperationTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/BadRequestResponseOperationTransformer.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,18 +17,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
     {
         public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
         {
-            if (operation.Responses.Remove(StatusCodeStrings.Status400BadRequest))
+            if (null != operation.Responses)
             {
-                operation.Responses.Add(
-                    StatusCodeStrings.Status400BadRequest,
-                    new OpenApiResponse()
-                    {
-                        Reference = new OpenApiReference()
-                        {
-                            Id = ResponseNames.BadRequestResponse,
-                            Type = ReferenceType.Response
-                        }
-                    });
+                if (operation.Responses.Remove(StatusCodeStrings.Status400BadRequest))
+                {
+                    operation.Responses.Add(
+                        StatusCodeStrings.Status400BadRequest,
+                        new OpenApiResponseReference(ResponseNames.BadRequestResponse));
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/RemoveFailureContentTypesOperationTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/RemoveFailureContentTypesOperationTransformer.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,11 +18,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
     {
         public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
         {
-            foreach (KeyValuePair<string, OpenApiResponse> response in operation.Responses)
+            if (null != operation.Responses)
             {
-                if (response.Key.StartsWith("2"))
+                foreach (KeyValuePair<string, IOpenApiResponse> response in operation.Responses)
                 {
-                    response.Value.Content.Remove(ContentTypes.ApplicationProblemJson);
+                    if (response.Key.StartsWith("2"))
+                    {
+                        response.Value.Content.Remove(ContentTypes.ApplicationProblemJson);
+                    }
                 }
             }
 

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/TooManyRequestsResponseDocumentTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/TooManyRequestsResponseDocumentTransformer.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Diagnostics.Monitoring.WebApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Models.References;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,17 +24,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
                  ContentTypes.ApplicationProblemJson,
                  new OpenApiMediaType()
                  {
-                     Schema = new OpenApiSchema()
-                     {
-                         Reference = new OpenApiReference()
-                         {
-                             Id = nameof(ProblemDetails),
-                             Type = ReferenceType.Schema
-                         }
-                     }
+                     Schema = new OpenApiSchemaReference(nameof(ProblemDetails))
                  });
 
-            openApiDoc.Components.Responses.Add(
+            OpenApiComponents components = openApiDoc.Components ??= new OpenApiComponents();
+            IDictionary<string, IOpenApiResponse> responses = components.Responses ??= new OpenApiResponses();
+            responses.Add(
                 ResponseNames.TooManyRequestsResponse,
                 tooManyRequests);
             

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/TooManyRequestsResponseOperationTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/TooManyRequestsResponseOperationTransformer.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,18 +13,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
     {
         public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
         {
-            if (operation.Responses.Remove(StatusCodeStrings.Status429TooManyRequests))
+            if (null != operation.Responses)
             {
-                operation.Responses.Add(
-                    StatusCodeStrings.Status429TooManyRequests,
-                    new OpenApiResponse()
-                    {
-                        Reference = new OpenApiReference()
-                        {
-                            Id = ResponseNames.TooManyRequestsResponse,
-                            Type = ReferenceType.Response
-                        }
-                    });
+                if (operation.Responses.Remove(StatusCodeStrings.Status429TooManyRequests))
+                {
+                    operation.Responses.Add(
+                        StatusCodeStrings.Status429TooManyRequests,
+                        new OpenApiResponseReference(ResponseNames.TooManyRequestsResponse));
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/UnauthorizedResponseDocumentTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/UnauthorizedResponseDocumentTransformer.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,13 +18,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
         public Task TransformAsync(OpenApiDocument openApiDoc, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
         {
             OpenApiHeader authenticateHeader = new();
-            authenticateHeader.Schema = new OpenApiSchema() { Type = "string" };
+            authenticateHeader.Schema = new OpenApiSchema() { Type = JsonSchemaType.String };
 
             OpenApiResponse unauthorizedResponse = new();
             unauthorizedResponse.Description = "Unauthorized";
             unauthorizedResponse.Headers.Add("WWW_Authenticate", authenticateHeader);
 
-            openApiDoc.Components.Responses.Add(
+            OpenApiComponents components = openApiDoc.Components ??= new OpenApiComponents();
+            IDictionary<string, IOpenApiResponse> responses = components.Responses ??= new OpenApiResponses();
+            responses.Add(
                 ResponseNames.UnauthorizedResponse,
                 unauthorizedResponse);
 

--- a/src/Tools/dotnet-monitor/OpenApi/Transformers/UnauthorizedResponseOperationTransformer.cs
+++ b/src/Tools/dotnet-monitor/OpenApi/Transformers/UnauthorizedResponseOperationTransformer.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,14 +17,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor.OpenApi.Transformers
     {
         public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
         {
-            if (operation.Responses.TryGetValue(StatusCodeStrings.Status401Unauthorized, out OpenApiResponse? unauthorizedResponse))
+            if (null != operation.Responses)
             {
-                unauthorizedResponse.Content.Clear();
-                unauthorizedResponse.Reference = new OpenApiReference()
+                if (operation.Responses.Remove(StatusCodeStrings.Status401Unauthorized))
                 {
-                    Id = ResponseNames.UnauthorizedResponse,
-                    Type = ReferenceType.Response
-                };
+                    operation.Responses.Add(
+                        StatusCodeStrings.Status401Unauthorized,
+                        new OpenApiResponseReference(ResponseNames.UnauthorizedResponse));
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
@@ -9,6 +9,7 @@
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <Nullable>enable</Nullable>
+    <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" />
     <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIAGNOSTICS_REPO_ROOT)' == ''">


### PR DESCRIPTION
###### Summary

These changes update .NET Monitor to be built on .NET 10, update testing to include `net10.0`, and to update the OpenAPI generation to work with Microsoft.AspNetCore.OpenApi for .NET 10.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
