### PR TITLE
Remove unused Swashbuckle.AspNetCore package

### DIFF
--- a/eng/dependabot/independent/Packages.props
+++ b/eng/dependabot/independent/Packages.props
@@ -17,7 +17,6 @@
     <!-- Third-party references -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="AWSSDK.S3" Version="$(AwsSdkS3Version)" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="$(AwsSdkSecurityTokenVersion)" />

--- a/eng/dependabot/independent/Versions.props
+++ b/eng/dependabot/independent/Versions.props
@@ -14,7 +14,6 @@
     <!-- Third-party references -->
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NJsonSchemaVersion>11.0.0</NJsonSchemaVersion>
-    <SwashbuckleAspNetCoreVersion>7.2.0</SwashbuckleAspNetCoreVersion>
     <AwsSdkS3Version>3.7.305.7</AwsSdkS3Version>
     <AwsSdkSecurityTokenVersion>3.7.300.33</AwsSdkSecurityTokenVersion>
 


### PR DESCRIPTION
###### Summary

The `Swashbuckle.AspNetCore` package is no longer used in .NET Monitor 9.1 and later. Remove this dependency from source since it is not used and so that Dependabot doesn't attempt for perform updates.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
