### PR TITLE
Change main to be .NET 9 for dependabot updates

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -17,7 +17,7 @@
 #! target branch and which major version of .NET Monitor it builds.
 #@ def getBranches():
 #@   return [
-#@     struct.encode({"name": "main", "majorVersion": "8"}),
+#@     struct.encode({"name": "main", "majorVersion": "9"}),
 #@     struct.encode({"name": "release/9.0", "majorVersion": "9"}),
 #@     struct.encode({"name": "release/8.x", "majorVersion": "8"}),
 #@   ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,23 @@ updates:
   commit-message:
     prefix: '[main] '
 - package-ecosystem: nuget
+  directory: /eng/dependabot/net9.0
+  schedule:
+    interval: daily
+  target-branch: main
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[main] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Text.Json
+- package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
   schedule:
     interval: daily


### PR DESCRIPTION
###### Summary

When the `main` branch was updated to build .NET Monitor 9.1, I forgot to update the dependabot configuration to specify that the branch is producing .NET Monitor 9.X versions. With this update, it should now get .NET 9 updates in the net9.0 dependabot versions.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
