### PR TITLE
[release/8.x] Merge internal/release/8.x

### DIFF
--- a/documentation/collectionrules/collectionrules.md
+++ b/documentation/collectionrules/collectionrules.md
@@ -156,7 +156,7 @@ In addition to dependencies, the following list of token substitutions are also 
 | `$(Process.RuntimeId)` | The unique identifier of the target process. Note for 3.1 applications, this will be the empty Guid. |
 | `$(Process.ProcessId)` | Process id of the target process. |
 | `$(Process.Name)` | Name of the target process. |
-| `$(Process.CommandLine)` | Command line of the target process. |
+| `$(Process.CommandLine)` | Command line of the target process. When used in an `ArtifactName`, only the file name portion is substituted. |
 
 ### Action List Execution
 

--- a/documentation/configuration/configuration-sources.md
+++ b/documentation/configuration/configuration-sources.md
@@ -20,6 +20,8 @@
 - Environment variables with `DOTNETMONITOR_` prefix e.g. `DOTNETMONITOR_Urls`
 - Full path to a JSON settings file via the `--configuration-file-path` command line option. First available in .NET Monitor 6.3
 
+On Windows, the shared settings path sources are not loaded when `dotnet monitor` is running with elevated permissions. Other configuration sources, including an explicit `--configuration-file-path`, continue to be loaded.
+
 ## Translating configuration between providers
 
 While the rest of this document will showcase configuration examples in a JSON format, the same configuration can be expressed via any of the other configuration sources. For example, the API Key configuration can be expressed via shown below:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,9 +38,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>25da4e8f08fab05a39c27443df99b96d738f3c82</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.414-servicing.25404.6">
-      <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>7b3032b6553f6436e8d1cdfd103c22187de53502</Sha>
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.425-servicing.26421.9">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-installer</Uri>
+      <Sha>4a98f641c7495721ab32b94dbda4f3bae02f837a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.26431.7">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,9 +38,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>9ae964c99c40b6028ce74b1e54acbaa89cdca350</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.425-servicing.26421.9">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-installer</Uri>
-      <Sha>4a98f641c7495721ab32b94dbda4f3bae02f837a</Sha>
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.414-servicing.25404.6">
+      <Uri>https://github.com/dotnet/installer</Uri>
+      <Sha>7b3032b6553f6436e8d1cdfd103c22187de53502</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.26429.2">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,9 +38,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>9ae964c99c40b6028ce74b1e54acbaa89cdca350</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.414-servicing.25404.6">
-      <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>7b3032b6553f6436e8d1cdfd103c22187de53502</Sha>
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.425-servicing.26421.9">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-installer</Uri>
+      <Sha>4a98f641c7495721ab32b94dbda4f3bae02f837a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.26429.2">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,7 +59,7 @@
     <MicrosoftDiagnosticsMonitoringVersion>10.0.731102</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>10.0.731102</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/installer references -->
-    <MicrosoftDotnetSdkInternalVersion>8.0.425-servicing.26421.9</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>8.0.414-servicing.25404.6</MicrosoftDotnetSdkInternalVersion>
     <!-- dotnet/roslyn-analyzers -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23614.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- dotnet/runtime references -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,7 +59,7 @@
     <MicrosoftDiagnosticsMonitoringVersion>10.0.731102</MicrosoftDiagnosticsMonitoringVersion>
     <MicrosoftDiagnosticsMonitoringEventPipeVersion>10.0.731102</MicrosoftDiagnosticsMonitoringEventPipeVersion>
     <!-- dotnet/installer references -->
-    <MicrosoftDotnetSdkInternalVersion>8.0.414-servicing.25404.6</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>8.0.425-servicing.26421.9</MicrosoftDotnetSdkInternalVersion>
     <!-- dotnet/roslyn-analyzers -->
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23614.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- dotnet/runtime references -->

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -130,10 +130,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             _outputHelper.WriteLine("Generating API key.");
 
-            // Set API key via key-per-file
+            // Set API key via reloadable user settings
             RootOptions options = new();
             options.UseApiKey(signingAlgo, Guid.NewGuid(), out string apiKey);
-            toolRunner.WriteKeyPerValueConfiguration(options);
+            await toolRunner.WriteUserSettingsAsync(options);
 
             // Start dotnet-monitor
             await toolRunner.StartAsync();
@@ -152,7 +152,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             // Rotate the API key
             options.UseApiKey(signingAlgo, Guid.NewGuid(), out string apiKey2);
-            toolRunner.WriteKeyPerValueConfiguration(options);
+            await toolRunner.WriteUserSettingsAsync(options);
 
             // Wait for the key rotation to be consumed by dotnet-monitor; detect this
             // by checking for when API returns a 401. Ideally, key rotation would write

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -262,7 +262,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: runner =>
                 {
-                    runner.WriteKeyPerValueConfiguration(new RootOptions()
+                    runner.WriteUserSettings(new RootOptions()
                     {
                         Metrics = new MetricsOptions()
                         {
@@ -344,7 +344,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: runner =>
                 {
-                    runner.WriteKeyPerValueConfiguration(new RootOptions()
+                    runner.WriteUserSettings(new RootOptions()
                     {
                         Metrics = new MetricsOptions()
                         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Tests that turning off metrics via key-per-file will have the /metrics route not serve metrics.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(MonitorRunner), nameof(MonitorRunner.IsSharedConfigurationSupported))]
         public async Task DisableMetricsViaKeyPerFileTest()
         {
             await using MonitorCollectRunner toolRunner = new(_outputHelper);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OperationsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OperationsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     {
                         Enabled = true
                     };
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 },
                 profilerLogLevel: LogLevel.Trace,
                 subScenarioName: subScenarioName,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -60,6 +61,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         public bool HasExited => _runner.HasExited;
 
         public int ExitCode => _runner.ExitCode;
+
+        public static bool IsSharedConfigurationSupported =>
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !EnvironmentInformation.IsElevated;
 
         /// <summary>
         /// The path to dotnet-monitor.
@@ -213,6 +217,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             _outputHelper.WriteLine("Wrote user settings.");
         }
 
+        public void WriteUserSettings(RootOptions options)
+        {
+            WriteSettingsFile(options, UserSettingsFilePath);
+            _outputHelper.WriteLine("Wrote user settings.");
+        }
+
         public async Task WriteExplicitlySetSettingsFileAsync(RootOptions options)
         {
             await WriteSettingsFileAsync(options, ExplicitlySetSettingsFilePath).ConfigureAwait(false);
@@ -227,10 +237,18 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         private static async Task WriteSettingsFileAsync(RootOptions options, string filePath)
         {
-            using FileStream stream = new(filePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
+            using FileStream stream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
 
             JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
             await JsonSerializer.SerializeAsync(stream, options, serializerOptions).ConfigureAwait(false);
+        }
+
+        private static void WriteSettingsFile(RootOptions options, string filePath)
+        {
+            using FileStream stream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+
+            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
+            JsonSerializer.Serialize(stream, options, serializerOptions);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -89,6 +89,14 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 
         private const string UserProvidedSettingsFileName = "UserSpecifiedFile.json"; // Note: if this name is updated, it must also be updated in the expected show sources configuration files
 
+        private const string SharedJsonTestKey = "SharedJsonTestKey";
+
+        private const string SharedKeyPerFileTestKey = "SharedKeyPerFileTestKey";
+
+        private const string UserJsonTestKey = "UserJsonTestKey";
+
+        private const string UserProvidedJsonTestKey = "UserProvidedJsonTestKey";
+
         private readonly ITestOutputHelper _outputHelper;
 
         public ConfigurationTests(ITestOutputHelper outputHelper)
@@ -194,6 +202,70 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             {
                 Assert.Equal(Enum.GetName(level), configuredUrls);
             }
+        }
+
+        [Theory]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        public void SharedConfigurationSourcesRespectWindowsElevation(
+            bool isWindows,
+            bool isElevated,
+            bool expectSharedConfiguration)
+        {
+            using TemporaryDirectory contentRootDirectory = new(_outputHelper);
+            using TemporaryDirectory sharedConfigDir = new(_outputHelper);
+            using TemporaryDirectory userConfigDir = new(_outputHelper);
+            using TemporaryDirectory userProvidedConfigDir = new(_outputHelper);
+
+            string userProvidedConfigFullPath = Path.Combine(userProvidedConfigDir.FullName, UserProvidedSettingsFileName);
+
+            File.WriteAllText(
+                Path.Combine(sharedConfigDir.FullName, "settings.json"),
+                JsonSerializer.Serialize(new Dictionary<string, string>
+                {
+                    { SharedJsonTestKey, SharedJsonTestKey }
+                }));
+            File.WriteAllText(
+                Path.Combine(sharedConfigDir.FullName, SharedKeyPerFileTestKey),
+                SharedKeyPerFileTestKey);
+            File.WriteAllText(
+                Path.Combine(userConfigDir.FullName, "settings.json"),
+                JsonSerializer.Serialize(new Dictionary<string, string>
+                {
+                    { UserJsonTestKey, UserJsonTestKey }
+                }));
+            File.WriteAllText(
+                userProvidedConfigFullPath,
+                JsonSerializer.Serialize(new Dictionary<string, string>
+                {
+                    { UserProvidedJsonTestKey, UserProvidedJsonTestKey }
+                }));
+
+            HostBuilderSettings settings = new()
+            {
+                AuthenticationMode = StartupAuthenticationMode.Deferred,
+                ContentRootDirectory = contentRootDirectory.FullName,
+                SharedConfigDirectory = sharedConfigDir.FullName,
+                IncludeSharedConfiguration = HostBuilderSettings.ShouldIncludeSharedConfiguration(
+                    isWindows,
+                    () => isElevated),
+                UserConfigDirectory = userConfigDir.FullName,
+                UserProvidedConfigFilePath = new FileInfo(userProvidedConfigFullPath)
+            };
+
+            IHostBuilder builder = HostBuilderHelper.CreateHostBuilder(settings);
+            builder.ReplaceAspnetEnvironment();
+            builder.ReplaceDotnetEnvironment();
+            builder.ReplaceMonitorEnvironment();
+
+            using IHost host = builder.Build();
+            IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
+
+            Assert.Equal(expectSharedConfiguration ? SharedJsonTestKey : null, configuration[SharedJsonTestKey]);
+            Assert.Equal(expectSharedConfiguration ? SharedKeyPerFileTestKey : null, configuration[SharedKeyPerFileTestKey]);
+            Assert.Equal(UserJsonTestKey, configuration[UserJsonTestKey]);
+            Assert.Equal(UserProvidedJsonTestKey, configuration[UserProvidedJsonTestKey]);
         }
 
         /// <summary>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTokenParserTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTokenParserTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    public sealed class ConfigurationTokenParserTests
+    {
+        [Theory]
+        [InlineData("../escape", "escape")]
+        [InlineData(@"..\escape", "escape")]
+        [InlineData("/tmp/escape", "escape")]
+        [InlineData(@"C:\temp\escape", "escape")]
+        [InlineData(@"\\server\share\escape", "escape")]
+        [InlineData("C:escape", "escape")]
+        [InlineData("volume:escape", "volume")]
+        [InlineData("artifact.dmp:stream", "artifact.dmp")]
+        [InlineData("C:artifact.dmp:stream", "artifact.dmp")]
+        [InlineData("..", "")]
+        [InlineData("C:..", "")]
+        [InlineData(".. ", "")]
+        [InlineData("C:.. ", "")]
+        [InlineData("...", "")]
+        [InlineData("   ", "")]
+        public void SubstituteOptionValues_CommandLineInArtifactName_UsesFileName(
+            string commandLine,
+            string expectedCommandLine)
+        {
+            const string ArtifactNamePrefix = "prefix-";
+            const string ArtifactNameSuffix = "-suffix";
+            string originalArtifactName = ArtifactNamePrefix +
+                ConfigurationTokenParser.CommandLineReference +
+                ArtifactNameSuffix;
+            CollectDumpOptions originalSettings = new()
+            {
+                ArtifactName = originalArtifactName
+            };
+            ConfigurationTokenParser parser = new(Mock.Of<ILogger>());
+
+            CollectDumpOptions newSettings = (CollectDumpOptions)parser.SubstituteOptionValues(
+                originalSettings,
+                new TokenContext { CommandLine = commandLine });
+
+            Assert.Equal(ArtifactNamePrefix + expectedCommandLine + ArtifactNameSuffix, newSettings.ArtifactName);
+            Assert.Equal(originalArtifactName, originalSettings.ArtifactName);
+        }
+
+        [Fact]
+        public void SubstituteOptionValues_CommandLineInOtherSettings_PreservesValue()
+        {
+            const string CommandLine = @"..\path/to/application --argument";
+            CollectDumpOptions originalSettings = new()
+            {
+                Egress = ConfigurationTokenParser.CommandLineReference
+            };
+            ConfigurationTokenParser parser = new(Mock.Of<ILogger>());
+
+            CollectDumpOptions newSettings = (CollectDumpOptions)parser.SubstituteOptionValues(
+                originalSettings,
+                new TokenContext { CommandLine = CommandLine });
+
+            Assert.Equal(CommandLine, newSettings.Egress);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -75,7 +77,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 string replacement = originalPropertyValue.Replace(RuntimeIdReference, context.RuntimeId.ToString("D"), StringComparison.Ordinal);
                 replacement = replacement.Replace(ProcessIdReference, context.ProcessId.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
                 replacement = replacement.Replace(ProcessNameReference, context.ProcessName, StringComparison.Ordinal);
-                replacement = replacement.Replace(CommandLineReference, context.CommandLine, StringComparison.Ordinal);
+                replacement = replacement.Replace(CommandLineReference, GetCommandLineReplacement(settings, propertyInfo, context.CommandLine), StringComparison.Ordinal);
                 replacement = replacement.Replace(HostNameReference, context.MonitorHostName, StringComparison.Ordinal);
                 replacement = replacement.Replace(UnixTimeReference, context.Timestamp.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
 
@@ -117,6 +119,36 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 }
             }
             return true;
+        }
+
+        private static string GetCommandLineReplacement(object? settings, PropertyInfo propertyInfo, string commandLine)
+        {
+            if (settings is not IEgressProviderProperties ||
+                propertyInfo.Name != nameof(IEgressProviderProperties.ArtifactName))
+            {
+                return commandLine;
+            }
+
+            string fileName = Path.GetFileName(
+                commandLine
+                    .Replace('\\', Path.DirectorySeparatorChar)
+                    .Replace('/', Path.DirectorySeparatorChar));
+
+            if (fileName.Length >= 2 &&
+                ((fileName[0] >= 'A' && fileName[0] <= 'Z') ||
+                 (fileName[0] >= 'a' && fileName[0] <= 'z')) &&
+                fileName[1] == ':')
+            {
+                fileName = fileName.Substring(2);
+            }
+
+            int colonIndex = fileName.IndexOf(':');
+            if (colonIndex >= 0)
+            {
+                fileName = fileName.Substring(0, colonIndex);
+            }
+
+            return fileName.TrimEnd(' ', '.').Length == 0 ? string.Empty : fileName;
         }
 
         public static IEnumerable<PropertyInfo> GetPropertiesFromSettings(object? settings, Predicate<PropertyInfo>? predicate = null) =>

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -54,27 +54,31 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     string userSettingsPath = Path.Combine(settings.UserConfigDirectory, SettingsFileName);
                     AddJsonFileHelper(builder, hostBuilderResults, userSettingsPath);
 
-                    string sharedSettingsPath = Path.Combine(settings.SharedConfigDirectory, SettingsFileName);
-                    AddJsonFileHelper(builder, hostBuilderResults, sharedSettingsPath);
-
-                    //HACK Workaround for https://github.com/dotnet/runtime/issues/36091
-                    //KeyPerFile provider uses a file system watcher to trigger changes.
-                    //The watcher does not follow symlinks inside the watched directory, such as mounted files
-                    //in Kubernetes.
-                    //We get around this by watching the target folder of the symlink instead.
-                    //See https://github.com/kubernetes/kubernetes/master/pkg/volume/util/atomic_writer.go
-                    string? path = settings.SharedConfigDirectory;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInfo.IsInKubernetes)
+                    if (settings.IncludeSharedConfiguration)
                     {
-                        string symlinkTarget = Path.Combine(settings.SharedConfigDirectory, "..data");
-                        if (Directory.Exists(symlinkTarget))
+                        string sharedSettingsPath = Path.Combine(settings.SharedConfigDirectory, SettingsFileName);
+                        AddJsonFileHelper(builder, hostBuilderResults, sharedSettingsPath);
+
+                        //HACK Workaround for https://github.com/dotnet/runtime/issues/36091
+                        //KeyPerFile provider uses a file system watcher to trigger changes.
+                        //The watcher does not follow symlinks inside the watched directory, such as mounted files
+                        //in Kubernetes.
+                        //We get around this by watching the target folder of the symlink instead.
+                        //See https://github.com/kubernetes/kubernetes/master/pkg/volume/util/atomic_writer.go
+                        string? path = settings.SharedConfigDirectory;
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInfo.IsInKubernetes)
                         {
-                            path = symlinkTarget;
+                            string symlinkTarget = Path.Combine(settings.SharedConfigDirectory, "..data");
+                            if (Directory.Exists(symlinkTarget))
+                            {
+                                path = symlinkTarget;
+                            }
                         }
+
+                        // If a file at this path does not have read permissions, the application will fail to launch.
+                        builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     }
 
-                    // If a file at this path does not have read permissions, the application will fail to launch.
-                    builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ToolIdentifiers.StandardPrefix);
 
                     // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public required string SharedConfigDirectory { get; set; }
 
+        public bool IncludeSharedConfiguration { get; set; } = true;
+
         public required string UserConfigDirectory { get; set; }
 
         public FileInfo? UserProvidedConfigFilePath { get; set; }
@@ -80,9 +82,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 AuthenticationMode = startupAuthMode,
                 ContentRootDirectory = AppContext.BaseDirectory,
                 SharedConfigDirectory = SharedConfigDirectoryPath,
+                IncludeSharedConfiguration = ShouldIncludeSharedConfiguration(
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                    () => EnvironmentInformation.IsElevated),
                 UserConfigDirectory = UserConfigDirectoryPath,
                 UserProvidedConfigFilePath = userProvidedConfigFilePath
             };
+        }
+
+        internal static bool ShouldIncludeSharedConfiguration(bool isWindows, Func<bool> isElevated)
+        {
+            return !isWindows || !isElevated();
         }
 
         private static string GetEnvironmentOverrideOrValue(string overrideEnvironmentVariable, string value)


### PR DESCRIPTION
###### Summary

Synchronizes the public `release/8.x` branch with `internal/release/8.x` from `https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor` and restores the intended internal .NET SDK dependency update.

- Public base tip: `26d9fa37dbcfed7c4c7814535a77a59fff4453b6`
- Internal source tip and exact matching PR commit: `17470eabc56943ee337c1974f2b0db93cf9d8928`
- Release merge commit: `c34a93ed67fc25e124e56ba56ee7715d261bf4cd`
- Merge parents: `26d9fa37dbcfed7c4c7814535a77a59fff4453b6 17470eabc56943ee337c1974f2b0db93cf9d8928`
- SDK recovery commit: `38be34b5bee7cae1c6d1ec6d0bb1f60d3c1898a0`
- `Microsoft.Dotnet.Sdk.Internal`: `8.0.414-servicing.25404.6` -> `8.0.425-servicing.26421.9`
- Updated dependency source: `https://dev.azure.com/dnceng/internal/_git/dotnet-installer` at `4a98f641c7495721ab32b94dbda4f3bae02f837a`
- Updated files: `eng/Versions.props`, `eng/Version.Details.xml`

The SDK update exactly restores the two-file delta from internal commit `a9ab8e3450127dfe5bad16aaba72f50669b5f8e8`, which was unintentionally reversed by `c5bdc20c626ecdf36290fc3d7c2c0a4dba57a057` while applying an unrelated functional-test fix.

Validation:

```
git rev-list 26d9fa37dbcfed7c4c7814535a77a59fff4453b6..38be34b5bee7cae1c6d1ec6d0bb1f60d3c1898a0 | grep -x 17470eabc56943ee337c1974f2b0db93cf9d8928
```

Result:

```
17470eabc56943ee337c1974f2b0db93cf9d8928
```

The exact internal source commit remains present verbatim in the PR commit range, and the release merge commit records it as its second parent. Repository restore completed successfully with zero warnings and zero errors after the SDK dependency metadata was restored.

###### Release Notes Entry
