### PR TITLE
[release/9.0] Pin System.Security.Cryptography.Xml

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -89,6 +89,7 @@ updates:
           - "Microsoft.AspNetCore.Authentication.Negotiate"
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.DotNetHost"
+          - "System.Security.Cryptography.Xml"
           - "System.Text.Json"
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,6 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
-    aws-sdk-dependencies:
-      patterns:
-      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -54,6 +51,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net9.0
@@ -72,6 +70,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -90,6 +89,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -113,9 +113,6 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
-    aws-sdk-dependencies:
-      patterns:
-      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -140,6 +137,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net9.0
@@ -158,6 +156,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -176,6 +175,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -199,9 +199,6 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
-    aws-sdk-dependencies:
-      patterns:
-      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -226,6 +223,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -244,6 +242,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -267,9 +266,6 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
-    aws-sdk-dependencies:
-      patterns:
-      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -294,40 +290,5 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
-      - System.Text.Json
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net10.0
-  schedule:
-    interval: daily
-  target-branch: release/9.0
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/9.0] '
-  groups:
-    runtime-dependencies:
-      patterns:
-      - Microsoft.AspNetCore.Authentication.Negotiate
-      - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost
-      - System.Text.Json
-- package-ecosystem: nuget
-  directory: /eng/dependabot/net10.0
-  schedule:
-    interval: daily
-  target-branch: release/8.x
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-  commit-message:
-    prefix: '[release/8.x] '
-  groups:
-    runtime-dependencies:
-      patterns:
-      - Microsoft.AspNetCore.Authentication.Negotiate
-      - Microsoft.Extensions.*
-      - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
+    aws-sdk-dependencies:
+      patterns:
+      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -113,6 +116,9 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
+    aws-sdk-dependencies:
+      patterns:
+      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -199,6 +205,9 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
+    aws-sdk-dependencies:
+      patterns:
+      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -266,6 +275,9 @@ updates:
       patterns:
       - Microsoft.Identity.*
       - Microsoft.IdentityModel.*
+    aws-sdk-dependencies:
+      patterns:
+      - AWSSDK.*
 - package-ecosystem: nuget
   directory: /eng/dependabot/nuget.org
   schedule:
@@ -275,6 +287,44 @@ updates:
     prefix: '[release/8.x] '
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
+  schedule:
+    interval: daily
+  target-branch: release/8.x
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[release/8.x] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
+      - System.Text.Json
+- package-ecosystem: nuget
+  directory: /eng/dependabot/net10.0
+  schedule:
+    interval: daily
+  target-branch: release/9.0
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+  commit-message:
+    prefix: '[release/9.0] '
+  groups:
+    runtime-dependencies:
+      patterns:
+      - Microsoft.AspNetCore.Authentication.Negotiate
+      - Microsoft.Extensions.*
+      - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
+      - System.Text.Json
+- package-ecosystem: nuget
+  directory: /eng/dependabot/net10.0
   schedule:
     interval: daily
   target-branch: release/8.x

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,6 +94,7 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging80Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions100Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole80Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyXml80Version)</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>$(SystemTextJson100Version)</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET 9 Dependent" Condition=" '$(TargetFramework)' == 'net9.0' ">
@@ -107,6 +108,7 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging90Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions100Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole90Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyXml90Version)</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>$(SystemTextJson100Version)</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">

--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -14,6 +14,7 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreApp80Version)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXml80Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson80Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -13,6 +13,8 @@
     <MicrosoftExtensionsLoggingConsole80Version>8.0.1</MicrosoftExtensionsLoggingConsole80Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp80Version>8.0.29</MicrosoftNETCoreApp80Version>
+    <!-- System.Security.Cryptography.Xml -->
+    <SystemSecurityCryptographyXml80Version>8.0.4</SystemSecurityCryptographyXml80Version>
     <!-- System.Text.Json -->
     <SystemTextJson80Version>8.0.6</SystemTextJson80Version>
   </PropertyGroup>

--- a/eng/dependabot/net9.0/Packages.props
+++ b/eng/dependabot/net9.0/Packages.props
@@ -14,6 +14,7 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetAppHost" Version="$(MicrosoftNETCoreApp90Version)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXml90Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson90Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net9.0/Versions.props
+++ b/eng/dependabot/net9.0/Versions.props
@@ -13,6 +13,8 @@
     <MicrosoftExtensionsLoggingConsole90Version>9.0.18</MicrosoftExtensionsLoggingConsole90Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp90Version>9.0.14</MicrosoftNETCoreApp90Version>
+    <!-- System.Security.Cryptography.Xml -->
+    <SystemSecurityCryptographyXml90Version>9.0.18</SystemSecurityCryptographyXml90Version>
     <!-- System.Text.Json -->
     <SystemTextJson90Version>9.0.18</SystemTextJson90Version>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

- pin `System.Security.Cryptography.Xml` to the patched TFM-specific floors for GHSA-23rf-6693-g89p / CVE-2026-50648 (`8.0.4` for .NET 8 and `9.0.18` for .NET 9)
- centrally pin the transitive dependency brought in through Microsoft.Identity.Web TokenCache/DataProtection
- add the package to every existing Dependabot runtime dependency group while preserving the generated matrix

## Validation

- `dotnet restore src\Tests\Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon\Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj --force-evaluate` (`System.Security.Cryptography.Xml/9.0.18`)
- `dotnet restore eng\dependabot\net8.0\dependabot.csproj --force-evaluate` (`System.Security.Cryptography.Xml/8.0.4`)
- `dotnet restore eng\dependabot\net9.0\dependabot.csproj --force-evaluate` (`System.Security.Cryptography.Xml/9.0.18`)
- `dotnet build src\Tests\Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon\Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon.csproj --no-restore -c Debug`
- `git diff --check`
- generated matrix check: 11 existing runtime groups and 11 matching cryptography patterns