### PR TITLE
Update versions to prepare for new Diagnostics release

### DIFF
--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -12,6 +12,6 @@
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp80Version>8.0.27</MicrosoftNETCoreApp80Version>
     <!-- System.Text.Json -->
-    <SystemTextJson80Version>8.0.6</SystemTextJson80Version>
+    <SystemTextJson80Version>10.0.3</SystemTextJson80Version>
   </PropertyGroup>
 </Project>

--- a/eng/dependabot/net9.0/Versions.props
+++ b/eng/dependabot/net9.0/Versions.props
@@ -12,6 +12,6 @@
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp90Version>9.0.11</MicrosoftNETCoreApp90Version>
     <!-- System.Text.Json -->
-    <SystemTextJson90Version>9.0.15</SystemTextJson90Version>
+    <SystemTextJson90Version>10.0.3</SystemTextJson90Version>
   </PropertyGroup>
 </Project>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.csproj
@@ -87,7 +87,6 @@
     This is the minimum overrides required to prevent package downgrades due to transitive dependencies -->
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" VersionOverride="$(MicrosoftExtensionsConfigurationAbstractions100Version)" Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="$(MicrosoftExtensionsLoggingAbstractions100Version)" Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJson100Version)" Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
###### Summary

Microsoft.Monitoring.EventPipe now depends on System.Text.Json version 10. 

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
