### PR TITLE
[feature/10.0] Make PR run .NET 10 tests

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,8 +32,8 @@
 
   <!-- Filter tests based on specified TestGroup -->
   <PropertyGroup Condition="'$(TestGroup)' == 'PR'">
-    <!-- Only run tests for .NET 9 -->
-    <TestRunnerFilterArguments>TargetFrameworkMoniker=Net90</TestRunnerFilterArguments>
+    <!-- Only run tests for .NET 10 -->
+    <TestRunnerFilterArguments>TargetFrameworkMoniker=Net100</TestRunnerFilterArguments>
     <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter "$(TestRunnerFilterArguments)"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -362,6 +362,8 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         }
 
 #if NET8_0_OR_GREATER
+        // See https://github.com/dotnet/dotnet-monitor/issues/8042
+#if !NET10_0
         [Fact]
         public async Task TestSystemDiagnosticsMetrics_MeterInstrumentTags()
         {
@@ -442,6 +444,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     });
                 });
         }
+#endif
 #endif
     }
 }


### PR DESCRIPTION
###### Summary

Missed this update in #8035 to run .NET 10 target tests in PR instead of .NET 9.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
