### PR TITLE
Pin System.Security.Cryptography.Xml to patched versions

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -89,6 +89,7 @@ updates:
           - "Microsoft.AspNetCore.Authentication.Negotiate"
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.DotNetHost"
+          - "System.Security.Cryptography.Xml"
           - "System.Text.Json"
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net9.0
@@ -72,6 +73,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -90,6 +92,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -140,6 +143,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net9.0
@@ -158,6 +162,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -176,6 +181,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -226,6 +232,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -244,6 +251,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -294,6 +302,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net10.0
@@ -312,6 +321,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net10.0
@@ -330,4 +340,5 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="OpenTelemetry.OutOfProcess.Forwarder.Configuration" Version="0.1.0-beta.1" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,6 +88,7 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging80Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions80Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole80Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyXml80Version)</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>$(SystemTextJson80Version)</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET 9 Dependent" Condition=" '$(TargetFramework)' == 'net9.0' ">
@@ -97,6 +98,7 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging90Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions90Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole90Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyXml90Version)</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>$(SystemTextJson90Version)</SystemTextJsonVersion>
     <MicrosoftAspNetCoreOpenApiVersion>$(MicrosoftAspNetCoreApp90Version)</MicrosoftAspNetCoreOpenApiVersion>
   </PropertyGroup>
@@ -110,6 +112,7 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging100Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions100Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole100Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyXml100Version)</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>$(SystemTextJson100Version)</SystemTextJsonVersion>
     <MicrosoftAspNetCoreOpenApiVersion>$(MicrosoftAspNetCoreApp100Version)</MicrosoftAspNetCoreOpenApiVersion>
   </PropertyGroup>

--- a/eng/dependabot/net10.0/Packages.props
+++ b/eng/dependabot/net10.0/Packages.props
@@ -14,6 +14,7 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetAppHost" Version="$(MicrosoftNETCoreApp100Version)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXml100Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson100Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net10.0/Versions.props
+++ b/eng/dependabot/net10.0/Versions.props
@@ -13,6 +13,8 @@
     <MicrosoftExtensionsLoggingConsole100Version>10.0.10</MicrosoftExtensionsLoggingConsole100Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp100Version>10.0.10</MicrosoftNETCoreApp100Version>
+    <!-- System.Security.Cryptography.Xml -->
+    <SystemSecurityCryptographyXml100Version>10.0.10</SystemSecurityCryptographyXml100Version>
     <!-- System.Text.Json -->
     <SystemTextJson100Version>10.0.10</SystemTextJson100Version>
   </PropertyGroup>

--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -14,6 +14,7 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreApp80Version)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXml80Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson80Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -13,6 +13,8 @@
     <MicrosoftExtensionsLoggingConsole80Version>8.0.1</MicrosoftExtensionsLoggingConsole80Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp80Version>8.0.29</MicrosoftNETCoreApp80Version>
+    <!-- System.Security.Cryptography.Xml -->
+    <SystemSecurityCryptographyXml80Version>8.0.4</SystemSecurityCryptographyXml80Version>
     <!-- System.Text.Json -->
     <SystemTextJson80Version>10.0.10</SystemTextJson80Version>
   </PropertyGroup>

--- a/eng/dependabot/net9.0/Packages.props
+++ b/eng/dependabot/net9.0/Packages.props
@@ -14,6 +14,7 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetAppHost" Version="$(MicrosoftNETCoreApp90Version)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXml90Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson90Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net9.0/Versions.props
+++ b/eng/dependabot/net9.0/Versions.props
@@ -13,6 +13,8 @@
     <MicrosoftExtensionsLoggingConsole90Version>9.0.18</MicrosoftExtensionsLoggingConsole90Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp90Version>9.0.11</MicrosoftNETCoreApp90Version>
+    <!-- System.Security.Cryptography.Xml -->
+    <SystemSecurityCryptographyXml90Version>9.0.18</SystemSecurityCryptographyXml90Version>
     <!-- System.Text.Json -->
     <SystemTextJson90Version>10.0.10</SystemTextJson90Version>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- centrally pin transitive `System.Security.Cryptography.Xml` to each patched servicing release
- use TFM-specific versions: 8.0.4, 9.0.18, and 10.0.10
- add the package to the per-TFM Dependabot projects and all runtime dependency groups

Fixes GHSA-23rf-6693-g89p / CVE-2026-50648.

## Validation
- restored the affected UnitTestCommon project after rebasing onto current `main`
- verified `System.Security.Cryptography.Xml` resolves to 10.0.10 for net10.0
- verified the rebased diff is limited to the Cryptography.Xml dependency-management changes