### PR TITLE
Use dotnet-monitor asset instead of merge manfest for versioning

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -141,7 +141,7 @@ variables:
         
         $buildData = $buildInfo | ConvertFrom-Json
         
-        [array]$matchingData = $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping }
+        [array]$matchingData = $buildData.assets | Where-Object { $_.name -eq 'dotnet-monitor' }
         
         if (!$matchingData -or $matchingData.Length -ne 1) {
             Write-Error 'Unable to obtain build version.'

--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -15,7 +15,7 @@ $buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
     -MaestroApiEndPoint $MaestroApiEndPoint `
     -DarcVersion $DarcVersion
 
-[array]$matchingData = $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping }
+[array]$matchingData = $buildData.assets | Where-Object { $_.name -eq 'dotnet-monitor' }
 
 if (!$matchingData -or $matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'


### PR DESCRIPTION
###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
