### PR TITLE
Bump .NET SDK pin to 10.0.109 to clear SFI-ES5.2 CG alert

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.108",
+    "dotnet": "10.0.109",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp80Version)",


### PR DESCRIPTION
Updates global.json tools.dotnet from 10.0.108 to 10.0.109 (the latest serviced 10.0.1xx feature-band SDK, released 2026-06-09). This addresses high-severity SDK CVEs flagged by Component Governance (SFI-ES5.2): CVE-2026-45490 (high, .NET SDK elevation of privilege), CVE-2026-45491, and CVE-2026-45591.

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
