### PR TITLE
[release/8.x] Fix TSA area path

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -2,7 +2,7 @@
     "instanceUrl": "https://devdiv.visualstudio.com/",
     "template": "TFSDEVDIV",
     "projectName": "DEVDIV",
-    "areaPath": "DevDiv\\VS Diagnostics\\Production Diagnostics\\Dotnet Monitor",
+    "areaPath": "DevDiv\\VS Diagnostics\\Production Diagnostics",
     "iterationPath": "DevDiv",
     "notificationAliases": [ "NETMonitorSdl@microsoft.com" ],
     "repositoryName": "dotnet-dotnet-monitor",


### PR DESCRIPTION
Backports the `.config/tsaoptions.json` portion of #8784 to release/8.x.

Removes the deleted `Dotnet Monitor` area leaf so TSA codebase onboarding no longer fails with HTTP 412 `PreconditionFailed` and causes Guardian to exit with code 1.