### PR TITLE
[release/8.x] Enable SBOM for 1ES artifact publishing

### DIFF
--- a/eng/pipelines/steps/publish-pipeline-artifact.yml
+++ b/eng/pipelines/steps/publish-pipeline-artifact.yml
@@ -14,6 +14,7 @@ steps:
     inputs:
       targetPath: ${{ parameters.targetPath }}
       artifact: ${{ parameters.artifact }}
+      sbomEnabled: true
 - ${{ else }}:
   - task: PublishPipelineArtifact@1
     displayName: ${{ parameters.displayName }}


### PR DESCRIPTION
###### Summary

Backports the SBOM publishing behavior from #9639 to `release/8.x`, incorporating maintainer feedback by enabling SBOM generation directly on every `1ES.PublishPipelineArtifact@1` task instead of adding optional template parameter plumbing.

- Source functional commit: `5238607f1f041b7a6d2ad275b9be686fc9f1e17f`
- Source upstream merge commit: `ca703a8613123a36befecd7b90682ef485dfc0bd`
- Release backport commit: `a0a137145f13f0490506673a6a802dffd3feabba`
- Changed file: `eng/pipelines/steps/publish-pipeline-artifact.yml`
- Behavior: 1ES artifact publishing always sets `sbomEnabled: true`; the `PublishPipelineArtifact@1` fallback remains unchanged because it does not support that input.

Validation:

- Parsed the changed template successfully as YAML.
- Verified exactly one `sbomEnabled: true` entry and that it is scoped to `1ES.PublishPipelineArtifact@1`.
- `git diff --check` passed.

Release-history invariant: exact internal commit `17470eabc56943ee337c1974f2b0db93cf9d8928` is already reachable verbatim from the public `release/8.x` base through merged #9818. It is intentionally not part of this SBOM-only PR range.

###### Release Notes Entry
