### PR TITLE
Add cpp CodeQL leg to official build (SFI-PS2.1)

### DIFF
--- a/eng/pipelines/dotnet-monitor-official.yml
+++ b/eng/pipelines/dotnet-monitor-official.yml
@@ -76,6 +76,17 @@ extends:
         # Generate a TPN for only the dotnet-monitor project
         - template: /eng/pipelines/jobs/tpn.yml@self
 
+      # Produce a cpp CodeQL snapshot for SDL compliance (SFI-PS2.1).
+      # csharp is already covered by 1ES PT auto-injection; this adds the native (cpp) leg.
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - template: /eng/pipelines/jobs/build-codeql.yml@self
+          parameters:
+            osGroup: Windows
+            configuration: Release
+            architecture: x64
+            language: cpp
+            enableTsa: true
+
       # Build binaries
       - template: /eng/pipelines/jobs/platform-matrix.yml@self
         parameters:

--- a/eng/pipelines/jobs/build-codeql.yml
+++ b/eng/pipelines/jobs/build-codeql.yml
@@ -9,6 +9,8 @@ parameters:
   architecture: x64
   # Enables TSA results upload
   enableTsa: false
+  # Languages to analyze with CodeQL (csharp, cpp, or csharp,cpp)
+  language: csharp,cpp
 
 jobs:
 - template: /eng/pipelines/jobs/build-binaries.yml@self
@@ -26,7 +28,7 @@ jobs:
     - Codeql.Cadence: 0
     # Force CodeQL enabled so it may be run on any branch
     - Codeql.Enabled: true
-    - Codeql.Language: csharp,cpp
+    - Codeql.Language: ${{ parameters.language }}
       # CodeQL needs this plumbed along as a variable to enable TSA
     - Codeql.TSAEnabled: ${{ parameters.enableTsa }}
 


### PR DESCRIPTION
## Summary

Adds a C++ (cpp) CodeQL leg to the dotnet-monitor official build so the public `dotnet/dotnet-monitor` repo produces a cpp CodeQL snapshot for SDL compliance (S360 SFI-PS2.1 / `Microsoft.Security.CodeQL.10000`).

## Why

- The official build already produces a **csharp** CodeQL snapshot via **1ES Pipeline Template auto-injection** (managed code is traced automatically).
- **cpp is NOT auto-traced.** CodeQL for native code requires the C++ compile to occur between `CodeQL3000Init@0` and `CodeQL3000Finalize@0`.
- The repo already has a ready-made job that does exactly this — `eng/pipelines/jobs/build-codeql.yml` — but it was only referenced by the orphaned `dotnet-monitor-codeql.yml` pipeline (no registered ADO definition), so cpp snapshots were never produced for the public repo.
- cpp was therefore the only language missing from the public repo's CodeQL compliance coverage.

## Changes

- **`eng/pipelines/jobs/build-codeql.yml`**: Added a `language` parameter (default `csharp,cpp` to preserve the existing orphaned-pipeline behavior) and used it for the `Codeql.Language` variable instead of the hardcoded `csharp,cpp`.
- **`eng/pipelines/dotnet-monitor-official.yml`**: In the `Build` stage `jobs:` list, added a job that includes `build-codeql.yml@self` for **Windows / Release / x64** with `language: cpp` and `enableTsa: true`. Gated to non-PR builds using the existing `notin(variables['Build.Reason'], 'PullRequest')` pattern.

## Scope / rationale

- **cpp-only**: csharp is already covered by 1ES PT auto-injection, so this avoids a duplicate csharp run. One platform's cpp snapshot satisfies the per-repo/per-language compliance requirement.
- **Non-PR only**: compliance snapshots come from the official (non-PR, scheduled main) build. No CodeQL leg is added to the PR/public CI path.
- The orphaned `dotnet-monitor-codeql.yml` behavior is unchanged (the new `language` param defaults to `csharp,cpp`).

## Validation

- Both modified YAML files parse cleanly with `yaml.safe_load`.
- New job mirrors the style/indentation of existing job entries in the file.
