### PR TITLE
Update release approval group to NETMonitor alias

### DIFF
--- a/eng/pipelines/dotnet-monitor-publish.yml
+++ b/eng/pipelines/dotnet-monitor-publish.yml
@@ -158,9 +158,9 @@ extends:
         - task: ManualValidation@1
           inputs:
             notifyUsers: |-
-              [TEAM FOUNDATION]\.NET Monitor Working Group
+              NETMonitor@service.microsoft.com
             approvers: |-
-              [TEAM FOUNDATION]\.NET Monitor Working Group
+              NETMonitor@service.microsoft.com
     - stage: Nuget
       displayName: Push To NuGet Feed
       dependsOn: Validation


### PR DESCRIPTION
Replace obsolete '.NET Monitor Working Group' with NETMonitor@service.microsoft.com in the ManualValidation notifyUsers/approvers of dotnet-monitor-publish.yml.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 182ebfa1-4c84-45a3-b0ab-0ef76501ecfe

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
