### PR TITLE
[release/8.x] Replace release asset PAT with WIF token

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -54,12 +54,14 @@ stages:
         inputs:
           azureSubscription: 'DotNetStaging'
           scriptType: ps
-          scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
-          arguments: >-
-            -BarBuildId "$(BARBuildId)"
-            -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
-            -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets"
-            -ReleaseVersion "$(Build.BuildNumber)"
+          scriptLocation: inlineScript
+          inlineScript: |
+            $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+            & '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1' `
+              -BarBuildId "$(BARBuildId)" `
+              -AzdoToken $azdoToken `
+              -DownloadTargetPath "$(System.ArtifactsDirectory)\BuildAssets" `
+              -ReleaseVersion "$(Build.BuildNumber)"
           workingDirectory: '$(Build.Repository.LocalPath)'
         continueOnError: true
 


### PR DESCRIPTION
## Summary

Backports only the `preparerelease` WIF-token change from #9351 (`51e975bbb`).

- acquires an Azure DevOps access token through the `DotNetStaging` Azure CLI service connection
- passes the token to `AcquireBuild.ps1` instead of the removed `dn-bot-all-drop-rw-code-rw-release-all` variable
- restores creation of the `BuildAssets` directory required by manifest generation

Fixes the **Stage Build Assets** failure seen in build `3047163`.

## Validation

- `git diff --check`
- confirmed `eng/pipelines/stages/preparerelease.yml` exactly matches upstream commit `51e975bbb`
- confirmed the commit changes only `eng/pipelines/stages/preparerelease.yml` (8 insertions, 6 deletions)