### PR TITLE
Use Build.Ubuntu.2204.Amd64 host image for internal Linux builds

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -64,7 +64,10 @@ jobs:
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         pool:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-2204
+          # Use the DncEng-maintained build image (matches the public leg's
+          # Build.Ubuntu.2204.Amd64.Open and dotnet/diagnostics' internal LinuxImage) instead of
+          # the leaner 1ES-managed 1es-ubuntu-2204.
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
           os: linux
 
     # Build OSX Pool


### PR DESCRIPTION
Aligns the internal Linux build pool image with dotnet/diagnostics (and the public leg) so the 1ES-injected Component Governance scan runs on a host that has the detector toolchain prerequisites.

###### Summary


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
