### PR TITLE
[release/9.0] Use WIF token to download build assets

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -54,12 +54,14 @@ stages:
         inputs:
           azureSubscription: 'DotNetStaging'
           scriptType: ps
-          scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
-          arguments: >-
-            -BarBuildId "$(BARBuildId)"
-            -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
-            -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
-            -ReleaseVersion "$(Build.BuildNumber)"
+          scriptLocation: inlineScript
+          inlineScript: |
+            $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+            & '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1' `
+              -BarBuildId "$(BARBuildId)" `
+              -AzdoToken $azdoToken `
+              -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets" `
+              -ReleaseVersion "$(Build.BuildNumber)"
           workingDirectory: '$(Build.Repository.LocalPath)'
         continueOnError: true
 


### PR DESCRIPTION
## Summary

Backports only the `preparerelease.yml` portion of #9351 (`51e975bbb`) to fix the **Stage Build Assets** job on `release/9.0`.

The **Download Build Assets** Azure CLI task now:
- acquires an Azure DevOps access token through the `DotNetStaging` workload identity using `az account get-access-token`
- passes that token to `AcquireBuild.ps1`
- no longer references the removed `dn-bot-all-drop-rw-code-rw-release-all` PAT variable

No unrelated changes from the upstream commit are included.

## Validation

- `git diff --check`
- parsed `eng/pipelines/stages/preparerelease.yml` with PyYAML
- verified the resulting file exactly matches `51e975bbb:eng/pipelines/stages/preparerelease.yml`
- confirmed the diff contains only `eng/pipelines/stages/preparerelease.yml` (8 additions, 6 deletions)
