### PR TITLE
Fix incorrect year in 10.0.2 patchReleaseDate

### DIFF
--- a/.github/releases.json
+++ b/.github/releases.json
@@ -51,7 +51,7 @@
     "10.0": {
       "tag": "v10.0.2",
       "minorReleaseDate": "2025-11-12T00:00:00.000Z",
-      "patchReleaseDate": "2025-04-14T00:00:00.000Z",
+      "patchReleaseDate": "2026-04-14T00:00:00.000Z",
       "supportedFrameworks": [
         "net10.0"
       ]


### PR DESCRIPTION
The 10.0 patchReleaseDate was set to 2025-04-14 instead of 2026-04-14. This typo was introduced in the manually-created release PR #9242 (the JSON got 2025 while the hand-edited markdown got the correct 2026), and surfaced when documentation/releases.md is regenerated from the JSON, showing the End of Support/patch date with the wrong year.

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
