### PR TITLE
Revert publishing files

### DIFF
--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -93,38 +93,55 @@
   <Import Project="$(RepoRoot)src\Microsoft.Diagnostics.Monitoring.StartupHook\ProjectsToPublish.props" />
   <Import Project="$(RepositoryEngineeringDir)PublishProjects.targets" />
 
-  <ItemGroup Label="Computed Publish Assets">
-    <!-- Pack the profiler library for each platform. -->
-    <AdditionalRIDSpecificPublishFile
-      Include="@(MonitorProfilerLibraryFile);
-               @(MutatingMonitorProfilerLibraryFile);
-               @(MonitorProfilerSymbolsFile);
-               @(MutatingMonitorProfilerSymbolsFile);
-               @(CommonMonitorProfilerSymbolsFile);
-              ">
-        <RelativePath>shared/%(TargetRid)/native/%(Filename)%(Extension)</RelativePath>
-     </AdditionalRIDSpecificPublishFile>
+  <!-- Publish projects unless skipped -->
+  <Target Name="PublishProjectsBeforePack"
+          Condition="'$(SkipPublishProjects)' != 'true'">
+    <CallTarget Targets="PublishProjects" />
+  </Target>
 
-     <!-- Pack startup hook files -->
-     <AdditionalRIDAgnosticPublishFile Include="$(StartupHookLibraryPath);$(StartupHookSymbolsPath)">
-       <RelativePath>shared/any/$(StartupHookTargetFramework)/%(FileName)%(Extension)</RelativePath>
-     </AdditionalRIDAgnosticPublishFile>
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CollectTfmSpecificPackageFiles</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
 
-     <!-- Pack extension files -->
-     <AdditionalRIDAgnosticPublishFile Include="$(AzureBlobStoragePublishRootPath)$(TargetFramework)\any\**">
-       <RelativePath>extensions/$(AzureBlobStorageExtensionFolderName)/%(RecursiveDir)%(FileName)%(Extension)</RelativePath>
-     </AdditionalRIDAgnosticPublishFile>
-     <AdditionalRIDAgnosticPublishFile Include="$(S3StoragePublishRootPath)$(TargetFramework)\any\**">
-       <RelativePath>extensions/$(S3StorageExtensionFolderName)/%(RecursiveDir)%(FileName)%(Extension)</RelativePath>
-     </AdditionalRIDAgnosticPublishFile>
-  </ItemGroup>
-
-  <Target Name="AddNativeAssetsToPublishLayout"
-          BeforeTargets="ComputeResolvedFilesToPublishList">
+  <Target Name="CollectTfmSpecificPackageFiles"
+          DependsOnTargets="PublishProjectsBeforePack">
     <ItemGroup>
-      <ResolvedFileToPublish Include="@(AdditionalRIDSpecificPublishFile->Exists());@(AdditionalRIDAgnosticPublishFile)">
-        <CopyFileToPublishDirectory>PreserveNewest</CopyFileToPublishDirectory>
-      </ResolvedFileToPublish>
+      <!-- Pack the profiler library for each platform. -->
+      <AdditionalPackageFile Include="@(MonitorProfilerLibraryFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
+      <AdditionalPackageFile Include="@(MutatingMonitorProfilerLibraryFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
+      <!-- Pack the profiler symbols for each platform. -->
+      <AdditionalPackageFile Include="@(MonitorProfilerSymbolsFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
+      <AdditionalPackageFile Include="@(MutatingMonitorProfilerSymbolsFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
+      <AdditionalPackageFile Include="@(CommonMonitorProfilerSymbolsFile)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/%(TargetRid)/native</PackagePath>
+      </AdditionalPackageFile>
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Pack the file if it exists. -->
+      <TfmSpecificPackageFile Include="@(AdditionalPackageFile->Exists())" />
+      <!-- Pack startup hook files -->
+      <TfmSpecificPackageFile Include="$(StartupHookLibraryPath)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/any/$(StartupHookTargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(StartupHookSymbolsPath)">
+        <PackagePath>tools/$(TargetFramework)/any/shared/any/$(StartupHookTargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+
+      <!-- Pack extension files -->
+      <TfmSpecificPackageFile Include="$(AzureBlobStoragePublishRootPath)$(TargetFramework)\any\**">
+        <PackagePath>tools/$(TargetFramework)/any/extensions/$(AzureBlobStorageExtensionFolderName)</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(S3StoragePublishRootPath)$(TargetFramework)\any\**">
+        <PackagePath>tools/$(TargetFramework)/any/extensions/$(S3StorageExtensionFolderName)</PackagePath>
+      </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
 

--- a/src/archives/dotnet-monitor-base/Package.props
+++ b/src/archives/dotnet-monitor-base/Package.props
@@ -11,12 +11,73 @@
   <ItemGroup>
     <FileToArchive Include="$(RepoRoot)LICENSE.TXT" />
     <FileToArchive Include="$(ThirdPartyNoticesFilePath)" Condition="Exists('$(ThirdPartyNoticesFilePath)')" />
+    <!-- Include the profiler for the current platform. -->
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MutatingMonitorProfilerLibraryFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </FileToArchive>
+    <!-- For linux, include both musl and glib variants; thus include the profiler for the other variant. -->
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-arm64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-musl-arm64'">
+      <PackagePath>shared\linux-arm64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MutatingMonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-arm64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-musl-arm64'">
+      <PackagePath>shared\linux-arm64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-x64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'">
+      <PackagePath>shared\linux-x64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MutatingMonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-x64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'">
+      <PackagePath>shared\linux-x64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-musl-arm64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+      <PackagePath>shared\linux-musl-arm64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MutatingMonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-musl-arm64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-arm64'">
+      <PackagePath>shared\linux-musl-arm64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-musl-x64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+      <PackagePath>shared\linux-musl-x64\native\</PackagePath>
+    </FileToArchive>
+    <FileToArchive Include="@(MutatingMonitorProfilerLibraryFile->WithMetadataValue('TargetRid', 'linux-musl-x64'))"
+                   Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+      <PackagePath>shared\linux-musl-x64\native\</PackagePath>
+    </FileToArchive>
+
+    <!-- Startup hook assemblies -->
+    <FileToArchive Include="$(StartupHookLibraryPath)">
+      <PackagePath>shared\any\$(StartupHookTargetFramework)\</PackagePath>
+    </FileToArchive>
     <!-- Hosting startup assemblies -->
     <FileToArchive Include="$(HostingStartupLibraryPath)">
       <PackagePath>shared\any\$(HostingStartupTargetFramework)\</PackagePath>
     </FileToArchive>
   </ItemGroup>
   <ItemGroup>
+    <!-- Do not include symbols for the extra native assemblies since they have their own symbols package. -->
+    <SymbolFileToArchive Include="@(MonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </SymbolFileToArchive>
+    <SymbolFileToArchive Include="@(MutatingMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </SymbolFileToArchive>
+    <!-- Symbols are not created for static libraries on non-Windows platforms -->
+    <SymbolFileToArchive Include="@(CommonMonitorProfilerSymbolsFile->WithMetadataValue('TargetRid', '$(RuntimeIdentifier)'))"
+                         Condition="$(RuntimeIdentifier.Contains(win))">
+      <PackagePath>shared\$(RuntimeIdentifier)\native\</PackagePath>
+    </SymbolFileToArchive>
+    <!-- Startup hook symbols -->
+    <SymbolFileToArchive Include="$(StartupHookSymbolsPath)">
+      <PackagePath>shared\any\$(StartupHookTargetFramework)\</PackagePath>
+    </SymbolFileToArchive>
     <!-- Hosting startup symbols -->
     <SymbolFileToArchive Include="$(HostingStartupSymbolsPath)">
       <PackagePath>shared\any\$(HostingStartupTargetFramework)\</PackagePath>


### PR DESCRIPTION
###### Summary

This is a revert for some of the publishing changes. We effectively publish 3 projects (dotnet-monitor, s3 extensions, azure extensions) with overlapping dependencies (e.g. System.CommandLine). The publish step erroneously determines that these dependencies are collisions and removes them for some of the 3 projects we publish. This revert goes back to manually staging out the files.

This is a partial revert of #8554 and #8552

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
