### PR TITLE
[dotnet-monitor] Migrate GitHub release publishing to GitHub App

### DIFF
--- a/eng/pipelines/dotnet-monitor-publish.yml
+++ b/eng/pipelines/dotnet-monitor-publish.yml
@@ -274,6 +274,14 @@ extends:
                   $shortVersion="$($Matches.major).$($Matches.minor).$($Matches.patch)"
               }
               Write-Host "##vso[task.setvariable variable=ShortReleaseVersion]v$shortVersion"
+        - template: /eng/common/templates-official/steps/get-github-app-token.yml@self
+          parameters:
+            azureSubscription: dnceng-dotnet-monitor-release-githubapp
+            keyVaultName: EngKeyVault
+            keyName: dotnet-monitor-release-app-key
+            appClientId: Iv23liBv4UYcLCWQNpMz
+            installationOwner: $(DRP_GithubOrg)
+            outputVariableName: GitHubAppInstallationToken
         - task: PowerShell@2
           displayName: Generate Release
           inputs:
@@ -281,6 +289,5 @@ extends:
             arguments: -ManifestPath $(DRP_OutputManifestPath) -ReleaseNotes $(DRP_ReleaseNotes) -GhRepository $(DRP_GithubRepo) -GhOrganization $(DRP_GithubOrg) -TagName $(ReleaseVersion) -DraftRelease $$(DRP_DraftRelease)
             workingDirectory: $(DRP_RepoRoot)
           env:
-            GITHUB_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
-
+            GITHUB_TOKEN: $(GitHubAppInstallationToken)
 

--- a/eng/release/Scripts/GenerateGithubRelease.ps1
+++ b/eng/release/Scripts/GenerateGithubRelease.ps1
@@ -84,7 +84,7 @@ function Post-GithubRelease($manifest, [string]$releaseBody)
 
     if (!(Test-Path env:GITHUB_TOKEN))
     {
-        Write-Error "Error: unable to find GitHub PAT. Please set in GITHUB_TOKEN."
+        Write-Error "Error: unable to find GitHub token. Please set GITHUB_TOKEN."
         exit 1
     }
 


### PR DESCRIPTION
## Summary

Replaces the broad `BotAccount-dotnet-bot-repo-PAT` used by the dotnet-monitor release stage with a short-lived token from the dedicated `dotnet-monitor-release` GitHub App.

The pipeline uses Arcade's synchronized `/eng/common/templates-official/steps/get-github-app-token.yml@self` template. It signs through EngKeyVault using the dedicated workload-identity-federated service connection, selects the `dotnet` installation, and exposes the resulting short-lived token only to the GitHub release step.

## Security scope

- GitHub App: [`dotnet-monitor-release`](https://github.com/apps/dotnet-monitor-release)
- Installation: `157362597`
- Repository selection: selected repositories only
- Repository: `dotnet/dotnet-monitor`
- Permissions: Contents read/write; Metadata read (implicit)
- Key: imported RSA key `dotnet-monitor-release-app-key` in EngKeyVault
- Azure DevOps service connection: `dnceng-dotnet-monitor-release-githubapp`
- Production pipeline authorized: definition `1444`

## Validation

End-to-end validation succeeded in [build 3060415](https://dev.azure.com/dnceng/internal/_build/results?buildId=3060415&view=results):

- Arcade's official helper selected installation `157362597` for owner `dotnet`.
- The dedicated WIF connection signed through the Key Vault key and minted a short-lived installation token.
- Draft release `378800162` was created by `dotnet-monitor-release[bot]`.
- The validation job deleted the draft release.
- Follow-up GitHub checks confirmed no residual draft or `github-app-validation-3060415` tag/ref.

The PowerShell script parses successfully and the checked-in Arcade helper is present on `main`.

## Servicing branches

No backport is needed for `release/8.x` or `release/9.0`. Neither branch contains `eng/pipelines/dotnet-monitor-publish.yml`; releases from both product lines use pipeline definition `1444` sourced from `main` and select the branch-specific build artifact at queue time.

## Rollout

After merge, run the integrated/default-branch release path with `DraftRelease: true` when a suitable producer build is available. Remove this consumer's shared PAT dependency only after that integrated validation; the shared PAT must remain available for other consumers tracked by AB#12331.

Tracking: [AB#12318](https://dev.azure.com/dnceng/internal/_workitems/edit/12318)  
Key declaration: [dotnet/arcade#17445](https://github.com/dotnet/arcade/pull/17445)
