### PR TITLE
[release/9.0] Use Build.Ubuntu.2204.Amd64 host image for internal Linux builds

### DIFF
--- a/eng/pipelines/jobs/build.yml
+++ b/eng/pipelines/jobs/build.yml
@@ -64,7 +64,10 @@ jobs:
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         pool:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-2204
+          # Use the DncEng-maintained build image (matches the public leg's
+          # Build.Ubuntu.2204.Amd64.Open and dotnet/diagnostics' internal LinuxImage) instead of
+          # the leaner 1ES-managed 1es-ubuntu-2204.
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
           os: linux
 
     # Build OSX Pool


### PR DESCRIPTION
Backports #9682 to release/9.0.

The internal Linux build now uses the DncEng-maintained `Build.Ubuntu.2204.Amd64` image rather than the leaner 1ES-managed image. The DncEng image includes the detector toolchain prerequisites required by the 1ES-injected Component Governance scan.