### PR TITLE
Map Uri config value as string

### DIFF
--- a/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
+++ b/src/Tools/dotnet-monitor/CommonOptionsExtensions.cs
@@ -118,7 +118,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     valueType.IsEnum ||
                     typeof(Guid) == valueType ||
                     typeof(string) == valueType ||
-                    typeof(TimeSpan) == valueType)
+                    typeof(TimeSpan) == valueType ||
+                    typeof(Uri) == valueType)
                 {
                     map.Add(
                         valueName,


### PR DESCRIPTION
Porting this part of https://github.com/dotnet/dotnet-monitor/pull/8233 to main.

I don't think this affects the product behavior since the `config show` command doesn't set a Uri.