### PR TITLE
[release/8.x] Pin System.Security.Cryptography.Xml 8.0.4

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -89,6 +89,7 @@ updates:
           - "Microsoft.AspNetCore.Authentication.Negotiate"
           - "Microsoft.Extensions.*"
           - "Microsoft.NETCore.DotNetHost"
+          - "System.Security.Cryptography.Xml"
           - "System.Text.Json"
 #@ end
 #@ end

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net9.0
@@ -72,6 +73,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -90,6 +92,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -140,6 +143,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net9.0
@@ -158,6 +162,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -176,6 +181,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -226,6 +232,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net8.0
@@ -244,6 +251,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/independent
@@ -294,6 +302,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net10.0
@@ -312,6 +321,7 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json
 - package-ecosystem: nuget
   directory: /eng/dependabot/net10.0
@@ -330,4 +340,5 @@ updates:
       - Microsoft.AspNetCore.Authentication.Negotiate
       - Microsoft.Extensions.*
       - Microsoft.NETCore.DotNetHost
+      - System.Security.Cryptography.Xml
       - System.Text.Json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwashbuckleAspNetCoreVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.Private.Uri" Version="$(SystemPrivateUriVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,6 +88,7 @@
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsLogging80Version)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(MicrosoftExtensionsLoggingAbstractions100Version)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>$(MicrosoftExtensionsLoggingConsole80Version)</MicrosoftExtensionsLoggingConsoleVersion>
+    <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyXml80Version)</SystemSecurityCryptographyXmlVersion>
     <SystemTextJsonVersion>$(SystemTextJson100Version)</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseMicrosoftDiagnosticsMonitoringShippedVersion)' == 'true'">

--- a/eng/dependabot/net8.0/Packages.props
+++ b/eng/dependabot/net8.0/Packages.props
@@ -14,6 +14,7 @@
       with the same version number.
     -->
     <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreApp80Version)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXml80Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson80Version)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/net8.0/Versions.props
+++ b/eng/dependabot/net8.0/Versions.props
@@ -13,6 +13,8 @@
     <MicrosoftExtensionsLoggingConsole80Version>8.0.1</MicrosoftExtensionsLoggingConsole80Version>
     <!-- Microsoft.NETCore.App -->
     <MicrosoftNETCoreApp80Version>8.0.29</MicrosoftNETCoreApp80Version>
+    <!-- System.Security.Cryptography.Xml -->
+    <SystemSecurityCryptographyXml80Version>8.0.4</SystemSecurityCryptographyXml80Version>
     <!-- System.Text.Json -->
     <SystemTextJson80Version>8.0.6</SystemTextJson80Version>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- pin `System.Security.Cryptography.Xml` to the patched .NET 8 floor, `8.0.4`, through Central Package Management
- add the net8 Dependabot shim reference and version mapping
- include the package in every generated runtime-dependencies group

Fixes GHSA-23rf-6693-g89p / CVE-2026-50648.

## Validation
- restored `Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon` and verified `System.Security.Cryptography.Xml` resolves to `8.0.4`
- restored `eng/dependabot/net8.0/dependabot.csproj` and verified `System.Security.Cryptography.Xml` resolves to `8.0.4`
- built `Microsoft.Diagnostics.Monitoring.Tool.UnitTestCommon` successfully
- ran `git diff --check`
- verified all 11 generated runtime-dependencies groups contain the package