### PR TITLE
Use Secret Manager GitHub App values for releases

### DIFF
--- a/eng/pipelines/dotnet-monitor-publish.yml
+++ b/eng/pipelines/dotnet-monitor-publish.yml
@@ -276,10 +276,8 @@ extends:
               Write-Host "##vso[task.setvariable variable=ShortReleaseVersion]v$shortVersion"
         - template: /eng/common/templates-official/steps/get-github-app-token.yml@self
           parameters:
-            azureSubscription: dnceng-dotnet-monitor-release-githubapp
-            keyVaultName: EngKeyVault
-            keyName: dotnet-monitor-release-app-key
-            appClientId: Iv23liBv4UYcLCWQNpMz
+            appId: $(dotnet-monitor-release-app-app-id)
+            appPrivateKey: $(dotnet-monitor-release-app-app-private-key)
             installationOwner: $(DRP_GithubOrg)
             outputVariableName: GitHubAppInstallationToken
         - task: PowerShell@2
@@ -290,4 +288,3 @@ extends:
             workingDirectory: $(DRP_RepoRoot)
           env:
             GITHUB_TOKEN: $(GitHubAppInstallationToken)
-


### PR DESCRIPTION
## Summary
- replace the legacy Key Vault RSA signing parameters in the dotnet-monitor release pipeline
- use `dotnet-monitor-release-app-app-id` and `dotnet-monitor-release-app-app-private-key` from the existing `Release-Pipeline` variable group

## Dependency
This PR is stacked on dotnet/arcade#17528. Before this can leave draft, the Arcade change must merge and its dependency update must be incorporated here so `eng/common` is updated by Arcade automation rather than edited manually.

## Validation
- parsed `eng/pipelines/dotnet-monitor-publish.yml` as YAML
- confirmed no dotnet-monitor references remain to the legacy RSA key, WIF signing service connection, or hard-coded GitHub App client ID

AB#12467