### PR TITLE
Add CFSClean2 network isolation policy to release pipeline

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -168,7 +168,7 @@ resources:
 extends:
   template: /eng/pipelines/templates/pipeline-template.yml@self
   parameters:
-    networkIsolationPolicy: Permissive,CFSClean
+    networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     sdl:
       sbom:
         enabled: false


### PR DESCRIPTION
Append CFSClean2 to the existing Permissive,CFSClean policy on the dotnet-monitor-release pipeline to block involuntary connections to PowerShell Gallery, Conda, and Gradle plugin endpoints (ES-4.2.4).

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
