### PR TITLE
Merge main into release/10.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,11 +4,11 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet</Uri>
       <Sha>b0f34d51fccc69fd334253924abd8d6853fad7aa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="10.0.0-preview.26430.1">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring" Version="10.0.0-preview.26431.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>d828f243cdb9ba8076c04eec72f48e3191795d16</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="10.0.0-preview.26430.1">
+    <Dependency Name="Microsoft.Diagnostics.Monitoring.EventPipe" Version="10.0.0-preview.26431.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>d828f243cdb9ba8076c04eec72f48e3191795d16</Sha>
     </Dependency>
@@ -42,7 +42,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>5593ffa7da58f76139b3b49aac38a757417c9526</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.FileFormats" Version="1.0.743001">
+    <Dependency Name="Microsoft.FileFormats" Version="1.0.743101">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>d828f243cdb9ba8076c04eec72f48e3191795d16</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,25 +22,25 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet</Uri>
       <Sha>96856fd726ffd058fb3dfef0851dbafc7ef3b011</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26429.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26431.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>5593ffa7da58f76139b3b49aac38a757417c9526</Sha>
+      <Sha>c642c365e52bd6c5bd979f759963260fb79d710a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="10.0.0-beta.26429.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="10.0.0-beta.26431.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>5593ffa7da58f76139b3b49aac38a757417c9526</Sha>
+      <Sha>c642c365e52bd6c5bd979f759963260fb79d710a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="10.0.0-beta.26429.1">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="10.0.0-beta.26431.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>5593ffa7da58f76139b3b49aac38a757417c9526</Sha>
+      <Sha>c642c365e52bd6c5bd979f759963260fb79d710a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.26429.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.26431.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>5593ffa7da58f76139b3b49aac38a757417c9526</Sha>
+      <Sha>c642c365e52bd6c5bd979f759963260fb79d710a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.26429.1">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.26431.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>5593ffa7da58f76139b3b49aac38a757417c9526</Sha>
+      <Sha>c642c365e52bd6c5bd979f759963260fb79d710a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FileFormats" Version="1.0.743101">
       <Uri>https://github.com/dotnet/diagnostics</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,9 +50,9 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- dotnet/diagnostics references -->
-    <MicrosoftDiagnosticsMonitoringVersion>10.0.0-preview.26430.1</MicrosoftDiagnosticsMonitoringVersion>
-    <MicrosoftDiagnosticsMonitoringEventPipeVersion>10.0.0-preview.26430.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
-    <MicrosoftFileFormatsVersion>1.0.743001</MicrosoftFileFormatsVersion>
+    <MicrosoftDiagnosticsMonitoringVersion>10.0.0-preview.26431.1</MicrosoftDiagnosticsMonitoringVersion>
+    <MicrosoftDiagnosticsMonitoringEventPipeVersion>10.0.0-preview.26431.1</MicrosoftDiagnosticsMonitoringEventPipeVersion>
+    <MicrosoftFileFormatsVersion>1.0.743101</MicrosoftFileFormatsVersion>
     <!-- dotnet/dotnet references -->
     <MicrosoftAspNetCoreAppRuntimewinx64Version>10.0.0</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>10.0.301</MicrosoftCodeAnalysisNetAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,9 +56,9 @@
     <!-- dotnet/dotnet references -->
     <MicrosoftAspNetCoreAppRuntimewinx64Version>10.0.0</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>10.0.301</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>10.0.0-beta.26429.1</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>10.0.0-beta.26429.1</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.26429.1</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>10.0.0-beta.26431.5</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>10.0.0-beta.26431.5</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.26431.5</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>10.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <SystemCommandLineVersion>2.0.0</SystemCommandLineVersion>
     <VSRedistCommonAspNetCoreSharedFrameworkx64100Version>10.0.0-rtm.25523.111</VSRedistCommonAspNetCoreSharedFrameworkx64100Version>

--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -110,19 +110,20 @@ $headers = @{
 
 Write-Host "Looking up installation for '$InstallationOwner'..."
 try {
-    $installations = @()
+    $installations = [System.Collections.Generic.List[object]]::new()
     $page = 1
     do {
-        # Assign the response before wrapping it in @(). PowerShell otherwise
-        # preserves a top-level JSON array as one nested pipeline object.
         $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
             -Method Get
-        $pageInstallations = @($pageResponse)
-        $installations += $pageInstallations
+        $pageInstallationCount = 0
+        foreach ($installation in $pageResponse) {
+            $installations.Add($installation)
+            $pageInstallationCount++
+        }
         $page++
-    } while ($pageInstallations.Count -eq 100)
+    } while ($pageInstallationCount -eq 100)
 }
 catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."

--- a/global.json
+++ b/global.json
@@ -26,7 +26,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26429.1",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26429.1"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26431.5",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26431.5"
   }
 }


### PR DESCRIPTION
## Summary
- merge the latest `main` changes into `release/10.0`
- retain release `10.0.4-servicing` product and shipped diagnostics versions
- update Arcade dependencies and SDKs to `10.0.0-beta.26431.5`
- retain the shared GitHub App token helper update from `main`

## Validation
- `./Build.cmd -skipnative -configuration Release`