### PR TITLE
[release/8.x] Track Negotiate independently

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -86,9 +86,7 @@ updates:
     groups:
       runtime-dependencies:
         patterns:
-#@ if tfm == "net8.0":
           - "Microsoft.AspNetCore.Authentication.Negotiate"
-#@ end
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.DotNetHost"
           - "System.Text.Json"

--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -86,6 +86,9 @@ updates:
     groups:
       runtime-dependencies:
         patterns:
+#@ if tfm == "net8.0":
+          - "Microsoft.AspNetCore.Authentication.Negotiate"
+#@ end
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.DotNetHost"
           - "System.Text.Json"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -68,6 +69,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -135,6 +137,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -152,6 +155,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -219,6 +223,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -304,6 +309,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -321,6 +327,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -168,6 +169,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -234,6 +236,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -283,6 +286,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,7 +79,7 @@
   </PropertyGroup>
   <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiate80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <!--
       Azure SDK dependencies require .NET 10 versions of these packages to avoid package downgrade errors.
       Using 100 versions for packages that have transitive dependencies from Azure.Core and Azure.Identity.

--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -3,6 +3,7 @@
     Packages in this file have versions updated periodically by Dependabot specifically for .NET 8.
   -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiate80Version)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions80Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging80Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions80Version)" />

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
+    <!-- Microsoft.AspNetCore.Authentication.Negotiate -->
+    <MicrosoftAspNetCoreAuthenticationNegotiate80Version>8.0.29</MicrosoftAspNetCoreAuthenticationNegotiate80Version>
     <!-- Microsoft.Extensions.Configuration.Abstractions -->
     <MicrosoftExtensionsConfigurationAbstractions80Version>8.0.0</MicrosoftExtensionsConfigurationAbstractions80Version>
     <!-- Microsoft.Extensions.Logging -->


### PR DESCRIPTION
## Summary
- manage Microsoft.AspNetCore.Authentication.Negotiate independently from the shared ASP.NET Core runtime version
- set the .NET 8 package floor to 8.0.29
- add the package to the synthetic Dependabot project and runtime dependency groups

## Validation
- evaluated the effective net8.0 MSBuild version as 8.0.29
- restored the net8.0 Dependabot project and dotnet-monitor project
- confirmed dotnet-monitor resolves Microsoft.AspNetCore.Authentication.Negotiate 8.0.29
- ran git diff --check