### PR TITLE
Fix release staging: remove broken SBOM download/copy steps

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -89,22 +89,11 @@ stages:
             --client-id "$env:servicePrincipalId"
             -v True
 
-      - task: DownloadPipelineArtifact@2
-        displayName: Download SBOM Artifact
-        inputs:
-          artifactName: PackSignPublish_Pack_and_Sign_SBOM
-          targetPath: '$(Agent.TempDirectory)\SbomArtifact'
-
-      - task: PowerShell@2
-        displayName: Copy SBOM to Assets Layout
-        inputs:
-          targetType: inline
-          script: |
-            $source = "$(Agent.TempDirectory)\SbomArtifact\PackSignPublish_Pack_and_Sign_SBOM\_manifest"
-            $destination = "$(System.ArtifactsDirectory)\AssetsLayout\_manifest"
-            Write-Host "Copying SBOM from $source to $destination"
-            Copy-Item -Path $source -Destination $destination -Recurse -Force
-
+      # SBOM generation is handled by 1ES PT at publish time: the 1ES.PublishPipelineArtifact
+      # task below auto-generates an SBOM (_manifest) over the published AssetsLayout, which
+      # includes the staged package. The previous explicit "Download SBOM Artifact" /
+      # "Copy SBOM to Assets Layout" steps relied on the per-job PackSignPublish_Pack_and_Sign_SBOM
+      # artifact, which Arcade no longer produces (SBOM moved to 1ES PT), causing the stage to fail.
       - template: /eng/pipelines/steps/publish-pipeline-artifact.yml@self
         parameters:
           displayName: 'Upload Assets Layout'


### PR DESCRIPTION
## Problem
The release pipeline's **Stage Build Assets** job fails with:

```
##[error]Artifact PackSignPublish_Pack_and_Sign_SBOM was not found for build <id>
```

## Root cause
The Arcade SDK update (`10.0.0-beta.26201.4` -> `10.0.0-beta.26304.4`) removed per-job SBOM generation. Arcade's `generate-sbom.yml` is now a deprecation stub stating *"SBOM generation is handled 1ES PT now"*, so the per-job `PackSignPublish_Pack_and_Sign_SBOM` artifact is no longer produced. The explicit `Download SBOM Artifact` step in `preparerelease.yml` then hard-fails.

## Fix
Remove the now-broken `Download SBOM Artifact` and `Copy SBOM to Assets Layout` steps. SBOM coverage is preserved: the `Upload Assets Layout` step publishes via `1ES.PublishPipelineArtifact@1`, which auto-generates an embedded `_manifest` SBOM over the published `AssetsLayout` (which contains the staged package).