### PR TITLE
[release/10.0] Pin Microsoft.OpenApi to 2.7.5 (#9607)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageVersion Include="Microsoft.FileFormats" Version="$(MicrosoftFileFormatsVersion)" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="$(MicrosoftIdentityWebVersion)" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="$(MicrosoftOpenApiReadersVersion)" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="$(MicrosoftOpenApiVersion)" />
     <PackageVersion Include="Moq" Version="$(MoqVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageVersion Include="NJsonSchema" Version="$(NJsonSchemaVersion)" />

--- a/documentation/openapi.json
+++ b/documentation/openapi.json
@@ -2079,14 +2079,13 @@
             "nullable": true
           },
           "error": {
+            "type": "object",
             "oneOf": [
-              {
-                "nullable": true
-              },
               {
                 "$ref": "#/components/schemas/OperationError"
               }
-            ]
+            ],
+            "nullable": true
           },
           "operationId": {
             "type": "string",
@@ -2100,14 +2099,13 @@
             "$ref": "#/components/schemas/OperationState"
           },
           "process": {
+            "type": "object",
             "oneOf": [
-              {
-                "nullable": true
-              },
               {
                 "$ref": "#/components/schemas/OperationProcessInfo"
               }
-            ]
+            ],
+            "nullable": true
           },
           "egressProviderName": {
             "type": "string",
@@ -2143,14 +2141,13 @@
             "$ref": "#/components/schemas/OperationState"
           },
           "process": {
+            "type": "object",
             "oneOf": [
-              {
-                "nullable": true
-              },
               {
                 "$ref": "#/components/schemas/OperationProcessInfo"
               }
-            ]
+            ],
+            "nullable": true
           },
           "egressProviderName": {
             "type": "string",

--- a/eng/dependabot/independent/Packages.props
+++ b/eng/dependabot/independent/Packages.props
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Azure.Storage.Queues" Version="$(AzureStorageQueuesVersion)" />
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="$(MicrosoftOpenApiReadersVersion)" />
+    <PackageReference Include="Microsoft.OpenApi" Version="$(MicrosoftOpenApiVersion)" />
     <PackageReference Include="Microsoft.Identity.Web" Version="$(MicrosoftIdentityWebVersion)" />
 
     <!-- Third-party references -->

--- a/eng/dependabot/independent/Versions.props
+++ b/eng/dependabot/independent/Versions.props
@@ -7,7 +7,7 @@
     <AzureStorageBlobsVersion>12.29.1</AzureStorageBlobsVersion>
     <AzureStorageQueuesVersion>12.27.1</AzureStorageQueuesVersion>
     <MicrosoftIdentityWebVersion>4.10.0</MicrosoftIdentityWebVersion>
-    <MicrosoftOpenApiReadersVersion>1.6.29</MicrosoftOpenApiReadersVersion>
+    <MicrosoftOpenApiVersion>2.7.5</MicrosoftOpenApiVersion>
     <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" />
+    <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests/OpenApiGeneratorTests.cs
@@ -3,10 +3,8 @@
 
 using Microsoft.Diagnostics.Monitoring.TestCommon;
 using Microsoft.Diagnostics.Monitoring.TestCommon.Runners;
-using Microsoft.OpenApi.Extensions;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Validations;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -80,11 +78,11 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
         /// Test that the committed OpenAPI document is valid.
         /// </summary>
         [Fact]
-        public void BaselineIsValidTest()
+        public async Task BaselineIsValidTestAsync()
         {
             using FileStream stream = new(OpenApiBaselinePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
-            ValidateDocument(stream);
+            await ValidateDocumentAsync(stream);
         }
 
         /// <summary>
@@ -95,7 +93,7 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
         {
             using FileStream stream = await GenerateDocumentAsync();
 
-            ValidateDocument(stream);
+            await ValidateDocumentAsync(stream);
         }
 
         private async Task<FileStream> GenerateDocumentAsync()
@@ -119,13 +117,12 @@ namespace Microsoft.Diagnostics.Monitoring.OpenApiGen.UnitTests
             return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
         }
 
-        private static void ValidateDocument(FileStream stream)
+        private static async Task ValidateDocumentAsync(Stream stream)
         {
-            OpenApiStreamReader reader = new();
-            OpenApiDocument document = reader.Read(stream, out OpenApiDiagnostic diagnostic);
-            Assert.Empty(diagnostic.Errors);
+            ReadResult result = await OpenApiDocument.LoadAsync(stream, OpenApiConstants.Json);
+            Assert.Empty(result.Diagnostic.Errors);
 
-            IEnumerable<OpenApiError> errors = document.Validate(ValidationRuleSet.GetDefaultRuleSet());
+            IEnumerable<OpenApiError> errors = result.Document.Validate(ValidationRuleSet.GetDefaultRuleSet());
             Assert.Empty(errors);
         }
     }


### PR DESCRIPTION
* Pin Microsoft.OpenApi to 2.7.5 to address GHSA-v5pm-xwqc-g5wc

Microsoft.AspNetCore.OpenApi transitively pulls Microsoft.OpenApi 2.0.0, which has a known high severity vulnerability (NU1903). Transitive-pin it to the patched 2.7.5 and keep the Microsoft.OpenApi.Readers 1.x consumer on 1.6.29 via VersionOverride.



* Use Microsoft.OpenApi 2.7.5 everywhere; migrate tests off Microsoft.OpenApi.Readers

Per PR feedback, drop the VersionOverride/downversioning for the OpenApiGen tests. Migrate the test to the Microsoft.OpenApi 2.x reader/validation API (OpenApiDocument.LoadAsync) and remove the now-unused Microsoft.OpenApi.Readers 1.x package.



---------

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
