### PR TITLE
Decode escaped counter tags in metrics output

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/CounterTags.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/CounterTags.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.EventPipe;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring.WebApi
+{
+    /// <summary>
+    /// Recovers the original key/value pairs from the tag strings carried on a counter payload.
+    /// </summary>
+    internal static class CounterTags
+    {
+        // System.Diagnostics.Metrics tags reach dotnet-monitor in a canonical escaped form
+        // ('\' -> '\\', ',' -> '\,', '=' -> '\=') so a ',' or '=' inside a key or value stays
+        // distinguishable from the ',' separating pairs and the '=' separating a key from its value.
+        // That form is a transport detail and must be decoded before tags are exposed to a caller.
+        // EventCounters metadata predates the encoding and uses unescaped ':'-separated pairs, so the
+        // two shapes cannot share a parser.
+        public static bool IsMeterPayload(ICounterPayload payload) =>
+            payload switch
+            {
+                GaugePayload or PercentilePayload or CounterEndedPayload or RatePayload or AggregatePercentilePayload or UpDownCounterPayload => true,
+                _ => false
+            };
+
+        public static IDictionary<string, string> GetLabels(ICounterPayload payload)
+        {
+            string tags = payload.CombineTags();
+
+            if (!IsMeterPayload(payload))
+            {
+                return CounterUtilities.GetMetadata(tags, ':');
+            }
+
+            // A later pair overwrites an earlier one with the same key, matching GetMetadata and
+            // keeping Prometheus label names unique. CombineTags orders meter, instrument then value
+            // tags, so the most specific tag wins.
+            Dictionary<string, string> labels = new();
+            foreach (KeyValuePair<string, string> tag in CounterTagFormatter.Decode(tags))
+            {
+                labels[tag.Key] = tag.Value;
+            }
+
+            return labels;
+        }
+
+        /// <summary>
+        /// Renders an escaped tag string as the flat "key=value,key=value" form used by the metrics
+        /// JSON output, with the keys and values unescaped.
+        /// </summary>
+        public static string Format(string tags)
+        {
+            // A counter without tags reports null, and callers serialize that as a JSON null. Decoding
+            // would turn it into an empty string and change the shape of the output for every
+            // untagged counter.
+            if (string.IsNullOrEmpty(tags))
+            {
+                return tags;
+            }
+
+            StringBuilder builder = new();
+            foreach (KeyValuePair<string, string> tag in CounterTagFormatter.Decode(tags))
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(',');
+                }
+
+                builder.Append(tag.Key).Append('=').Append(tag.Value);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/JsonCounterLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/JsonCounterLogger.cs
@@ -75,10 +75,10 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                         counter.DisplayName,
                         counter.Unit,
                         counter.CounterType.ToString(),
-                        CounterUtilities.AppendPercentile(counter.ValueTags, quantile.Percentage),
+                        FormatValueTags(counter, CounterUtilities.AppendPercentile(counter.ValueTags, quantile.Percentage)),
                         quantile.Value,
-                        counter.CounterMetadata.MeterTags,
-                        counter.CounterMetadata.InstrumentTags);
+                        CounterTags.Format(counter.CounterMetadata.MeterTags),
+                        CounterTags.Format(counter.CounterMetadata.InstrumentTags));
 
                     if (i < aggregatePercentilePayload.Quantiles.Length - 1)
                     {
@@ -97,15 +97,20 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     counter.DisplayName,
                     counter.Unit,
                     counter.CounterType.ToString(),
-                    counter.ValueTags,
+                    FormatValueTags(counter, counter.ValueTags),
                     counter.Value,
-                    counter.CounterMetadata.MeterTags,
-                    counter.CounterMetadata.InstrumentTags);
+                    CounterTags.Format(counter.CounterMetadata.MeterTags),
+                    CounterTags.Format(counter.CounterMetadata.InstrumentTags));
             }
             await _stream.WriteAsync(_bufferWriter.WrittenMemory);
 
             await _stream.WriteAsync(NewLineSeparator);
         }
+
+        // An EventCounters payload carries its metadata in ValueTags as unescaped ':'-separated pairs,
+        // which decoding would corrupt, so only meter tags are decoded.
+        private static string FormatValueTags(ICounterPayload counter, string valueTags) =>
+            CounterTags.IsMeterPayload(counter) ? CounterTags.Format(valueTags) : valueTags;
 
         private void SerializeCounterValues(
             DateTime timestamp,

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -165,10 +165,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private static string GetMetricLabels(ICounterPayload metric, double? quantile)
         {
-            string allMetadata = metric.CombineTags();
-
-            char separator = IsMeter(metric) ? '=' : ':';
-            var metadataValues = CounterUtilities.GetMetadata(allMetadata, separator);
+            IDictionary<string, string> metadataValues = CounterTags.GetLabels(metric);
             if (quantile.HasValue)
             {
                 metadataValues.Add("quantile", quantile.Value.ToString(CultureInfo.InvariantCulture));
@@ -181,14 +178,6 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
             return metricLabels;
         }
-
-        //HACK We should make this easier in the base api
-        private static bool IsMeter(ICounterPayload payload) =>
-            payload switch
-            {
-                GaugePayload or PercentilePayload or CounterEndedPayload or RatePayload or AggregatePercentilePayload or UpDownCounterPayload => true,
-                _ => false
-            };
 
         private static async Task WriteMetricHeader(ICounterPayload metricInfo, StreamWriter writer, string metricName)
         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/JsonCounterLoggerTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/JsonCounterLoggerTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Monitoring.EventPipe;
+using Microsoft.Diagnostics.Monitoring.TestCommon;
+using Microsoft.Diagnostics.Monitoring.WebApi;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    [TargetFrameworkMonikerTrait(TargetFrameworkMonikerExtensions.CurrentTargetFrameworkMoniker)]
+    public sealed class JsonCounterLoggerTests
+    {
+        private const string MeterName = "MeterName";
+        private const string InstrumentName = "InstrumentName";
+        private const int IntervalSeconds = 10;
+
+        private static readonly DateTime Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(10000000).DateTime;
+
+        [Theory]
+        // Escaped input, then the decoded tag string the JSON output should expose.
+        [InlineData(@"Key=Value", "Key=Value")]
+        [InlineData(@"Key=a\,b", "Key=a,b")]
+        [InlineData(@"Key=a\=b", "Key=a=b")]
+        [InlineData(@"Path=C:\\temp", @"Path=C:\temp")]
+        [InlineData(@"Key=a\\b\,c\=d", @"Key=a\b,c=d")]
+        [InlineData(@"a\,b=v,c\=d=w", "a,b=v,c=d=w")]
+        [InlineData(@"Key=", "Key=")]
+        [InlineData(@"Flag", "Flag=")]
+        [InlineData("", "")]
+        public async Task ValueTags_AreDecoded(string valueTags, string expectedTags)
+        {
+            CounterMetadata counterInfo = new CounterMetadata(MeterName, InstrumentName, meterTags: null, instrumentTags: null, scopeHash: null);
+
+            JsonElement counter = await SerializeAsync(new RatePayload(counterInfo, "DisplayName", string.Empty, valueTags, 1, IntervalSeconds, Timestamp));
+
+            Assert.Equal(expectedTags, counter.GetProperty("tags").GetString());
+        }
+
+        [Fact]
+        public async Task MeterAndInstrumentTags_AreDecoded()
+        {
+            CounterMetadata counterInfo = new CounterMetadata(
+                MeterName,
+                InstrumentName,
+                meterTags: @"Meter\,Key=meter\=value",
+                instrumentTags: @"Path=C:\\temp,Empty=",
+                scopeHash: null);
+
+            JsonElement counter = await SerializeAsync(new GaugePayload(counterInfo, "DisplayName", string.Empty, null, 1, Timestamp));
+
+            Assert.Equal("Meter,Key=meter=value", counter.GetProperty("meterTags").GetString());
+            Assert.Equal(@"Path=C:\temp,Empty=", counter.GetProperty("instrumentTags").GetString());
+        }
+
+        [Fact]
+        public async Task Histogram_DecodesTagsAndKeepsPercentile()
+        {
+            CounterMetadata counterInfo = new CounterMetadata(MeterName, InstrumentName, meterTags: null, instrumentTags: null, scopeHash: null);
+
+            JsonElement counter = await SerializeAsync(new AggregatePercentilePayload(
+                counterInfo,
+                "DisplayName",
+                string.Empty,
+                @"Route=/a\,b",
+                new Quantile[] { new Quantile(0.5, 1) },
+                Timestamp));
+
+            Assert.Equal("Route=/a,b,Percentile=50", counter.GetProperty("tags").GetString());
+        }
+
+        [Fact]
+        public async Task EventCounterMetadata_IsNotUnescaped()
+        {
+            // EventCounters metadata is unescaped and ':'-separated; a '\' in it is a literal.
+            const string Metadata = @"Path:C:\temp,Key2:Value2";
+
+            JsonElement counter = await SerializeAsync(new EventCounterPayload(
+                Timestamp, "System.Runtime", "cpu-usage", "DisplayName", string.Empty, 1, CounterType.Metric, IntervalSeconds, IntervalSeconds, Metadata));
+
+            Assert.Equal(Metadata, counter.GetProperty("tags").GetString());
+        }
+
+        [Fact]
+        public async Task UntaggedCounter_KeepsNullTags()
+        {
+            CounterMetadata counterInfo = new CounterMetadata(MeterName, InstrumentName, meterTags: null, instrumentTags: null, scopeHash: null);
+
+            JsonElement counter = await SerializeAsync(new GaugePayload(counterInfo, "DisplayName", string.Empty, null, 1, Timestamp));
+
+            Assert.Equal(JsonValueKind.Null, counter.GetProperty("tags").ValueKind);
+            Assert.Equal(JsonValueKind.Null, counter.GetProperty("meterTags").ValueKind);
+            Assert.Equal(JsonValueKind.Null, counter.GetProperty("instrumentTags").ValueKind);
+        }
+
+        private static async Task<JsonElement> SerializeAsync(ICounterPayload payload)
+        {
+            using MemoryStream stream = new();
+
+            JsonCounterLogger logger = new(stream, NullLogger.Instance);
+            await logger.PipelineStarted(CancellationToken.None);
+            logger.Log(payload);
+            await logger.PipelineStopped(CancellationToken.None);
+
+            // Each record is prefixed with the RS control character required by JSON sequences (RFC 7464).
+            string content = System.Text.Encoding.UTF8.GetString(stream.ToArray()).Trim('\u001e', '\n');
+
+            return JsonDocument.Parse(content).RootElement;
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
@@ -203,6 +203,82 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             Assert.Equal(FormattableString.Invariant($"{metricName}{metricTags} {payload.Value} {new DateTimeOffset(payload.Timestamp).ToUnixTimeMilliseconds()}"), lines[2]);
         }
 
+        [Fact]
+        public async Task CounterFormat_Test_EscapedTags()
+        {
+            // Canonical escaped form of:
+            //   MeterTags:      "Meter,Key" = "meter=value", "Path" = "C:\temp"
+            //   InstrumentTags: "Empty" = "", "Mixed" = "a,b=c\d"
+            string meterTags = @"Meter\,Key=meter\=value,Path=C:\\temp";
+            string instrumentTags = @"Empty=,Mixed=a\,b\=c\\d";
+
+            CounterMetadata counterInfo = new CounterMetadata(MeterName, InstrumentName, meterTags, instrumentTags, scopeHash: null);
+
+            ICounterPayload payload = new RatePayload(counterInfo, "DisplayName", "", null, Value1, IntervalSeconds, Timestamp);
+
+            MemoryStream stream = await GetMetrics(new() { payload });
+
+            List<string> lines = ReadStream(stream);
+
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.CounterMetadata.CounterName}";
+            string metricTags = "{Meter_Key=\"meter=value\", Path=\"C:\\\\temp\", Empty=\"\", Mixed=\"a,b=c\\\\d\"}";
+
+            Assert.Equal(3, lines.Count);
+            Assert.Equal($"{metricName}{metricTags} {payload.Value} {new DateTimeOffset(payload.Timestamp).ToUnixTimeMilliseconds()}", lines[2]);
+        }
+
+        [Fact]
+        public async Task CounterFormat_Test_ValueTagWithoutValue()
+        {
+            CounterMetadata counterInfo = new CounterMetadata(MeterName, InstrumentName, meterTags: null, instrumentTags: null, scopeHash: null);
+
+            ICounterPayload payload = new RatePayload(counterInfo, "DisplayName", "", "Flag", Value1, IntervalSeconds, Timestamp);
+
+            MemoryStream stream = await GetMetrics(new() { payload });
+
+            List<string> lines = ReadStream(stream);
+
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.CounterMetadata.CounterName}";
+
+            Assert.Equal(3, lines.Count);
+            Assert.Equal($"{metricName}{{Flag=\"\"}} {payload.Value} {new DateTimeOffset(payload.Timestamp).ToUnixTimeMilliseconds()}", lines[2]);
+        }
+
+        [Fact]
+        public async Task HistogramFormat_Test_EscapedTags()
+        {
+            List<ICounterPayload> payload = new();
+
+            CounterMetadata counterInfo = new CounterMetadata(MeterName, InstrumentName, meterTags: null, instrumentTags: null, scopeHash: null);
+
+            payload.Add(new AggregatePercentilePayload(counterInfo, "DisplayName", string.Empty, @"Route=/a\,b",
+                new Quantile[] { new Quantile(0.5, Value1) },
+                Timestamp));
+
+            using MemoryStream stream = await GetMetrics(payload);
+            List<string> lines = ReadStream(stream);
+
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload[0].CounterMetadata.CounterName}";
+
+            Assert.Equal(3, lines.Count);
+            Assert.Equal(FormattableString.Invariant($"{metricName}{{Route=\"/a,b\", quantile=\"0.5\"}} {Value1}"), lines[2]);
+        }
+
+        [Fact]
+        public async Task EventCounterFormat_Test_MetadataIsNotUnescaped()
+        {
+            // EventCounters metadata is unescaped and ':'-separated; a '\' in it is a literal.
+            ICounterPayload payload = new EventCounterPayload(Timestamp, "System.Runtime", "cpu-usage", "DisplayName", string.Empty,
+                Value1, CounterType.Metric, IntervalSeconds, IntervalSeconds, @"Path:C:\temp,Key2:Value2");
+
+            MemoryStream stream = await GetMetrics(new() { payload });
+
+            List<string> lines = ReadStream(stream);
+
+            Assert.Equal(3, lines.Count);
+            Assert.Equal($"systemruntime_cpu_usage{{Path=\"C:\\\\temp\", Key2=\"Value2\"}} {payload.Value} {new DateTimeOffset(payload.Timestamp).ToUnixTimeMilliseconds()}", lines[2]);
+        }
+
         private async Task<MemoryStream> GetMetrics(List<ICounterPayload> payloads)
         {
             IMetricsStore metricsStore = new MetricsStore(_logger, MetricCount);


### PR DESCRIPTION
MetricsEventSource escapes meter tag keys and values in newer event versions so delimiters inside tags remain distinguishable from separators. Decode that transport representation before exposing tags through Prometheus or `/livemetrics` JSON.

- Recover original meter tag key/value pairs for Prometheus labels.
- Decode value, meter, and instrument tags in JSON output.
- Preserve legacy EventCounters `:`-separated metadata and null tags.
- Cover commas, equals signs, backslashes, combinations, empty values, histograms, and EventCounters metadata.

This depends on a future `Microsoft.Diagnostics.Monitoring.EventPipe` package containing `CounterTagFormatter` from dotnet/diagnostics commit `19fd00d3e`. The current pinned package does not contain that helper, so the dependency must flow before this PR can leave draft.