### PR TITLE
Change TargetFrameworks to TargetFramework

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,8 +24,8 @@
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)Common.props" />
   <PropertyGroup Label="TargetFrameworks">
-    <!-- The TFMs of the dotnet-monitor tool.  -->
-    <ToolTargetFrameworks>$(LatestTargetFramework)</ToolTargetFrameworks>
+    <!-- The TFM of the dotnet-monitor tool.  -->
+    <ToolTargetFramework>$(LatestTargetFramework)</ToolTargetFramework>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
     <TestTargetFrameworks>net8.0;net9.0;$(LatestTargetFramework)</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->

--- a/src/Extensions/AzureBlobStorage/AzureBlobStorage.csproj
+++ b/src/Extensions/AzureBlobStorage/AzureBlobStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.Monitoring.AzureBlobStorage</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/src/Extensions/S3Storage/S3Storage.csproj
+++ b/src/Extensions/S3Storage/S3Storage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.Monitoring.Extension.S3Storage</RootNamespace>
     <Description>S3 Storage extension for dotnet-monitor</Description>
     <PackageTags>Diagnostic</PackageTags>

--- a/src/Microsoft.Diagnostics.Monitoring.Extension.Common/Microsoft.Diagnostics.Monitoring.Extension.Common.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.Extension.Common/Microsoft.Diagnostics.Monitoring.Extension.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <PackAsTool>false</PackAsTool>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <DefineConstants>$(DefineConstants);EXTENSION</DefineConstants>
     <IsPackable>true</IsPackable>
     <IsShippingAssembly>true</IsShippingAssembly>

--- a/src/Tests/CollectionRuleActions.UnitTests/CollectionRuleActions.UnitTests.csproj
+++ b/src/Tests/CollectionRuleActions.UnitTests/CollectionRuleActions.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.AzureBlobStorageTests.UnitTests/Microsoft.Diagnostics.Monitoring.AzureBlobStorageTests.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.AzureBlobStorageTests.UnitTests/Microsoft.Diagnostics.Monitoring.AzureBlobStorageTests.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <HelixRequiresAzurite>true</HelixRequiresAzurite>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp/Microsoft.Diagnostics.Monitoring.EgressExtensibilityApp.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen/Microsoft.Diagnostics.Monitoring.OpenApiGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup/Microsoft.Diagnostics.Monitoring.Tool.TestHostingStartup.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook/Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook/Microsoft.Diagnostics.Monitoring.Tool.TestStartupHook.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon/Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <DisableCompileTimeOpenApiXmlGenerator>true</DisableCompileTimeOpenApiXmlGenerator>
   </PropertyGroup>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests/Microsoft.Diagnostics.Monitoring.WebApi.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <DefineConstants>$(DefineConstants);UNITTEST</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFramework>$(ToolTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.Tools.Monitor</RootNamespace>
     <ToolCommandName>dotnet-monitor</ToolCommandName>
     <Description>.NET Core Diagnostic Monitoring Tool</Description>

--- a/src/archives/Directory.Build.props
+++ b/src/archives/Directory.Build.props
@@ -6,7 +6,7 @@
       Only include TargetFrameworks if a single TFM is not specified, otherwise nuget pack will include all TFMs in the same package.
       Specify all TFMs to restore the project for all of them, but only build the symbols package for a single TFM.
       -->
-    <TargetFrameworks Condition="'$(TargetFramework)' == ''">$(ToolTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFramework)' == ''">$(ToolTargetFramework)</TargetFrameworks>
     <RuntimeIdentifiers>$(DefaultRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
###### Summary
During pack/sign the rid specific staticwebassets.build.json is being accessed instead of the neutral one. Current speculation is that the cause is our use of TargetFrameworks instead of TargetFramework.

cc @baronfel 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
