### PR TITLE
Add 10.0.1 release notes

### DIFF
--- a/documentation/releaseNotes/releaseNotes.v10.0.1.md
+++ b/documentation/releaseNotes/releaseNotes.v10.0.1.md
@@ -1,0 +1,7 @@
+Today we are releasing the 10.0.1 build of the `dotnet monitor` tool. This release includes:
+
+- Updated dependencies
+
+
+
+If you would like to provide additional feedback to the team [please fill out this survey](https://aka.ms/dotnet-monitor-survey?src=rn).


### PR DESCRIPTION
Add 10.0.1 release notes. Note that this was manually generated, the automation is currently failing, but I haven't put up a fix yet for it.
