### PR TITLE
[release/8.x] Manually update dependencies that dependabot is failing to update

### DIFF
--- a/eng/dependabot/independent/Versions.props
+++ b/eng/dependabot/independent/Versions.props
@@ -2,12 +2,12 @@
   <!-- Import references updated by Dependabot. -->
 
   <PropertyGroup>
-    <AzureCoreVersion>1.44.1</AzureCoreVersion>
+    <AzureCoreVersion>1.45.0</AzureCoreVersion>
     <AzureIdentityVersion>1.13.2</AzureIdentityVersion>
-    <AzureStorageBlobsVersion>12.23.0</AzureStorageBlobsVersion>
-    <AzureStorageQueuesVersion>12.21.0</AzureStorageQueuesVersion>
-    <MicrosoftIdentityWebVersion>3.6.2</MicrosoftIdentityWebVersion>
-    <MicrosoftOpenApiReadersVersion>1.6.23</MicrosoftOpenApiReadersVersion>
+    <AzureStorageBlobsVersion>12.24.0</AzureStorageBlobsVersion>
+    <AzureStorageQueuesVersion>12.22.0</AzureStorageQueuesVersion>
+    <MicrosoftIdentityWebVersion>3.8.3</MicrosoftIdentityWebVersion>
+    <MicrosoftOpenApiReadersVersion>1.6.24</MicrosoftOpenApiReadersVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
 


### PR DESCRIPTION
###### Summary

Dependabot is failing to update some dependencies in the `release/8.x` branch "because it would cause a dependency conflict." The [logs](https://github.com/dotnet/dotnet-monitor/actions/runs/14457024012/job/40542366897) are not clear as to what conflict that might be. I've updated the dependencies manually and the build seems to be fine.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
