### PR TITLE
[S3 egress] Support S3-compatible endpoints: SessionToken, endpoint on every credential path, DisablePayloadSigning

### DIFF
--- a/documentation/configuration/egress-configuration.md
+++ b/documentation/configuration/egress-configuration.md
@@ -155,6 +155,7 @@ First Available: 8.0
 | bucketName | string | true | The name of the S3 Bucket to which the blob will be egressed. |
 | accessKeyId | string | false | The AWS AccessKeyId for IAM user to login.  |
 | secretAccessKey | string | false | The AWS SecretAccessKey associated AccessKeyId for IAM user to login. To login by access key id the 'secretAccessKey' must be set. |
+| sessionToken | string | false | (10.1+) The AWS SessionToken that accompanies temporary (STS-issued) credentials, e.g. those returned by `sts:AssumeRole` or by an S3-compatible service that issues short-lived credentials. When set, both 'accessKeyId' and 'secretAccessKey' must also be set. |
 | awsProfileName | string | false | The AWS profile name to be used for login. |
 | awsProfilePath | string | false | The AWS profile path, if profile details not stored in default path. |
 | regionName | string | false | A Region is a named set of AWS resources in the same geographical area. This option specifies the region to connect to. If the Endpoint is specified, this is the AuthenticationRegion; otherwise, it is the RegionEndpoint. |
@@ -221,9 +222,68 @@ First Available: 8.0
  ```
 </details>
 
+### Authenticating to S3 using temporary credentials
+
+First Available: 10.1
+
+Some credential issuers (`sts:AssumeRole`, HashiCorp Vault, and several S3-compatible services) only ever hand out short-lived credentials, which consist of an access key id, a secret access key **and** a session token. All three must be presented on every request; a request signed with only the first two is rejected by the service.
+
+Set `sessionToken` alongside `accessKeyId` and `secretAccessKey` to use such credentials. `endpoint`, `regionName` and `forcePathStyle` are honored as usual, so this works against a custom S3-compatible endpoint.
+
+<details>
+  <summary>JSON with a session token</summary>
+
+  ```json
+  {
+      "Egress": {
+          "S3Storage": {
+              "monitorS3Blob": {
+                  "endpoint": "https://s3.example.com",
+                  "bucketName": "myS3Bucket",
+                  "accessKeyId": "myTemporaryAccessKeyId",
+                  "secretAccessKey": "myTemporarySecretAccessKey",
+                  "sessionToken": "mySessionToken",
+                  "regionName": "auto",
+                  "forcePathStyle": true
+              }
+          }
+      }
+  }
+  ```
+</details>
+
+<details>
+  <summary>Kubernetes Secret</summary>
+
+  ```sh
+  #!/bin/sh
+  kubectl create secret generic my-s3-secrets \
+  --from-literal=Egress__S3Storage__monitorS3Blob__bucketName=myS3Bucket \
+  --from-literal=Egress__S3Storage__monitorS3Blob__accessKeyId=myTemporaryAccessKeyId \
+  --from-literal=Egress__S3Storage__monitorS3Blob__secretAccessKey=myTemporarySecretAccessKey \
+  --from-literal=Egress__S3Storage__monitorS3Blob__sessionToken=mySessionToken \
+  --from-literal=Egress__S3Storage__monitorS3Blob__regionName=auto \
+  --dry-run=client -o yaml | kubectl apply -f -
+ ```
+</details>
+
+> **Note:** Temporary credentials expire. It is the responsibility of the credential source (for example a sidecar that refreshes a mounted secret) to keep the configured values current; `dotnet monitor` does not renew them.
+
 ### Authenticating to S3 using service accounts
 
 First Available: 9.0 Preview 5
+
+> **Behavior change:** `endpoint`, `regionName` and `forcePathStyle` are applied on **every**
+> authentication path. Previously they were only applied when `accessKeyId` and `secretAccessKey`
+> were both set, and were silently ignored when authenticating via `awsProfileName` or via the
+> default credential chain — which made those paths unusable against a custom S3-compatible
+> endpoint (the client failed with `No RegionEndpoint or ServiceURL configured`).
+>
+> If you authenticate with a profile or the default chain, set no `endpoint`, and previously
+> relied on the region coming from the profile or `AWS_REGION` while *also* having a stale
+> `regionName` configured, the configured `regionName` now wins. Note that an unrecognized
+> region name does not fail fast: `RegionEndpoint.GetBySystemName` returns a placeholder region
+> and the failure surfaces later, when the request is made.
 
 If running workloads in Kubernetes it is common to authenticate with AWS via Kubernetes service accounts ([AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)). This is supported in dotnet monitor if none of: `accessKeyId`, `secretAccessKey`, `awsProfileName` are specified. In this case dotnet monitor will fallback to load credentials to login using AWS default defined environment variables, this means that workloads running in EKS can utilize service accounts as discussed in the above AWS documentation.
 

--- a/documentation/configuration/egress-configuration.md
+++ b/documentation/configuration/egress-configuration.md
@@ -161,6 +161,7 @@ First Available: 8.0
 | regionName | string | false | A Region is a named set of AWS resources in the same geographical area. This option specifies the region to connect to. If the Endpoint is specified, this is the AuthenticationRegion; otherwise, it is the RegionEndpoint. |
 | preSignedUrlExpiry | TimeStamp? | false | When specified, a pre-signed url is returned after successful upload; this value specifies the amount of time the generated pre-signed url should be accessible. The value has to be between 1 minute and 1 day. |
 | forcePathStyle | bool | false | The boolean flag set for AWS connection configuration ForcePathStyle option. |
+| disablePayloadSigning | bool | false | (10.1+) Sends request payloads with an `UNSIGNED-PAYLOAD` signature, suppressing flexible-checksum trailers and response checksum validation. Required by S3-compatible services that do not implement chunked or trailered payloads (for example Cloudflare R2). The endpoint must use HTTPS. |
 | copyBufferSize | int | false | The buffer size to use when copying data from the original artifact to the blob stream. There is a minimum size of 5 MB which is set when the given value is lower.|
 | useKmsEncryption | bool | false | (9.0 Preview 6+) A boolean flag which controls whether the Egress should use KMS server side encryption. |
 | kmsEncryptionKey | string | false | (9.0 Preview 6+) If UseKmsEncryption is true, this specifies the arn of the "customer managed" KMS encryption key to be used for server side encryption. If no value is set for this field then S3 will use an AWS managed key for KMS encryption. |
@@ -269,9 +270,52 @@ Set `sessionToken` alongside `accessKeyId` and `secretAccessKey` to use such cre
 
 > **Note:** Temporary credentials expire. It is the responsibility of the credential source (for example a sidecar that refreshes a mounted secret) to keep the configured values current; `dotnet monitor` does not renew them.
 
-### Authenticating to S3 using service accounts
+### Egressing to S3-compatible services without chunked payload support
 
-First Available: 9.0 Preview 5
+First Available: 10.1
+
+By default the AWS SDK uploads with a signed streaming payload (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD`)
+and attaches a flexible checksum as an `aws-chunked` trailer. Several S3-compatible services implement
+neither, and reject every upload:
+
+```
+S3 storage egress failed: STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER not implemented
+```
+
+Because artifacts are streamed as a multi-part upload, this affects all of them — dumps, traces, logs
+and GC dumps alike. Cloudflare R2 is the common case.
+
+Set `disablePayloadSigning` to `true` to send `UNSIGNED-PAYLOAD` instead and drop the checksum trailer.
+The request is then authenticated by its SigV4-signed headers, and the body is protected by TLS rather
+than by the payload signature — so the endpoint must be HTTPS, which is validated at startup.
+
+<details>
+  <summary>JSON for an endpoint without chunked payload support</summary>
+
+  ```json
+  {
+      "Egress": {
+          "S3Storage": {
+              "monitorS3Blob": {
+                  "endpoint": "https://<accountid>.r2.cloudflarestorage.com",
+                  "bucketName": "myS3Bucket",
+                  "accessKeyId": "myAccessKeyId",
+                  "secretAccessKey": "mySecretAccessKey",
+                  "regionName": "auto",
+                  "disablePayloadSigning": true
+              }
+          }
+      }
+  }
+  ```
+</details>
+
+> **Note:** Leave this off for Amazon S3, which implements both features. Turning it off where it is
+> not needed loses the end-to-end integrity check that the payload signature and checksum provide.
+
+### S3 endpoint handling on every authentication path
+
+First Available: 10.1
 
 > **Behavior change:** `endpoint`, `regionName` and `forcePathStyle` are applied on **every**
 > authentication path. Previously they were only applied when `accessKeyId` and `secretAccessKey`
@@ -284,6 +328,11 @@ First Available: 9.0 Preview 5
 > `regionName` configured, the configured `regionName` now wins. Note that an unrecognized
 > region name does not fail fast: `RegionEndpoint.GetBySystemName` returns a placeholder region
 > and the failure surfaces later, when the request is made.
+
+### Authenticating to S3 using service accounts
+
+First Available: 9.0 Preview 5
+
 
 If running workloads in Kubernetes it is common to authenticate with AWS via Kubernetes service accounts ([AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)). This is supported in dotnet monitor if none of: `accessKeyId`, `secretAccessKey`, `awsProfileName` are specified. In this case dotnet monitor will fallback to load credentials to login using AWS default defined environment variables, this means that workloads running in EKS can utilize service accounts as discussed in the above AWS documentation.
 

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -3000,6 +3000,13 @@
           ],
           "description": "The AWS SecretAccessKey associated AccessKeyId for IAM user to login"
         },
+        "SessionToken": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The AWS SessionToken associated with temporary (STS-issued) credentials. When set, AccessKeyId and SecretAccessKey must also be set."
+        },
         "AwsProfileName": {
           "type": [
             "null",

--- a/documentation/schema.json
+++ b/documentation/schema.json
@@ -3033,6 +3033,10 @@
           "type": "boolean",
           "description": "The boolean flag set for AWS connection configuration ForcePathStyle option."
         },
+        "DisablePayloadSigning": {
+          "type": "boolean",
+          "description": "Sends request payloads with an UNSIGNED-PAYLOAD signature, suppressing flexible-checksum trailers and response checksum validation. Required by S3-compatible services that do not implement chunked or trailered payloads (for example Cloudflare R2). The endpoint must use HTTPS."
+        },
         "CopyBufferSize": {
           "type": [
             "integer",

--- a/src/Extensions/S3Storage/OptionsDisplayStrings.Designer.cs
+++ b/src/Extensions/S3Storage/OptionsDisplayStrings.Designer.cs
@@ -105,6 +105,15 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sends request payloads with an UNSIGNED-PAYLOAD signature, suppressing flexible-checksum trailers and response checksum validation. Required by S3-compatible services that do not implement chunked or trailered payloads (for example Cloudflare R2). The endpoint must use HTTPS..
+        /// </summary>
+        public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_DisablePayloadSigning {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_S3StorageEgressProviderOptions_DisablePayloadSigning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The endpoint of S3 to connect to. This is optional in case of using AWS storage..
         /// </summary>
         public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_Endpoint {
@@ -119,15 +128,6 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_ForcePathStyle {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_S3StorageEgressProviderOptions_ForcePathStyle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The AWS SessionToken associated with temporary (STS-issued) credentials. When set, AccessKeyId and SecretAccessKey must also be set..
-        /// </summary>
-        public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken {
-            get {
-                return ResourceManager.GetString("DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken", resourceCulture);
             }
         }
         
@@ -173,6 +173,15 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_SecretAccessKey {
             get {
                 return ResourceManager.GetString("DisplayAttributeDescription_S3StorageEgressProviderOptions_SecretAccessKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The AWS SessionToken associated with temporary (STS-issued) credentials. When set, AccessKeyId and SecretAccessKey must also be set..
+        /// </summary>
+        public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken", resourceCulture);
             }
         }
         

--- a/src/Extensions/S3Storage/OptionsDisplayStrings.Designer.cs
+++ b/src/Extensions/S3Storage/OptionsDisplayStrings.Designer.cs
@@ -123,6 +123,15 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The AWS SessionToken associated with temporary (STS-issued) credentials. When set, AccessKeyId and SecretAccessKey must also be set..
+        /// </summary>
+        public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken {
+            get {
+                return ResourceManager.GetString("DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A boolean flag indicates if the return value of egress provider should be a pre-signed URL or only the bucket name and object id of uploaded entry..
         /// </summary>
         public static string DisplayAttributeDescription_S3StorageEgressProviderOptions_GeneratePreSignedUrl {

--- a/src/Extensions/S3Storage/OptionsDisplayStrings.resx
+++ b/src/Extensions/S3Storage/OptionsDisplayStrings.resx
@@ -149,6 +149,10 @@
     <value>The AWS SessionToken associated with temporary (STS-issued) credentials. When set, AccessKeyId and SecretAccessKey must also be set.</value>
     <comment>The description provided for the SessionToken parameter on S3StorageEgressProviderOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_S3StorageEgressProviderOptions_DisablePayloadSigning" xml:space="preserve">
+    <value>Sends request payloads with an UNSIGNED-PAYLOAD signature, suppressing flexible-checksum trailers and response checksum validation. Required by S3-compatible services that do not implement chunked or trailered payloads (for example Cloudflare R2). The endpoint must use HTTPS.</value>
+    <comment>The description provided for the DisablePayloadSigning parameter on S3StorageEgressProviderOptions.</comment>
+  </data>
   <data name="DisplayAttributeDescription_S3StorageEgressProviderOptions_GeneratePreSignedUrl" xml:space="preserve">
     <value>A boolean flag indicates if the return value of egress provider should be a pre-signed URL or only the bucket name and object id of uploaded entry.</value>
     <comment>The description provided for the GeneratePresSignedUrl parameter on S3StorageEgressProviderOptions.</comment>

--- a/src/Extensions/S3Storage/OptionsDisplayStrings.resx
+++ b/src/Extensions/S3Storage/OptionsDisplayStrings.resx
@@ -145,6 +145,10 @@
     <value>The AWS SecretAccessKey associated AccessKeyId for IAM user to login</value>
     <comment>The description provided for the SecretAccessKey parameter on S3StorageEgressProviderOptions.</comment>
   </data>
+  <data name="DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken" xml:space="preserve">
+    <value>The AWS SessionToken associated with temporary (STS-issued) credentials. When set, AccessKeyId and SecretAccessKey must also be set.</value>
+    <comment>The description provided for the SessionToken parameter on S3StorageEgressProviderOptions.</comment>
+  </data>
   <data name="DisplayAttributeDescription_S3StorageEgressProviderOptions_GeneratePreSignedUrl" xml:space="preserve">
     <value>A boolean flag indicates if the return value of egress provider should be a pre-signed URL or only the bucket name and object id of uploaded entry.</value>
     <comment>The description provided for the GeneratePresSignedUrl parameter on S3StorageEgressProviderOptions.</comment>

--- a/src/Extensions/S3Storage/S3Storage.cs
+++ b/src/Extensions/S3Storage/S3Storage.cs
@@ -26,8 +26,9 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
         private readonly string _contentType;
         private readonly bool _useKmsEncryption;
         private readonly string? _kmsEncryptionKey;
+        private readonly bool _disablePayloadSigning;
 
-        public S3Storage(IAmazonS3 client, string bucketName, string objectId, string contentType, bool useKmsEncryption, string? kmsEncryptionKey)
+        public S3Storage(IAmazonS3 client, string bucketName, string objectId, string contentType, bool useKmsEncryption, string? kmsEncryptionKey, bool disablePayloadSigning)
         {
             _s3Client = client;
             _bucketName = bucketName;
@@ -35,6 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
             _contentType = contentType;
             _useKmsEncryption = useKmsEncryption;
             _kmsEncryptionKey = kmsEncryptionKey;
+            _disablePayloadSigning = disablePayloadSigning;
         }
 
         /// <summary>
@@ -50,6 +52,16 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
             {
                 ForcePathStyle = options.ForcePathStyle
             };
+
+            // Flexible checksums are sent as an aws-chunked trailer, which is a separate wire feature
+            // from payload signing: leaving them on would still produce a STREAMING-...-TRAILER request
+            // that an endpoint without chunked-payload support rejects. Opting out of payload signing
+            // therefore has to opt out of request checksums as well, or the option cannot do its job.
+            if (options.DisablePayloadSigning)
+            {
+                configuration.RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED;
+                configuration.ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED;
+            }
 
             if (!string.IsNullOrEmpty(options.Endpoint))
                 configuration.ServiceURL = options.Endpoint;
@@ -115,7 +127,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
             bool exists = await AmazonS3Util.DoesS3BucketExistV2Async(s3Client, options.BucketName);
             if (!exists)
                 await s3Client.PutBucketAsync(options.BucketName, cancellationToken);
-            return new S3Storage(s3Client, options.BucketName, settings.Name, settings.ContentType, options.UseKmsEncryption, options.KmsEncryptionKey);
+            return new S3Storage(s3Client, options.BucketName, settings.Name, settings.ContentType, options.UseKmsEncryption, options.KmsEncryptionKey, options.DisablePayloadSigning);
         }
 
         public async Task PutAsync(Stream inputStream, CancellationToken token)
@@ -127,6 +139,7 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
                 Key = _objectId,
                 InputStream = inputStream,
                 AutoCloseStream = false,
+                DisablePayloadSigning = _disablePayloadSigning,
             };
 
             if (_useKmsEncryption)
@@ -144,7 +157,14 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
         public async Task UploadAsync(Stream inputStream, CancellationToken token)
         {
             using TransferUtility transferUtility = new(_s3Client);
-            await transferUtility.UploadAsync(inputStream, _bucketName, _objectId, token);
+            TransferUtilityUploadRequest request = new()
+            {
+                BucketName = _bucketName,
+                Key = _objectId,
+                InputStream = inputStream,
+                DisablePayloadSigning = _disablePayloadSigning,
+            };
+            await transferUtility.UploadAsync(request, token);
         }
 
         public async Task<string> InitMultiPartUploadAsync(IDictionary<string, string> metadata, CancellationToken cancellationToken)
@@ -198,7 +218,8 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
                 InputStream = inputStream,
                 PartSize = partSize,
                 UploadId = uploadId,
-                PartNumber = partNumber
+                PartNumber = partNumber,
+                DisablePayloadSigning = _disablePayloadSigning,
             };
             var response = await _s3Client.UploadPartAsync(uploadRequest, token);
             return new PartETag(response.PartNumber ?? partNumber, response.ETag);

--- a/src/Extensions/S3Storage/S3Storage.cs
+++ b/src/Extensions/S3Storage/S3Storage.cs
@@ -37,30 +37,55 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
             _kmsEncryptionKey = kmsEncryptionKey;
         }
 
-        public static async Task<IS3Storage> CreateAsync(S3StorageEgressProviderOptions options, EgressArtifactSettings settings, CancellationToken cancellationToken)
+        /// <summary>
+        /// Builds the <see cref="AmazonS3Config"/> describing which endpoint the client should talk to.
+        /// </summary>
+        /// <remarks>
+        /// This is applied regardless of how the credentials are obtained: the endpoint of the storage
+        /// service is orthogonal to the way the caller authenticates against it.
+        /// </remarks>
+        internal static AmazonS3Config CreateConfiguration(S3StorageEgressProviderOptions options)
+        {
+            AmazonS3Config configuration = new()
+            {
+                ForcePathStyle = options.ForcePathStyle
+            };
+
+            if (!string.IsNullOrEmpty(options.Endpoint))
+                configuration.ServiceURL = options.Endpoint;
+
+            if (!string.IsNullOrEmpty(options.RegionName))
+            {
+                if (string.IsNullOrEmpty(configuration.ServiceURL))
+                {
+                    configuration.RegionEndpoint = RegionEndpoint.GetBySystemName(options.RegionName);
+                }
+                else
+                {
+                    configuration.AuthenticationRegion = options.RegionName;
+                }
+            }
+
+            return configuration;
+        }
+
+        /// <summary>
+        /// Resolves the credentials used to authenticate against the storage service.
+        /// </summary>
+        internal static AWSCredentials CreateCredentials(S3StorageEgressProviderOptions options)
         {
             AWSCredentials? awsCredentials = null;
-            AmazonS3Config configuration = new();
+
             // use the specified access key and the secrets taken from configuration
             if (!string.IsNullOrEmpty(options.AccessKeyId) && !string.IsNullOrEmpty(options.SecretAccessKey))
             {
                 string secretAccessKeyId = options.SecretAccessKey;
-                awsCredentials = new BasicAWSCredentials(options.AccessKeyId, secretAccessKeyId);
 
-                configuration.ForcePathStyle = options.ForcePathStyle;
-                if (!string.IsNullOrEmpty(options.Endpoint))
-                    configuration.ServiceURL = options.Endpoint;
-                if (!string.IsNullOrEmpty(options.RegionName))
-                {
-                    if (string.IsNullOrEmpty(configuration.ServiceURL))
-                    {
-                        configuration.RegionEndpoint = RegionEndpoint.GetBySystemName(options.RegionName);
-                    }
-                    else
-                    {
-                        configuration.AuthenticationRegion = options.RegionName;
-                    }
-                }
+                // A session token indicates temporary (STS-style) credentials, which must be signed
+                // with the token in addition to the access key id and secret access key.
+                awsCredentials = string.IsNullOrEmpty(options.SessionToken)
+                    ? new BasicAWSCredentials(options.AccessKeyId, secretAccessKeyId)
+                    : new SessionAWSCredentials(options.AccessKeyId, secretAccessKeyId, options.SessionToken);
             }
             // use configured AWS profile
             else if (!string.IsNullOrEmpty(options.AwsProfileName))
@@ -77,6 +102,14 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
 
             if (awsCredentials == null)
                 throw new AmazonClientException("Failed to find AWS Credentials for constructing AWS service client");
+
+            return awsCredentials;
+        }
+
+        public static async Task<IS3Storage> CreateAsync(S3StorageEgressProviderOptions options, EgressArtifactSettings settings, CancellationToken cancellationToken)
+        {
+            AWSCredentials awsCredentials = CreateCredentials(options);
+            AmazonS3Config configuration = CreateConfiguration(options);
 
             IAmazonS3 s3Client = new AmazonS3Client(awsCredentials, configuration);
             bool exists = await AmazonS3Util.DoesS3BucketExistV2Async(s3Client, options.BucketName);

--- a/src/Extensions/S3Storage/S3StorageEgressProvider.cs
+++ b/src/Extensions/S3Storage/S3StorageEgressProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Amazon.Runtime;
 using Amazon.S3;
 using Microsoft.Diagnostics.Monitoring.Extension.Common;
 using Microsoft.Extensions.Logging;
@@ -68,7 +69,13 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
                 string resourceId = GetResourceId(client, options, artifactSettings);
                 return resourceId;
             }
-            catch (AmazonS3Exception e)
+            // AmazonClientException is a sibling of AmazonServiceException (the base of
+            // AmazonS3Exception), not its base: client-side failures such as the signer
+            // refusing DisablePayloadSigning over a non-HTTPS endpoint surface as
+            // AmazonClientException from the first UploadPartAsync call, after the
+            // multi-part upload has been initiated. Catch both so the upload is aborted
+            // (otherwise the parts are orphaned and billed) and the message is wrapped.
+            catch (Exception e) when (e is AmazonS3Exception or AmazonClientException)
             {
                 if (client != null && uploadId != null && !uploadDone)
                     await client.AbortMultipartUploadAsync(uploadId, token);

--- a/src/Extensions/S3Storage/S3StorageEgressProviderOptions.Validate.cs
+++ b/src/Extensions/S3Storage/S3StorageEgressProviderOptions.Validate.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
@@ -19,6 +20,17 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
             // A session token is only meaningful alongside a temporary access key id / secret access key pair.
             if (!string.IsNullOrEmpty(SessionToken) && (string.IsNullOrEmpty(AccessKeyId) || string.IsNullOrEmpty(SecretAccessKey)))
                 yield return new ValidationResult(Strings.ErrorMessage_EgressS3FailedMissingSessionCredentials);
+
+            // An unsigned payload is only tamper-protected by the transport, so the AWS SDK refuses to
+            // send one over plain HTTP. Uri parsing (rather than a string prefix check) tolerates the
+            // leading whitespace and casing that environment-injected values can carry. This check only
+            // sees the configured Endpoint: when it is empty the SDK may still resolve an endpoint from
+            // the environment (AWS_ENDPOINT_URL_S3 / AWS_ENDPOINT_URL); a non-HTTPS endpoint from that
+            // path escapes validation here and is rejected by the SDK's signer at upload time instead.
+            if (DisablePayloadSigning
+                && !string.IsNullOrEmpty(Endpoint)
+                && !(Uri.TryCreate(Endpoint, UriKind.Absolute, out Uri? endpointUri) && endpointUri.Scheme == Uri.UriSchemeHttps))
+                yield return new ValidationResult(Strings.ErrorMessage_EgressS3FailedInsecurePayloadSigningOptOut);
         }
     }
 }

--- a/src/Extensions/S3Storage/S3StorageEgressProviderOptions.Validate.cs
+++ b/src/Extensions/S3Storage/S3StorageEgressProviderOptions.Validate.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
         {
             if (!string.IsNullOrEmpty(AccessKeyId) && string.IsNullOrEmpty(SecretAccessKey))
                 yield return new ValidationResult(Strings.ErrorMessage_EgressS3FailedMissingSecrets);
+
+            // A session token is only meaningful alongside a temporary access key id / secret access key pair.
+            if (!string.IsNullOrEmpty(SessionToken) && (string.IsNullOrEmpty(AccessKeyId) || string.IsNullOrEmpty(SecretAccessKey)))
+                yield return new ValidationResult(Strings.ErrorMessage_EgressS3FailedMissingSessionCredentials);
         }
     }
 }

--- a/src/Extensions/S3Storage/S3StorageEgressProviderOptions.cs
+++ b/src/Extensions/S3Storage/S3StorageEgressProviderOptions.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_S3StorageEgressProviderOptions_DisablePayloadSigning))]
+        public bool DisablePayloadSigning { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_CommonEgressProviderOptions_CopyBufferSize))]
         [Range(1, int.MaxValue)]
         public int? CopyBufferSize { get; set; }

--- a/src/Extensions/S3Storage/S3StorageEgressProviderOptions.cs
+++ b/src/Extensions/S3Storage/S3StorageEgressProviderOptions.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage
 
         [Display(
             ResourceType = typeof(OptionsDisplayStrings),
+            Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_S3StorageEgressProviderOptions_SessionToken))]
+        public string? SessionToken { get; set; }
+
+        [Display(
+            ResourceType = typeof(OptionsDisplayStrings),
             Description = nameof(OptionsDisplayStrings.DisplayAttributeDescription_S3StorageEgressProviderOptions_AWSProfileName))]
         public string? AwsProfileName { get; set; }
 

--- a/src/Extensions/S3Storage/Strings.Designer.cs
+++ b/src/Extensions/S3Storage/Strings.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to S3 storage egress failed: A session token was specified without an access key id and secret access key..
+        /// </summary>
+        internal static string ErrorMessage_EgressS3FailedMissingSessionCredentials {
+            get {
+                return ResourceManager.GetString("ErrorMessage_EgressS3FailedMissingSessionCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Provider {providerType}: Invoking stream action..
         /// </summary>
         internal static string LogFormatString_EgressProviderInvokeStreamAction {

--- a/src/Extensions/S3Storage/Strings.Designer.cs
+++ b/src/Extensions/S3Storage/Strings.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Diagnostics.Monitoring.Extension.S3Storage {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to S3 storage egress failed: DisablePayloadSigning requires an HTTPS endpoint, because an unsigned payload is only protected by the transport..
+        /// </summary>
+        internal static string ErrorMessage_EgressS3FailedInsecurePayloadSigningOptOut {
+            get {
+                return ResourceManager.GetString("ErrorMessage_EgressS3FailedInsecurePayloadSigningOptOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} field is required..
         /// </summary>
         internal static string ErrorMessage_EgressS3FailedMissingOption {

--- a/src/Extensions/S3Storage/Strings.resx
+++ b/src/Extensions/S3Storage/Strings.resx
@@ -141,6 +141,10 @@
     <value>S3 storage egress failed: A session token was specified without an access key id and secret access key.</value>
     <comment>Gets the string for rejecting validation due to a session token being specified without the corresponding access key id and secret access key.</comment>
   </data>
+  <data name="ErrorMessage_EgressS3FailedInsecurePayloadSigningOptOut" xml:space="preserve">
+    <value>S3 storage egress failed: DisablePayloadSigning requires an HTTPS endpoint, because an unsigned payload is only protected by the transport.</value>
+    <comment>Gets the string for rejecting validation due to payload signing being disabled on a non-HTTPS endpoint.</comment>
+  </data>
   <data name="LogFormatString_EgressProviderInvokeStreamAction" xml:space="preserve">
     <value>Provider {providerType}: Invoking stream action.</value>
     <comment>Gets the format string that is printed in the 11:EgressProviderInvokeStreamAction event.

--- a/src/Extensions/S3Storage/Strings.resx
+++ b/src/Extensions/S3Storage/Strings.resx
@@ -137,6 +137,10 @@
     <value>S3 storage egress failed: Neither the secrets file nor the password are specified.</value>
     <comment>Gets the string for rejecting validation due to missing credentials for S3 options.</comment>
   </data>
+  <data name="ErrorMessage_EgressS3FailedMissingSessionCredentials" xml:space="preserve">
+    <value>S3 storage egress failed: A session token was specified without an access key id and secret access key.</value>
+    <comment>Gets the string for rejecting validation due to a session token being specified without the corresponding access key id and secret access key.</comment>
+  </data>
   <data name="LogFormatString_EgressProviderInvokeStreamAction" xml:space="preserve">
     <value>Provider {providerType}: Invoking stream action.</value>
     <comment>Gets the format string that is printed in the 11:EgressProviderInvokeStreamAction event.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests/S3StorageCredentialsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests/S3StorageCredentialsTests.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Microsoft.Diagnostics.Monitoring.Extension.S3Storage;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests
+{
+    public class S3StorageCredentialsTests
+    {
+        private const string AccessKeyId = "accessKeyId";
+        private const string SecretAccessKey = "secretAccessKey";
+        private const string SessionToken = "sessionToken";
+
+        private static S3StorageEgressProviderOptions ConstructOptions() => new()
+        {
+            BucketName = "bucket",
+            Endpoint = "https://example.invalid",
+            RegionName = "auto"
+        };
+
+        [Fact]
+        public async Task ItShouldUseSessionCredentialsWhenSessionTokenIsSpecified()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = AccessKeyId;
+            options.SecretAccessKey = SecretAccessKey;
+            options.SessionToken = SessionToken;
+
+            AWSCredentials credentials = S3Storage.CreateCredentials(options);
+
+            Assert.IsType<SessionAWSCredentials>(credentials);
+
+            ImmutableCredentials immutableCredentials = await credentials.GetCredentialsAsync();
+            Assert.Equal(AccessKeyId, immutableCredentials.AccessKey);
+            Assert.Equal(SecretAccessKey, immutableCredentials.SecretKey);
+            Assert.Equal(SessionToken, immutableCredentials.Token);
+            Assert.True(immutableCredentials.UseToken);
+        }
+
+        [Fact]
+        public async Task ItShouldUseBasicCredentialsWhenSessionTokenIsNotSpecified()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = AccessKeyId;
+            options.SecretAccessKey = SecretAccessKey;
+
+            AWSCredentials credentials = S3Storage.CreateCredentials(options);
+
+            Assert.IsType<BasicAWSCredentials>(credentials);
+
+            ImmutableCredentials immutableCredentials = await credentials.GetCredentialsAsync();
+            Assert.Equal(AccessKeyId, immutableCredentials.AccessKey);
+            Assert.Equal(SecretAccessKey, immutableCredentials.SecretKey);
+            Assert.False(immutableCredentials.UseToken);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ItShouldUseBasicCredentialsWhenSessionTokenIsEmpty(string sessionToken)
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = AccessKeyId;
+            options.SecretAccessKey = SecretAccessKey;
+            options.SessionToken = sessionToken;
+
+            AWSCredentials credentials = S3Storage.CreateCredentials(options);
+
+            Assert.IsType<BasicAWSCredentials>(credentials);
+        }
+
+        [Fact]
+        public void ItShouldApplyEndpointToConfigurationWhenSessionTokenIsSpecified()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = AccessKeyId;
+            options.SecretAccessKey = SecretAccessKey;
+            options.SessionToken = SessionToken;
+            options.ForcePathStyle = true;
+
+            AmazonS3Config configuration = S3Storage.CreateConfiguration(options);
+
+            // The AWS SDK normalizes the service URL with a trailing slash.
+            Assert.Equal(options.Endpoint + "/", configuration.ServiceURL);
+            Assert.Equal(options.RegionName, configuration.AuthenticationRegion);
+            Assert.True(configuration.ForcePathStyle);
+        }
+
+        [Fact]
+        public void ItShouldApplyEndpointToConfigurationWhenUsingAnAwsProfile()
+        {
+            // Regression test: the endpoint / region / path-style settings used to be applied only on the
+            // access key code path, which left the AWS profile code path without any endpoint at all.
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AwsProfileName = "profile";
+            options.ForcePathStyle = true;
+
+            AmazonS3Config configuration = S3Storage.CreateConfiguration(options);
+
+            // The AWS SDK normalizes the service URL with a trailing slash.
+            Assert.Equal(options.Endpoint + "/", configuration.ServiceURL);
+            Assert.Equal(options.RegionName, configuration.AuthenticationRegion);
+            Assert.True(configuration.ForcePathStyle);
+        }
+
+        [Fact]
+        public void ItShouldUseRegionEndpointWhenNoEndpointIsSpecified()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.Endpoint = null;
+            options.RegionName = "us-east-1";
+
+            AmazonS3Config configuration = S3Storage.CreateConfiguration(options);
+
+            Assert.True(string.IsNullOrEmpty(configuration.ServiceURL));
+            Assert.Equal(RegionEndpoint.USEast1, configuration.RegionEndpoint);
+            Assert.True(string.IsNullOrEmpty(configuration.AuthenticationRegion));
+        }
+
+        [Fact]
+        public void ItShouldAcceptSessionTokenWithAccessKeyAndSecret()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = AccessKeyId;
+            options.SecretAccessKey = SecretAccessKey;
+            options.SessionToken = SessionToken;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.True(valid);
+            Assert.Empty(results);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(AccessKeyId, null)]
+        [InlineData(null, SecretAccessKey)]
+        public void ItShouldNotAcceptSessionTokenWithoutAccessKeyAndSecret(string accessKeyId, string secretAccessKey)
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = accessKeyId;
+            options.SecretAccessKey = secretAccessKey;
+            options.SessionToken = SessionToken;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.False(valid);
+            Assert.Contains(results, r => r.ErrorMessage == Strings.ErrorMessage_EgressS3FailedMissingSessionCredentials);
+        }
+
+        [Fact]
+        public void ItShouldAcceptNoSessionToken()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.AccessKeyId = AccessKeyId;
+            options.SecretAccessKey = SecretAccessKey;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.True(valid);
+            Assert.Empty(results);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests/S3StoragePayloadSigningTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests/S3StoragePayloadSigningTests.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Amazon.Runtime;
+using Amazon.S3;
+using Microsoft.Diagnostics.Monitoring.Extension.S3Storage;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.S3StorageTests.UnitTests
+{
+    public class S3StoragePayloadSigningTests
+    {
+        private const string UnsignedPayload = "UNSIGNED-PAYLOAD";
+        private const string ContentSha256Header = "x-amz-content-sha256";
+
+        private static S3StorageEgressProviderOptions ConstructOptions() => new()
+        {
+            BucketName = "bucket",
+            Endpoint = "https://example.invalid",
+            RegionName = "auto",
+            AccessKeyId = "accessKeyId",
+            SecretAccessKey = "secretAccessKey"
+        };
+
+        [Fact]
+        public void ItShouldNotModifyChecksumBehaviorWhenPayloadSigningIsEnabled()
+        {
+            // The SDK resolves these settings from the environment (AWS_REQUEST_CHECKSUM_CALCULATION /
+            // AWS_RESPONSE_CHECKSUM_VALIDATION) and the shared config file, so the resolved values are
+            // machine-dependent. Assert that the option-off path leaves them at whatever the SDK
+            // resolved, rather than asserting a specific value.
+            S3StorageEgressProviderOptions options = ConstructOptions();
+
+            AmazonS3Config configuration = S3Storage.CreateConfiguration(options);
+            AmazonS3Config untouched = new();
+
+            Assert.Equal(untouched.RequestChecksumCalculation, configuration.RequestChecksumCalculation);
+            Assert.Equal(untouched.ResponseChecksumValidation, configuration.ResponseChecksumValidation);
+        }
+
+        [Fact]
+        public void ItShouldOptOutOfChecksumsWhenPayloadSigningIsDisabled()
+        {
+            // Checksums travel as an aws-chunked trailer, so leaving them enabled would still emit a
+            // STREAMING-...-TRAILER request against an endpoint that cannot accept one.
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.DisablePayloadSigning = true;
+
+            AmazonS3Config configuration = S3Storage.CreateConfiguration(options);
+
+            Assert.Equal(RequestChecksumCalculation.WHEN_REQUIRED, configuration.RequestChecksumCalculation);
+            Assert.Equal(ResponseChecksumValidation.WHEN_REQUIRED, configuration.ResponseChecksumValidation);
+        }
+
+        [Fact]
+        public async Task ItShouldSendUnsignedPayloadOnPutWhenPayloadSigningIsDisabled()
+        {
+            RecordingHttpHandler handler = new();
+            S3Storage storage = CreateStorage(handler, disablePayloadSigning: true);
+
+            await storage.PutAsync(new MemoryStream(new byte[64]), CancellationToken.None);
+
+            HttpRequestMessage request = Assert.Single(handler.Requests);
+            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.Equal(UnsignedPayload, GetContentSha256(request));
+        }
+
+        [Fact]
+        public async Task ItShouldSignPutPayloadByDefault()
+        {
+            RecordingHttpHandler handler = new();
+            S3Storage storage = CreateStorage(handler, disablePayloadSigning: false);
+
+            await storage.PutAsync(new MemoryStream(new byte[64]), CancellationToken.None);
+
+            HttpRequestMessage request = Assert.Single(handler.Requests);
+            Assert.NotEqual(UnsignedPayload, GetContentSha256(request));
+        }
+
+        [Fact]
+        public async Task ItShouldSendUnsignedPayloadOnUploadPartWhenPayloadSigningIsDisabled()
+        {
+            // The multi-part path is the one every artifact takes in production
+            // (S3StorageEgressProvider always initiates a multi-part upload).
+            RecordingHttpHandler handler = new();
+            S3Storage storage = CreateStorage(handler, disablePayloadSigning: true);
+
+            await storage.UploadPartAsync("uploadId", partNumber: 1, partSize: 64, new MemoryStream(new byte[64]), CancellationToken.None);
+
+            HttpRequestMessage request = Assert.Single(handler.Requests);
+            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.Equal(UnsignedPayload, GetContentSha256(request));
+        }
+
+        [Fact]
+        public async Task ItShouldSignUploadPartPayloadByDefault()
+        {
+            RecordingHttpHandler handler = new();
+            S3Storage storage = CreateStorage(handler, disablePayloadSigning: false);
+
+            await storage.UploadPartAsync("uploadId", partNumber: 1, partSize: 64, new MemoryStream(new byte[64]), CancellationToken.None);
+
+            HttpRequestMessage request = Assert.Single(handler.Requests);
+            Assert.NotEqual(UnsignedPayload, GetContentSha256(request));
+        }
+
+        [Fact]
+        public void ItShouldAcceptDisabledPayloadSigningOverHttps()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.DisablePayloadSigning = true;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.True(valid);
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void ItShouldAcceptDisabledPayloadSigningWithoutAnEndpoint()
+        {
+            // An empty endpoint usually means the AWS-hosted (HTTPS) endpoints. The SDK can still
+            // resolve a non-HTTPS endpoint from the environment; that case is rejected by the SDK's
+            // signer at upload time rather than here.
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.Endpoint = null;
+            options.DisablePayloadSigning = true;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.True(valid);
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void ItShouldAcceptDisabledPayloadSigningWithSurroundingWhitespace()
+        {
+            // Environment-injected values can carry stray whitespace; Uri parsing tolerates it and so
+            // does the SDK, so validation must not reject it.
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.Endpoint = " https://example.invalid";
+            options.DisablePayloadSigning = true;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.True(valid);
+            Assert.Empty(results);
+        }
+
+        [Theory]
+        [InlineData("http://example.invalid")]
+        [InlineData("HTTP://example.invalid")]
+        [InlineData("example.invalid")]
+        public void ItShouldNotAcceptDisabledPayloadSigningOverNonHttpsEndpoints(string endpoint)
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.Endpoint = endpoint;
+            options.DisablePayloadSigning = true;
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.False(valid);
+            Assert.Contains(results, r => r.ErrorMessage == Strings.ErrorMessage_EgressS3FailedInsecurePayloadSigningOptOut);
+        }
+
+        [Fact]
+        public void ItShouldAcceptPlainHttpWhenPayloadSigningIsEnabled()
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.Endpoint = "http://example.invalid";
+
+            List<ValidationResult> results = new();
+            bool valid = Validator.TryValidateObject(options, new ValidationContext(options), results, true);
+
+            Assert.True(valid);
+            Assert.Empty(results);
+        }
+
+        private static S3Storage CreateStorage(RecordingHttpHandler handler, bool disablePayloadSigning)
+        {
+            S3StorageEgressProviderOptions options = ConstructOptions();
+            options.DisablePayloadSigning = disablePayloadSigning;
+
+            AmazonS3Config configuration = S3Storage.CreateConfiguration(options);
+            configuration.HttpClientFactory = new StubHttpClientFactory(handler);
+
+            IAmazonS3 client = new AmazonS3Client(S3Storage.CreateCredentials(options), configuration);
+            return new S3Storage(client, options.BucketName, "objectId", "application/octet-stream",
+                useKmsEncryption: false, kmsEncryptionKey: null, disablePayloadSigning: disablePayloadSigning);
+        }
+
+        private static string GetContentSha256(HttpRequestMessage request)
+        {
+            Assert.True(request.Headers.TryGetValues(ContentSha256Header, out IEnumerable<string> values));
+            return values.Single();
+        }
+
+        /// <summary>
+        /// Records every signed request and answers with a minimal success response, so the assertion
+        /// is on the wire form the storage service actually receives.
+        /// </summary>
+        private sealed class RecordingHttpHandler : HttpMessageHandler
+        {
+            public List<HttpRequestMessage> Requests { get; } = new();
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Content != null)
+                {
+                    // Buffer so the request stays inspectable after the SDK disposes its stream.
+                    await request.Content.LoadIntoBufferAsync(cancellationToken);
+                }
+                Requests.Add(request);
+
+                HttpResponseMessage response = new(HttpStatusCode.OK)
+                {
+                    RequestMessage = request,
+                    Content = new StringContent(string.Empty)
+                };
+                response.Headers.TryAddWithoutValidation("ETag", "\"0123456789abcdef0123456789abcdef\"");
+                return response;
+            }
+        }
+
+        private sealed class StubHttpClientFactory : Amazon.Runtime.HttpClientFactory
+        {
+            private readonly HttpMessageHandler _handler;
+
+            public StubHttpClientFactory(HttpMessageHandler handler)
+            {
+                _handler = handler;
+            }
+
+            public override HttpClient CreateHttpClient(IClientConfig clientConfig)
+                => new(_handler, disposeHandler: false);
+        }
+    }
+}


### PR DESCRIPTION
###### Summary

Fixes #9768.

Three changes that make the S3 egress provider work against S3-compatible services (Cloudflare R2, MinIO, and similar), in two commits:

**1. `sessionToken` option** — temporary (STS-style) credentials consist of an access key id, a secret access key **and** a session token; all three must be presented on every request. The provider had no way to configure the third, so temporary credentials were unusable. Validated to require both companions; switches the client to `SessionAWSCredentials`.

**2. `endpoint`/`regionName`/`forcePathStyle` honored on every credential path** — previously they were only applied when `accessKeyId` and `secretAccessKey` were both set, and silently ignored with `awsProfileName` or the default credential chain (`No RegionEndpoint or ServiceURL configured`). The connection configuration is now built identically on every path: the endpoint of the storage service is orthogonal to how the caller authenticates. A "Behavior change" note in the docs covers the one observable difference (a configured `regionName` now wins over a profile-sourced region on those paths).

**3. `disablePayloadSigning` option** — the SDK uploads with a signed streaming payload plus a flexible-checksum `aws-chunked` trailer; services that implement neither reject every artifact (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER not implemented`). `DisablePayloadSigning` is a per-request SDK property with no config/env binding, and `EgressAsync` always takes the multi-part path, so no configuration could work around it.

##### Why the option also moves checksums to `WHEN_REQUIRED`

The trailer and the payload signature are independent wire features. Disabling only the signature still emits `STREAMING-UNSIGNED-PAYLOAD-TRAILER` (`ChecksumUtils` forces the checksum into a trailer whenever `DisablePayloadSigning` is set), which the same endpoints reject. A knob that requires a second undocumented knob to function is a trap, so the one option sets `UNSIGNED-PAYLOAD` on the requests *and* `RequestChecksumCalculation`/`ResponseChecksumValidation = WHEN_REQUIRED` on the client. The option description and schema say so.

Setting `DisablePayloadSigning` is also Cloudflare's own documented integration path for this SDK — their [R2 example for the AWS SDK for .NET](https://developers.cloudflare.com/r2/examples/aws/aws-sdk-net/#upload-and-retrieve-objects) sets it on upload requests — so the option mirrors the vendor-recommended usage rather than inventing a workaround.

##### Wire-level evidence (recorded via a stub HttpClientFactory against the real AmazonS3Client)

With `disablePayloadSigning: true`, the full provider sequence signs as:

| request | `x-amz-content-sha256` | body form |
|---|---|---|
| `GetBucketAcl` (bucket probe) | hex SHA-256 (empty) | none |
| `PutBucket` | hex SHA-256 (empty) | 0-byte |
| `InitiateMultipartUpload` | hex SHA-256 (empty) | 0-byte |
| `UploadPart` | **`UNSIGNED-PAYLOAD`** | raw bytes, no `aws-chunked` |
| `CompleteMultipartUpload` | hex SHA-256 of the XML | XML |
| `PutObject` (empty-artifact path) | **`UNSIGNED-PAYLOAD`** | 0-byte |
| `AbortMultipartUpload` | hex SHA-256 (empty) | none |

— i.e. exactly the shape the AWS CLI produces, and the shape R2 accepts.

##### Safety

- An unsigned payload is integrity-protected by the transport, so validation rejects `disablePayloadSigning` with a non-HTTPS endpoint (`Uri`-parsed, whitespace/case tolerant). An unset endpoint passes — the AWS-hosted endpoints are HTTPS; an endpoint resolved from `AWS_ENDPOINT_URL_S3` escapes options-level validation and is rejected by the SDK's signer at upload time instead.
- That signer refusal is an `AmazonClientException` — a **sibling** of `AmazonS3Exception` in AWS SDK v4, not a subclass — thrown after the multi-part upload is initiated. `EgressAsync` now catches it too, so the upload is aborted instead of leaving orphaned (billed) parts, and the message is wrapped like other egress failures.
- Default `false`; Amazon S3 behavior is unchanged. `UseChunkEncoding` deliberately not touched: the SDK's post-marshall handler skips that assignment entirely when `DisablePayloadSigning` is set.

##### Tests

- Wire-level assertions through the real `AmazonS3Client` + recording `HttpMessageHandler`: `x-amz-content-sha256` is `UNSIGNED-PAYLOAD` with the option on (PutObject and UploadPart — the path every artifact takes) and not with it off.
- Checksum-default assertions compare against an `AmazonS3Config` built in-process, so the suite stays green under `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` in the environment (the very variable a user might set while debugging this).
- Credentials tests cover `SessionAWSCredentials`/`BasicAWSCredentials` selection and option validation; endpoint-validation tests cover https/http/scheme-less/whitespace.
- `documentation/schema.json` is generator-produced (`SchemaGenerationTests` green).

This change runs in production against Cloudflare R2 (process dumps egressing from Kubernetes sidecars); the first artifact uploads failed with the exact error strings above on the stock image and succeed with this change.

Docs claim `First Available: 10.1` / `(10.1+)` following the 8.1/9.1 minor convention — maintainers, please adjust if the next feature release is numbered differently.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Added `sessionToken` and `disablePayloadSigning` options to the S3 egress provider and honored `endpoint`/`regionName`/`forcePathStyle` on every credential path, enabling egress to S3-compatible services such as Cloudflare R2 and MinIO.
