### PR TITLE
Revert "[main] Bump Microsoft.Diagnostics.DbgShim from 9.0.621003 to …

### DIFF
--- a/eng/dependabot/nuget.org/Versions.props
+++ b/eng/dependabot/nuget.org/Versions.props
@@ -2,6 +2,6 @@
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
     <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringShippedVersion>9.0.652701</MicrosoftDiagnosticsMonitoringShippedVersion>
+    <MicrosoftDiagnosticsMonitoringShippedVersion>9.0.621003</MicrosoftDiagnosticsMonitoringShippedVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Main branch consumes daily dotnet/diagnostics builds, but bumping this version in main causes it to flow to release/10. The problem with the latest version of dotnet/diagnostics packages is that they point to 9.0 versions of Microsoft.Extensions.Logging instead of 8.0 versions, causing incompatibility in our code.