### PR TITLE
[release/9.0] Backport explicit SBOM enablement

### DIFF
--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -89,11 +89,19 @@ stages:
             --client-id "$env:servicePrincipalId"
             -v True
 
+      # SBOM generation is handled by 1ES PT at publish time. Setting sbomEnabled: true on the
+      # 1ES.PublishPipelineArtifact task below makes 1ES generate an embedded _manifest SBOM over
+      # the published AssetsLayout (which includes the staged package). Downstream, the publish
+      # pipeline's release job validates this _manifest. The previous explicit "Download SBOM
+      # Artifact" / "Copy SBOM to Assets Layout" steps relied on the per-job
+      # PackSignPublish_Pack_and_Sign_SBOM artifact, which Arcade no longer produces (SBOM moved
+      # to 1ES PT).
       - template: /eng/pipelines/steps/publish-pipeline-artifact.yml@self
         parameters:
           displayName: 'Upload Assets Layout'
           targetPath: '$(System.ArtifactsDirectory)\AssetsLayout'
           artifact: 'StagingToolAssetsLayout'
+          sbomEnabled: true
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
       # Only tag build from real release branches

--- a/eng/pipelines/steps/publish-pipeline-artifact.yml
+++ b/eng/pipelines/steps/publish-pipeline-artifact.yml
@@ -4,6 +4,8 @@ parameters:
   displayName: 'PublishPipelineArtifact'
   targetPath: ''
   artifact: ''
+  # When true, 1ES PT generates an embedded _manifest SBOM over the published artifact.
+  sbomEnabled: ''
   # Adjust for 1ES pipeline template
   is1ESPipeline: true
 
@@ -14,6 +16,8 @@ steps:
     inputs:
       targetPath: ${{ parameters.targetPath }}
       artifact: ${{ parameters.artifact }}
+      ${{ if ne(parameters.sbomEnabled, '') }}:
+        sbomEnabled: ${{ parameters.sbomEnabled }}
 - ${{ else }}:
   - task: PublishPipelineArtifact@1
     displayName: ${{ parameters.displayName }}


### PR DESCRIPTION
###### Summary

Backports the applicable explicit SBOM enablement from #9639 to `release/9.0`.

- Source PR: #9639 (`Try explicit sbom enable`)
- Source commit: `5238607f1f041b7a6d2ad275b9be686fc9f1e17f`
- Upstream squash commit: `ca703a8613123a36befecd7b90682ef485dfc0bd`
- Release backport commit: `d591f4bb7e95ef225ceb47cc877f10f343d55c68`

This change:

- Adds an optional `sbomEnabled` parameter to `eng/pipelines/steps/publish-pipeline-artifact.yml` and forwards it only to `1ES.PublishPipelineArtifact@1`.
- Sets `sbomEnabled: true` for the Assets Layout artifact in `eng/pipelines/stages/preparerelease.yml`, causing 1ES PT to generate the embedded `_manifest` SBOM validated by the release pipeline.
- Leaves the logs artifact and the non-1ES `PublishPipelineArtifact@1` path unchanged.

`eng/pipelines/dotnet-monitor-publish.yml` does not exist on `release/9.0`, so the main-branch-only feature-flag removal from #9639 is intentionally not included.

Validation:

```text
YAML_PARSE_OK=eng\pipelines\steps\publish-pipeline-artifact.yml,eng\pipelines\stages\preparerelease.yml
TEMPLATE_WIRING_OK=true
PR9639_EQUIVALENCE_OK=true
git diff --check  # passed
```

Release-history invariant: exact internal commit `d18246a35defda4ceb4c31df2f1fd57cef7737ec` is already reachable verbatim from public base `6668af88e8f0487ccd7e35bc645193f92633b593` after #9819 merged. It is therefore part of the base history, not this SBOM-only PR range.

```text
git merge-base --is-ancestor d18246a35defda4ceb4c31df2f1fd57cef7737ec 6668af88e8f0487ccd7e35bc645193f92633b593
# exit 0
```

###### Release Notes Entry