### PR TITLE
[release/9.0] Update Negotiate dependency

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -86,6 +86,7 @@ updates:
     groups:
       runtime-dependencies:
         patterns:
+          - "Microsoft.AspNetCore.Authentication.Negotiate"
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.DotNetHost"
           - "System.Text.Json"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -68,6 +69,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -85,6 +87,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -134,6 +137,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -151,6 +155,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -168,6 +173,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -217,6 +223,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -234,6 +241,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -283,6 +291,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -300,6 +309,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json
@@ -317,6 +327,7 @@ updates:
   groups:
     runtime-dependencies:
       patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
       - System.Text.Json

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -85,7 +85,7 @@
   </PropertyGroup>
   <PropertyGroup Label=".NET 8 Dependent" Condition=" '$(TargetFramework)' == 'net8.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiate80Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <!--
       Azure SDK dependencies require .NET 10 versions of these packages to avoid package downgrade errors.
       Using 100 versions for packages that have transitive dependencies from Azure.Core and Azure.Identity.
@@ -98,7 +98,7 @@
   </PropertyGroup>
   <PropertyGroup Label=".NET 9 Dependent" Condition=" '$(TargetFramework)' == 'net9.0' ">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(MicrosoftAspNetCoreApp90Version)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreApp90Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>$(MicrosoftAspNetCoreAuthenticationNegotiate90Version)</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <!--
       Azure SDK dependencies require .NET 10 versions of these packages to avoid package downgrade errors.
       Using 100 versions for packages that have transitive dependencies from Azure.Core and Azure.Identity.

--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -3,6 +3,7 @@
     Packages in this file have versions updated periodically by Dependabot specifically for .NET 8.
   -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiate80Version)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions80Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging80Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions80Version)" />

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
+    <!-- Microsoft.AspNetCore.Authentication.Negotiate -->
+    <MicrosoftAspNetCoreAuthenticationNegotiate80Version>8.0.29</MicrosoftAspNetCoreAuthenticationNegotiate80Version>
     <!-- Microsoft.Extensions.Configuration.Abstractions -->
     <MicrosoftExtensionsConfigurationAbstractions80Version>8.0.0</MicrosoftExtensionsConfigurationAbstractions80Version>
     <!-- Microsoft.Extensions.Logging -->

--- a/eng/dependabot/net9.0/Packages.props
+++ b/eng/dependabot/net9.0/Packages.props
@@ -3,6 +3,7 @@
     Packages in this file have versions updated periodically by Dependabot specifically for .NET 9.
   -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiate90Version)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractions90Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLogging90Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractions90Version)" />

--- a/eng/dependabot/net9.0/Versions.props
+++ b/eng/dependabot/net9.0/Versions.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- Import references updated by Dependabot. -->
   <PropertyGroup>
+    <!-- Microsoft.AspNetCore.Authentication.Negotiate -->
+    <MicrosoftAspNetCoreAuthenticationNegotiate90Version>9.0.18</MicrosoftAspNetCoreAuthenticationNegotiate90Version>
     <!-- Microsoft.Extensions.Configuration.Abstractions -->
     <MicrosoftExtensionsConfigurationAbstractions90Version>9.0.18</MicrosoftExtensionsConfigurationAbstractions90Version>
     <!-- Microsoft.Extensions.Logging -->


### PR DESCRIPTION
## Summary
- manage `Microsoft.AspNetCore.Authentication.Negotiate` independently from the shared ASP.NET Core runtime version
- pin the supported package versions to 8.0.29 and 9.0.18
- add the package to the synthetic Dependabot projects and runtime dependency groups

## Validation
- restored the net8.0 and net9.0 Dependabot projects
- restored `src/Tools/dotnet-monitor/dotnet-monitor.csproj` for net9.0
- verified effective Negotiate versions for net8.0 and net9.0
- ran `git diff --check`