### PR TITLE
Replace dn-bot-all-drop-rw-code-rw-release-all PAT with WIF token

### DIFF
--- a/eng/pipelines/dotnet-monitor-compliance.yml
+++ b/eng/pipelines/dotnet-monitor-compliance.yml
@@ -68,13 +68,15 @@ extends:
           inputs:
             azureSubscription: 'DotNetStaging'
             scriptType: ps
-            scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
-            arguments: >-
-              -BarBuildId "$(BuildBarId)"
-              -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
-              -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
-              -ReleaseVersion "$(BuildVersion)"
-              -Separated $False
+            scriptLocation: inlineScript
+            inlineScript: |
+              $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              & '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1' `
+                -BarBuildId "$(BuildBarId)" `
+                -AzdoToken $azdoToken `
+                -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets" `
+                -ReleaseVersion "$(BuildVersion)" `
+                -Separated $False
             workingDirectory: '$(Build.Repository.LocalPath)'
           continueOnError: true
 

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -54,12 +54,14 @@ stages:
         inputs:
           azureSubscription: 'DotNetStaging'
           scriptType: ps
-          scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
-          arguments: >-
-            -BarBuildId "$(BARBuildId)"
-            -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
-            -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
-            -ReleaseVersion "$(Build.BuildNumber)"
+          scriptLocation: inlineScript
+          inlineScript: |
+            $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+            & '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1' `
+              -BarBuildId "$(BARBuildId)" `
+              -AzdoToken $azdoToken `
+              -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets" `
+              -ReleaseVersion "$(Build.BuildNumber)"
           workingDirectory: '$(Build.Repository.LocalPath)'
         continueOnError: true
 


### PR DESCRIPTION
## Summary

Migrate Download Build Assets tasks in both compliance and release pipelines from using the \dn-bot-all-drop-rw-code-rw-release-all\ PAT to acquiring an AzDO access token from the **DotNetStaging** service connection via \z account get-access-token\.

## Files changed

- \ng/pipelines/dotnet-monitor-compliance.yml\ — compliance scan asset download
- \ng/pipelines/stages/preparerelease.yml\ — release asset staging

## What changed

Both \AzureCLI@2\ tasks already run with the \DotNetStaging\ service connection (WIF). Instead of passing the PAT variable, we now:
1. Acquire an AzDO token: \z account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798\
2. Pass that token to \AcquireBuild.ps1 -AzdoToken\

This switches from \scriptPath\+\rguments\ to \inlineScript\ to allow the token acquisition step.

## Why

Part of the 1ES PAT Disable Policy migration. The \dn-bot-all-drop-rw-code-rw-release-all\ PAT is being retired in favor of Entra-based authentication.

Tracked by: https://dev.azure.com/dnceng/internal/_workitems/edit/10105

## Validation

- The DotNetStaging SP is already enrolled in the \dnceng\ AzDO org with appropriate group memberships
- The SP already authenticates blob storage downloads (\--use-azure-credential-for-blobs\) in these same tasks
- Post-merge, monitor the first compliance/release pipeline run to confirm end-to-end