### PR TITLE
[release/9.0] Merge internal/release/9.0 into release/9.0

### DIFF
--- a/documentation/collectionrules/collectionrules.md
+++ b/documentation/collectionrules/collectionrules.md
@@ -156,7 +156,7 @@ In addition to dependencies, the following list of token substitutions are also 
 | `$(Process.RuntimeId)` | The unique identifier of the target process. Note for 3.1 applications, this will be the empty Guid. |
 | `$(Process.ProcessId)` | Process id of the target process. |
 | `$(Process.Name)` | Name of the target process. |
-| `$(Process.CommandLine)` | Command line of the target process. |
+| `$(Process.CommandLine)` | Command line of the target process. When used in `ArtifactName`, only the command line's final path segment is substituted. |
 
 ### Action List Execution
 

--- a/documentation/configuration/configuration-sources.md
+++ b/documentation/configuration/configuration-sources.md
@@ -20,6 +20,8 @@
 - Environment variables with `DOTNETMONITOR_` prefix e.g. `DOTNETMONITOR_Urls`
 - Full path to a JSON settings file via the `--configuration-file-path` command line option. First available in .NET Monitor 6.3
 
+When `dotnet monitor` runs with elevated permissions on Windows, it does not read the shared settings sources under `%ProgramData%\dotnet-monitor`. Other configuration sources, including a file explicitly specified with `--configuration-file-path`, are unaffected.
+
 ## Translating configuration between providers
 
 While the rest of this document will showcase configuration examples in a JSON format, the same configuration can be expressed via any of the other configuration sources. For example, the API Key configuration can be expressed via shown below:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -54,9 +54,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
       <Sha>af22effae4069a5dfb9b0735859de48820104f5b</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0" Version="9.0.100-rtm.24529.9">
+    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0" Version="9.0.318-servicing.26421.8">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-sdk</Uri>
-      <Sha>59db016f11bb27d359336cf37524b863d77e7fea</Sha>
+      <Sha>415ddb56e684aa46a3b2c0231341eb503a1063c7</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.0-rtm.24528.9" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -54,9 +54,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
       <Sha>af22effae4069a5dfb9b0735859de48820104f5b</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0" Version="9.0.318-servicing.26421.8">
+    <Dependency Name="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0" Version="9.0.100-rtm.24529.9">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-sdk</Uri>
-      <Sha>415ddb56e684aa46a3b2c0231341eb503a1063c7</Sha>
+      <Sha>59db016f11bb27d359336cf37524b863d77e7fea</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.9.0" Version="9.0.0-rtm.24528.9" CoherentParentDependency="VS.Redist.Common.NetCore.SdkPlaceholder.x64.9.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftNETCoreAppRuntimewinx64Version>9.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6490Version>9.0.0-rtm.24528.9</VSRedistCommonNetCoreSharedFrameworkx6490Version>
     <!-- dotnet/sdk references -->
-    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.100-rtm.24529.9</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
+    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.318-servicing.26421.8</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.731102</MicrosoftFileFormatsVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftNETCoreAppRuntimewinx64Version>9.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6490Version>9.0.0-rtm.24528.9</VSRedistCommonNetCoreSharedFrameworkx6490Version>
     <!-- dotnet/sdk references -->
-    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.318-servicing.26421.8</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
+    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.100-rtm.24529.9</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.731102</MicrosoftFileFormatsVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftNETCoreAppRuntimewinx64Version>9.0.0</MicrosoftNETCoreAppRuntimewinx64Version>
     <VSRedistCommonNetCoreSharedFrameworkx6490Version>9.0.0-rtm.24528.9</VSRedistCommonNetCoreSharedFrameworkx6490Version>
     <!-- dotnet/sdk references -->
-    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.100-rtm.24529.9</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
+    <VSRedistCommonNetCoreSdkPlaceholderx6490Version>9.0.318-servicing.26421.8</VSRedistCommonNetCoreSdkPlaceholderx6490Version>
     <!-- dotnet/symstore references -->
     <MicrosoftFileFormatsVersion>1.0.637302</MicrosoftFileFormatsVersion>
   </PropertyGroup>

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/AuthenticationTests.cs
@@ -130,10 +130,10 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             _outputHelper.WriteLine("Generating API key.");
 
-            // Set API key via key-per-file
+            // Set API key via reloadable user settings
             RootOptions options = new();
             options.UseApiKey(signingAlgo, Guid.NewGuid(), out string apiKey);
-            toolRunner.WriteKeyPerValueConfiguration(options);
+            await toolRunner.WriteUserSettingsAsync(options);
 
             // Start dotnet-monitor
             await toolRunner.StartAsync();
@@ -152,7 +152,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
 
             // Rotate the API key
             options.UseApiKey(signingAlgo, Guid.NewGuid(), out string apiKey2);
-            toolRunner.WriteKeyPerValueConfiguration(options);
+            await toolRunner.WriteUserSettingsAsync(options);
 
             // Wait for the key rotation to be consumed by dotnet-monitor; detect this
             // by checking for when API returns a 401. Ideally, key rotation would write

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/EgressTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 
@@ -262,7 +262,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: runner =>
                 {
-                    runner.WriteKeyPerValueConfiguration(new RootOptions()
+                    runner.WriteUserSettings(new RootOptions()
                     {
                         Metrics = new MetricsOptions()
                         {
@@ -344,7 +344,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: runner =>
                 {
-                    runner.WriteKeyPerValueConfiguration(new RootOptions()
+                    runner.WriteUserSettings(new RootOptions()
                     {
                         Metrics = new MetricsOptions()
                         {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/MetricsTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
         /// <summary>
         /// Tests that turning off metrics via key-per-file will have the /metrics route not serve metrics.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(MonitorRunner), nameof(MonitorRunner.IsSharedConfigurationSupported))]
         public async Task DisableMetricsViaKeyPerFileTest()
         {
             await using MonitorCollectRunner toolRunner = new(_outputHelper);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OperationsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/OperationsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 },
                 configureTool: (toolRunner) =>
                 {
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 });
         }
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/ParameterCapturingTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     {
                         Enabled = true
                     };
-                    toolRunner.WriteKeyPerValueConfiguration(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
+                    toolRunner.WriteUserSettings(new RootOptions().AddFileSystemEgress(FileProviderName, _tempDirectory.FullName));
                 },
                 profilerLogLevel: LogLevel.Trace,
                 subScenarioName: subScenarioName,

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/Runners/MonitorRunner.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -60,6 +61,9 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
         public bool HasExited => _runner.HasExited;
 
         public int ExitCode => _runner.ExitCode;
+
+        public static bool IsSharedConfigurationSupported =>
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !EnvironmentInformation.IsElevated;
 
         /// <summary>
         /// The path to dotnet-monitor.
@@ -213,6 +217,12 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
             _outputHelper.WriteLine("Wrote user settings.");
         }
 
+        public void WriteUserSettings(RootOptions options)
+        {
+            WriteSettingsFile(options, UserSettingsFilePath);
+            _outputHelper.WriteLine("Wrote user settings.");
+        }
+
         public async Task WriteExplicitlySetSettingsFileAsync(RootOptions options)
         {
             await WriteSettingsFileAsync(options, ExplicitlySetSettingsFilePath).ConfigureAwait(false);
@@ -227,10 +237,18 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests.Runners
 
         private static async Task WriteSettingsFileAsync(RootOptions options, string filePath)
         {
-            using FileStream stream = new(filePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
+            using FileStream stream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
 
             JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
             await JsonSerializer.SerializeAsync(stream, options, serializerOptions).ConfigureAwait(false);
+        }
+
+        private static void WriteSettingsFile(RootOptions options, string filePath)
+        {
+            using FileStream stream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+
+            JsonSerializerOptions serializerOptions = JsonSerializerOptionsFactory.Create(JsonIgnoreCondition.WhenWritingNull);
+            JsonSerializer.Serialize(stream, options, serializerOptions);
         }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTests.cs
@@ -196,6 +196,80 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, false)]
+        [InlineData(false, true, true)]
+        public void SharedConfigurationOperatingSystemAndElevationTest(
+            bool isWindows,
+            bool isElevated,
+            bool expectSharedConfiguration)
+        {
+            const string SharedJsonKey = "SharedJsonKey";
+            const string SharedJsonValue = "SharedJsonValue";
+            const string SharedKeyPerFileKey = "SharedKeyPerFileKey";
+            const string SharedKeyPerFileValue = "SharedKeyPerFileValue";
+            const string UserProvidedKey = "UserProvidedKey";
+            const string UserProvidedValue = "UserProvidedValue";
+
+            using TemporaryDirectory contentRootDirectory = new(_outputHelper);
+            using TemporaryDirectory sharedConfigDir = new(_outputHelper);
+            using TemporaryDirectory userConfigDir = new(_outputHelper);
+            using TemporaryDirectory userProvidedConfigDir = new(_outputHelper);
+
+            File.WriteAllText(
+                Path.Combine(sharedConfigDir.FullName, "settings.json"),
+                JsonSerializer.Serialize(new Dictionary<string, string>()
+                {
+                    { SharedJsonKey, SharedJsonValue }
+                }));
+            File.WriteAllText(
+                Path.Combine(sharedConfigDir.FullName, SharedKeyPerFileKey),
+                SharedKeyPerFileValue);
+
+            string userProvidedConfigFullPath = Path.Combine(userProvidedConfigDir.FullName, UserProvidedSettingsFileName);
+            File.WriteAllText(
+                userProvidedConfigFullPath,
+                JsonSerializer.Serialize(new Dictionary<string, string>()
+                {
+                    { UserProvidedKey, UserProvidedValue }
+                }));
+
+            HostBuilderSettings settings = HostBuilderSettings.CreateMonitor(
+                urls: null,
+                metricUrls: null,
+                metrics: false,
+                diagnosticPort: null,
+                startupAuthMode: StartupAuthenticationMode.Deferred,
+                userProvidedConfigFilePath: new FileInfo(userProvidedConfigFullPath),
+                isWindows: () => isWindows,
+                isElevated: () => isElevated);
+            settings.ContentRootDirectory = contentRootDirectory.FullName;
+            settings.SharedConfigDirectory = sharedConfigDir.FullName;
+            settings.UserConfigDirectory = userConfigDir.FullName;
+
+            IHostBuilder builder = HostBuilderHelper.CreateHostBuilder(settings);
+            builder.ReplaceAspnetEnvironment();
+            builder.ReplaceDotnetEnvironment();
+            builder.ReplaceMonitorEnvironment();
+
+            using IHost host = builder.Build();
+            IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
+
+            if (expectSharedConfiguration)
+            {
+                Assert.Equal(SharedJsonValue, configuration[SharedJsonKey]);
+                Assert.Equal(SharedKeyPerFileValue, configuration[SharedKeyPerFileKey]);
+            }
+            else
+            {
+                Assert.Null(configuration[SharedJsonKey]);
+                Assert.Null(configuration[SharedKeyPerFileKey]);
+            }
+
+            Assert.Equal(UserProvidedValue, configuration[UserProvidedKey]);
+        }
+
         /// <summary>
         /// Instead of having to explicitly define every expected value, this reuses the individual categories to ensure they
         /// assemble properly when combined.

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTokenParserTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/ConfigurationTokenParserTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Tools.Monitor;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
+{
+    public sealed class ConfigurationTokenParserTests
+    {
+        [Theory]
+        [InlineData("../outside.dmp", "outside.dmp")]
+        [InlineData(@"..\outside.dmp", "outside.dmp")]
+        [InlineData("/tmp/outside.dmp", "outside.dmp")]
+        [InlineData(@"\outside.dmp", "outside.dmp")]
+        [InlineData(@"C:\tmp\outside.dmp", "outside.dmp")]
+        [InlineData(@"\\server\share\outside.dmp", "outside.dmp")]
+        [InlineData("C:outside.dmp", "outside.dmp")]
+        [InlineData("artifact.dmp:stream", "artifact.dmp")]
+        [InlineData("C:artifact.dmp:stream", "artifact.dmp")]
+        [InlineData("..", "")]
+        [InlineData("C:..", "")]
+        [InlineData(".. ", "")]
+        [InlineData("C:.. ", "")]
+        public void CommandLineReferenceInArtifactNameUsesFileName(string commandLine, string expectedArtifactName)
+        {
+            CollectDumpOptions settings = new()
+            {
+                Egress = ConfigurationTokenParser.CommandLineReference,
+                ArtifactName = ConfigurationTokenParser.CommandLineReference
+            };
+            ConfigurationTokenParser parser = new(NullLogger.Instance);
+
+            CollectDumpOptions newSettings = Assert.IsType<CollectDumpOptions>(
+                parser.SubstituteOptionValues(settings, new TokenContext { CommandLine = commandLine }));
+
+            Assert.Equal(commandLine, newSettings.Egress);
+            Assert.Equal(expectedArtifactName, newSettings.ArtifactName);
+            Assert.Equal(ConfigurationTokenParser.CommandLineReference, settings.Egress);
+            Assert.Equal(ConfigurationTokenParser.CommandLineReference, settings.ArtifactName);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
+++ b/src/Tools/dotnet-monitor/ConfigurationTokenParser.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.Actions;
+using Microsoft.Diagnostics.Tools.Monitor.CollectionRules.Options.CollectionRuleDefaultsInterfaces;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -75,7 +77,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 string replacement = originalPropertyValue.Replace(RuntimeIdReference, context.RuntimeId.ToString("D"), StringComparison.Ordinal);
                 replacement = replacement.Replace(ProcessIdReference, context.ProcessId.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
                 replacement = replacement.Replace(ProcessNameReference, context.ProcessName, StringComparison.Ordinal);
-                replacement = replacement.Replace(CommandLineReference, context.CommandLine, StringComparison.Ordinal);
+                string commandLine = IsArtifactNameProperty(settings, propertyInfo) ?
+                    GetFileName(context.CommandLine) :
+                    context.CommandLine;
+                replacement = replacement.Replace(CommandLineReference, commandLine, StringComparison.Ordinal);
                 replacement = replacement.Replace(HostNameReference, context.MonitorHostName, StringComparison.Ordinal);
                 replacement = replacement.Replace(UnixTimeReference, context.Timestamp.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
 
@@ -127,5 +132,35 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static string CreateTokenReference(string category, string token) =>
             FormattableString.Invariant($"{SubstitutionPrefix}{category}{Separator}{token}{SubstitutionSuffix}");
+
+        private static string GetFileName(string path)
+        {
+            string fileName = Path.GetFileName(
+                path.Replace('\\', Path.DirectorySeparatorChar)
+                    .Replace('/', Path.DirectorySeparatorChar));
+
+            if (fileName.Length >= 2 &&
+                IsAsciiLetter(fileName[0]) &&
+                fileName[1] == ':')
+            {
+                fileName = fileName.Substring(2);
+            }
+
+            int streamSeparatorIndex = fileName.IndexOf(':');
+            if (streamSeparatorIndex >= 0)
+            {
+                fileName = fileName.Substring(0, streamSeparatorIndex);
+            }
+
+            return string.IsNullOrEmpty(fileName.TrimEnd(' ', '.')) ? string.Empty : fileName;
+        }
+
+        private static bool IsAsciiLetter(char value) =>
+            (value >= 'A' && value <= 'Z') ||
+            (value >= 'a' && value <= 'z');
+
+        private static bool IsArtifactNameProperty(object? settings, PropertyInfo propertyInfo) =>
+            settings is IEgressProviderProperties &&
+            propertyInfo.Name == nameof(IEgressProviderProperties.ArtifactName);
     }
 }

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderHelper.cs
@@ -54,27 +54,31 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     string userSettingsPath = Path.Combine(settings.UserConfigDirectory, SettingsFileName);
                     AddJsonFileHelper(builder, hostBuilderResults, userSettingsPath);
 
-                    string sharedSettingsPath = Path.Combine(settings.SharedConfigDirectory, SettingsFileName);
-                    AddJsonFileHelper(builder, hostBuilderResults, sharedSettingsPath);
-
-                    //HACK Workaround for https://github.com/dotnet/runtime/issues/36091
-                    //KeyPerFile provider uses a file system watcher to trigger changes.
-                    //The watcher does not follow symlinks inside the watched directory, such as mounted files
-                    //in Kubernetes.
-                    //We get around this by watching the target folder of the symlink instead.
-                    //See https://github.com/kubernetes/kubernetes/master/pkg/volume/util/atomic_writer.go
-                    string? path = settings.SharedConfigDirectory;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInfo.IsInKubernetes)
+                    if (settings.IncludeSharedConfiguration)
                     {
-                        string symlinkTarget = Path.Combine(settings.SharedConfigDirectory, "..data");
-                        if (Directory.Exists(symlinkTarget))
+                        string sharedSettingsPath = Path.Combine(settings.SharedConfigDirectory, SettingsFileName);
+                        AddJsonFileHelper(builder, hostBuilderResults, sharedSettingsPath);
+
+                        //HACK Workaround for https://github.com/dotnet/runtime/issues/36091
+                        //KeyPerFile provider uses a file system watcher to trigger changes.
+                        //The watcher does not follow symlinks inside the watched directory, such as mounted files
+                        //in Kubernetes.
+                        //We get around this by watching the target folder of the symlink instead.
+                        //See https://github.com/kubernetes/kubernetes/master/pkg/volume/util/atomic_writer.go
+                        string? path = settings.SharedConfigDirectory;
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInfo.IsInKubernetes)
                         {
-                            path = symlinkTarget;
+                            string symlinkTarget = Path.Combine(settings.SharedConfigDirectory, "..data");
+                            if (Directory.Exists(symlinkTarget))
+                            {
+                                path = symlinkTarget;
+                            }
                         }
+
+                        // If a file at this path does not have read permissions, the application will fail to launch.
+                        builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     }
 
-                    // If a file at this path does not have read permissions, the application will fail to launch.
-                    builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ToolIdentifiers.StandardPrefix);
 
                     // User-specified configuration file path is considered highest precedence, but does NOT override other configuration sources

--- a/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
+++ b/src/Tools/dotnet-monitor/HostBuilder/HostBuilderSettings.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public required string SharedConfigDirectory { get; set; }
 
+        public bool IncludeSharedConfiguration { get; set; } = true;
+
         public required string UserConfigDirectory { get; set; }
 
         public FileInfo? UserProvidedConfigFilePath { get; set; }
@@ -71,6 +73,30 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             StartupAuthenticationMode startupAuthMode,
             FileInfo? userProvidedConfigFilePath)
         {
+            return CreateMonitor(
+                urls,
+                metricUrls,
+                metrics,
+                diagnosticPort,
+                startupAuthMode,
+                userProvidedConfigFilePath,
+                () => RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                () => EnvironmentInformation.IsElevated);
+        }
+
+        public static HostBuilderSettings CreateMonitor(
+            string[]? urls,
+            string[]? metricUrls,
+            bool metrics,
+            string? diagnosticPort,
+            StartupAuthenticationMode startupAuthMode,
+            FileInfo? userProvidedConfigFilePath,
+            Func<bool> isWindows,
+            Func<bool> isElevated)
+        {
+            ArgumentNullException.ThrowIfNull(isWindows);
+            ArgumentNullException.ThrowIfNull(isElevated);
+
             return new HostBuilderSettings()
             {
                 Urls = urls,
@@ -80,6 +106,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 AuthenticationMode = startupAuthMode,
                 ContentRootDirectory = AppContext.BaseDirectory,
                 SharedConfigDirectory = SharedConfigDirectoryPath,
+                IncludeSharedConfiguration = !isWindows() || !isElevated(),
                 UserConfigDirectory = UserConfigDirectoryPath,
                 UserProvidedConfigFilePath = userProvidedConfigFilePath
             };


### PR DESCRIPTION
###### Summary

Synchronizes the public `release/9.0` branch with Azure DevOps `internal/release/9.0` and restores the intended .NET 9 SDK servicing dependency that was inadvertently downgraded by a later unrelated internal change.

- Internal source branch: `https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor` at `internal/release/9.0`
- Public base tip: `3b7339ecca5201527e76c7f6fbc91cf3d6ba9fce`
- Exact matching internal commit: `d18246a35defda4ceb4c31df2f1fd57cef7737ec`
- Release synchronization merge commit: `9e93c2da1e0745ba553afef9f8b97822f8125b5c`
- .NET version restoration commit: `7b91a9f5b32f6be691bbe8f68fc4bf61fd317c4c`
- SDK placeholder: `9.0.100-rtm.24529.9` -> `9.0.318-servicing.26421.8`
- SDK dependency SHA: `59db016f11bb27d359336cf37524b863d77e7fea` -> `415ddb56e684aa46a3b2c0231341eb503a1063c7`

The restored values match internal dependency-flow commit `59dd9239227fddc2eed41ca96c903ffce4ea1217` and are synchronized in `eng/Versions.props` and `eng/Version.Details.xml`.

Validation:

```text
git rev-list refs/releasesync/push-public-release-9.0..HEAD
7b91a9f5b32f6be691bbe8f68fc4bf61fd317c4c
9e93c2da1e0745ba553afef9f8b97822f8125b5c
d18246a35defda4ceb4c31df2f1fd57cef7737ec
f764506c14b9c52685cbe6db1c78e825d8d23ee5
61cf2ea932fcd371315648ffbdb74f52e2c10abe
59dd9239227fddc2eed41ca96c903ffce4ea1217
59a73fd6ddeb1427f7da847ec62e6b8566b4424f
b29a52b2f0953b608d7624c82468d6de9841a49c

git rev-list --parents -n 1 9e93c2da1e0745ba553afef9f8b97822f8125b5c
9e93c2da1e0745ba553afef9f8b97822f8125b5c 3b7339ecca5201527e76c7f6fbc91cf3d6ba9fce d18246a35defda4ceb4c31df2f1fd57cef7737ec

.\Restore.cmd -projects src\Tools\dotnet-monitor\dotnet-monitor.csproj -verbosity minimal
Build succeeded. 0 Warning(s), 0 Error(s).
```

The internal tip remains present verbatim in both the local PR commit range and GitHub's PR commit list, and it remains the second parent of the release synchronization merge commit.

###### Release Notes Entry
