### PR TITLE
Remove NuGet.config links

### DIFF
--- a/eng/dependabot/independent/NuGet.config
+++ b/eng/dependabot/independent/NuGet.config
@@ -1,1 +1,0 @@
-../../../NuGet.config

--- a/eng/dependabot/net8.0/NuGet.config
+++ b/eng/dependabot/net8.0/NuGet.config
@@ -1,1 +1,0 @@
-../../../NuGet.config

--- a/eng/dependabot/net9.0/NuGet.config
+++ b/eng/dependabot/net9.0/NuGet.config
@@ -1,1 +1,0 @@
-../../../NuGet.config


### PR DESCRIPTION
###### Summary

There have been recent changes to dependabot that are causing the NuGet.config links under each of the dependabot folders to seemingly be ignored. Dependabot them falls back to using nuget.org, which is never what we want to happen. This is causing PRs such as #8216 and #8230 to be opened.

I tested the removal of these file links in my fork of the repo and it seems to behave correctly by locating the NuGet.config at the root of the repository (which the file links were pointing at) and performing updates.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
