### PR TITLE
Fix legacy release build version lookup

### DIFF
--- a/eng/pipelines/dotnet-monitor-release.yml
+++ b/eng/pipelines/dotnet-monitor-release.yml
@@ -141,7 +141,21 @@ variables:
 
         $buildData = $buildInfo | ConvertFrom-Json
 
-        [array]$matchingData = $buildData.assets | Where-Object { $_.name -eq 'dotnet-monitor' }
+        [array]$monitorAssets = $buildData.assets | Where-Object { $_.name -eq 'dotnet-monitor' }
+
+        if (!$monitorAssets -or $monitorAssets.Length -ne 1) {
+            Write-Error 'Unable to determine target .NET version.'
+        }
+
+        [int]$targetMajorVersion = ($monitorAssets[0].version -split '\.')[0]
+
+        # Starting with .NET 10, the dotnet-monitor asset version matches the staging path.
+        # Earlier releases use the merged manifest's product build version for that path.
+        [array]$matchingData = if ($targetMajorVersion -ge 10) {
+            $monitorAssets
+        } else {
+            $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping }
+        }
 
         if (!$matchingData -or $matchingData.Length -ne 1) {
             Write-Error 'Unable to obtain build version.'

--- a/eng/release/Scripts/GetBuildVersion.ps1
+++ b/eng/release/Scripts/GetBuildVersion.ps1
@@ -15,7 +15,21 @@ $buildData = & $PSScriptRoot\GetDarcBuild.ps1 `
     -MaestroApiEndPoint $MaestroApiEndPoint `
     -DarcVersion $DarcVersion
 
-[array]$matchingData = $buildData.assets | Where-Object { $_.name -eq 'dotnet-monitor' }
+[array]$monitorAssets = $buildData.assets | Where-Object { $_.name -eq 'dotnet-monitor' }
+
+if (!$monitorAssets -or $monitorAssets.Length -ne 1) {
+    Write-Error 'Unable to determine target .NET version.'
+}
+
+[int]$targetMajorVersion = ($monitorAssets[0].version -split '\.')[0]
+
+# Starting with .NET 10, the dotnet-monitor asset version matches the staging path.
+# Earlier releases use the merged manifest's product build version for that path.
+[array]$matchingData = if ($targetMajorVersion -ge 10) {
+    $monitorAssets
+} else {
+    $buildData.assets | Where-Object { $_.name -match 'MergedManifest.xml$' -and $_.nonShipping }
+}
 
 if (!$matchingData -or $matchingData.Length -ne 1) {
     Write-Error 'Unable to obtain build version.'


### PR DESCRIPTION
## Summary

- select the non-shipping merged manifest build version for .NET 8 and .NET 9 payload staging paths
- retain the `dotnet-monitor` asset version for .NET 10 and later
- keep the standalone and inline release-pipeline version lookup behavior consistent

## Testing

- validated PowerShell syntax
- exercised version selection for .NET 8, 9, 10, and 11 payload versions
- ran `git diff --check`